### PR TITLE
routes/base: add extra assertion for clarity

### DIFF
--- a/tests/unit/routes/base.py
+++ b/tests/unit/routes/base.py
@@ -800,14 +800,17 @@ class BaseDataApiTestSuite(BaseApiTestSuite):
         data_response_dict = data_response.json()
 
         unknown_entity_id = str(ObjectId())
-        columns_info[-1]["entity_id"] = unknown_entity_id
+        column = "item_id"
+        column_to_update = columns_info[-1]
+        assert column_to_update["name"] == column
+        column_to_update["entity_id"] = unknown_entity_id
         response = test_api_client.patch(
             f"{self.base_route}/{data_response_dict['_id']}",
             json={"columns_info": columns_info},
         )
         assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
         assert response.json()["detail"] == (
-            f"Entity IDs ['{unknown_entity_id}'] not found for columns ['item_id']."
+            f"Entity IDs ['{unknown_entity_id}'] not found for columns ['{column}']."
         )
 
     def test_update_record_creation_date(


### PR DESCRIPTION
## Description
This test would occasionally fail, depending on how the column_info fixture is updated. This commit adds some extra assertions to make sure that the test fails with a clearer indication as to what is expected from the fixture (i.e. the item_id column is the last element in the array).

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
