### PR TITLE
[DEV-921] Include deployment information in feature and featurelist list output

### DIFF
--- a/featurebyte/api/feature.py
+++ b/featurebyte/api/feature.py
@@ -52,11 +52,28 @@ class FeatureNamespace(FeatureNamespaceModel, ApiObject):
     _route = "/feature_namespace"
     _update_schema_class = FeatureNamespaceUpdate
     _list_schema = FeatureNamespaceModel
-    _list_fields = ["name", "dtype", "readiness", "data", "entities", "created_at"]
+    _list_fields = [
+        "name",
+        "dtype",
+        "readiness",
+        "online_enabled",
+        "data",
+        "entities",
+        "created_at",
+    ]
     _list_foreign_keys = [
         ("entity_ids", Entity, "entities"),
         ("tabular_data_ids", DataApiObject, "data"),
     ]
+
+    @classmethod
+    def _post_process_list(cls, item_list: pd.DataFrame) -> pd.DataFrame:
+        features = super()._post_process_list(item_list)
+        # add online_enabled
+        features["online_enabled"] = features[
+            ["default_feature_id", "online_enabled_feature_ids"]
+        ].apply(lambda row: row[0] in row[1], axis=1)
+        return features
 
     @classmethod
     def list(

--- a/featurebyte/api/feature_list.py
+++ b/featurebyte/api/feature_list.py
@@ -294,6 +294,7 @@ class FeatureListNamespace(FeatureListNamespaceModel, ApiObject):
         "name",
         "num_features",
         "status",
+        "deployed",
         "readiness_frac",
         "online_frac",
         "data",
@@ -312,7 +313,7 @@ class FeatureListNamespace(FeatureListNamespaceModel, ApiObject):
         # add information about default feature list version
         feature_list_versions = FeatureList.list_versions(include_id=True)
         feature_lists = feature_lists.merge(
-            feature_list_versions[["id", "online_frac"]],
+            feature_list_versions[["id", "online_frac", "deployed"]],
             left_on="default_feature_list_id",
             right_on="id",
         )
@@ -390,6 +391,7 @@ class FeatureList(BaseFeatureGroup, FeatureListModel, SavableApiObject):
         "feature_list_namespace_id",
         "num_features",
         "online_frac",
+        "deployed",
         "created_at",
     ]
 

--- a/tests/unit/api/test_feature.py
+++ b/tests/unit/api/test_feature.py
@@ -21,10 +21,8 @@ from featurebyte.exception import (
 )
 from featurebyte.models.event_data import FeatureJobSetting
 from featurebyte.models.feature import DefaultVersionMode, FeatureReadiness
-from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.graph import GlobalQueryGraph
 from featurebyte.query_graph.model.graph import QueryGraphModel
-from featurebyte.query_graph.node.generic import GroupbyNode, ItemGroupbyNode
 from featurebyte.query_graph.node.metadata.operation import GroupOperationStructure
 from tests.util.helper import get_node
 
@@ -277,6 +275,7 @@ def saved_feature_fixture(
                 "name": [float_feature_namespace.name],
                 "dtype": [float_feature_namespace.dtype],
                 "readiness": [float_feature_namespace.readiness],
+                "online_enabled": [float_feature.online_enabled],
                 "data": [["sf_event_data"]],
                 "entities": [["customer"]],
                 "created_at": [float_feature_namespace.created_at],

--- a/tests/unit/api/test_feature_list.py
+++ b/tests/unit/api/test_feature_list.py
@@ -554,6 +554,7 @@ def test_list(saved_feature_list):
                 "name": [saved_feature_list_namespace.name],
                 "num_features": 1,
                 "status": [saved_feature_list_namespace.status],
+                "deployed": [saved_feature_list.deployed],
                 "readiness_frac": 0.0,
                 "online_frac": 0.0,
                 "data": [["sf_event_data"]],
@@ -575,6 +576,7 @@ def test_list_versions(saved_feature_list):
                 "feature_list_namespace_id": [saved_feature_list.feature_list_namespace.id],
                 "num_features": 1,
                 "online_frac": 0.0,
+                "deployed": [saved_feature_list.deployed],
                 "created_at": [saved_feature_list.created_at],
             }
         ),


### PR DESCRIPTION
## Description

Current `list` output of Feature and FeatureList API objects do not reflect deployment and online_enabled statuses.
These are added in this PR.

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-921

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
