### PR TITLE
session/base: setDaemon -> thread.daemon

### DIFF
--- a/featurebyte/session/base.py
+++ b/featurebyte/session/base.py
@@ -227,7 +227,7 @@ class BaseSession(BaseModel):
             # set pipe to non-blocking if fcntl is available
             fcntl.fcntl(input_pipe, fcntl.F_SETFL, os.O_NONBLOCK)
         thread = RunThread(cursor, query, out_fd, self.fetch_query_stream_impl)
-        thread.setDaemon(True)
+        thread.daemon = True
         thread.start()
 
         start_time = time.time()


### PR DESCRIPTION
## Description
Small refactor to update the callsite to not use `setDaemon` which has been marked as deprecated. Came across this via a lint warning when running `make lint` locally. As such, this PR will remove that lint warning as well. This should be safe as the setDaemon function was already doing the same action.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
