### PR TITLE
feature_store/controller: mv persist to the end

### DIFF
--- a/tests/unit/routes/feature_store/test_controller.py
+++ b/tests/unit/routes/feature_store/test_controller.py
@@ -5,11 +5,14 @@ import shutil
 import tempfile
 from unittest.mock import patch
 
+import pytest
+
 from featurebyte.config import Configurations, LoggingSettings
 from featurebyte.models.credential import Credential, CredentialType, UsernamePasswordCredential
 
 
-def test_persist_credential(app_container):
+@pytest.mark.asyncio
+async def test_persist_credential(app_container):
     """
     Test persist credential has an update as expected
     """
@@ -40,7 +43,7 @@ def test_persist_credential(app_container):
         with patch("featurebyte.routes.feature_store.controller.Configurations") as mock_config:
             mock_config.return_value = config
             controller = app_container.feature_store_controller
-            did_update = controller.persist_credential(cred, feature_store_name)
+            did_update = await controller.persist_credentials_if_needed(cred, feature_store_name)
             assert did_update
 
         # Reload config


### PR DESCRIPTION
## Description
To simplify the code on the SaaS side, we'll move the persistence to the end of this block, after the feature store has been created. This way, we'll be able to just pass in the feature store ID for credential creation on the SaaS side. This is a no-op for the existing functionality.

Also renames the function to be more indicative that we'll only persist the configuration if needed.

See https://github.com/featurebyte/featurebyte-app/compare/jevon/updatesForValidation?expand=1 for implementation we'll be making on the SaaS side.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
