### PR TITLE
[DEV-806] Make event_id_column field optional in EventView for backward compatibility

### DIFF
--- a/featurebyte/api/item_data.py
+++ b/featurebyte/api/item_data.py
@@ -80,8 +80,16 @@ class ItemData(ItemDataModel, DataApiObject):
         Returns
         -------
         EventData
+
+        Raises
+        ------
+        ValueError
+            If the associated EventData does not have event_id_column defined
         """
-        event_data_id = EventData.get(event_data_name).id
+        event_data = EventData.get(event_data_name)
+        if event_data.event_id_column is None:
+            raise ValueError("EventData without event_id_column is not supported")
+        event_data_id = event_data.id
         return super().create(
             tabular_source=tabular_source,
             name=name,

--- a/featurebyte/api/item_view.py
+++ b/featurebyte/api/item_view.py
@@ -56,8 +56,6 @@ class ItemView(View):
         """
         event_data = EventData.get_by_id(item_data.event_data_id)
         event_view = EventView.from_event_data(event_data)
-        if event_view.event_id_column is None:
-            raise ValueError("EventData without event_id_column is not supported")
         item_view = cls.from_data(
             item_data,
             event_id_column=item_data.event_id_column,

--- a/tests/unit/api/test_item_view.py
+++ b/tests/unit/api/test_item_view.py
@@ -2,7 +2,6 @@
 Unit test for ItemView class
 """
 import textwrap
-from unittest.mock import Mock, patch
 
 import pytest
 
@@ -153,19 +152,6 @@ def test_from_item_data__auto_join_columns(
         """
     ).strip()
     assert preview_sql == expected_sql
-
-
-def test_from_item_data__event_data_without_event_id_column(snowflake_item_data):
-    """
-    Test attempting to create ItemView using an old EventData without event_id_column
-
-    Can probably be removed once DEV-556 is resolved
-    """
-    with patch("featurebyte.api.item_view.EventView") as patched_event_view_cls:
-        patched_event_view_cls.from_event_data.return_value = Mock(event_id_column=None)
-        with pytest.raises(ValueError) as exc:
-            ItemView.from_item_data(snowflake_item_data)
-        assert str(exc.value) == "EventData without event_id_column is not supported"
 
 
 def test_has_event_timestamp_column(snowflake_item_view):


### PR DESCRIPTION
## Description

This makes the `event_id_column` field optional in EventView for backward compatibility since old EventData might not have that field defined.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
