### PR TITLE
[DEV-903] Track primary keys for SCD and Dimension tables

### DIFF
--- a/featurebyte/service/data_update.py
+++ b/featurebyte/service/data_update.py
@@ -176,7 +176,8 @@ class DataUpdateService(BaseService):
         # update data references in affected entities
         primary_keys_cols_mapping = {
             TableDataType.EVENT_DATA: ["event_id_column"],
-            TableDataType.ITEM_DATA: [],
+            TableDataType.ITEM_DATA: ["item_id_column"],
+            TableDataType.SCD_DATA: ["surrogate_key_column"],
             TableDataType.DIMENSION_DATA: ["dimension_data_id_column"],
         }
         primary_keys_cols = cast(List[str], primary_keys_cols_mapping.get(document.type, []))

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -219,21 +219,6 @@ def saved_scd_data_fixture(snowflake_feature_store, snowflake_scd_data):
     yield snowflake_scd_data
 
 
-@pytest.fixture(name="snowflake_database_table_item_data")
-def snowflake_database_table_item_data_fixture(
-    snowflake_connector, snowflake_execute_query, snowflake_feature_store
-):
-    """
-    DatabaseTable object fixture for ItemData (using config object)
-    """
-    _ = snowflake_connector, snowflake_execute_query
-    yield snowflake_feature_store.get_table(
-        database_name="sf_database",
-        schema_name="sf_schema",
-        table_name="items_table",
-    )
-
-
 @pytest.fixture(name="snowflake_item_data")
 def snowflake_item_data_fixture(
     snowflake_database_table_item_data,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -289,6 +289,21 @@ def snowflake_database_table_fixture(
     yield snowflake_table
 
 
+@pytest.fixture(name="snowflake_database_table_item_data")
+def snowflake_database_table_item_data_fixture(
+    snowflake_connector, snowflake_execute_query, snowflake_feature_store
+):
+    """
+    DatabaseTable object fixture for ItemData (using config object)
+    """
+    _ = snowflake_connector, snowflake_execute_query
+    yield snowflake_feature_store.get_table(
+        database_name="sf_database",
+        schema_name="sf_schema",
+        table_name="items_table",
+    )
+
+
 @pytest.fixture(name="snowflake_dimension_data_id")
 def snowflake_dimension_data_id_fixture():
     """Snowflake dimension data ID"""
@@ -365,11 +380,13 @@ def snowflake_item_data_fixture(
     mock_get_persistent,
     snowflake_item_data_id,
     snowflake_event_data,
+    snowflake_feature_store,
 ):
     """
     Snowflake ItemData object fixture
     """
     _ = mock_get_persistent
+    snowflake_feature_store.save(conflict_resolution="retrieve")
     snowflake_event_data.save()
     yield ItemData.from_tabular_source(
         tabular_source=snowflake_database_table_item_data,


### PR DESCRIPTION
## Description

Fixes bug where primary keys in SCD and Dimension data is not tracked in entity collection

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-903

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
