### PR TITLE
service/test_feature: autouse mock execute query

### DIFF
--- a/tests/unit/service/test_feature.py
+++ b/tests/unit/service/test_feature.py
@@ -49,8 +49,16 @@ def sqlite_feature_store_fixture(mock_get_persistent):
     )
 
 
+@pytest.fixture(name="mock_execute_query", autouse=True)
+def execute_query_fixture():
+    """
+    Execute query fixture
+    """
+    with patch("featurebyte.session.base.BaseSession.execute_query") as mock_execute_query:
+        yield mock_execute_query
+
+
 @pytest.mark.asyncio
-@patch("featurebyte.session.base.BaseSession.execute_query")
 async def test_insert_feature_registry__non_snowflake_feature_store(
     mock_execute_query, feature_model_dict, get_credential, sqlite_feature_store
 ):
@@ -75,7 +83,6 @@ async def test_insert_feature_registry__non_snowflake_feature_store(
 
 
 @pytest.mark.asyncio
-@patch("featurebyte.session.snowflake.SnowflakeSession.execute_query")
 async def test_insert_feature_registry(
     mock_execute_query,
     feature_model_dict,


### PR DESCRIPTION
## Description

We were seeing some extra errors when trying to merge some of the feature store ID validation changes. This is because the session object is shared between unit tests, and making any updates to that was causing some errors since the updates were now returning a new session for each test (functionally scoped).

If the session is functionally scoped, running individual unit tests breaks since they're not explicitly mocked. As such, each unit tests try to make a call, which is not what the test was expecting, since the unit test was expecting a mocked call.

As such, we auto inject a mocked execute query fixture around all the tests in this module to handle this automatically for us.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
