### PR TITLE
[DEV-657] session/test_base: unit test two functions that were previously added

### DIFF
--- a/featurebyte/session/base.py
+++ b/featurebyte/session/base.py
@@ -490,7 +490,7 @@ class BaseSchemaInitializer(ABC):
             return True
         if registered_working_schema_version == MetadataSchemaInitializer.SCHEMA_NO_RESULTS_FOUND:
             logger.debug(f"No results found for the working schema {self.session.schema_name}")
-            return False
+            return True
         current_version = self.current_working_schema_version
         return current_version > registered_working_schema_version
 

--- a/tests/unit/session/test_base.py
+++ b/tests/unit/session/test_base.py
@@ -94,6 +94,12 @@ def base_schema_initializer_test_fixture():
     return BaseSchemaInitializerTestFixture
 
 
+@pytest.fixture(name="base_schema_initializer")
+def base_schema_initializer_fixture(base_schema_initializer_test, base_session_test):
+    base_session = base_session_test()
+    return base_schema_initializer_test(base_session)
+
+
 def test_get_current_working_schema_version(base_schema_initializer_test, base_session_test):
     base_session = base_session_test()
     base_schema_initializer = base_schema_initializer_test(base_session)
@@ -104,10 +110,7 @@ def test_get_current_working_schema_version(base_schema_initializer_test, base_s
 
 
 @pytest.mark.asyncio
-async def test_get_working_schema_version(base_schema_initializer_test, base_session_test):
-    base_session = base_session_test()
-    base_schema_initializer = base_schema_initializer_test(base_session)
-
+async def test_get_working_schema_version__no_data(base_schema_initializer):
     async def mocked_execute_query(self, query: str) -> pd.DataFrame | None:
         return None
 
@@ -115,6 +118,9 @@ async def test_get_working_schema_version(base_schema_initializer_test, base_ses
         version = await base_schema_initializer.get_working_schema_version()
     assert version == MetadataSchemaInitializer.SCHEMA_NO_RESULTS_FOUND
 
+
+@pytest.mark.asyncio
+async def test_get_working_schema_version__with_version_set(base_schema_initializer):
     schema_version = 2
 
     async def mocked_execute_query_with_version(self, query: str) -> pd.DataFrame | None:
@@ -128,9 +134,92 @@ async def test_get_working_schema_version(base_schema_initializer_test, base_ses
         version = await base_schema_initializer.get_working_schema_version()
     assert version == schema_version
 
+
+@pytest.mark.asyncio
+async def test_get_working_schema_version__schema_not_registered(base_schema_initializer):
     async def mocked_execute_query_with_exception(self, query: str) -> pd.DataFrame | None:
         raise ProgrammingError
 
     with patch.object(BaseSession, "execute_query", mocked_execute_query_with_exception):
         version = await base_schema_initializer.get_working_schema_version()
     assert version == MetadataSchemaInitializer.SCHEMA_NOT_REGISTERED
+
+
+def get_mocked_working_schema_version(version: int):
+    async def mocked_get_working_schema_version(self) -> int:
+        return version
+
+    return mocked_get_working_schema_version
+
+
+@pytest.mark.asyncio
+async def test_should_update_schema__users_version_gt_code(base_schema_initializer):
+    # working schema version in users is greater than current working version in code
+    # -> should not update
+    mocked_get_working_schema_version = get_mocked_working_schema_version(
+        CURRENT_WORKING_SCHEMA_VERSION_TEST + 1
+    )
+
+    with patch.object(
+        BaseSchemaInitializer, "get_working_schema_version", mocked_get_working_schema_version
+    ):
+        should_update_schema = await base_schema_initializer.should_update_schema()
+    assert not should_update_schema
+
+
+@pytest.mark.asyncio
+async def test_should_update_schema__users_version_equals_code(base_schema_initializer):
+    # working schema version in users is equal to current working version in code
+    # -> should not update
+    mocked_get_working_schema_version = get_mocked_working_schema_version(
+        CURRENT_WORKING_SCHEMA_VERSION_TEST
+    )
+
+    with patch.object(
+        BaseSchemaInitializer, "get_working_schema_version", mocked_get_working_schema_version
+    ):
+        should_update_schema = await base_schema_initializer.should_update_schema()
+    assert not should_update_schema
+
+
+@pytest.mark.asyncio
+async def test_should_update_schema__users_version_lt_code(base_schema_initializer):
+    # working schema version in users is lesser than current working version in code
+    # -> should update
+    mocked_get_working_schema_version = get_mocked_working_schema_version(
+        CURRENT_WORKING_SCHEMA_VERSION_TEST - 1
+    )
+
+    with patch.object(
+        BaseSchemaInitializer, "get_working_schema_version", mocked_get_working_schema_version
+    ):
+        should_update_schema = await base_schema_initializer.should_update_schema()
+    assert should_update_schema
+
+
+@pytest.mark.asyncio
+async def test_should_update_schema__not_registered(base_schema_initializer):
+    # should update if schema is not registered
+    mocked_get_working_schema_version = get_mocked_working_schema_version(
+        MetadataSchemaInitializer.SCHEMA_NOT_REGISTERED
+    )
+
+    with patch.object(
+        BaseSchemaInitializer, "get_working_schema_version", mocked_get_working_schema_version
+    ):
+        should_update_schema = await base_schema_initializer.should_update_schema()
+    assert should_update_schema
+
+
+@pytest.mark.asyncio
+async def test_should_update_schema__no_results_found(base_schema_initializer):
+    # should not update if no results found
+    mocked_get_working_schema_version = get_mocked_working_schema_version(
+        MetadataSchemaInitializer.SCHEMA_NO_RESULTS_FOUND
+    )
+
+    with patch.object(
+        BaseSchemaInitializer, "get_working_schema_version", mocked_get_working_schema_version
+    ):
+        should_update_schema = await base_schema_initializer.should_update_schema()
+    assert should_update_schema


### PR DESCRIPTION
## Description
Adds a couple unit tests for the previously added functions. Decided to split this up from the next PR that will add the integration test as well.
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-657
<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
