### PR TITLE
Add `kill_after_timeout` parameter to git `push`

### DIFF
--- a/tests/integration/persistent/test_git.py
+++ b/tests/integration/persistent/test_git.py
@@ -68,7 +68,8 @@ def persistent_data_fixture():
     origin = repo.remotes.origin
     if origin:
         with repo.git.custom_environment(GIT_SSH_COMMAND=ssh_cmd):
-            origin.push(refspec=(f":{branch}"))
+            # add kill_after_timeout to avoid process blocking which causes timeout exception
+            origin.push(refspec=f":{branch}", kill_after_timeout=30)
 
 
 def _get_commit_messages(repo, branch, max_count=5):

--- a/tests/integration/persistent/test_mongo.py
+++ b/tests/integration/persistent/test_mongo.py
@@ -60,7 +60,7 @@ async def test_start_transaction__exception_within_transaction(mongo_persistent)
         async with persistent.start_transaction() as session:
             await session.insert_one(collection_name=col, document={"key1": "value1"})
             await session.insert_one(collection_name=col, document={"key2": "value2"})
-            raise TypeError
+            await session.find(collection_name="data4", query_filter={})[0]
 
     # ensure persistent is working after failed transaction
     await persistent.find(collection_name="data4", query_filter={})


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

The remote git cleanup command is flaky as it may have process blocking issue and cause time out exception. Add a parameter to enable killing the thread after timeout to avoid causing time out exception during cleaning process.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
