### PR TITLE
[DEV-853] Disable too-few-public-methods warning globally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 #* Variables
 MAKE := make
 EXECUTABLES = poetry git docker docker-compose
+PYLINT_DISABLE := too-few-public-methods
 PYLINT_DISABLE_FOR_TESTS := redefined-outer-name,invalid-name,protected-access,too-few-public-methods,unspecified-encoding,duplicate-code
 POETRY_ENV_PIP := $(shell poetry env info --path)/bin/pip
 PERMISSIVE_LICENSES := "\
@@ -66,7 +67,7 @@ lint-style:
 	poetry run toml-sort --check poetry.lock pyproject.toml    # Check if user been using pre-commit hook
 	poetry run isort --diff --check-only --settings-path pyproject.toml .
 	poetry run black --diff --check .
-	poetry run pylint --rcfile pyproject.toml featurebyte
+	poetry run pylint --disable=${PYLINT_DISABLE} --rcfile pyproject.toml featurebyte
 	poetry run pylint --disable=${PYLINT_DISABLE_FOR_TESTS} --rcfile pyproject.toml tests
 
 	find featurebyte -type d \( -path featurebyte/routes \) -prune -false -o -name "*.py" | xargs poetry run darglint --verbosity 2

--- a/featurebyte/api/api_object.py
+++ b/featurebyte/api/api_object.py
@@ -45,7 +45,7 @@ ConflictResolution = Literal["raise", "retrieve"]
 PAGINATED_CALL_PAGE_SIZE = 100
 
 
-class ApiObjectProxy(lazy_object_proxy.Proxy):  # pylint: disable=too-few-public-methods
+class ApiObjectProxy(lazy_object_proxy.Proxy):
     """
     Proxy with customized representation
     """

--- a/featurebyte/api/database_table.py
+++ b/featurebyte/api/database_table.py
@@ -29,8 +29,6 @@ class DatabaseTable(DatabaseTableModel, BaseFrame):
     DatabaseTable class to preview table
     """
 
-    # pylint: disable=too-few-public-methods
-
     feature_store: FeatureStoreModel = Field(allow_mutation=False, exclude=True)
 
     class Config:

--- a/featurebyte/api/view.py
+++ b/featurebyte/api/view.py
@@ -73,7 +73,7 @@ class ViewColumn(Series, SampleMixin):
         return {"tabular_data_ids": self.tabular_data_ids}
 
 
-class GroupByMixin:  # pylint: disable=too-few-public-methods
+class GroupByMixin:
     """
     Mixin that provides groupby functionality to a View object
     """

--- a/featurebyte/app.py
+++ b/featurebyte/app.py
@@ -1,7 +1,6 @@
 """
 FastAPI Application
 """
-# pylint: disable=too-few-public-methods
 from __future__ import annotations
 
 from typing import Callable

--- a/featurebyte/config.py
+++ b/featurebyte/config.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, List, Optional, Union
 import os
 from pathlib import Path
 
-# pylint: disable=too-few-public-methods
 import requests
 import yaml
 from pydantic import AnyHttpUrl, BaseModel, Field, validator

--- a/featurebyte/core/accessor/count_dict.py
+++ b/featurebyte/core/accessor/count_dict.py
@@ -23,8 +23,6 @@ class CdAccessorMixin:
     CdAccessorMixin class
     """
 
-    # pylint: disable=too-few-public-methods
-
     @property
     def cd(self: Feature) -> CountDictAccessor:  # type: ignore # pylint: disable=invalid-name
         """

--- a/featurebyte/core/accessor/datetime.py
+++ b/featurebyte/core/accessor/datetime.py
@@ -18,8 +18,6 @@ class DtAccessorMixin:
     DtAccessorMixin class
     """
 
-    # pylint: disable=too-few-public-methods
-
     @property
     def dt(self: Series) -> DatetimeAccessor:  # type: ignore # pylint: disable=invalid-name
         """
@@ -36,8 +34,6 @@ class DatetimeAccessor:
     """
     DatetimeAccessor class used to manipulate datetime-like type Series object
     """
-
-    # pylint: disable=too-few-public-methods
 
     def __init__(self, obj: Series):
         if obj.is_datetime:

--- a/featurebyte/core/accessor/string.py
+++ b/featurebyte/core/accessor/string.py
@@ -24,8 +24,6 @@ class StrAccessorMixin:
     StrAccessorMixin class
     """
 
