### PR TITLE
[DEV-726] Add event_data_id in ItemDataModel

### DIFF
--- a/featurebyte/models/item_data.py
+++ b/featurebyte/models/item_data.py
@@ -9,6 +9,7 @@ from typing import Any, Optional
 from pydantic import Field, StrictStr, validator
 
 from featurebyte.enum import DBVarType, TableDataType
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.feature_store import DataModel
 
 
@@ -17,28 +18,31 @@ class ItemDataModel(DataModel):
     Model for ItemData entity
 
     id: PydanticObjectId
-        EventData id of the object
+        Id of the object
     name : str
-        Name of the EventData
+        Name of the ItemData
     tabular_source : TabularSource
         Data warehouse connection information & table name tuple
     columns_info: List[ColumnInfo]
-        List of event data columns
+        List of ItemData columns
     status: DataStatus
         Status of the ItemData
     event_id_column: str
         Event ID column name
     item_id_column: str
         Item ID column name
+    event_data_id: PydanticObjectId
+        Id of the associated EventData
     created_at : Optional[datetime]
-        Datetime when the EventData was first saved or published
+        Datetime when the ItemData was first saved or published
     updated_at: Optional[datetime]
-        Datetime when the EventData object was last updated
+        Datetime when the ItemData object was last updated
     """
 
     type: TableDataType = Field(TableDataType.ITEM_DATA, const=True)
     event_id_column: StrictStr
     item_id_column: StrictStr
+    event_data_id: PydanticObjectId
 
     @validator("record_creation_date_column")
     @classmethod

--- a/featurebyte/schema/item_data.py
+++ b/featurebyte/schema/item_data.py
@@ -5,6 +5,7 @@ from typing import List
 
 from pydantic import StrictStr
 
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.item_data import ItemDataModel
 from featurebyte.schema.common.base import PaginationMixin
 from featurebyte.schema.data import DataCreate, DataUpdate
@@ -17,6 +18,7 @@ class ItemDataCreate(DataCreate):
 
     event_id_column: StrictStr
     item_id_column: StrictStr
+    event_data_id: PydanticObjectId
 
 
 class ItemDataList(PaginationMixin):

--- a/tests/fixtures/request_payloads/item_data.json
+++ b/tests/fixtures/request_payloads/item_data.json
@@ -49,6 +49,7 @@
     ],
     "event_id_column": "col_int",
     "item_id_column": "cust_id",
+    "event_data_id": "63653f33a170799463a57fa7",
     "name": "sf_item_data",
     "tabular_source": {
         "feature_store_id": "6332fdb21e8f0eeccc414510",

--- a/tests/unit/routes/test_item_data.py
+++ b/tests/unit/routes/test_item_data.py
@@ -59,16 +59,17 @@ class TestItemDataApi(BaseDataApiTestSuite):
     @pytest.fixture(name="data_model_dict")
     def data_model_dict_fixture(self, tabular_source, columns_info, user_id):
         """Fixture for a Item Data dict"""
-        event_data_dict = {
+        item_data_dict = {
             "name": "订单表",
             "tabular_source": tabular_source,
             "columns_info": columns_info,
             "event_id_column": "event_id",
             "item_id_column": "item_id",
+            "event_data_id": str(ObjectId()),
             "status": "PUBLISHED",
             "user_id": str(user_id),
         }
-        output = ItemDataModel(**event_data_dict).json_dict()
+        output = ItemDataModel(**item_data_dict).json_dict()
         assert output.pop("created_at") is None
         assert output.pop("updated_at") is None
         return output


### PR DESCRIPTION
## Description

Update `ItemDataModel` to include `event_data_id` since an ItemData needs to be aware of the associated EventData.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
