### PR TITLE
[DEV-460] Fix KeyError when creating TileSpec if time modulo frequency is 0

### DIFF
--- a/featurebyte/models/tile.py
+++ b/featurebyte/models/tile.py
@@ -39,7 +39,7 @@ class TileSpec(FeatureByteBaseModel):
         optional category column name when the groupby operation specifies a category
     """
 
-    time_modulo_frequency_second: int = Field(gt=0)
+    time_modulo_frequency_second: int = Field(gte=0)
     blind_spot_second: int
     frequency_minute: int = Field(gt=0, le=60)
     tile_sql: str

--- a/tests/unit/tile/test_unit_snowflake_tile.py
+++ b/tests/unit/tile/test_unit_snowflake_tile.py
@@ -25,6 +25,25 @@ def test_construct_snowflaketile_time_modulo_error():
     assert "time_modulo_frequency_second must be less than 180" in str(excinfo.value)
 
 
+def test_construct_snowflaketile_zero_time_modulo_frequency():
+    """
+    Test construct TileSpec with time modulo frequency of 0
+    """
+    tile_spec = TileSpec(
+        time_modulo_frequency_second=0,
+        blind_spot_second=3,
+        frequency_minute=3,
+        tile_sql="select c1 from dummy where tile_start_ts >= FB_START_TS and tile_start_ts < FB_END_TS",
+        value_column_names=["col2"],
+        entity_column_names=["col1"],
+        tile_id="some_tile_id",
+        aggregation_id="some_agg_id",
+    )
+    assert tile_spec.time_modulo_frequency_second == 0
+    assert tile_spec.blind_spot_second == 3
+    assert tile_spec.frequency_minute == 3
+
+
 def test_generate_tiles(mock_snowflake_tile, tile_manager):
     """
     Test generate_tiles method in TileSnowflake


### PR DESCRIPTION
## Description

This fixes a bug where a valid time modulo frequency of 0 causes KeyError when `TileManagerSnowflake` attempts to create a `TileSpec`.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
