### PR TITLE
[DEV-665] Handle plain text 500 http responses as exceptions

### DIFF
--- a/featurebyte/exception.py
+++ b/featurebyte/exception.py
@@ -29,7 +29,7 @@ class ResponseException(Exception):
             if resolution:
                 exc_info += resolution
         except JSONDecodeError:
-            pass
+            exc_info = response.text
 
         if exc_info:
             super().__init__(exc_info, *args, **kwargs)

--- a/tests/unit/test_exception.py
+++ b/tests/unit/test_exception.py
@@ -26,3 +26,14 @@ def test_response_exception__json_text_response():
     assert str(response_exception) == "some error"
     assert response_exception.text == '{"detail": "some error"}'
     assert response_exception.status_code == 500
+
+
+def test_response_exception__plain_text_response():
+    """Test response exception for plain text 500 response"""
+    response = Response()
+    response._content = bytes("some error", "utf-8")
+    response.status_code = 500
+    response_exception = ResponseException(response=response)
+    assert str(response_exception) == "some error"
+    assert response_exception.text == "some error"
+    assert response_exception.status_code == 500


### PR DESCRIPTION
## Description

Make 500 plain text http responses visible in the SDK by handling the content as traceback.

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-665

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
