### PR TITLE
[DEV-74] Include column_entity_map in event data creation schema

### DIFF
--- a/featurebyte/routes/event_data/schema.py
+++ b/featurebyte/routes/event_data/schema.py
@@ -2,7 +2,7 @@
 EventData API payload schema
 """
 # pylint: disable=too-few-public-methods
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import datetime
 
@@ -30,6 +30,7 @@ class EventDataCreate(BaseModel):
     name: str
     tabular_source: Tuple[DatabaseSourceModel, str]
     event_timestamp_column: str
+    column_entity_map: Dict[str, str] = Field(default_factory=dict)
     record_creation_date_column: Optional[str]
     default_feature_job_setting: Optional[FeatureJobSetting]
 

--- a/tests/unit/routes/test_event_data.py
+++ b/tests/unit/routes/test_event_data.py
@@ -23,6 +23,7 @@ def event_data_dict_fixture(event_data_model_dict):
     event_data_dict = json.loads(EventDataModel(**event_data_model_dict).json())
     event_data_dict["name"] = "订单表"
     event_data_dict.pop("created_at")
+    event_data_dict["column_entity_map"] = {"O_CUSTKEY": "Customer"}
     return event_data_dict
 
 


### PR DESCRIPTION
## Description

Fix bug where the newly added "column_entity_map" field is not saved in the Event Data api.
This is due to the field not added to the EventDataCreate payload schema.

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-74

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [x] I have written tests for the changes made.
- [x] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [x] I have labeled my Pull Request correctly
