### PR TITLE
[DEV-607] Exclude TYPE_CHECKING branches from coverage report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,10 @@ line-length = 100
 target-version = ["py38"]
 
 [tool.coverage.report] # https://coverage.readthedocs.io/en/6.4.1/config.html#run
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+]
 fail_under = 50
 show_missing = true
 


### PR DESCRIPTION
## Description

Code below `if TYPE_CHECKING: ...` are marked as missing coverage but it is expected that they are never executed during runtime. This change excludes them from coverage report to reduce noise and make the report more useful.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
