### PR TITLE
Ignore vulnerability GHSA-hcpj-qp55-gfph temporarily (gitpython)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ lint-type:
 
 lint-safety: generate-requirements-file
 	poetry run pip-licenses --packages $(shell cut -d= -f 1 requirements.txt | grep -v "\--" | tr "\n" " ") --allow-only=${PERMISSIVE_LICENSES}
-	poetry run pip-audit
+	poetry run pip-audit --ignore-vul GHSA-hcpj-qp55-gfph
 	poetry run bandit -c pyproject.toml -ll --recursive featurebyte
 #* Testing
 test: test-setup


### PR DESCRIPTION
## Description

Temporarily ignore vulnerability `GHSA-hcpj-qp55-gfph` for gitpython until patch is released upstream.

Details: https://github.com/advisories/GHSA-hcpj-qp55-gfph

Currently failing `lint-safety`: https://github.com/featurebyte/featurebyte/actions/runs/3705395490/jobs/6279252794

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
