### PR TITLE
[DEV-657] session/base: add get_current_working_schema_version

### DIFF
--- a/featurebyte/enum.py
+++ b/featurebyte/enum.py
@@ -142,6 +142,9 @@ class SourceType(StrEnum):
     SQLITE = "sqlite"
     DATABRICKS = "databricks"
 
+    # TEST source type should only be used for mocking in unit tests.
+    TEST = "test"
+
 
 class SpecialColumnName(StrEnum):
     """

--- a/featurebyte/session/base.py
+++ b/featurebyte/session/base.py
@@ -414,6 +414,23 @@ class BaseSchemaInitializer(ABC):
     def sql_directory_name(self) -> str:
         """Directory name containing the SQL initialization scripts"""
 
+    @property
+    @abstractmethod
+    def current_working_schema_version(self) -> int:
+        """Gets the current working schema version.
+
+        We should increase this value if we want to re-run the session
+        initialization functions (eg. registering new functions, procedures
+        and tables).
+
+        We can consider moving this to a config/json file down the line, but
+        opting to keep it simple for now.
+
+        Returns
+        -------
+        int that is the current working schema version.
+        """
+
     async def initialize(self) -> None:
         """Entry point to set up the featurebyte working schema"""
 

--- a/featurebyte/session/databricks.py
+++ b/featurebyte/session/databricks.py
@@ -152,6 +152,10 @@ class DatabricksSchemaInitializer(BaseSchemaInitializer):
     def sql_directory_name(self) -> str:
         return "databricks"
 
+    @property
+    def current_working_schema_version(self) -> int:
+        return 1
+
     async def create_schema(self) -> None:
         create_schema_query = f"CREATE SCHEMA {self.session.schema_name}"
         await self.session.execute_query(create_schema_query)

--- a/featurebyte/session/snowflake.py
+++ b/featurebyte/session/snowflake.py
@@ -264,6 +264,10 @@ class SnowflakeSchemaInitializer(BaseSchemaInitializer):
     def sql_directory_name(self) -> str:
         return "snowflake"
 
+    @property
+    def current_working_schema_version(self) -> int:
+        return 1
+
     async def create_schema(self) -> None:
         create_schema_query = f"CREATE SCHEMA {self.session.schema_name}"
         await self.session.execute_query(create_schema_query)

--- a/tests/unit/session/test_base.py
+++ b/tests/unit/session/test_base.py
@@ -1,0 +1,101 @@
+"""
+Unit test for base snowflake session.
+"""
+from __future__ import annotations
+
+from typing import OrderedDict
+
+import collections
+
+import pandas as pd
+import pytest
+from pydantic import Field
+
+from featurebyte.enum import DBVarType, SourceType
+from featurebyte.session.base import BaseSchemaInitializer, BaseSession
+
+CURRENT_WORKING_SCHEMA_VERSION_TEST = 1
+
+
+@pytest.fixture(name="base_session_test")
+def base_session_test_fixture():
+    """
+    Base session test fixture.
+
+    This fixture is a no-op implementation of the BaseSession.
+    """
+
+    class BaseSessionTestFixture(BaseSession):
+        source_type: SourceType = Field(SourceType.TEST, const=True)
+
+        @property
+        def schema_name(self) -> str:
+            return "test base session - schema"
+
+        @property
+        def database_name(self) -> str:
+            return "test base session - database name"
+
+        async def list_databases(self) -> list[str]:
+            return []
+
+        async def list_schemas(self, database_name: str | None = None) -> list[str]:
+            return []
+
+        async def list_tables(
+            self, database_name: str | None = None, schema_name: str | None = None
+        ) -> list[str]:
+            return []
+
+        async def list_table_schema(
+            self,
+            table_name: str | None,
+            database_name: str | None = None,
+            schema_name: str | None = None,
+        ) -> OrderedDict[str, DBVarType]:
+            return collections.OrderedDict()
+
+        async def register_temp_table(self, table_name: str, dataframe: pd.DataFrame) -> None:
+            return None
+
+    return BaseSessionTestFixture
+
+
+@pytest.fixture(name="base_schema_initializer_test")
+def base_schema_initializer_test_fixture():
+    """
+    Base schema initializer fixture.
+
+    This fixture is a no-op implementation of the BaseSchemaInitializer.
+    """
+
+    class BaseSchemaInitializerTestFixture(BaseSchemaInitializer):
+        """Snowflake schema initializer class"""
+
+        @property
+        def sql_directory_name(self) -> str:
+            return "test"
+
+        @property
+        def current_working_schema_version(self) -> int:
+            return CURRENT_WORKING_SCHEMA_VERSION_TEST
+
+        async def create_schema(self) -> None:
+            return
+
+        async def list_functions(self) -> list[str]:
+            return []
+
+        async def list_procedures(self) -> list[str]:
+            return []
+
+    return BaseSchemaInitializerTestFixture
+
+
+def test_get_current_working_schema_version(base_schema_initializer_test, base_session_test):
+    base_session = base_session_test()
+    base_schema_initializer = base_schema_initializer_test(base_session)
+    assert (
+        base_schema_initializer.current_working_schema_version
+        == CURRENT_WORKING_SCHEMA_VERSION_TEST
+    )


### PR DESCRIPTION
## Description

Adds a basic `get_current_working_schema_version` for us to keep track of what the local working schema version is. This will eventually be compared with a version that we persist in the end-users working schema. We will then compare the two values to determine if we want to run the more expensive initialization functions.

Splitting this out from a parent PR as I didn't want to put out too big a PR, and also wanted to separate out the changes that would actually change existing behaviour.

## Related Issue

https://github.com/featurebyte/featurebyte/pull/359/files

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
