### PR TITLE
change_view: add update_default_feature_job_setting

### DIFF
--- a/featurebyte/api/change_view.py
+++ b/featurebyte/api/change_view.py
@@ -39,7 +39,7 @@ class ChangeView(View, GroupByMixin):
 
     _series_class = ChangeViewColumn
 
-    default_feature_job_setting: FeatureJobSetting = Field(allow_mutation=False)
+    default_feature_job_setting: FeatureJobSetting
     effective_timestamp_column: str = Field(allow_mutation=False)
     natural_key_column: str = Field(allow_mutation=False)
 
@@ -245,6 +245,18 @@ class ChangeView(View, GroupByMixin):
             ]
         ]  # type: ignore
         return change_view
+
+    @typechecked
+    def update_default_feature_job_setting(self, feature_job_setting: FeatureJobSetting) -> None:
+        """
+        Update default feature job setting
+
+        Parameters
+        ----------
+        feature_job_setting: FeatureJobSetting
+            Feature job setting
+        """
+        self.default_feature_job_setting = feature_job_setting
 
     @staticmethod
     def get_default_feature_job_setting(

--- a/tests/unit/api/test_change_view.py
+++ b/tests/unit/api/test_change_view.py
@@ -144,3 +144,19 @@ def test_from_scd_data__with_default_job_setting(snowflake_scd_data):
     change_view = ChangeView.from_scd_data(snowflake_scd_data, "col_int", job_setting_provided)
     assert change_view.default_feature_job_setting == job_setting_provided
     change_view_test_helper(snowflake_scd_data, change_view)
+
+
+def test_update_feature_job_setting(snowflake_change_view):
+    """
+    Test update feature job setting
+    """
+    # Assert that a feature job setting exists
+    assert snowflake_change_view.default_feature_job_setting is not None
+
+    new_feature_job_setting = FeatureJobSetting(
+        blind_spot="15m",
+        time_modulo_frequency="30m",
+        frequency="1h",
+    )
+    snowflake_change_view.update_default_feature_job_setting(new_feature_job_setting)
+    assert snowflake_change_view.default_feature_job_setting == new_feature_job_setting


### PR DESCRIPTION
## Description
This method was included in the spec, and I accidentally removed it from the previous PR. This adds it back.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/wiki/spaces/DEV/pages/34734081/Change+View+from+SCD+Data

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
