### PR TITLE
utils/credential: move to a class

### DIFF
--- a/featurebyte/app.py
+++ b/featurebyte/app.py
@@ -25,7 +25,7 @@ import featurebyte.routes.temp_data.api as temp_data_api
 from featurebyte.middleware import request_handler
 from featurebyte.routes.app_container import AppContainer
 from featurebyte.service.task_manager import TaskManager
-from featurebyte.utils.credential import get_credential
+from featurebyte.utils.credential import ConfigCredentialProvider
 from featurebyte.utils.persistent import get_persistent
 from featurebyte.utils.storage import get_storage, get_temp_storage
 
@@ -60,7 +60,7 @@ def _get_api_deps() -> Callable[[Request], None]:
 
         request.state.persistent = get_persistent()
         request.state.user = User()
-        request.state.get_credential = get_credential
+        request.state.get_credential = ConfigCredentialProvider().get_credential
         request.state.get_storage = get_storage
         request.state.get_temp_storage = get_temp_storage
 

--- a/featurebyte/utils/credential.py
+++ b/featurebyte/utils/credential.py
@@ -3,15 +3,56 @@ Utility functions for credential management
 """
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
+
 from bson.objectid import ObjectId
 
 from featurebyte.config import Configurations
 from featurebyte.models.credential import Credential
 
 
+class CredentialProvider(ABC):
+    """
+    CredentialProvider is the base class for users to get credentials.
+    """
+
+    @abstractmethod
+    async def get_credential(
+        self, user_id: ObjectId | None, feature_store_name: str
+    ) -> Credential | None:
+        """
+        Retrieve credentials from some persistent source.
+
+        Parameters
+        ----------
+        user_id: ObjectId | None
+            User ID
+        feature_store_name: str
+            FeatureStore name
+
+        Returns
+        -------
+        Credential
+            Credential for the database source
+        """
+
+
+class ConfigCredentialProvider(CredentialProvider):
+    """
+    ConfigCredentialProvider will retrieve the users credentials from a configuration file.
+    """
+
+    async def get_credential(
+        self, user_id: ObjectId | None, feature_store_name: str
+    ) -> Credential | None:
+        _ = user_id
+        config = Configurations()
+        return config.credentials.get(feature_store_name)
+
+
 async def get_credential(user_id: ObjectId | None, feature_store_name: str) -> Credential | None:
     """
-    Retrieve credential from FeatureStoreModel
+    Delegate to the ConfigCredentialProvider. We will look to deprecate direct access to this function in the future.
 
     Parameters
     ----------
@@ -25,6 +66,5 @@ async def get_credential(user_id: ObjectId | None, feature_store_name: str) -> C
     Credential
         Credential for the database source
     """
-    _ = user_id
-    config = Configurations()
-    return config.credentials.get(feature_store_name)
+    credential_provider = ConfigCredentialProvider()
+    return await credential_provider.get_credential(user_id, feature_store_name)


### PR DESCRIPTION
## Description
This commit moves the `get_credential` function into an interface. This will allow us to have better encapsulation/overriding when we need a different implementation (eg. in the SaaS version).

Eventually, we can move away from passing the get_credential handler via the request.state.get_credential function, since this functionality is not request scoped. This would then simplify some of the code paths.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
