### PR TITLE
api/feature_store: add Create endpoint

### DIFF
--- a/featurebyte/api/feature_store.py
+++ b/featurebyte/api/feature_store.py
@@ -11,8 +11,14 @@ from typeguard import typechecked
 
 from featurebyte.api.api_object import SavableApiObject
 from featurebyte.config import Configurations
+from featurebyte.enum import SourceType
 from featurebyte.exception import RecordRetrievalException
-from featurebyte.models.feature_store import FeatureStoreModel, TableDetails, TabularSource
+from featurebyte.models.feature_store import (
+    DatabaseDetails,
+    FeatureStoreModel,
+    TableDetails,
+    TabularSource,
+)
 from featurebyte.schema.feature_store import FeatureStoreCreate
 
 if TYPE_CHECKING:
@@ -32,6 +38,33 @@ class FeatureStore(FeatureStoreModel, SavableApiObject):
     def _get_create_payload(self) -> dict[str, Any]:
         data = FeatureStoreCreate(**self.json_dict())
         return data.json_dict()
+
+    @classmethod
+    def create(cls, name: str, source_type: SourceType, details: DatabaseDetails) -> FeatureStore:
+        """
+        Create will return a new instance of a feature store.
+        We prefer to use this over the default constructor of `FeatureStore` because
+        we want to perform some additional validation checks.
+        Note that this function should only be called once for a specific set of details.
+
+        Parameters
+        ----------
+        name: str
+            feature store name
+        source_type: SourceType
+            type of feature store
+        details: DatabaseDetails
+            details of the database we want to connect to
+
+
+        Returns
+        -------
+        FeatureStore
+        """
+        # Construct object, and save to persistent layer.
+        feature_store = FeatureStore(name=name, type=source_type, details=details)
+        feature_store.save()
+        return feature_store
 
     @typechecked
     def list_databases(self) -> List[str]:


### PR DESCRIPTION
## Description
We want to consolidate the creation of a feature_store, together with the `.save()` endpoint. This will help to simplify the user experience, and also allow us to hook some validation into the feature store creation process, while reducing the chances for concurrency issues.

Splitting out changes from https://github.com/featurebyte/featurebyte/pull/409/files as I work through some test updates!

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
