### PR TITLE
[FIX] Tagging workflow will fail if another PR is merged before completion

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -262,7 +262,7 @@ jobs:
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
         git tag "${PUBLISH_VERSION}"
-        git push origin --tags
+        git push origin "${PUBLISH_VERSION}"
 
         # Slack outputs
         export REPOSITORY=$(grep -oP '/\K.+' <<< $GITHUB_REPOSITORY)
@@ -294,10 +294,14 @@ jobs:
         # => filter by 1 month ago
         # => Convert ref/tags/ABC = :ref/tags/ABC
         # RUN: git push origin :ref/tags/ABC :ref/tags/BCD
-        git for-each-ref --format '%(creatordate:short) %(refname)' refs/tags |\
+        export ONE_MONTH_AGO_TAGS=$(git for-each-ref --format '%(creatordate:short) %(refname)' refs/tags |\
             awk "{ if (\$1 < $ONE_MONTH_AGO) print \$2; }" |\
-            sed -nE 's/refs\//:refs\//p' |\
-            xargs git push origin
+            sed -nE 's/refs\//:refs\//p')
+
+        # Only push if there are tags to remove
+        if [[ "${ONE_MONTH_AGO_TAGS}" != "" ]]; then
+            git push origin ${ONE_MONTH_AGO_TAGS}
+        fi
 
     - name: Slack Message Pull Request
       if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Description

+ An error occurs when main is updated before the whole merge workflow has completed

Refer to: 
https://github.com/featurebyte/featurebyte/actions/runs/3636508552/jobs/6136565337

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
