### PR TITLE
Print only slowest 50 tests after pytest finishes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,6 +203,6 @@ ignore-signatures = true
 min-similarity-lines = 10
 
 [tool.pytest.ini_options]
-addopts = ["--strict-markers", "-v", "--doctest-modules", "--durations=0", "--doctest-continue-on-failure"] # Extra options:
+addopts = ["--strict-markers", "-v", "--doctest-modules", "--durations=50", "--doctest-continue-on-failure"] # Extra options:
 doctest_optionflags = ["NUMBER", "NORMALIZE_WHITESPACE", "IGNORE_EXCEPTION_DETAIL"]
 norecursedirs = ["hooks", "*.egg", ".eggs", "dist", "build", "docs", ".tox", ".git", "__pycache__"]


### PR DESCRIPTION
## Description

Printing durations of all tests (`--durations=0`) makes finding tracebacks difficult since we have to scroll past the test timings which can be thousands of lines long. This limits pytest to print only the 50 slowest tests.

https://docs.pytest.org/en/latest/how-to/usage.html#profiling-test-execution-duration

The 50th test is at about 1s on GitHub Actions:
```
1.43s teardown tests/integration/tile/snowflake/test_snowflake_tile.py::test_generate_tile
1.43s teardown tests/integration/tile/snowflake/test_snowflake_tile.py::test_disable_tiles
=========== 1378 passed, 12 skipped, 2 warnings in 459.52s (0:07:39) ===========
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
