### PR TITLE
featurebyte/core: mv append_to_lineage to util

### DIFF
--- a/featurebyte/api/item_view.py
+++ b/featurebyte/api/item_view.py
@@ -14,6 +14,7 @@ from featurebyte.api.event_data import EventData
 from featurebyte.api.event_view import EventView
 from featurebyte.api.item_data import ItemData
 from featurebyte.api.view import GroupByMixin, View, ViewColumn
+from featurebyte.core.util import append_to_lineage
 from featurebyte.enum import TableDataType
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.event_data import FeatureJobSetting
@@ -129,10 +130,10 @@ class ItemView(View, GroupByMixin):
         for col in columns:
             joined_column_lineage_map[col] = self.event_view.column_lineage_map[col]
         for col, lineage in joined_column_lineage_map.items():
-            joined_column_lineage_map[col] = self._append_to_lineage(lineage, node.name)
+            joined_column_lineage_map[col] = append_to_lineage(lineage, node.name)
 
         # Construct new row_index_lineage
-        joined_row_index_lineage = self._append_to_lineage(self.row_index_lineage, node.name)
+        joined_row_index_lineage = append_to_lineage(self.row_index_lineage, node.name)
 
         # Construct new tabular_data_ids
         joined_tabular_data_ids = sorted(

--- a/featurebyte/core/frame.py
+++ b/featurebyte/core/frame.py
@@ -12,6 +12,7 @@ from typeguard import typechecked
 from featurebyte.core.generic import QueryObject
 from featurebyte.core.mixin import GetAttrMixin, OpsMixin
 from featurebyte.core.series import Series
+from featurebyte.core.util import append_to_lineage
 from featurebyte.enum import DBVarType
 from featurebyte.models.feature_store import ColumnInfo
 from featurebyte.query_graph.enum import NodeOutputType, NodeType
@@ -183,9 +184,7 @@ class Frame(BaseFrame, OpsMixin, GetAttrMixin):
             )
             column_lineage_map = {}
             for col in item:
-                column_lineage_map[col] = self._append_to_lineage(
-                    self.column_lineage_map[col], node.name
-                )
+                column_lineage_map[col] = append_to_lineage(self.column_lineage_map[col], node.name)
             return type(self)(
                 feature_store=self.feature_store,
                 tabular_source=self.tabular_source,
@@ -201,14 +200,14 @@ class Frame(BaseFrame, OpsMixin, GetAttrMixin):
         )
         column_lineage_map = {}
         for col, lineage in self.column_lineage_map.items():
-            column_lineage_map[col] = self._append_to_lineage(lineage, node.name)
+            column_lineage_map[col] = append_to_lineage(lineage, node.name)
         return type(self)(
             feature_store=self.feature_store,
             tabular_source=self.tabular_source,
             columns_info=self.columns_info,
             node_name=node.name,
             column_lineage_map=column_lineage_map,
-            row_index_lineage=self._append_to_lineage(self.row_index_lineage, node.name),
+            row_index_lineage=append_to_lineage(self.row_index_lineage, node.name),
             **self._getitem_frame_params,
         )
 
@@ -239,7 +238,7 @@ class Frame(BaseFrame, OpsMixin, GetAttrMixin):
                 input_nodes=[self.node, value.node],
             )
             self.columns_info.append(ColumnInfo(name=key, dtype=value.dtype))
-            self.column_lineage_map[key] = self._append_to_lineage(
+            self.column_lineage_map[key] = append_to_lineage(
                 self.column_lineage_map.get(key, tuple()), node.name
             )
         else:
@@ -252,7 +251,7 @@ class Frame(BaseFrame, OpsMixin, GetAttrMixin):
             self.columns_info.append(
                 ColumnInfo(name=key, dtype=self.pytype_dbtype_map[type(value)])
             )
-            self.column_lineage_map[key] = self._append_to_lineage(
+            self.column_lineage_map[key] = append_to_lineage(
                 self.column_lineage_map.get(key, tuple()), node.name
             )
 

--- a/featurebyte/core/mixin.py
+++ b/featurebyte/core/mixin.py
@@ -81,28 +81,6 @@ class OpsMixin:
         )
         return node
 
-    @staticmethod
-    def _append_to_lineage(lineage: tuple[str, ...], node_name: str) -> tuple[str, ...]:
-        """
-        Add operation node name to the (row-index) lineage (list of node names)
-
-        Parameters
-        ----------
-        lineage: tuple[str, ...]
-            tuple of node names to represent the feature/row-index lineage
-        node_name: str
-            operation node name
-
-        Returns
-        -------
-        updated_lineage: tuple[str, ...]
-            updated lineage after adding the new operation name
-
-        """
-        output = list(lineage)
-        output.append(node_name)
-        return tuple(output)
-
 
 class ParentMixin(BaseModel):
     """

--- a/featurebyte/core/series.py
+++ b/featurebyte/core/series.py
@@ -16,7 +16,7 @@ from featurebyte.core.accessor.datetime import DtAccessorMixin
 from featurebyte.core.accessor.string import StrAccessorMixin
 from featurebyte.core.generic import QueryObject
 from featurebyte.core.mixin import OpsMixin, ParentMixin
-from featurebyte.core.util import series_binary_operation, series_unary_operation
+from featurebyte.core.util import append_to_lineage, series_binary_operation, series_unary_operation
 from featurebyte.enum import DBVarType
 from featurebyte.query_graph.algorithm import dfs_traversal
 from featurebyte.query_graph.enum import NodeOutputType, NodeType
@@ -75,7 +75,7 @@ class Series(QueryObject, OpsMixin, ParentMixin, StrAccessorMixin, DtAccessorMix
             node_name=node.name,
             name=self.name,
             dtype=self.dtype,
-            row_index_lineage=self._append_to_lineage(self.row_index_lineage, node.name),
+            row_index_lineage=append_to_lineage(self.row_index_lineage, node.name),
             **self.unary_op_series_params(),
         )
 

--- a/featurebyte/core/util.py
+++ b/featurebyte/core/util.py
@@ -126,3 +126,25 @@ def series_binary_operation(
         row_index_lineage=input_series.row_index_lineage,
         **kwargs,
     )
+
+
+def append_to_lineage(lineage: tuple[str, ...], node_name: str) -> tuple[str, ...]:
+    """
+    Add operation node name to the (row-index) lineage (list of node names)
+
+    Parameters
+    ----------
+    lineage: tuple[str, ...]
+        tuple of node names to represent the feature/row-index lineage
+    node_name: str
+        operation node name
+
+    Returns
+    -------
+    updated_lineage: tuple[str, ...]
+        updated lineage after adding the new operation name
+
+    """
+    output = list(lineage)
+    output.append(node_name)
+    return tuple(output)


### PR DESCRIPTION
## Description
There didn't really seem to be a need for this function to be in a mixin since it didn't have any dependencies on `self`, and looked like it could be a pure util function. This also makes it easier to reuse in other utils that I'm planning to have for adding the join functionality into Views, since I don't need to add the mixin just to be able to use this one function.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
