### PR TITLE
[wip] test moving DI closer to classes; less reliance on raw strings

### DIFF
--- a/featurebyte/routes/app_container.py
+++ b/featurebyte/routes/app_container.py
@@ -1,286 +1,45 @@
 """
 Container for Controller objects to enable Dependency Injection
 """
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from featurebyte.persistent import Persistent
-from featurebyte.routes.dimension_data.controller import DimensionDataController
-from featurebyte.routes.entity.controller import EntityController
-from featurebyte.routes.event_data.controller import EventDataController
-from featurebyte.routes.feature.controller import FeatureController
-from featurebyte.routes.feature_job_setting_analysis.controller import (
-    FeatureJobSettingAnalysisController,
-)
-from featurebyte.routes.feature_list.controller import FeatureListController
-from featurebyte.routes.feature_list_namespace.controller import FeatureListNamespaceController
-from featurebyte.routes.feature_namespace.controller import FeatureNamespaceController
-from featurebyte.routes.feature_store.controller import FeatureStoreController
-from featurebyte.routes.item_data.controller import ItemDataController
-from featurebyte.routes.scd_data.controller import SCDDataController
-from featurebyte.routes.semantic.controller import SemanticController
-from featurebyte.routes.tabular_data.controller import TabularDataController
 from featurebyte.routes.task.controller import TaskController
 from featurebyte.routes.temp_data.controller import TempDataController
-from featurebyte.service.data_update import DataUpdateService
-from featurebyte.service.default_version_mode import DefaultVersionModeService
-from featurebyte.service.deploy import DeployService
-from featurebyte.service.dimension_data import DimensionDataService
-from featurebyte.service.entity import EntityService
-from featurebyte.service.event_data import EventDataService
-from featurebyte.service.feature import FeatureService
-from featurebyte.service.feature_job_setting_analysis import FeatureJobSettingAnalysisService
-from featurebyte.service.feature_list import FeatureListService
-from featurebyte.service.feature_list_namespace import FeatureListNamespaceService
-from featurebyte.service.feature_namespace import FeatureNamespaceService
-from featurebyte.service.feature_readiness import FeatureReadinessService
-from featurebyte.service.feature_store import FeatureStoreService
-from featurebyte.service.feature_store_warehouse import FeatureStoreWarehouseService
-from featurebyte.service.info import InfoService
-from featurebyte.service.item_data import ItemDataService
-from featurebyte.service.online_enable import OnlineEnableService
-from featurebyte.service.online_serving import OnlineServingService
-from featurebyte.service.preview import PreviewService
-from featurebyte.service.relationship import EntityRelationshipService, SemanticRelationshipService
-from featurebyte.service.scd_data import SCDDataService
-from featurebyte.service.semantic import SemanticService
-from featurebyte.service.session_manager import SessionManagerService
-from featurebyte.service.session_validator import SessionValidatorService
-from featurebyte.service.tabular_data import DataService
 from featurebyte.service.task_manager import AbstractTaskManager
