### PR TITLE
feature_store/controller: allow validation to be done

### DIFF
--- a/featurebyte/routes/feature_store/controller.py
+++ b/featurebyte/routes/feature_store/controller.py
@@ -89,8 +89,6 @@ class FeatureStoreController(
             FeatureStore creation payload
         get_credential: Any
             credential handler function
-        skip_validation: bool
-            decide whether to skip validation
 
         Returns
         -------


### PR DESCRIPTION
## Description
We've now made the changes to the frontend, and have tested end-to-end. This will allow us to perform validation when we create a feature store.

Frontend change here - https://github.com/featurebyte/frontend/pull/79

Note that this change does _not_ need to be deployed at the same time as the frontend. It just needs to be deployed at any point after the frontend changes have been rolled out. Otherwise, trying to create a feature store via the SaaS UI will fail.

The final PR of my starter task :)

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
