### PR TITLE
[DEV-657] session/base: check and create metadata schema table as needed

### DIFF
--- a/tests/integration/session/test_snowflake.py
+++ b/tests/integration/session/test_snowflake.py
@@ -1,0 +1,36 @@
+"""
+This module contains session to Snowflake integration tests.
+"""
+
+import pytest
+
+from featurebyte.session.manager import SessionManager
+from featurebyte.session.snowflake import SnowflakeSession
+
+
+@pytest.mark.asyncio
+async def test_schema_initializer(config, snowflake_feature_store):
+    """
+    Test the session initialization in snowflake works properly.
+    """
+    session_manager = SessionManager(credentials=config.credentials)
+    session = await session_manager.get_session(snowflake_feature_store)
+    assert isinstance(session, SnowflakeSession)
+
+    # query for the data in the metadata schema table
+    get_version_query = "SELECT * FROM METADATA_SCHEMA"
+    results = await session.execute_query(get_version_query)
+
+    # verify that we only have one row
+    assert results is not None
+    working_schema_version_column = "WORKING_SCHEMA_VERSION"
+    assert len(results[working_schema_version_column]) == 1
+    # check that this is set to the default value
+    assert int(results[working_schema_version_column][0]) == 1
+
+    # Try to retrieve the session again - this should trigger a re-initialization
+    # Verify that there's still only one row in table
+    session = await session_manager.get_session(snowflake_feature_store)
+    results = await session.execute_query(get_version_query)
+    assert results is not None
+    assert len(results[working_schema_version_column]) == 1