-from featurebyte.service.version import VersionService
 from featurebyte.storage import Storage
 
 app_container_config = {
-    "services": [
-        {
-            "name": "entity_service",
-            "clazz": EntityService,
-        },
-        {
-            "name": "dimension_data_service",
-            "clazz": DimensionDataService,
-        },
-        {
-            "name": "event_data_service",
-            "clazz": EventDataService,
-        },
-        {
-            "name": "item_data_service",
-            "clazz": ItemDataService,
-        },
-        {
-            "name": "scd_data_service",
-            "clazz": SCDDataService,
-        },
-        {
-            "name": "feature_service",
-            "clazz": FeatureService,
-        },
-        {
-            "name": "feature_list_service",
-            "clazz": FeatureListService,
-        },
-        {
-            "name": "session_validator_service",
-            "clazz": SessionValidatorService,
-        },
-        {
-            "name": "feature_readiness_service",
-            "clazz": FeatureReadinessService,
-        },
-        {
-            "name": "online_enable_service",
-            "clazz": OnlineEnableService,
-        },
-        {
-            "name": "online_serving_service",
-            "clazz": OnlineServingService,
-        },
-        {
-            "name": "deploy_service",
-            "clazz": DeployService,
-        },
-        {
-            "name": "feature_job_setting_analysis_service",
-            "clazz": FeatureJobSettingAnalysisService,
-        },
-        {
-            "name": "feature_list_namespace_service",
-            "clazz": FeatureListNamespaceService,
-        },
-        {
-            "name": "feature_namespace_service",
-            "clazz": FeatureNamespaceService,
-        },
-        {
-            "name": "data_update_service",
-            "clazz": DataUpdateService,
-        },
-        {
-            "name": "default_version_mode_service",
-            "clazz": DefaultVersionModeService,
-        },
-        {
-            "name": "feature_store_service",
-            "clazz": FeatureStoreService,
-        },
-        {
-            "name": "preview_service",
-            "clazz": PreviewService,
-        },
-        {
-            "name": "semantic_service",
-            "clazz": SemanticService,
-        },
-        {
-            "name": "tabular_data_service",
-            "clazz": DataService,
-        },
-        {
-            "name": "version_service",
-            "clazz": VersionService,
-        },
-        {
-            "name": "entity_relationship_service",
-            "clazz": EntityRelationshipService,
-        },
-        {
-            "name": "semantic_relationship_service",
-            "clazz": SemanticRelationshipService,
-        },
-        {
-            "name": "info_service",
-            "clazz": InfoService,
-        },
-        {
-            "name": "session_manager_service",
-            "clazz": SessionManagerService,
-        },
-        {
-            "name": "feature_store_warehouse_service",
-            "clazz": FeatureStoreWarehouseService,
-        },
-    ],
-    "controllers": [
-        {
-            "name": "entity_controller",
-            "clazz": EntityController,
-            "depends": ["entity_service", "entity_relationship_service", "info_service"],
-        },
-        {
-            "name": "event_data_controller",
-            "clazz": EventDataController,
-            "depends": [
-                "event_data_service",
-                "data_update_service",
-                "semantic_service",
-                "info_service",
-            ],
-        },
-        {
-            "name": "dimension_data_controller",
-            "clazz": DimensionDataController,
-            "depends": [
-                "dimension_data_service",
-                "data_update_service",
-                "semantic_service",
-                "info_service",
-            ],
-        },
-        {
-            "name": "item_data_controller",
-            "clazz": ItemDataController,
-            "depends": [
-                "item_data_service",
-                "data_update_service",
-                "semantic_service",
-                "info_service",
-            ],
-        },
-        {
-            "name": "scd_data_controller",
-            "clazz": SCDDataController,
-            "depends": [
-                "scd_data_service",
-                "data_update_service",
-                "semantic_service",
-                "info_service",
-            ],
-        },
-        {
-            "name": "feature_controller",
-            "clazz": FeatureController,
-            "depends": [
-                "feature_service",
-                "feature_list_service",
-                "feature_readiness_service",
-                "preview_service",
-                "version_service",
-                "info_service",
-            ],
-        },
-        {
-            "name": "feature_list_controller",
-            "clazz": FeatureListController,
-            "depends": [
-                "feature_list_service",
-                "feature_readiness_service",
-                "deploy_service",
-                "preview_service",
-                "version_service",
-                "info_service",
-                "online_serving_service",
-            ],
-        },
-        {
-            "name": "feature_job_setting_analysis_controller",
-            "clazz": FeatureJobSettingAnalysisController,
-            "depends": ["feature_job_setting_analysis_service", "task_controller"],
-        },
-        {
-            "name": "feature_list_namespace_controller",
-            "clazz": FeatureListNamespaceController,
-            "depends": [
-                "feature_list_namespace_service",
-                "default_version_mode_service",
-                "info_service",
-            ],
-        },
-        {
-            "name": "feature_namespace_controller",
-            "clazz": FeatureNamespaceController,
-            "depends": [
-                "feature_namespace_service",
-                "default_version_mode_service",
-                "info_service",
-            ],
-        },
-        {
-            "name": "feature_store_controller",
-            "clazz": FeatureStoreController,
-            "depends": [
-                "feature_store_service",
-                "preview_service",
-                "info_service",
-                "session_manager_service",
-                "session_validator_service",
-                "feature_store_warehouse_service",
-            ],
-        },
-        {
-            "name": "semantic_controller",
-            "clazz": SemanticController,
-            "depends": ["semantic_service", "semantic_relationship_service"],
-        },
-        {
-            "name": "tabular_data_controller",
-            "clazz": TabularDataController,
-            "depends": [
-                "tabular_data_service",
-            ],
-        },
-    ],
+    "services": [],
+    "controllers": [],
 }
+
+
+def register_service_constructor(clazz: Any):
+    classes = app_container_config["services"]
+    classes.extend(
+        [
+            {
+                "name": clazz.__name__,
+                "clazz": clazz,
+            }
+        ]
+    )
+    app_container_config["services"] = classes
+
+
+def register_controller_constructor(clazz: Any, dependencies: List[Any]) -> None:
+    controllers = app_container_config["controllers"]
+    controllers.extend(
+        [
+            {
+                "name": clazz.__name__,
+                "clazz": clazz,
+                "depends": dependencies,
+            }
+        ]
+    )
+    app_container_config["controllers"] = controllers
 
 
 class AppContainer:
@@ -338,6 +97,7 @@ class AppContainer:
                     instance = clazz(*depend_instances)
 
                 self.instance_map[name] = instance
+        print(self.instance_map)
 
     def __getattr__(self, key: str) -> Any:
         return self.instance_map[key]

--- a/featurebyte/routes/dimension_data/controller.py
+++ b/featurebyte/routes/dimension_data/controller.py
@@ -7,9 +7,13 @@ from typing import Any
 
 from featurebyte.enum import SemanticType
 from featurebyte.models.dimension_data import DimensionDataModel
+from featurebyte.routes.app_container import register_controller_constructor
 from featurebyte.routes.common.base_data import BaseDataDocumentController
 from featurebyte.schema.dimension_data import DimensionDataList, DimensionDataUpdate
+from featurebyte.service.data_update import DataUpdateService
 from featurebyte.service.dimension_data import DimensionDataService