-    # pylint: disable=too-few-public-methods
-
     @property
     def str(self: Series) -> StringAccessor:  # type: ignore
         """

--- a/featurebyte/core/mixin.py
+++ b/featurebyte/core/mixin.py
@@ -1,7 +1,6 @@
 """
 Mixin classes used by core objects
 """
-# pylint: disable=too-few-public-methods
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Protocol, Union

--- a/featurebyte/migration/model.py
+++ b/featurebyte/migration/model.py
@@ -1,7 +1,6 @@
 """
 This module contains schema related model
 """
-# pylint: disable=too-few-public-methods
 from typing import List
 
 from pydantic import Field

--- a/featurebyte/models/base.py
+++ b/featurebyte/models/base.py
@@ -1,7 +1,6 @@
 """
 FeatureByte specific BaseModel
 """
-# pylint: disable=too-few-public-methods
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Type, TypeVar, Union

--- a/featurebyte/models/credential.py
+++ b/featurebyte/models/credential.py
@@ -1,7 +1,6 @@
 """
 Document model for stored credentials
 """
-# pylint: disable=too-few-public-methods
 from typing import Union
 
 from pydantic import StrictStr

--- a/featurebyte/models/entity.py
+++ b/featurebyte/models/entity.py
@@ -1,7 +1,6 @@
 """
 This module contains Entity related models
 """
-# pylint: disable=too-few-public-methods
 from __future__ import annotations
 
 from typing import Any, List

--- a/featurebyte/models/event_data.py
+++ b/featurebyte/models/event_data.py
@@ -1,7 +1,6 @@
 """
 This module contains EventData related models
 """
-# pylint: disable=too-few-public-methods
 from __future__ import annotations
 
 from typing import Any, Dict, Literal, Optional, Tuple

--- a/featurebyte/models/feature.py
+++ b/featurebyte/models/feature.py
@@ -1,7 +1,6 @@
 """
 This module contains Feature related models
 """
-# pylint: disable=too-few-public-methods
 from __future__ import annotations
 
 from typing import Any, List, Optional, Tuple

--- a/featurebyte/models/feature_job_setting_analysis.py
+++ b/featurebyte/models/feature_job_setting_analysis.py
@@ -1,7 +1,6 @@
 """
 This module contains FeatureJobSettingAnalysis related models
 """
-# pylint: disable=too-few-public-methods
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Union

--- a/featurebyte/models/feature_list.py
+++ b/featurebyte/models/feature_list.py
@@ -1,7 +1,6 @@
 """
 This module contains Feature list related models
 """
-# pylint: disable=too-few-public-methods
 from __future__ import annotations
 
 from typing import Any, List, Optional

--- a/featurebyte/models/feature_store.py
+++ b/featurebyte/models/feature_store.py
@@ -1,7 +1,6 @@
 """
 This module contains DatabaseSource related models
 """
-# pylint: disable=too-few-public-methods
 from __future__ import annotations
 
 from typing import Any, ClassVar, List, Literal, Optional, Union

--- a/featurebyte/models/item_data.py
+++ b/featurebyte/models/item_data.py
@@ -1,7 +1,6 @@
 """
 This module contains ItemData related models
 """
-# pylint: disable=too-few-public-methods
 from __future__ import annotations
 
 from typing import Any, Literal, Optional

--- a/featurebyte/models/relationship.py
+++ b/featurebyte/models/relationship.py
@@ -1,7 +1,6 @@
 """
 This module contains Relation mixin model
 """
-# pylint: disable=too-few-public-methods
 from typing import List
 
 from bson import ObjectId

--- a/featurebyte/models/semantic.py
+++ b/featurebyte/models/semantic.py
@@ -1,7 +1,6 @@
 """
 This module contains Semantic related models
 """
-# pylint: disable=too-few-public-methods
 from typing import List
 
 from featurebyte.models.base import UniqueValuesConstraint

--- a/featurebyte/query_graph/node/metadata/operation.py
+++ b/featurebyte/query_graph/node/metadata/operation.py
@@ -1,7 +1,6 @@
 """
 This module contains models used to store node output operation info
 """
-# pylint: disable=too-few-public-methods
 from typing import (
     Any,
     Dict,

--- a/featurebyte/query_graph/node/mixin.py
+++ b/featurebyte/query_graph/node/mixin.py
@@ -1,7 +1,6 @@
 """
 This module contains mixins used in node classes
 """
-# pylint: disable=too-few-public-methods
 from typing import Any, Dict, List, Set
 
 from abc import abstractmethod

--- a/featurebyte/query_graph/node/nested.py
+++ b/featurebyte/query_graph/node/nested.py
@@ -14,8 +14,6 @@ from featurebyte.query_graph.node.metadata.operation import NodeOutputCategory, 
 class NestedGraphMixin:
     """Mixin shared by nested graph related node"""
 
-    # pylint: disable=too-few-public-methods
-
     def _derive_node_operation_info(
         self, inputs: List[OperationStructure], visited_node_types: Set[NodeType]
     ) -> OperationStructure:

--- a/featurebyte/query_graph/sql/adapter.py
+++ b/featurebyte/query_graph/sql/adapter.py
@@ -1,7 +1,6 @@
 """
 Module for helper classes to generate engine specific SQL expressions
 """
-# pylint: disable=too-few-public-methods
 from __future__ import annotations
 
 from typing import Literal, Optional

--- a/featurebyte/query_graph/sql/builder.py
+++ b/featurebyte/query_graph/sql/builder.py
@@ -106,8 +106,6 @@ class SQLOperationGraph:
         Type of SQL to generate
     """
 
