### PR TITLE
session_validator: simplify by not stringifying

### DIFF
--- a/featurebyte/service/session_validator.py
+++ b/featurebyte/service/session_validator.py
@@ -59,11 +59,7 @@ class SessionValidatorService:
         working_schema_metadata = await session.get_working_schema_metadata()
         registered_feature_store_id = working_schema_metadata.get("feature_store_id")
         # Check that a feature store ID has been registered, and whether they're the same.
-        if (
-            registered_feature_store_id == ""
-            or registered_feature_store_id == "None"
-            or registered_feature_store_id is None
-        ):
+        if not registered_feature_store_id:
             return ValidateStatus.NOT_IN_DWH
         if users_feature_store_id != registered_feature_store_id:
             logger.debug(

--- a/featurebyte/session/base.py
+++ b/featurebyte/session/base.py
@@ -297,7 +297,7 @@ class BaseSession(BaseModel):
             return {"version": MetadataSchemaInitializer.SCHEMA_NO_RESULTS_FOUND}
         return {
             "version": int(results["WORKING_SCHEMA_VERSION"][0]),
-            "feature_store_id": str(results["FEATURE_STORE_ID"][0]),
+            "feature_store_id": results["FEATURE_STORE_ID"][0],
         }
 
     async def execute_query(self, query: str, timeout: float = 600) -> pd.DataFrame | None:


### PR DESCRIPTION
## Description
We can simplify callsites by returning a falsy value. This was previously failing because we would stringify a potentially `None` response.

Addressing a comment from this PR - https://github.com/featurebyte/featurebyte/pull/409#discussion_r1025947308

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