+from featurebyte.service.info import InfoService
+from featurebyte.service.semantic import SemanticService
 
 
 class DimensionDataController(
@@ -29,3 +33,8 @@ class DimensionDataController(
         return {
             document.dimension_data_id_column: dimension_data_id,
         }
+
+
+register_controller_constructor(
+    DimensionDataController, [DimensionDataService, DataUpdateService, SemanticService, InfoService]
+)

--- a/featurebyte/routes/entity/controller.py
+++ b/featurebyte/routes/entity/controller.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from bson.objectid import ObjectId
 
 from featurebyte.models.entity import EntityModel, ParentEntity
+from featurebyte.routes.app_container import register_controller_constructor
 from featurebyte.routes.common.base import BaseDocumentController, RelationshipMixin
 from featurebyte.schema.entity import EntityCreate, EntityList, EntityServiceUpdate, EntityUpdate
 from featurebyte.schema.info import EntityInfo
@@ -101,3 +102,8 @@ class EntityController(
             document_id=document_id, verbose=verbose
         )
         return info_document
+
+
+register_controller_constructor(
+    EntityController, [EntityService, EntityRelationshipService, InfoService]
+)

--- a/featurebyte/routes/event_data/controller.py
+++ b/featurebyte/routes/event_data/controller.py
@@ -9,10 +9,14 @@ from bson.objectid import ObjectId
 
 from featurebyte.enum import SemanticType
 from featurebyte.models.event_data import EventDataModel
+from featurebyte.routes.app_container import register_controller_constructor
 from featurebyte.routes.common.base_data import BaseDataDocumentController
 from featurebyte.schema.event_data import EventDataList, EventDataUpdate
 from featurebyte.schema.info import EventDataInfo
+from featurebyte.service.data_update import DataUpdateService
 from featurebyte.service.event_data import EventDataService
+from featurebyte.service.info import InfoService
+from featurebyte.service.semantic import SemanticService
 
 
 class EventDataController(
@@ -59,3 +63,8 @@ class EventDataController(
             document_id=document_id, verbose=verbose
         )
         return info_document
+
+
+register_controller_constructor(
+    EventDataController, [EventDataService, DataUpdateService, SemanticService, InfoService]
+)

--- a/featurebyte/routes/feature/controller.py
+++ b/featurebyte/routes/feature/controller.py
@@ -11,6 +11,7 @@ from bson.objectid import ObjectId
 from fastapi.exceptions import HTTPException
 
 from featurebyte.models.feature import FeatureModel, FeatureReadiness
+from featurebyte.routes.app_container import register_controller_constructor
 from featurebyte.routes.common.base import BaseDocumentController
 from featurebyte.schema.feature import (
     FeatureCreate,
@@ -232,3 +233,16 @@ class FeatureController(BaseDocumentController[FeatureModel, FeatureService, Fea
             Dataframe converted to json string
         """
         return await self.preview_service.feature_sql(feature_sql=feature_sql)
+
+
+register_controller_constructor(
+    FeatureController,
+    [
+        FeatureService,
+        FeatureListService,
+        FeatureReadinessService,
+        PreviewService,
+        VersionService,
+        InfoService,
+    ],
+)

--- a/featurebyte/routes/feature_job_setting_analysis/controller.py
+++ b/featurebyte/routes/feature_job_setting_analysis/controller.py
@@ -4,6 +4,7 @@ FeatureJobSettingAnalysis API route controller
 from __future__ import annotations
 
 from featurebyte.models.feature_job_setting_analysis import FeatureJobSettingAnalysisModel
+from featurebyte.routes.app_container import register_controller_constructor
 from featurebyte.routes.common.base import BaseDocumentController
 from featurebyte.routes.task.controller import TaskController
 from featurebyte.schema.feature_job_setting_analysis import (
@@ -79,3 +80,8 @@ class FeatureJobSettingAnalysisController(
             data=data, task_manager=self.task_controller.task_manager
         )
         return await self.task_controller.get_task(task_id=str(task_id))
+
+
+register_controller_constructor(
+    FeatureJobSettingAnalysisController, [FeatureJobSettingAnalysisService, TaskController]
+)

--- a/featurebyte/routes/feature_list/controller.py
+++ b/featurebyte/routes/feature_list/controller.py
@@ -20,6 +20,7 @@ from featurebyte.exception import (
 )
 from featurebyte.models.feature import FeatureReadiness
 from featurebyte.models.feature_list import FeatureListModel
+from featurebyte.routes.app_container import register_controller_constructor
 from featurebyte.routes.common.base import BaseDocumentController
 from featurebyte.schema.feature_list import (
     FeatureListCreate,
@@ -372,3 +373,17 @@ class FeatureListController(
                 status_code=HTTPStatus.UNPROCESSABLE_ENTITY, detail=exc.args[0]
             ) from exc
         return result
+
+
+register_controller_constructor(
+    FeatureListController,
+    [
+        FeatureListService,
+        FeatureReadinessService,
+        DeployService,
+        PreviewService,
+        VersionService,
+        InfoService,
+        OnlineServingService,
+    ],
+)

--- a/featurebyte/routes/feature_list_namespace/controller.py
+++ b/featurebyte/routes/feature_list_namespace/controller.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from bson.objectid import ObjectId
 
 from featurebyte.models.feature_list import FeatureListNamespaceModel
+from featurebyte.routes.app_container import register_controller_constructor
 from featurebyte.routes.common.base import BaseDocumentController
 from featurebyte.schema.feature_list_namespace import (
     FeatureListNamespaceList,
@@ -96,3 +97,9 @@ class FeatureListNamespaceController(
             document_id=document_id, verbose=verbose
         )
         return info_document
+
+
+register_controller_constructor(
+    FeatureListNamespaceController,
+    [FeatureListNamespaceService, DefaultVersionModeService, InfoService],
+)

--- a/featurebyte/routes/feature_namespace/controller.py
+++ b/featurebyte/routes/feature_namespace/controller.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from bson.objectid import ObjectId
 
 from featurebyte.models.feature import FeatureNamespaceModel
+from featurebyte.routes.app_container import register_controller_constructor
 from featurebyte.routes.common.base import BaseDocumentController
 from featurebyte.schema.feature_namespace import FeatureNamespaceList, FeatureNamespaceUpdate
 from featurebyte.schema.info import FeatureNamespaceInfo
@@ -84,3 +85,8 @@ class FeatureNamespaceController(
             document_id=document_id, verbose=verbose
         )
         return info_document
+
+
+register_controller_constructor(
+    FeatureNamespaceController, [FeatureNamespaceService, DefaultVersionModeService, InfoService]
+)

--- a/featurebyte/routes/feature_store/controller.py
+++ b/featurebyte/routes/feature_store/controller.py
@@ -8,6 +8,7 @@ from typing import Any, List
 from bson.objectid import ObjectId
 
 from featurebyte.models.feature_store import ColumnSpec, FeatureStoreModel
+from featurebyte.routes.app_container import register_controller_constructor
 from featurebyte.routes.common.base import BaseDocumentController
 from featurebyte.schema.feature_store import (
     FeatureStoreCreate,
@@ -283,3 +284,16 @@ class FeatureStoreController(
             document_id=document_id, verbose=verbose
         )
         return info_document
+
+
+register_controller_constructor(
+    FeatureStoreController,
+    [
+        FeatureStoreService,
+        PreviewService,
+        InfoService,
+        SessionManagerService,
+        SessionValidatorService,
+        FeatureStoreWarehouseService,
+    ],
+)

--- a/featurebyte/routes/item_data/controller.py
+++ b/featurebyte/routes/item_data/controller.py
@@ -7,9 +7,13 @@ from typing import Any
 
 from featurebyte.enum import SemanticType
 from featurebyte.models.item_data import ItemDataModel
+from featurebyte.routes.app_container import register_controller_constructor
 from featurebyte.routes.common.base_data import BaseDataDocumentController
 from featurebyte.schema.item_data import ItemDataList, ItemDataUpdate
+from featurebyte.service.data_update import DataUpdateService
+from featurebyte.service.info import InfoService
 from featurebyte.service.item_data import ItemDataService
+from featurebyte.service.semantic import SemanticService
 
 
 class ItemDataController(BaseDataDocumentController[ItemDataModel, ItemDataService, ItemDataList]):
@@ -23,3 +27,8 @@ class ItemDataController(BaseDataDocumentController[ItemDataModel, ItemDataServi
     async def _get_column_semantic_map(self, document: ItemDataModel) -> dict[str, Any]:
         item_id = await self.semantic_service.get_or_create_document(name=SemanticType.ITEM_ID)
         return {document.item_id_column: item_id}
+
+
+register_controller_constructor(
+    ItemDataController, [ItemDataService, DataUpdateService, SemanticService, InfoService]
+)

--- a/featurebyte/routes/scd_data/controller.py
+++ b/featurebyte/routes/scd_data/controller.py
@@ -7,9 +7,13 @@ from typing import Any
 
 from featurebyte.enum import SemanticType
 from featurebyte.models.scd_data import SCDDataModel
+from featurebyte.routes.app_container import register_controller_constructor
 from featurebyte.routes.common.base_data import BaseDataDocumentController
 from featurebyte.schema.scd_data import SCDDataList, SCDDataUpdate
+from featurebyte.service.data_update import DataUpdateService
+from featurebyte.service.info import InfoService
 from featurebyte.service.scd_data import SCDDataService
+from featurebyte.service.semantic import SemanticService
 
 
 class SCDDataController(BaseDataDocumentController[SCDDataModel, SCDDataService, SCDDataList]):
@@ -37,3 +41,8 @@ class SCDDataController(BaseDataDocumentController[SCDDataModel, SCDDataService,
                 }
             )
         return column_semantic_map
+
+
+register_controller_constructor(
+    SCDDataController, [SCDDataService, DataUpdateService, SemanticService, InfoService]
+)

--- a/featurebyte/routes/semantic/controller.py
+++ b/featurebyte/routes/semantic/controller.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from featurebyte.models.relationship import Parent
 from featurebyte.models.semantic import SemanticModel
+from featurebyte.routes.app_container import register_controller_constructor
 from featurebyte.routes.common.base import BaseDocumentController, RelationshipMixin
 from featurebyte.schema.semantic import SemanticCreate, SemanticList
 from featurebyte.service.relationship import SemanticRelationshipService
@@ -47,3 +48,6 @@ class SemanticController(
             Newly created semantic object
         """
         return await self.service.create_document(data)
+
+
+register_controller_constructor(SemanticController, [SemanticService, SemanticRelationshipService])

--- a/featurebyte/routes/tabular_data/controller.py
+++ b/featurebyte/routes/tabular_data/controller.py
@@ -4,6 +4,7 @@ TabularData API route controller
 from __future__ import annotations
 
 from featurebyte.models.tabular_data import TabularDataModel
+from featurebyte.routes.app_container import register_controller_constructor
 from featurebyte.routes.common.base import BaseDocumentController
 from featurebyte.schema.tabular_data import TabularDataList
 from featurebyte.service.tabular_data import DataService
@@ -15,3 +16,6 @@ class TabularDataController(BaseDocumentController[TabularDataModel, DataService
     """
 
     paginated_document_class = TabularDataList
+
+
+register_controller_constructor(TabularDataController, [DataService])

--- a/featurebyte/service/data_update.py
+++ b/featurebyte/service/data_update.py
@@ -12,6 +12,7 @@ from bson.objectid import ObjectId
 from featurebyte.enum import TableDataType
 from featurebyte.exception import DocumentUpdateError
 from featurebyte.models.feature_store import DataModel, DataStatus
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.dimension_data import DimensionDataUpdate
 from featurebyte.schema.entity import EntityServiceUpdate
 from featurebyte.schema.event_data import EventDataUpdate
@@ -219,3 +220,6 @@ class DataUpdateService(BaseService):
                 document_id=entity_id,
                 data=EntityServiceUpdate(**update_values),
             )
+
+
+register_service_constructor(DataUpdateService)

--- a/featurebyte/service/default_version_mode.py
+++ b/featurebyte/service/default_version_mode.py
@@ -9,6 +9,7 @@ from bson.objectid import ObjectId
 
 from featurebyte.models.feature import DefaultVersionMode, FeatureNamespaceModel
 from featurebyte.models.feature_list import FeatureListNamespaceModel
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.feature_list_namespace import FeatureListNamespaceServiceUpdate
 from featurebyte.schema.feature_namespace import FeatureNamespaceServiceUpdate
 from featurebyte.service.base_service import BaseService, DocServiceName
@@ -118,3 +119,6 @@ class DefaultVersionModeService(BaseService):
             )
             return feature_list_namespace
         return self.conditional_return(document=document, condition=return_document)
+
+
+register_service_constructor(DefaultVersionModeService)

--- a/featurebyte/service/deploy.py
+++ b/featurebyte/service/deploy.py
@@ -10,6 +10,7 @@ from bson.objectid import ObjectId
 from featurebyte.exception import DocumentUpdateError
 from featurebyte.models.feature import FeatureModel, FeatureReadiness
 from featurebyte.models.feature_list import FeatureListModel, FeatureListNamespaceModel
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.feature import FeatureServiceUpdate
 from featurebyte.schema.feature_list import FeatureListServiceUpdate
 from featurebyte.schema.feature_list_namespace import FeatureListNamespaceServiceUpdate
@@ -195,3 +196,6 @@ class DeployService(BaseService):
                 if return_document:
                     return await self.feature_list_service.get_document(document_id=feature_list_id)
         return self.conditional_return(document=document, condition=return_document)
+
+
+register_service_constructor(DeployService)

--- a/featurebyte/service/dimension_data.py
+++ b/featurebyte/service/dimension_data.py
@@ -4,6 +4,7 @@ DimensionDataService class
 from __future__ import annotations
 
 from featurebyte.models.dimension_data import DimensionDataModel
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.dimension_data import DimensionDataCreate, DimensionDataUpdate
 from featurebyte.service.base_data_document import BaseDataDocumentService
 
@@ -16,3 +17,6 @@ class DimensionDataService(
     """
 
     document_class = DimensionDataModel
+
+
+register_service_constructor(DimensionDataService)

--- a/featurebyte/service/entity.py
+++ b/featurebyte/service/entity.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Any
 
 from featurebyte.models.entity import EntityModel
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.entity import EntityCreate, EntityServiceUpdate
 from featurebyte.service.base_document import BaseDocumentService
 
@@ -20,3 +21,6 @@ class EntityService(BaseDocumentService[EntityModel, EntityCreate, EntityService
     @staticmethod
     def _extract_additional_creation_kwargs(data: EntityCreate) -> dict[str, Any]:
         return {"serving_names": [data.serving_name]}
+
+
+register_service_constructor(EntityService)

--- a/featurebyte/service/event_data.py
+++ b/featurebyte/service/event_data.py
@@ -4,6 +4,7 @@ EventDataService class
 from __future__ import annotations
 
 from featurebyte.models.event_data import EventDataModel
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.event_data import EventDataCreate, EventDataUpdate
 from featurebyte.service.base_data_document import BaseDataDocumentService
 
@@ -14,3 +15,6 @@ class EventDataService(BaseDataDocumentService[EventDataModel, EventDataCreate, 
     """
 
     document_class = EventDataModel
+
+
+register_service_constructor(EventDataService)

--- a/featurebyte/service/feature.py
+++ b/featurebyte/service/feature.py
@@ -14,6 +14,7 @@ from featurebyte.models.feature import (
     FeatureNamespaceModel,
     FeatureReadiness,
 )
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.feature import FeatureCreate, FeatureServiceUpdate
 from featurebyte.schema.feature_namespace import (
     FeatureNamespaceCreate,
@@ -176,3 +177,6 @@ class FeatureService(BaseDocumentService[FeatureModel, FeatureCreate, FeatureSer
             )
             raise DocumentNotFoundError(exception_detail)
         return FeatureModel(**document_dict)
+
+
+register_service_constructor(FeatureService)

--- a/featurebyte/service/feature_job_setting_analysis.py
+++ b/featurebyte/service/feature_job_setting_analysis.py
@@ -9,6 +9,7 @@ from featurebyte.exception import DocumentError
 from featurebyte.models.base import FeatureByteBaseDocumentModel
 from featurebyte.models.event_data import EventDataModel
 from featurebyte.models.feature_job_setting_analysis import FeatureJobSettingAnalysisModel
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema
 from featurebyte.schema.feature_job_setting_analysis import (
     FeatureJobSettingAnalysisBacktest,
@@ -114,3 +115,6 @@ class FeatureJobSettingAnalysisService(
 
         # submit a task to run analysis
         return await task_manager.submit(payload=payload)
+
+
+register_service_constructor(FeatureJobSettingAnalysisService)

--- a/featurebyte/service/feature_list.py
+++ b/featurebyte/service/feature_list.py
@@ -12,6 +12,7 @@ from featurebyte.exception import DocumentError, DocumentInconsistencyError, Doc
 from featurebyte.models.base import VersionIdentifier
 from featurebyte.models.feature import DefaultVersionMode, FeatureModel
 from featurebyte.models.feature_list import FeatureListModel, FeatureListNamespaceModel
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.feature import FeatureServiceUpdate
 from featurebyte.schema.feature_list import FeatureListCreate, FeatureListServiceUpdate
 from featurebyte.schema.feature_list_namespace import FeatureListNamespaceServiceUpdate
@@ -201,3 +202,6 @@ class FeatureListService(
             # update feature's feature_list_ids attribute
             await self._update_features(feature_data["features"], insert_id)
         return await self.get_document(document_id=insert_id)
+
+
+register_service_constructor(FeatureListService)

--- a/featurebyte/service/feature_list_namespace.py
+++ b/featurebyte/service/feature_list_namespace.py
@@ -4,6 +4,7 @@ FeatureListNamespaceService class
 from __future__ import annotations
 
 from featurebyte.models.feature_list import FeatureListNamespaceModel
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.feature_list_namespace import FeatureListNamespaceServiceUpdate
 from featurebyte.service.base_document import BaseDocumentService
 
@@ -18,3 +19,6 @@ class FeatureListNamespaceService(
     """
 
     document_class = FeatureListNamespaceModel
+
+
+register_service_constructor(FeatureListNamespaceService)

--- a/featurebyte/service/feature_namespace.py
+++ b/featurebyte/service/feature_namespace.py
@@ -4,6 +4,7 @@ FeatureNamespaceService class
 from __future__ import annotations
 
 from featurebyte.models.feature import FeatureNamespaceModel
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.feature_namespace import (
     FeatureNamespaceCreate,
     FeatureNamespaceServiceUpdate,
@@ -21,3 +22,6 @@ class FeatureNamespaceService(
     """
 
     document_class = FeatureNamespaceModel
+
+
+register_service_constructor(FeatureNamespaceService)

--- a/featurebyte/service/feature_readiness.py
+++ b/featurebyte/service/feature_readiness.py
@@ -18,6 +18,7 @@ from featurebyte.models.feature_list import (
     FeatureListNamespaceModel,
     FeatureReadinessTransition,
 )
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.feature import FeatureServiceUpdate
 from featurebyte.schema.feature_list import FeatureListServiceUpdate
 from featurebyte.schema.feature_list_namespace import FeatureListNamespaceServiceUpdate
@@ -250,3 +251,6 @@ class FeatureReadinessService(BaseService):
                     )
                 return self.conditional_return(document=feature, condition=return_document)
         return self.conditional_return(document=document, condition=return_document)
+
+
+register_service_constructor(FeatureReadinessService)

--- a/featurebyte/service/feature_store.py
+++ b/featurebyte/service/feature_store.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Type
 
 from featurebyte.models.feature_store import FeatureStoreModel
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema
 from featurebyte.schema.feature_store import FeatureStoreCreate
 from featurebyte.service.base_document import BaseDocumentService
@@ -19,3 +20,6 @@ class FeatureStoreService(
     """
 
     document_class: Type[FeatureStoreModel] = FeatureStoreModel
+
+
+register_service_constructor(FeatureStoreService)

--- a/featurebyte/service/feature_store_warehouse.py
+++ b/featurebyte/service/feature_store_warehouse.py
@@ -7,6 +7,7 @@ from typing import Any, List
 
 from featurebyte.models.feature_store import ColumnSpec, FeatureStoreModel
 from featurebyte.persistent import Persistent
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.service.base_service import BaseService
 from featurebyte.service.session_manager import SessionManagerService
 
@@ -138,3 +139,6 @@ class FeatureStoreWarehouseService(BaseService):
             database_name=database_name, schema_name=schema_name, table_name=table_name
         )
         return [ColumnSpec(name=name, dtype=dtype) for name, dtype in table_schema.items()]
+
+
+register_service_constructor(FeatureStoreWarehouseService)

--- a/featurebyte/service/info.py
+++ b/featurebyte/service/info.py
@@ -11,6 +11,7 @@ from featurebyte.enum import TableDataType
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.tabular_data import TabularDataModel
 from featurebyte.query_graph.node.metadata.operation import GroupOperationStructure
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.feature import FeatureBriefInfoList
 from featurebyte.schema.info import (
     DataBriefInfoList,
@@ -441,3 +442,6 @@ class InfoService(BaseService):
             feature_count=len(namespace.feature_namespace_ids),
             status=namespace.status,
         )
+
+
+register_service_constructor(InfoService)

--- a/featurebyte/service/item_data.py
+++ b/featurebyte/service/item_data.py
@@ -4,6 +4,7 @@ ItemDataService class
 from __future__ import annotations
 
 from featurebyte.models.item_data import ItemDataModel
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.item_data import ItemDataCreate, ItemDataUpdate
 from featurebyte.service.base_data_document import BaseDataDocumentService
 
@@ -14,3 +15,6 @@ class ItemDataService(BaseDataDocumentService[ItemDataModel, ItemDataCreate, Ite
     """
 
     document_class = ItemDataModel
+
+
+register_service_constructor(ItemDataService)

--- a/featurebyte/service/online_enable.py
+++ b/featurebyte/service/online_enable.py
@@ -13,6 +13,7 @@ from featurebyte.feature_manager.snowflake_feature import FeatureManagerSnowflak
 from featurebyte.models.feature import FeatureModel, FeatureNamespaceModel
 from featurebyte.models.feature_list import FeatureListModel
 from featurebyte.models.online_store import OnlineFeatureSpec
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.feature import FeatureServiceUpdate
 from featurebyte.schema.feature_list import FeatureListServiceUpdate
 from featurebyte.schema.feature_namespace import FeatureNamespaceServiceUpdate
@@ -217,3 +218,6 @@ class OnlineEnableService(BaseService):
                 if return_document:
                     return await self.get_document(DocServiceName.FEATURE, feature_id)
         return self.conditional_return(document=document, condition=return_document)
+
+
+register_service_constructor(OnlineEnableService)

--- a/featurebyte/service/online_serving.py
+++ b/featurebyte/service/online_serving.py
@@ -15,6 +15,7 @@ from featurebyte.logger import logger
 from featurebyte.models.feature_list import FeatureListModel
 from featurebyte.query_graph.sql.dataframe import construct_dataframe_sql_expr
 from featurebyte.query_graph.sql.online_serving import get_online_store_retrieval_sql
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.feature_list import OnlineFeaturesResponseModel
 from featurebyte.service.base_service import BaseService
 from featurebyte.service.session_manager import SessionManagerService
@@ -106,3 +107,6 @@ class OnlineServingService(BaseService):
         result = OnlineFeaturesResponseModel(features=features)
 
         return result
+
+
+register_service_constructor(OnlineServingService)

--- a/featurebyte/service/preview.py
+++ b/featurebyte/service/preview.py
@@ -19,6 +19,7 @@ from featurebyte.query_graph.sql.feature_historical import (
 )
 from featurebyte.query_graph.sql.feature_preview import get_feature_preview_sql
 from featurebyte.query_graph.sql.interpreter import GraphInterpreter
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.feature import FeaturePreview, FeatureSQL
 from featurebyte.schema.feature_list import (
     FeatureListGetHistoricalFeatures,
@@ -327,3 +328,6 @@ class PreviewService(BaseService):
             source_type=source_type,
             serving_names_mapping=featurelist_get_historical_features.serving_names_mapping,
         )
+
+
+register_service_constructor(PreviewService)

--- a/featurebyte/service/relationship.py
+++ b/featurebyte/service/relationship.py
@@ -12,6 +12,7 @@ from bson import ObjectId
 from featurebyte.exception import DocumentUpdateError
 from featurebyte.models.base import FeatureByteBaseDocumentModel, FeatureByteBaseModel
 from featurebyte.models.relationship import Parent, Relationship
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema
 from featurebyte.schema.entity import EntityServiceUpdate
 from featurebyte.schema.semantic import SemanticServiceUpdate
@@ -209,6 +210,9 @@ class EntityRelationshipService(RelationshipService):
         return EntityServiceUpdate(ancestor_ids=ancestor_ids, parents=parents)
 
 
+register_service_constructor(EntityRelationshipService)
+
+
 class SemanticRelationshipService(RelationshipService):
     """
     SemanticRelationshipService is responsible to update relationship between different semantics.
@@ -223,3 +227,6 @@ class SemanticRelationshipService(RelationshipService):
         cls, ancestor_ids: set[ObjectId], parents: list[ParentT]
     ) -> BaseDocumentServiceUpdateSchema:
         return SemanticServiceUpdate(ancestor_ids=ancestor_ids, parents=parents)
+
+
+register_service_constructor(SemanticRelationshipService)

--- a/featurebyte/service/scd_data.py
+++ b/featurebyte/service/scd_data.py
@@ -4,6 +4,7 @@ SCDDataService class
 from __future__ import annotations
 
 from featurebyte.models.scd_data import SCDDataModel
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.scd_data import SCDDataCreate, SCDDataUpdate
 from featurebyte.service.base_data_document import BaseDataDocumentService
 
@@ -18,3 +19,6 @@ class SCDDataService(BaseDataDocumentService[SCDDataModel, SCDDataCreate, SCDDat
     @property
     def class_name(self) -> str:
         return "SCDData"
+
+
+register_service_constructor(SCDDataService)

--- a/featurebyte/service/semantic.py
+++ b/featurebyte/service/semantic.py
@@ -4,6 +4,7 @@ SemanticService class
 from __future__ import annotations
 
 from featurebyte.models.semantic import SemanticModel
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.semantic import SemanticCreate, SemanticServiceUpdate
 from featurebyte.service.base_document import BaseDocumentService
 from featurebyte.service.mixin import GetOrCreateMixin
@@ -19,3 +20,6 @@ class SemanticService(
 
     document_class = SemanticModel
     document_create_class = SemanticCreate
+
+
+register_service_constructor(SemanticService)

--- a/featurebyte/service/session_manager.py
+++ b/featurebyte/service/session_manager.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 from featurebyte.exception import CredentialsError
 from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.persistent import Persistent
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.service.session_validator import SessionValidatorService
 from featurebyte.session.base import BaseSession
 from featurebyte.session.manager import SessionManager
@@ -65,3 +66,6 @@ class SessionManagerService:
             raise CredentialsError(
                 f'Credential used to access FeatureStore (name: "{feature_store.name}") is missing or invalid.'
             ) from exc
+
+
+register_service_constructor(SessionManagerService)

--- a/featurebyte/service/session_validator.py
+++ b/featurebyte/service/session_validator.py
@@ -9,6 +9,7 @@ from featurebyte.logger import logger
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.feature_store import DatabaseDetails
 from featurebyte.persistent import Persistent
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.session.base import BaseSession
 from featurebyte.session.manager import SessionManager
@@ -220,3 +221,6 @@ class SessionValidatorService:
         if does_exist:
             return PydanticObjectId(response["data"][0]["_id"])
         return None
+
+
+register_service_constructor(SessionValidatorService)

--- a/featurebyte/service/tabular_data.py
+++ b/featurebyte/service/tabular_data.py
@@ -9,6 +9,7 @@ from bson import ObjectId
 
 from featurebyte.models.feature_store import DataModel as BaseDataModel
 from featurebyte.models.tabular_data import TabularDataModel
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.tabular_data import DataCreate, DataUpdate
 from featurebyte.service.base_document import BaseDocumentService, DocumentUpdateSchema
 from featurebyte.service.mixin import Document, DocumentCreateSchema
@@ -35,3 +36,6 @@ class DataService(BaseDocumentService[BaseDataModel, DataCreate, DataUpdate]):
         return_document: bool = True,
     ) -> Optional[Document]:
         raise NotImplementedError
+
+
+register_service_constructor(DataService)

--- a/featurebyte/service/version.py
+++ b/featurebyte/service/version.py
@@ -16,6 +16,7 @@ from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.query_graph.node import Node
 from featurebyte.query_graph.node.generic import GroupbyNode, InputNode
+from featurebyte.routes.app_container import register_service_constructor
 from featurebyte.schema.feature import FeatureCreate, FeatureNewVersionCreate
 from featurebyte.schema.feature_list import FeatureListCreate, FeatureListNewVersionCreate
 from featurebyte.service.base_service import BaseService, DocServiceName
@@ -197,3 +198,6 @@ class VersionService(BaseService):
             data=FeatureListCreate(**new_feature_list.dict(by_alias=True)),
             get_credential=get_credential,
         )
+
+
+register_service_constructor(VersionService)

--- a/tests/unit/routes/test_app_container.py
+++ b/tests/unit/routes/test_app_container.py
@@ -1,0 +1,20 @@
+"""
+Test app container
+"""
+from featurebyte.routes.app_container import app_container_config, register_service_constructor
+
+
+class TestClass:
+    """
+    Local test class
+    """
+
+    pass
+
+
+def test_register_service_constructor():
+    original_services = app_container_config["services"].copy()
+    assert len(original_services) > 0
+    register_service_constructor(TestClass)
+    services = app_container_config["services"].copy()
+    assert len(services) == (len(original_services) + 1)


### PR DESCRIPTION
## Description
- test out moving constructor registration to a helper func
- moves the registration closer to the class definition
- less reliance on raw strings; less room for typos
- can potentially open up the API for wider adoption of DI

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