-    # pylint: disable=too-few-public-methods
-
     def __init__(
         self, query_graph: QueryGraphModel, sql_type: SQLType, source_type: SourceType
     ) -> None:

--- a/featurebyte/query_graph/sql/template.py
+++ b/featurebyte/query_graph/sql/template.py
@@ -13,7 +13,7 @@ from featurebyte.query_graph.sql.ast.literal import make_literal_value
 from featurebyte.query_graph.sql.common import sql_to_string
 
 
-class SqlExpressionTemplate:  # pylint: disable=too-few-public-methods
+class SqlExpressionTemplate:
     """
     Representation of a SQL template with placeholders
 

--- a/featurebyte/query_graph/transform/base.py
+++ b/featurebyte/query_graph/transform/base.py
@@ -17,8 +17,6 @@ QueryGraphT = TypeVar("QueryGraphT", bound=QueryGraphModel)
 class BaseGraphExtractor(Generic[ExtractorOutputT, BranchStateT, GlobalStateT]):
     """BaseGraphExtractor class"""
 
-    # pylint: disable=too-few-public-methods
-
     def __init__(self, graph: QueryGraphT):
         self.graph = graph
 

--- a/featurebyte/query_graph/transform/graph_pruning.py
+++ b/featurebyte/query_graph/transform/graph_pruning.py
@@ -35,8 +35,6 @@ class GraphPruningExtractor(
 ):
     """GraphPruningExtractor class"""
 
-    # pylint: disable=too-few-public-methods
-
     def _pre_compute(
         self,
         branch_state: GraphPruningBranchState,

--- a/featurebyte/query_graph/transform/operation_structure.py
+++ b/featurebyte/query_graph/transform/operation_structure.py
@@ -1,7 +1,6 @@
 """
 This module contains operation structure extraction related classes.
 """
-# pylint: disable=too-few-public-methods
 from typing import Any, Dict, List, Set, Tuple
 
 from pydantic import BaseModel, Field

--- a/featurebyte/query_graph/transformation.py
+++ b/featurebyte/query_graph/transformation.py
@@ -1,7 +1,6 @@
 """
 This module contains Query graph transformation related classes
 """
-# pylint: disable=too-few-public-methods
 from typing import Any, Dict, Type, TypeVar, cast
 
 from abc import abstractmethod

--- a/featurebyte/routes/temp_data/controller.py
+++ b/featurebyte/routes/temp_data/controller.py
@@ -13,7 +13,7 @@ from fastapi.responses import StreamingResponse
 from featurebyte.storage.base import Storage
 
 
-class TempDataController:  # pylint: disable=too-few-public-methods
+class TempDataController:
     """
     TempDataController
     """

--- a/featurebyte/schema/common/base.py
+++ b/featurebyte/schema/common/base.py
@@ -1,7 +1,6 @@
 """
 Base info related schema
 """
-# pylint: disable=too-few-public-methods
 from typing import Any, List, Optional
 
 from datetime import datetime

--- a/featurebyte/schema/entity.py
+++ b/featurebyte/schema/entity.py
@@ -1,7 +1,6 @@
 """
 Entity API payload schema
 """
-# pylint: disable=too-few-public-methods
 from __future__ import annotations
 
 from typing import List, Optional

--- a/featurebyte/schema/worker/task/base.py
+++ b/featurebyte/schema/worker/task/base.py
@@ -29,8 +29,6 @@ class BaseTaskPayload(FeatureByteBaseModel):
         Configurations for BaseTaskPayload
         """
 
-        # pylint: disable=too-few-public-methods
-
         # With `frozen` flag enable, all the object attributes are immutable.
         frozen = True
 

--- a/featurebyte/service/session_manager.py
+++ b/featurebyte/service/session_manager.py
@@ -18,8 +18,6 @@ class SessionManagerService:
     SessionManagerService class is responsible for retrieving a session manager.
     """
 
-    # pylint: disable=too-few-public-methods
-
     def __init__(self, user: Any, persistent: Persistent):
         self.user = user
         self.persistent = persistent

--- a/featurebyte/worker/progress.py
+++ b/featurebyte/worker/progress.py
@@ -1,7 +1,6 @@
 """
 This module contains Progress class which is used for tracking progress update
 """
-# pylint: disable=too-few-public-methods
 from __future__ import annotations
 
 from typing import Any, Optional

--- a/featurebyte/worker/task/base.py
+++ b/featurebyte/worker/task/base.py
@@ -19,8 +19,6 @@ class BaseTask:
     Base class for Task
     """
 
-    # pylint: disable=too-few-public-methods
-
     payload_class: type[BaseTaskPayload] = BaseTaskPayload
 
     def __init__(

--- a/featurebyte/worker/task_executor.py
+++ b/featurebyte/worker/task_executor.py
@@ -23,8 +23,6 @@ class TaskExecutor:
     TaskExecutor class
     """
 
-    # pylint: disable=too-few-public-methods
-
     command_type = WorkerCommand
 
     def __init__(self, payload: dict[str, Any], queue: Any, progress: Any = None) -> None:


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

Disable pylint `too-few-public-methods` warning globally.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
