### PR TITLE
[DEV-572] Fix numerical issue causing error in std aggregator

### DIFF
--- a/featurebyte/query_graph/tiling.py
+++ b/featurebyte/query_graph/tiling.py
@@ -159,7 +159,7 @@ class StdAggregator(TilingAggregator):
     def merge(agg_id: str) -> str:
         expected_x2 = f"(SUM(sum_value_squared_{agg_id}) / SUM(count_value_{agg_id}))"
         expected_x = f"(SUM(sum_value_{agg_id}) / SUM(count_value_{agg_id}))"
-        variance = f"{expected_x2} - ({expected_x} * {expected_x})"
+        variance = f"({expected_x2} - ({expected_x} * {expected_x}))"
         variance = f"CASE WHEN {variance} < 0 THEN 0 ELSE {variance} END"
         stddev = f"SQRT({variance})"
         return stddev

--- a/tests/unit/query_graph/test_tiling.py
+++ b/tests/unit/query_graph/test_tiling.py
@@ -64,9 +64,13 @@ from featurebyte.query_graph.tiling import AggFunc, TileSpec, get_aggregator
                 TileSpec(tile_expr='COUNT("a_column")', tile_column_name="count_value_1234beef"),
             ],
             (
-                "SQRT((SUM(sum_value_squared_1234beef) / SUM(count_value_1234beef))"
-                " - ((SUM(sum_value_1234beef) / SUM(count_value_1234beef))"
-                " * (SUM(sum_value_1234beef) / SUM(count_value_1234beef))))"
+                "SQRT(CASE WHEN ({variance}) < 0 THEN 0 ELSE ({variance}) END)".format(
+                    variance=(
+                        "(SUM(sum_value_squared_1234beef) / SUM(count_value_1234beef)) - "
+                        "((SUM(sum_value_1234beef) / SUM(count_value_1234beef)) * "
+                        "(SUM(sum_value_1234beef) / SUM(count_value_1234beef)))"
+                    )
+                )
             ),
         ),
     ],


### PR DESCRIPTION
## Description

Due to numerical issues related to precision / rounding, standard deviation aggregator might produce error such as
```
ProgrammingError: 100044 (22P01): Invalid floating point operation: sqrt(-3.63798e-12)
```
when evaluating the `sqrt` function. This fixes the issue by clipping the the input to `sqrt` to be at least 0.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
