### PR TITLE
Clean up online enabled feature lists as soon as possible in integration tests

### DIFF
--- a/featurebyte/models/tile.py
+++ b/featurebyte/models/tile.py
@@ -40,7 +40,7 @@ class TileSpec(FeatureByteBaseModel):
 
     time_modulo_frequency_second: int = Field(ge=0)
     blind_spot_second: int
-    frequency_minute: int = Field(gt=0)
+    frequency_minute: int = Field(gt=0, le=60)
     tile_sql: str
     entity_column_names: List[str]
     value_column_names: List[str]

--- a/tests/integration/api/test_online_enable.py
+++ b/tests/integration/api/test_online_enable.py
@@ -25,11 +25,6 @@ def online_enabled_feature_list_fixture(event_data, config):
         method="sum",
         windows=["24h"],
         feature_names=["FEATURE_FOR_ONLINE_ENABLE_TESTING"],
-        feature_job_setting={
-            "frequency": "7d",
-            "time_modulo_frequency": "0s",
-            "blind_spot": "1h",
-        },
     )
     features = [feature_group["FEATURE_FOR_ONLINE_ENABLE_TESTING"]]
     for feature in features:

--- a/tests/integration/query_graph/test_online_serving.py
+++ b/tests/integration/query_graph/test_online_serving.py
@@ -28,21 +28,11 @@ def features_fixture(event_data):
         method="sum",
         windows=["2h", "24h"],
         feature_names=["AMOUNT_SUM_2h", "AMOUNT_SUM_24h"],
-        feature_job_setting={
-            "frequency": "7d",
-            "time_modulo_frequency": "0s",
-            "blind_spot": "1h",
-        },
     )
     feature_group_dict = event_view.groupby("USER ID", category="PRODUCT_ACTION").aggregate_over(
         method="count",
         windows=["24h"],
         feature_names=["EVENT_COUNT_BY_ACTION_24h"],
-        feature_job_setting={
-            "frequency": "7d",
-            "time_modulo_frequency": "0s",
-            "blind_spot": "1h",
-        },
     )
     features = [
         feature_group["AMOUNT_SUM_2h"],


### PR DESCRIPTION
## Description

I noticed occasional high resource usage on the COMPUTE_WH warehouse even when no PR tests are running:

<img width="1749" alt="image" src="https://user-images.githubusercontent.com/2175543/206518735-7483affb-76fa-4d52-ba61-c4f21edfea97.png">

While integration tests ideally always drop the testing schema on teardown and therefore delete any scheduled tasks, sometimes the clean up doesn't happen properly when test suite is terminated abruptly. The above high usage might be caused by online enabled features in integration tests not being cleaned up.

This might explain the instability and timeouts we observed with Snowflake in integration tests recently. 

This PR makes some updates to online serving related integration tests to perform clean up as soon as possible, instead of waiting until the end of the test session. This should reduce the possibility of orphaned scheduled tasks.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
