### PR TITLE
feature_store/controller: await get cred

### DIFF
--- a/featurebyte/routes/feature_store/controller.py
+++ b/featurebyte/routes/feature_store/controller.py
@@ -124,7 +124,7 @@ class FeatureStoreController(
             creds_from_params = data.credentials
             if creds_from_params is not None:
 
-                def _updated_get_credential(user_id: str, feature_store_name: str) -> Any:
+                async def _updated_get_credential(user_id: str, feature_store_name: str) -> Any:
                     """
                     Updated get_credential will try to look up the credentials from config.
 


### PR DESCRIPTION
## Description
We need to await this response here. Otherwise, this will always return the coroutine as a result of the _updated_get_credential call, resulting in strange behaviour.

DIscovered when trying to integrate the frontend with these changes as part of this PR - https://github.com/featurebyte/frontend/pull/79

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