--- a/tests/unit/session/test_snowflake_session.py
+++ b/tests/unit/session/test_snowflake_session.py
@@ -163,6 +163,7 @@ EXPECTED_PROCEDURES = [
 EXPECTED_TABLES = [
     "FEATURE_LIST_REGISTRY",
     "FEATURE_REGISTRY",
+    "METADATA_SCHEMA",
     "TILE_REGISTRY",
     "TILE_MONITOR_SUMMARY",
 ]
@@ -359,6 +360,66 @@ def check_create_commands(mock_session):
 @pytest.mark.parametrize("is_procedures_missing", [False])
 @pytest.mark.parametrize("is_tables_missing", [False])
 @pytest.mark.asyncio
+async def test_schema_initializer__dont_reinitialize(
+    patched_snowflake_session_cls,
+    is_schema_missing,
+    is_functions_missing,
+    is_procedures_missing,
+    is_tables_missing,
+):
+    """Test SchemaInitializer doesn't re-run all the queries when re-initialized."""
+
+    session = patched_snowflake_session_cls()
+    snowflake_initializer = SnowflakeSchemaInitializer(session)
+    await snowflake_initializer.initialize()
+    # Nothing to do except checking schemas and existing objects
+    assert session.list_schemas.call_args_list == [call(database_name="sf_database")]
+    original_call_list = [
+        call("SELECT WORKING_SCHEMA_VERSION FROM METADATA_SCHEMA"),
+        call(
+            "CREATE TABLE IF NOT EXISTS METADATA_SCHEMA "
+            "( WORKING_SCHEMA_VERSION INT, FEATURE_STORE_ID VARCHAR, "
+            "CREATED_AT TIMESTAMP DEFAULT SYSDATE() ) AS "
+            "SELECT 0 AS WORKING_SCHEMA_VERSION, NULL AS FEATURE_STORE_ID, "
+            "SYSDATE() AS CREATED_AT;"
+        ),
+        call("SHOW USER FUNCTIONS IN DATABASE sf_database"),
+        call("SHOW PROCEDURES IN DATABASE sf_database"),
+        # TODO (jevon.yeoh): make sure these versions are updated accordingly
+        call("UPDATE METADATA_SCHEMA SET WORKING_SCHEMA_VERSION = 1"),
+    ]
+    assert session.execute_query.call_args_list == original_call_list
+
+    # update mock to have new return value for execute query
+    mocked_execute_query = session.execute_query.side_effect
+
+    def new_mock_execute_query(query):
+        if query.startswith("SELECT WORKING_SCHEMA_VERSION FROM METADATA_SCHEMA"):
+            return pd.DataFrame(
+                {
+                    # TODO (jevon.yeoh): make sure these versions are updated accordingly
+                    "WORKING_SCHEMA_VERSION": [1],
+                }
+            )
+        return mocked_execute_query(query)
+
+    session.execute_query.side_effect = new_mock_execute_query
+
+    # re-initialize
+    await snowflake_initializer.initialize()
+    # verify that only one additional call is made
+    assert len(session.execute_query.call_args_list) == len(original_call_list) + 1
+    # verify that the new call is the one to check the working version
+    assert session.execute_query.call_args_list[-1:] == [
+        call("SELECT WORKING_SCHEMA_VERSION FROM METADATA_SCHEMA"),
+    ]
+
+
+@pytest.mark.parametrize("is_schema_missing", [False])
+@pytest.mark.parametrize("is_functions_missing", [False])
+@pytest.mark.parametrize("is_procedures_missing", [False])
+@pytest.mark.parametrize("is_tables_missing", [False])
+@pytest.mark.asyncio
 async def test_schema_initializer__everything_exists(
     patched_snowflake_session_cls,
     is_schema_missing,
@@ -378,14 +439,23 @@ async def test_schema_initializer__everything_exists(
     # Nothing to do except checking schemas and existing objects
     assert session.list_schemas.call_args_list == [call(database_name="sf_database")]
     assert session.execute_query.call_args_list == [
+        call("SELECT WORKING_SCHEMA_VERSION FROM METADATA_SCHEMA"),
+        call(
+            "CREATE TABLE IF NOT EXISTS METADATA_SCHEMA "
+            "( WORKING_SCHEMA_VERSION INT, FEATURE_STORE_ID VARCHAR, "
+            "CREATED_AT TIMESTAMP DEFAULT SYSDATE() ) AS "
+            "SELECT 0 AS WORKING_SCHEMA_VERSION, NULL AS FEATURE_STORE_ID, "
+            "SYSDATE() AS CREATED_AT;"
+        ),
         call("SHOW USER FUNCTIONS IN DATABASE sf_database"),
         call("SHOW PROCEDURES IN DATABASE sf_database"),
+        call("UPDATE METADATA_SCHEMA SET WORKING_SCHEMA_VERSION = 1"),
     ]
     assert session.list_tables.call_args_list == [
         call(database_name="sf_database", schema_name="FEATUREBYTE")
     ]
     counts = check_create_commands(session)
-    assert counts == {"schema": 0, "functions": 0, "procedures": 0, "tables": 0}
+    assert counts == {"schema": 0, "functions": 0, "procedures": 0, "tables": 1}
 
 
 @pytest.mark.parametrize("is_schema_missing", [True])
@@ -411,7 +481,7 @@ async def test_schema_initializer__all_missing(
     await SnowflakeSchemaInitializer(session).initialize()
     # Should create schema if not exists
     assert session.list_schemas.call_args_list == [call(database_name="sf_database")]
-    assert session.execute_query.call_args_list[:1] == [
+    assert session.execute_query.call_args_list[1:2] == [
         call("CREATE SCHEMA FEATUREBYTE"),
     ]
     # Should register custom functions and procedures
@@ -446,7 +516,7 @@ async def test_schema_initializer__partial_missing(
     await SnowflakeSchemaInitializer(session).initialize()
     # Should register custom functions and procedures
     counts = check_create_commands(session)
-    expected_counts = {"schema": 0, "functions": 0, "procedures": 0, "tables": 0}
+    expected_counts = {"schema": 0, "functions": 0, "procedures": 0, "tables": 1}
     if is_functions_missing:
         expected_counts["functions"] = len(EXPECTED_FUNCTIONS)
     if is_procedures_missing:


### PR DESCRIPTION
## Description

Early return if we don't need to update the metadata schema.

Adds an integration test to verify that we're creating the metadata schema, and that repeated calls will only result in one row in the table.

Example of table being created - 
![Screenshot 2022-11-03 at 11 18 35 AM](https://user-images.githubusercontent.com/2313101/199641582-fa1291f8-8473-443d-9030-da597ff4a02c.png)


## Related Issue
https://featurebyte.atlassian.net/browse/DEV-657

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
