### PR TITLE
test_snowflake_session: use the version number from src

### DIFF
--- a/tests/unit/session/test_snowflake_session.py
+++ b/tests/unit/session/test_snowflake_session.py
@@ -398,9 +398,9 @@ async def test_schema_initializer__dont_reinitialize(
             "SYSDATE() AS CREATED_AT;"
         ),
     ]
+    working_schema_version = snowflake_initializer.current_working_schema_version
     assert session.execute_query.call_args_list[-1:] == [
-        # TODO (jevon.yeoh): make sure these versions are updated accordingly
-        call("UPDATE METADATA_SCHEMA SET WORKING_SCHEMA_VERSION = 1"),
+        call(f"UPDATE METADATA_SCHEMA SET WORKING_SCHEMA_VERSION = {working_schema_version}"),
     ]
     counts = check_create_commands(session)
     assert counts == {
@@ -417,8 +417,7 @@ async def test_schema_initializer__dont_reinitialize(
         if query == METADATA_QUERY:
             return pd.DataFrame(
                 {
-                    # TODO (jevon.yeoh): make sure these versions are updated accordingly
-                    "WORKING_SCHEMA_VERSION": [1],
+                    "WORKING_SCHEMA_VERSION": [working_schema_version],
                     "FEATURE_STORE_ID": "test_store_id",
                 }
             )


### PR DESCRIPTION
## Description
Update the test to reference the version number in the src code. This will allow us to not have to update this test every time we bump the version number in the code.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
