### PR TITLE
[DEV-172] Raise KeyboardInterrupt after cleaning up temp files on SIGINT

### DIFF
--- a/featurebyte/app.py
+++ b/featurebyte/app.py
@@ -158,6 +158,7 @@ def _sigint_handler(signum, frame):  # type: ignore
     Raises
     ------
     KeyboardInterrupt
+        After performing persistent clean up
     """
     _cleanup_persistent(signum, frame)
     raise KeyboardInterrupt


### PR DESCRIPTION
## Description

Handling `SIGINT` without raising `KeyboardInterrupt` causes PyCharm debugger's stop button to hang. Raising `KeyboardInterrupt` (the [default behaviour](https://docs.python.org/3/library/signal.html#signal.SIGINT)) after cleaning up fixes it.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
