### PR TITLE
api/view: add descriptive error message to joins with repeated col names

### DIFF
--- a/featurebyte/api/view.py
+++ b/featurebyte/api/view.py
@@ -370,7 +370,14 @@ class View(ProtectedColumnsQueryObject, Frame, ABC):
         if is_column_name_in_columns(other_join_key, self.columns_info):
             return other_join_key, other_join_key
 
-        raise NoJoinKeyFoundError
+        raise NoJoinKeyFoundError(
+            "Unable to automatically find a default join column key based on:\n"
+            "- matching entities, or\n"
+            f"- the join column '{other_join_key}' in the target view as it is not present in the"
+            f" calling view\n"
+            f"Please consider adding the `on` parameter in `join()` to explicitly specify a "
+            f"column to join on."
+        )
 
     def _validate_join(
         self,
@@ -421,7 +428,10 @@ class View(ProtectedColumnsQueryObject, Frame, ABC):
         if on is not None:
             current_column_names = {col.name for col in self.columns_info}
             if on not in current_column_names:
-                raise NoJoinKeyFoundError
+                raise NoJoinKeyFoundError(
+                    f"The `on` column name provided '{on}' is not found in the calling view. "
+                    f"Please pick a valid column name from {current_column_names} to join on."
+                )
 
         # Perform other validation
         self.validate_join(other_view)

--- a/tests/unit/api/test_view.py
+++ b/tests/unit/api/test_view.py
@@ -399,8 +399,9 @@ def test_validate_join__no_overlapping_columns():
     view_without_overlap = SimpleTestView(columns_info=[col_info_c], join_col=col_info_c.name)
 
     # joining two views with no overlapping columns should have an error
-    with pytest.raises(NoJoinKeyFoundError):
+    with pytest.raises(NoJoinKeyFoundError) as exc_info:
         base_view._validate_join(view_without_overlap)
+    assert "Unable to automatically find a default join column key" in str(exc_info)
 
     # no overlap should have no error with suffix, since we'll use primary keys to join
     base_view._validate_join(view_without_overlap, rsuffix="suffix")
@@ -480,5 +481,6 @@ def test_validate_join__check_on_column():
     base_view._validate_join(other_view, on=col_info_a.name, rsuffix="_suffix")
 
     # `on` provided for column not in calling view should have an error
-    with pytest.raises(NoJoinKeyFoundError):
+    with pytest.raises(NoJoinKeyFoundError) as exc_info:
         base_view._validate_join(other_view, on=col_info_c.name, rsuffix="_suffix")
+    assert "The `on` column name provided 'colC' is not found in the calling view" in str(exc_info)


### PR DESCRIPTION
## Description
Add a more descriptive error message to allow users to get a better understanding of the issue when they encounter this error.

Example
![Screenshot 2022-12-08 at 10 55 21 AM](https://user-images.githubusercontent.com/2313101/206345039-0c1ca743-c47e-4325-9242-c63ecebbf0d0.png)


<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
