### PR TITLE
routes/test_feature_store: refactor get session mock

### DIFF
--- a/tests/unit/routes/test_feature_store.py
+++ b/tests/unit/routes/test_feature_store.py
@@ -81,7 +81,7 @@ class TestFeatureStoreApi(BaseApiTestSuite):
         )
         assert "created_at" in response_dict
 
-    @pytest.fixture(name="mock_get_session")
+    @pytest.fixture(name="mock_get_session", autouse=True)
     def get_mock_get_session_fixture(self):
         """
         Return
@@ -128,7 +128,6 @@ class TestFeatureStoreApi(BaseApiTestSuite):
         assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
         assert response.json() == {"detail": str(credentials_error)}
 
-    @pytest.mark.usefixtures("mock_get_session")
     def test_list_schemas__422(self, test_api_client_persistent, create_success_response):
         """
         Test list schemas
@@ -167,7 +166,6 @@ class TestFeatureStoreApi(BaseApiTestSuite):
         assert response.status_code == HTTPStatus.OK
         assert response.json() == schemas
 
-    @pytest.mark.usefixtures("mock_get_session")
     def test_list_tables_422(self, test_api_client_persistent, create_success_response):
         """
         Test list tables
@@ -211,7 +209,6 @@ class TestFeatureStoreApi(BaseApiTestSuite):
         assert response.status_code == HTTPStatus.OK
         assert response.json() == tables
 
-    @pytest.mark.usefixtures("mock_get_session")
     def test_list_columns_422(self, test_api_client_persistent, create_success_response):
         """
         Test list columns


### PR DESCRIPTION
## Description
Refactor some get_session mocks so that we don't have to replace all the patch file paths if we ever move the location of the file in the future. Cleaning up a painpoint I had to deal with in a previous PR (https://github.com/featurebyte/featurebyte/pull/413/files)

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
