### PR TITLE
Update make lint and make test commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ formatting: codestyle
 #* Linting
 .PHONY: test
 test:
-	PYTHONPATH=$(PYTHONPATH) poetry run pytest --junitxml=pytest.xml --cov-report=term-missing --cov=featurebyte tests/ featurebyte/ | tee pytest-coverage.txt
+	PYTHONPATH=$(PYTHONPATH) poetry run pytest --junitxml=pytest.xml --cov-report=term-missing --cov=featurebyte tests/ featurebyte/ -v | tee pytest-coverage.txt
 	poetry run coverage-badge -o assets/images/coverage.svg -f
 
 .PHONY: check-codestyle


### PR DESCRIPTION
## Description

This PR makes the following changes:
1. Do not run the full test suite when running `make lint`. I almost always have to comment this out locally for the `make lint` command to be useful
2. Run `pytest` by specifying `-v` flag to get more verbose output (prints the name of the currently running test case). In case of hanging tests this could help us troubleshoot the problematic test cases <img width="1073" alt="image" src="https://user-images.githubusercontent.com/2175543/177966755-0e6f8212-2f69-4fe1-8b06-0504c96141b0.png">

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
