### PR TITLE
[DEV-909] api/*_data: use PrettyDict in info endpoint

### DIFF
--- a/featurebyte/api/dimension_data.py
+++ b/featurebyte/api/dimension_data.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional
 from bson.objectid import ObjectId
 from typeguard import typechecked
 
+from featurebyte.api.api_object import PrettyDict
 from featurebyte.api.data import DataApiObject
 from featurebyte.api.database_table import DatabaseTable
 from featurebyte.common.doc_util import FBAutoDoc
@@ -68,7 +69,7 @@ class DimensionData(DimensionDataModel, DataApiObject):
 
     def info(self, verbose: bool = False) -> Dict[str, Any]:
         """
-        Provide baisc info for the dimension data.
+        Provide basic info for the dimension data.
 
         Parameters
         ----------
@@ -79,12 +80,14 @@ class DimensionData(DimensionDataModel, DataApiObject):
         -------
         Dict[str, Any]
         """
-        return {
-            "name": self.name,
-            "record_creation_date_column": self.record_creation_date_column,
-            "updated_at": self.updated_at,
-            "status": self.status,
-            "entities": self.entity_ids,
-            "tabular_source": self.tabular_source,
-            "dimension_data_id_column": self.dimension_data_id_column,
-        }
+        return PrettyDict(
+            {
+                "name": self.name,
+                "record_creation_date_column": self.record_creation_date_column,
+                "updated_at": self.updated_at,
+                "status": self.status,
+                "entities": self.entity_ids,
+                "tabular_source": self.tabular_source,
+                "dimension_data_id_column": self.dimension_data_id_column,
+            }
+        )

--- a/featurebyte/api/item_data.py
+++ b/featurebyte/api/item_data.py
@@ -9,6 +9,7 @@ from bson.objectid import ObjectId
 from pydantic import Field, root_validator
 from typeguard import typechecked
 
+from featurebyte.api.api_object import PrettyDict
 from featurebyte.api.data import DataApiObject
 from featurebyte.api.database_table import DatabaseTable
 from featurebyte.api.event_data import EventData
@@ -122,13 +123,15 @@ class ItemData(ItemDataModel, DataApiObject):
         -------
         Dict[str, Any]
         """
-        return {
-            "name": self.name,
-            "record_creation_date_column": self.record_creation_date_column,
-            "updated_at": self.updated_at,
-            "status": self.status,
-            "tabular_source": self.tabular_source,
-            "event_id_column": self.event_id_column,
-            "item_id_column": self.item_id_column,
-            "entities": self.entity_ids,
-        }
+        return PrettyDict(
+            {
+                "name": self.name,
+                "record_creation_date_column": self.record_creation_date_column,
+                "updated_at": self.updated_at,
+                "status": self.status,
+                "tabular_source": self.tabular_source,
+                "event_id_column": self.event_id_column,
+                "item_id_column": self.item_id_column,
+                "entities": self.entity_ids,
+            }
+        )

--- a/featurebyte/api/scd_data.py
+++ b/featurebyte/api/scd_data.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional
 from bson.objectid import ObjectId
 from typeguard import typechecked
 
+from featurebyte.api.api_object import PrettyDict
 from featurebyte.api.data import DataApiObject
 from featurebyte.api.database_table import DatabaseTable
 from featurebyte.common.doc_util import FBAutoDoc
@@ -106,16 +107,18 @@ class SlowlyChangingData(SCDDataModel, DataApiObject):
         -------
         Dict[str, Any]
         """
-        return {
-            "name": self.name,
-            "record_creation_date_column": self.record_creation_date_column,
-            "updated_at": self.updated_at,
-            "status": self.status,
-            "entities": self.entity_ids,
-            "natural_key_column": self.natural_key_column,
-            "surrogate_key_column": self.surrogate_key_column,
-            "effective_timestamp_column": self.effective_timestamp_column,
-            "end_timestamp_column": self.end_timestamp_column,
-            "current_flag_column": self.current_flag_column,
-            "tabular_source": self.tabular_source,
-        }
+        return PrettyDict(
+            {
+                "name": self.name,
+                "record_creation_date_column": self.record_creation_date_column,
+                "updated_at": self.updated_at,
+                "status": self.status,
+                "entities": self.entity_ids,
+                "natural_key_column": self.natural_key_column,
+                "surrogate_key_column": self.surrogate_key_column,
+                "effective_timestamp_column": self.effective_timestamp_column,
+                "end_timestamp_column": self.end_timestamp_column,
+                "current_flag_column": self.current_flag_column,
+                "tabular_source": self.tabular_source,
+            }
+        )


### PR DESCRIPTION
## Description
Minor cleanup to use PrettyDict for better info printing.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-909
<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
