### PR TITLE
[DEV-437] Handle query_filter in base document service

### DIFF
--- a/featurebyte/service/base_document.py
+++ b/featurebyte/service/base_document.py
@@ -133,12 +133,16 @@ class BaseDocumentService(Generic[Document]):
         )
         return self.document_class(**document_dict)
 
-    def _construct_list_query_filter(self, **kwargs: Any) -> QueryFilter:
+    def _construct_list_query_filter(
+        self, query_filter: Optional[Dict[str, Any]] = None, **kwargs: Any
+    ) -> QueryFilter:
         """
         Construct query filter used in list route
 
         Parameters
         ----------
+        query_filter: Optional[Dict[str, Any]]
+            Query filter to use as starting point
         kwargs: Any
             Keyword arguments passed to the list controller
 
@@ -147,7 +151,10 @@ class BaseDocumentService(Generic[Document]):
         QueryFilter
         """
         _ = self
-        output = {}
+        if not query_filter:
+            output = {}
+        else:
+            output = copy.deepcopy(query_filter)
         if kwargs.get("name"):
             output["name"] = kwargs["name"]
         if kwargs.get("search"):

--- a/tests/unit/service/test_base_document.py
+++ b/tests/unit/service/test_base_document.py
@@ -13,7 +13,7 @@ from featurebyte.models.base import (
     UniqueConstraintResolutionSignature,
 )
 from featurebyte.models.persistent import AuditActionType
-from featurebyte.routes.common.base import BaseDocumentService
+from featurebyte.service.base_document import BaseDocumentService
 
 
 @pytest.mark.asyncio
@@ -272,3 +272,25 @@ def test_field_path_value(doc, field_path, expected):
     assert (
         BaseDocumentService._get_field_path_value(doc_dict=doc, field_path=field_path) == expected
     )
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        ({}, {}),
+        ({"name": "some_name"}, {"name": "some_name"}),
+        ({"search": "some_value"}, {"$text": {"$search": "some_value"}}),
+        ({"query_filter": {"field": {"$in": ["a", "b"]}}}, {"field": {"$in": ["a", "b"]}}),
+        (
+            {
+                "name": "some_name",
+                "search": "some_value",
+                "query_filter": {"field": {"$in": ["a", "b"]}},
+            },
+            {"name": "some_name", "$text": {"$search": "some_value"}, "field": {"$in": ["a", "b"]}},
+        ),
+    ],
+)
+def test_construct_list_query_filter(kwargs, expected):
+    """Test construct_list_query_filter logic"""
+    assert BaseDocumentService._construct_list_query_filter(None, **kwargs) == expected


### PR DESCRIPTION
## Description

Handle query_filter in base document service, so we can inject query filter from outside the service (e.g. in route controllers). Needed to support advanced filtering in list routes.

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-437

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
