### PR TITLE
session_validator: explicitly cast to dict

### DIFF
--- a/featurebyte/service/session_validator.py
+++ b/featurebyte/service/session_validator.py
@@ -175,7 +175,7 @@ class SessionValidatorService:
         """
         response, count = await self.persistent.find(
             FeatureStoreModel.collection_name(),
-            query_filter={"details": details},
+            query_filter={"details": details.dict()},
         )
         does_exist = count != 0
         # We expect to see at most one entry. Error if there's more than one.


### PR DESCRIPTION
## Description
There looks to be a small difference with how our test mongo client, and the production one interpret the details object in a find lookup. This updates to explicitly cast to a dictionary so that we can resolve an issue that is causing the functional tests to fail when we bump the version on the featurebyte-app.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
