### PR TITLE
[DEV-798] Simplify ExtendedFeatureModel model by removing unnecessary fields

### DIFF
--- a/featurebyte/feature_manager/model.py
+++ b/featurebyte/feature_manager/model.py
@@ -7,10 +7,10 @@ from typing import List, Optional
 
 from pydantic import Field, StrictStr
 
+from featurebyte.enum import SourceType
 from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId, VersionIdentifier
 from featurebyte.models.feature import FeatureModel
 from featurebyte.models.feature_list import FeatureListModel, FeatureListStatus
-from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.models.tile import TileSpec
 from featurebyte.query_graph.sql.interpreter import GraphInterpreter
 
@@ -20,7 +20,16 @@ class ExtendedFeatureModel(FeatureModel):
     ExtendedFeatureModel contains tile manager specific methods or properties
     """
 
-    feature_store: FeatureStoreModel
+    @property
+    def feature_store_type(self) -> SourceType:
+        """
+        Type of the FeatureStore
+
+        Returns
+        -------
+        SourceType
+        """
+        return self.graph.get_input_node(self.node.name).parameters.feature_store_details.type
 
     @property
     def tile_specs(self) -> list[TileSpec]:
@@ -31,7 +40,7 @@ class ExtendedFeatureModel(FeatureModel):
         -------
         list[TileSpec]
         """
-        interpreter = GraphInterpreter(self.graph, self.feature_store.type)
+        interpreter = GraphInterpreter(self.graph, self.feature_store_type)
         node = self.graph.get_node_by_name(self.node_name)
         tile_infos = interpreter.construct_tile_gen_sql(node, is_on_demand=False)
         out = []

--- a/featurebyte/models/online_store.py
+++ b/featurebyte/models/online_store.py
@@ -92,7 +92,7 @@ class OnlineFeatureSpec(FeatureByteBaseModel):
         return get_online_store_feature_compute_sql(
             graph=self.feature.graph,
             node=self.feature.node,
-            source_type=self.feature.feature_store.type,
+            source_type=self.feature.feature_store_type,
         )
 
     @property

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -514,7 +514,7 @@ async def snowflake_feature(feature_model_dict, snowflake_session, snowflake_fea
             ],
         }
     )
-    feature = ExtendedFeatureModel(**feature_model_dict, feature_store=snowflake_feature_store)
+    feature = ExtendedFeatureModel(**feature_model_dict)
     tile_id = feature.tile_specs[0].tile_id
 
     yield feature

--- a/tests/integration/query_graph/test_online_serving.py
+++ b/tests/integration/query_graph/test_online_serving.py
@@ -32,12 +32,12 @@ def features_fixture(event_data):
     return features
 
 
-async def update_online_store(session, feature_store, feature, feature_job_time_ts):
+async def update_online_store(session, feature, feature_job_time_ts):
     """
     Trigger the SP_TILE_SCHEDULE_ONLINE_STORE with a fixed feature job time
     """
     # Manually update feature mapping table. Should only be done in test
-    extended_feature_model = ExtendedFeatureModel(**feature.dict(), feature_store=feature_store)
+    extended_feature_model = ExtendedFeatureModel(**feature.dict())
     online_feature_spec = OnlineFeatureSpec(feature=extended_feature_model)
     feature_manager = FeatureManagerSnowflake(session)
     await feature_manager._update_tile_feature_mapping_table(online_feature_spec)
@@ -49,7 +49,7 @@ async def update_online_store(session, feature_store, feature, feature_job_time_
 
 
 @pytest.mark.asyncio
-async def test_online_serving_sql(features, snowflake_session, snowflake_feature_store):
+async def test_online_serving_sql(features, snowflake_session):
     """
     Test executing feature compute sql and feature retrieval SQL for online store
     """
@@ -67,12 +67,8 @@ async def test_online_serving_sql(features, snowflake_session, snowflake_feature
     df_historical = feature_list.get_historical_features(df_training_events)
 
     # Trigger SP_TILE_SCHEDULE_ONLINE_STORE to compute features and update online store
-    await update_online_store(
-        snowflake_session, snowflake_feature_store, features[0], feature_job_time
-    )
-    await update_online_store(
-        snowflake_session, snowflake_feature_store, features[1], feature_job_time
-    )
+    await update_online_store(snowflake_session, features[0], feature_job_time)
+    await update_online_store(snowflake_session, features[1], feature_job_time)
 
     # Run online store retrieval sql
     df_entities = pd.DataFrame({"user id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]})

--- a/tests/unit/feature_manager/test_model.py
+++ b/tests/unit/feature_manager/test_model.py
@@ -5,11 +5,10 @@ from featurebyte.feature_manager.model import ExtendedFeatureModel, TileSpec
 from featurebyte.models.base import VersionIdentifier
 
 
-def test_extended_feature_model__float_feature(float_feature, snowflake_feature_store):
+def test_extended_feature_model__float_feature(float_feature):
     """Test ExtendedFeatureModel has correct tile_specs"""
     model = ExtendedFeatureModel(
         **float_feature.dict(exclude={"version": True}),
-        feature_store=snowflake_feature_store,
         version=VersionIdentifier(name=get_version()),
     )
     aggregation_id = "8b878f7930698eb4e97cf8e756044109f968dc7a"
@@ -66,13 +65,10 @@ def test_extended_feature_model__float_feature(float_feature, snowflake_feature_
     assert model.tile_specs == expected_tile_specs
 
 
-def test_extended_feature_model__agg_per_category_feature(
-    agg_per_category_feature, snowflake_feature_store
-):
+def test_extended_feature_model__agg_per_category_feature(agg_per_category_feature):
     """Test ExtendedFeatureModel has correct tile_specs for category groupby feature"""
     model = ExtendedFeatureModel(
         **agg_per_category_feature.dict(exclude={"version": True}),
-        feature_store=snowflake_feature_store,
         version=VersionIdentifier(name=get_version()),
     )
     aggregation_id = "152129a9b37bdd83ab6282c0e2118e277b272328"

--- a/tests/unit/feature_manager/test_unit_snowflake_feature.py
+++ b/tests/unit/feature_manager/test_unit_snowflake_feature.py
@@ -24,7 +24,6 @@ def mock_snowflake_feature_fixture(mock_snowflake_feature):
     """
     return ExtendedFeatureModel(
         **mock_snowflake_feature.dict(exclude={"version": True}),
-        feature_store=mock_snowflake_feature.feature_store,
         version=get_version(),
     )
 


### PR DESCRIPTION
## Description

Simplify `ExtendedFeatureModel` by removing the following fields:
* `is_default`: This doesn't seem used anywhere, probably used by already deleted code
* `feature_store`: This is used to obtain the type of the feature store. The same information can be derived from the query graph

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
