### PR TITLE
[DEV-148] Support publishing workflow for repo/featurebyte

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -3,6 +3,9 @@ name: build-publish-dev
 on:
   release:
     types: [created]
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -14,9 +17,9 @@ jobs:
       matrix:
         python-version: ["3.8"]
     env:
-      GCR_REPO_NAME: '${{ secrets.GCR_REPO_NAME }}'
-      GCR_REPO_LOCATION: '${{ secrets.GCR_REPO_LOCATION }}'
-      GC_PROJECT_ID: '${{ secrets.GC_PROJECT_ID }}'
+      GCR_REPO_NAME: featurebyte-pypi
+      GCR_REPO_LOCATION: us-central1
+      GC_PROJECT_ID: vpc-host-nonprod-xa739-xz970
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description

+ Added build and publish workflow for dev
  + if version == `1.0.3` => published version = `1.0.3.dev1`
  + if highest version in private repo == `1.0.3.dev9` => published => `1.0.3.dev10`

## Related Issue

[DEV-148](https://featurebyte.atlassian.net/browse/DEV-148?atlOrigin=eyJpIjoiNjYyODdkYTczMWFlNDdjZjgzZDIzZGI5ODdhZmE3ZWEiLCJwIjoiaiJ9)

## Type of Change

Feature

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [X] I have labeled my Pull Request correctly
