### PR TITLE
[DEV-679] Use 422 for response status code instead of 401 on feature store credential error

### DIFF
--- a/featurebyte/api/event_data.py
+++ b/featurebyte/api/event_data.py
@@ -14,7 +14,7 @@ from typeguard import typechecked
 from featurebyte.api.api_object import SavableApiObject
 from featurebyte.api.database_table import DatabaseTable
 from featurebyte.api.entity import Entity
-from featurebyte.common.env_util import is_notebook
+from featurebyte.common.env_util import display_html_in_notebook
 from featurebyte.config import Configurations
 from featurebyte.core.mixin import GetAttrMixin, ParentMixin
 from featurebyte.enum import TableDataType
@@ -231,11 +231,7 @@ class EventData(EventDataModel, DatabaseTable, SavableApiObject, GetAttrMixin):
                 frequency=f'{recommended_setting["frequency"]}s',
             )
 
-            if is_notebook():
-                # pylint: disable=import-outside-toplevel
-                from IPython.display import HTML, display  # pylint: disable=import-error
-
-                display(HTML(job_setting_analysis["analysis_report"]))
+            display_html_in_notebook(job_setting_analysis["analysis_report"])
 
         self.update(
             update_payload={"default_feature_job_setting": feature_job_setting.dict()},

--- a/featurebyte/common/env_util.py
+++ b/featurebyte/common/env_util.py
@@ -34,3 +34,20 @@ def get_alive_bar_additional_params() -> dict[str, Any]:
     if is_notebook():
         return {"force_tty": True}
     return {"dual_line": True}
+
+
+def display_html_in_notebook(html_content: str) -> None:
+    """
+    Display html content in notebook environment
+
+    Parameters
+    ----------
+    html_content: str
+        HTML content to display
+    """
+
+    if is_notebook():
+        # pylint: disable=import-outside-toplevel
+        from IPython.display import HTML, display  # pylint: disable=import-error
+
+        display(HTML(html_content), metadata=dict(isolated=True))

--- a/featurebyte/middleware.py
+++ b/featurebyte/middleware.py
@@ -145,7 +145,7 @@ class ExecutionContext:
         return False
 
 
-ExecutionContext.register(CredentialsError, handle_status_code=HTTPStatus.UNAUTHORIZED)
+ExecutionContext.register(CredentialsError, handle_status_code=HTTPStatus.UNPROCESSABLE_ENTITY)
 
 ExecutionContext.register(DocumentConflictError, handle_status_code=HTTPStatus.CONFLICT)
 

--- a/tests/unit/api/test_event_data.py
+++ b/tests/unit/api/test_event_data.py
@@ -431,7 +431,7 @@ def test_update_default_job_setting__saved_event_data(saved_event_data, config):
     }
 
 
-@patch("featurebyte.api.event_data.is_notebook")
+@patch("featurebyte.common.env_util.is_notebook")
 @patch("featurebyte.api.event_data.EventData.post_async_task")
 def test_update_default_feature_job_setting__using_feature_job_analysis(
     mock_post_async_task,

--- a/tests/unit/routes/test_feature.py
+++ b/tests/unit/routes/test_feature.py
@@ -12,7 +12,6 @@ from bson.objectid import ObjectId
 from pandas.testing import assert_frame_equal
 
 from featurebyte.common.model_util import get_version
-from featurebyte.exception import CredentialsError
 from tests.unit.routes.base import BaseApiTestSuite
 
 
@@ -238,15 +237,6 @@ class TestFeatureApi(BaseApiTestSuite):
         assert parameters["time_modulo_frequency"] == 3600
         assert parameters["frequency"] == 86400
         assert parameters["blind_spot"] == 86400
-
-    @pytest.mark.skip("Skip feature registry insertion")
-    def test_create_401(self, test_api_client_persistent, mock_insert_feature_registry_fixture):
-        """Test create (unauthorized)"""
-        mock_insert_feature_registry_fixture.side_effect = CredentialsError
-        test_api_client, _ = test_api_client_persistent
-        self.setup_creation_route(test_api_client)
-        response = test_api_client.post(f"{self.base_route}", json=self.payload)
-        assert response.status_code == HTTPStatus.UNAUTHORIZED
 
     def test_create_422__create_new_version(
         self, test_api_client_persistent, create_success_response

--- a/tests/unit/routes/test_feature_store.py
+++ b/tests/unit/routes/test_feature_store.py
@@ -115,7 +115,7 @@ class TestFeatureStoreApi(BaseApiTestSuite):
         ) as mock_get_session:
             mock_get_session.return_value.list_databases.side_effect = credentials_error
             response = test_api_client.post(f"{self.base_route}/database", json=feature_store)
-        assert response.status_code == HTTPStatus.UNAUTHORIZED
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
         assert response.json() == {"detail": str(credentials_error)}
 
     def test_list_schemas__422(self, test_api_client_persistent, create_success_response):


### PR DESCRIPTION
## Description

401 response indicates unauthorized access to the API service and can trigger security responses such as redirection etc.
Invalid credentials for feature stores is just a form of invalid user input that requires corrective action from the user, and hence a 422 status code is more appropriate.

Also included a minor fix to improve html display layout in notebooks

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-679

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
