### PR TITLE
[DEV-783] api/base_data_test: extract common test to base_data_test

### DIFF
--- a/tests/unit/api/base_data_test.py
+++ b/tests/unit/api/base_data_test.py
@@ -1,0 +1,64 @@
+"""
+Base View test suite
+"""
+
+import pytest
+
+from featurebyte.api.data import DataColumn
+from featurebyte.enum import StrEnum
+
+
+class DataType(StrEnum):
+    """
+    Data API object types
+    """
+
+    ITEM_DATA = "ItemData"
+    EVENT_DATA = "EventData"
+    DIMENSION_DATA = "DimensionData"
+
+
+class BaseDataTestSuite:
+    """
+    BaseViewTestSuite contains common view tests
+    """
+
+    data_type: DataType = ""
+    expected_columns = None
+    col = ""
+
+    @pytest.fixture(name="data_under_test")
+    def get_data_under_test_fixture(
+        self, snowflake_item_data, snowflake_event_data, snowflake_dimension_data
+    ):
+        """
+        Retrieves fixture for data under test.
+        """
+        data_map = {
+            DataType.ITEM_DATA: snowflake_item_data,
+            DataType.EVENT_DATA: snowflake_event_data,
+            DataType.DIMENSION_DATA: snowflake_dimension_data,
+        }
+        if self.data_type not in data_map:
+            pytest.fail(
+                f"Invalid view type `{self.data_type}` found. Please use (or map) a valid DataType."
+            )
+        return data_map[self.data_type]
+
+    def test_data_column__not_exists(self, data_under_test):
+        """
+        Test non-exist column retrieval
+        """
+        with pytest.raises(KeyError) as exc:
+            _ = data_under_test["non_exist_column"]
+        assert 'Column "non_exist_column" does not exist!' in str(exc.value)
+
+        with pytest.raises(AttributeError) as exc:
+            _ = data_under_test.non_exist_column
+        assert f"'{self.data_type}' object has no attribute 'non_exist_column'" in str(exc.value)
+
+        # check __getattr__ is working properly
+        assert isinstance(data_under_test[self.col], DataColumn)
+
+        # when accessing the `columns` attribute, make sure we retrieve it properly
+        assert set(data_under_test.columns) == self.expected_columns

--- a/tests/unit/api/test_dimension_data.py
+++ b/tests/unit/api/test_dimension_data.py
@@ -9,6 +9,24 @@ from featurebyte.api.dimension_data import DimensionData
 from featurebyte.enum import TableDataType
 from featurebyte.exception import DuplicatedRecordException, RecordRetrievalException
 from featurebyte.models.feature_store import DataStatus
+from tests.unit.api.base_data_test import BaseDataTestSuite, DataType
+
+
+class TestEventDataTestSuite(BaseDataTestSuite):
+
+    data_type = DataType.DIMENSION_DATA
+    col = "col_int"
+    expected_columns = {
+        "col_char",
+        "col_float",
+        "col_boolean",
+        "event_timestamp",
+        "col_text",
+        "created_at",
+        "col_binary",
+        "col_int",
+        "cust_id",
+    }
 
 
 @pytest.fixture(name="dimension_data_dict")

--- a/tests/unit/api/test_event_data.py
+++ b/tests/unit/api/test_event_data.py
@@ -22,6 +22,7 @@ from featurebyte.exception import (
     TableSchemaHasBeenChangedError,
 )
 from featurebyte.models.event_data import FeatureJobSetting
+from tests.unit.api.base_data_test import BaseDataTestSuite, DataType
 from tests.util.helper import patch_import_package
 
 
@@ -169,23 +170,11 @@ def test_deserialization__column_name_not_found(
     assert 'Column "some_timestamp_column" not found in the table!' in str(exc.value)
 
 
-def test_event_data_column__not_exists(snowflake_event_data):
-    """
-    Test non-exist column retrieval
-    """
-    with pytest.raises(KeyError) as exc:
-        _ = snowflake_event_data["non_exist_column"]
-    assert 'Column "non_exist_column" does not exist!' in str(exc.value)
+class TestEventDataTestSuite(BaseDataTestSuite):
 
-    with pytest.raises(AttributeError) as exc:
-        _ = snowflake_event_data.non_exist_column
-    assert "'EventData' object has no attribute 'non_exist_column'" in str(exc.value)
-
-    # check __getattr__ is working properly
-    assert isinstance(snowflake_event_data.col_int, DataColumn)
-
-    # when accessing the `columns` attribute, make sure we retrieve it properly
-    assert set(snowflake_event_data.columns) == {
+    data_type = DataType.EVENT_DATA
+    col = "col_int"
+    expected_columns = {
         "col_char",
         "col_float",
         "col_boolean",

--- a/tests/unit/api/test_item_data.py
+++ b/tests/unit/api/test_item_data.py
@@ -22,6 +22,7 @@ from featurebyte.exception import (
 )
 from featurebyte.models.event_data import FeatureJobSetting
 from featurebyte.models.feature_store import DataStatus
+from tests.unit.api.base_data_test import BaseDataTestSuite, DataType
 
 
 @pytest.fixture(name="item_data_dict")
@@ -176,23 +177,11 @@ def test_deserialization__column_name_not_found(
     assert 'Column "some_random_name" not found in the table!' in str(exc.value)
 
 
-def test_item_data_column__not_exists(snowflake_item_data):
-    """
-    Test non-exist column retrieval
-    """
-    with pytest.raises(KeyError) as exc:
-        _ = snowflake_item_data["non_exist_column"]
-    assert 'Column "non_exist_column" does not exist!' in str(exc.value)
+class TestItemDataTestSuite(BaseDataTestSuite):
 
-    with pytest.raises(AttributeError) as exc:
-        _ = snowflake_item_data.non_exist_column
-    assert "'ItemData' object has no attribute 'non_exist_column'" in str(exc.value)
-
-    # check __getattr__ is working properly
-    assert isinstance(snowflake_item_data.event_id_col, DataColumn)
-
-    # when accessing the `columns` attribute, make sure we retrieve it properly
-    assert set(snowflake_item_data.columns) == {
+    data_type = DataType.ITEM_DATA
+    col = "event_id_col"
+    expected_columns = {
         "event_id_col",
         "item_id_col",
         "item_type",


### PR DESCRIPTION
## Description
We can move some of the common tests into a `base_data_test` file. This PR stubs out the file, and adds the base test suite into the `EventData`, `ItemData`, and `DimensionData` test files. We'll move more functions into the base class in a subsequent PR.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-730

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
