### PR TITLE
[DEV-364] Fix backtest and temp data route response and update storage tests

### DIFF
--- a/featurebyte/routes/temp_data/controller.py
+++ b/featurebyte/routes/temp_data/controller.py
@@ -49,4 +49,8 @@ class TempDataController:  # pylint: disable=too-few-public-methods
             bytestream = temp_storage.get_file_stream(remote_path=path)
         except FileNotFoundError as exc:
             raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="Invalid path") from exc
-        return StreamingResponse(bytestream, media_type=media_type)
+        return StreamingResponse(
+            bytestream,
+            media_type=media_type,
+            headers={"content-disposition": f"filename={path.name}"},
+        )

--- a/featurebyte/schema/worker/task/feature_job_setting_analysis.py
+++ b/featurebyte/schema/worker/task/feature_job_setting_analysis.py
@@ -1,6 +1,8 @@
 """
 FeatureJobSettingAnalysisTaskPayload schema
 """
+from typing import Optional
+
 from featurebyte.enum import WorkerCommand
 from featurebyte.models.feature_job_setting_analysis import FeatureJobSettingAnalysisModel
 from featurebyte.schema.feature_job_setting_analysis import (
@@ -28,3 +30,14 @@ class FeatureJobSettingAnalysisBackTestTaskPayload(
 
     output_collection_name = "temp_data"
     command = WorkerCommand.FEATURE_JOB_SETTING_ANALYSIS_BACKTEST
+
+    @property
+    def task_output_path(self) -> Optional[str]:
+        """
+        Redirect route used to retrieve the task result
+
+        Returns
+        -------
+        Optional[str]
+        """
+        return f"/{self.output_collection_name}?path=feature_job_setting_analysis/backtest/{self.output_document_id}"

--- a/featurebyte/storage/base.py
+++ b/featurebyte/storage/base.py
@@ -136,9 +136,11 @@ class Storage(ABC):
         str
             Text data
         """
-        with tempfile.NamedTemporaryFile(mode="r") as file_obj:
-            await self.get(remote_path, Path(file_obj.name))
-            return file_obj.read()
+        with tempfile.NamedTemporaryFile(mode="r") as tmp_file:
+            await self.get(remote_path, Path(tmp_file.name))
+            with open(tmp_file.name, encoding="utf8") as file_obj:
+                text = file_obj.read()
+            return text
 
     async def put_dataframe(self, dataframe: DataFrame, remote_path: Path) -> None:
         """

--- a/tests/unit/routes/test_feature_job_setting_analysis.py
+++ b/tests/unit/routes/test_feature_job_setting_analysis.py
@@ -200,7 +200,11 @@ class TestFeatureJobSettingAnalysisApi(BaseAsyncApiTestSuite):
             f"{self.base_route}/{feature_job_setting_analysis_id}/backtest", json=payload
         )
         assert response.status_code == HTTPStatus.ACCEPTED
-        output_document_id = response.json()["payload"]["output_document_id"]
+        response_dict = response.json()
+        output_document_id = response_dict["payload"]["output_document_id"]
+        assert response_dict["output_path"] == (
+            f"/temp_data?path=feature_job_setting_analysis/backtest/{output_document_id}"
+        )
 
         self.wait_for_results(test_api_client, response)
 

--- a/tests/unit/routes/test_temp_data.py
+++ b/tests/unit/routes/test_temp_data.py
@@ -47,6 +47,9 @@ class TestTempDataApi:
         response = test_api_client.get(f"/temp_data?path={dest_path}")
         assert response.status_code == HTTPStatus.OK
         assert response.headers["content-type"] == "application/octet-stream"
+        assert (
+            response.headers["content-disposition"] == "filename=62f301e841b9a757c9ff871b.parquet"
+        )
 
         with open(source_file, "rb") as file_obj:
             expected_content = file_obj.read()


### PR DESCRIPTION
## Description

- Fix feature job settings backtest route response to include correct output path
- Fix temp data route response to include filename
- Update storage tests to improve coverage

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-364

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
