### PR TITLE
core/frame: add docstring for column_lineage_map

### DIFF
--- a/featurebyte/core/frame.py
+++ b/featurebyte/core/frame.py
@@ -22,6 +22,18 @@ from featurebyte.query_graph.util import append_to_lineage
 class BaseFrame(QueryObject, SampleMixin):
     """
     BaseFrame class
+
+    Parameters
+    ----------
+    columns_info: List[ColumnInfo]
+        List of column specifications that are contained in this frame.
+    column_lineage_map: Dict[str, Tuple[str, ...]]
+        Column lineage map tracks a mapping of a column name, to a tuple of node names that have caused the values in a
+        column to have changed. This could include situations where
+        - the number of rows are decreasing in a column due to a selection (eg. select col_a from table(col_a, col_b))
+        - changing the values through an assignment (eg. col["a"] = col["b"])
+        - we apply an operation to update the value (eg. col["a"] = col["a"] + 123)
+        This is used to help us optimize some logic to not create nodes unnecessarily.
     """
 
     columns_info: List[ColumnInfo] = Field(description="List of columns specifications")


### PR DESCRIPTION
## Description
I was a little confused when trying to update these parmaeters, and thus am including a docstring to hopefully make it clearer for the future.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
