### PR TITLE
[DEV-160] Allow letters in version for github publish action

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -50,7 +50,7 @@ jobs:
           )
           export DEV_VERSION=${DEV_VERSION:-0}  # Set .dev to 0 if not exist
           export PUBLISH_VERSION="${VERSION}.dev$((DEV_VERSION+=1))"
-          sed -i -E "s|version = \"[0-9.]+\"|version = \"${PUBLISH_VERSION}\"|g" pyproject.toml
+          sed -i -E "s|^version = \"[^\"]+\"|version = \"${PUBLISH_VERSION}\"|g" pyproject.toml
 
           poetry config repositories.featurebyte_np https://$GCR_REPO_LOCATION-python.pkg.dev/$GC_PROJECT_ID/$GCR_REPO_NAME
           poetry publish --build -r featurebyte_np


### PR DESCRIPTION
## Description

Fixed bug because version `0.1.0-alpha` did not conform to `[0-9.]+` regex
Changed regex to `[^"]+` instead

Working, refer to: https://github.com/featurebyte/featurebyte/actions/runs/2688707733

