### PR TITLE
Use tempfile to create non existent path to ensure cleanup in test

### DIFF
--- a/tests/unit/session/test_manager.py
+++ b/tests/unit/session/test_manager.py
@@ -1,6 +1,8 @@
 """
 Tests for SessionManager class
 """
+import os
+import tempfile
 from unittest.mock import Mock, patch
 
 import pytest
@@ -102,10 +104,12 @@ async def test_session_manager__wrong_configuration_file(snowflake_feature_store
     """
     Test exception raised when wrong configuration file is used
     """
-    config = Configurations("non/existent/path")
-    session_manager = SessionManager(credentials=config.credentials)
-    with pytest.raises(ValueError) as exc:
-        _ = await session_manager.get_session(snowflake_feature_store)
-    assert 'Credentials do not contain info for the feature store "sf_featurestore"' in str(
-        exc.value
-    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+        non_existent_path = os.path.join(temp_dir, "non", "existent", "path")
+        config = Configurations(non_existent_path)
+        session_manager = SessionManager(credentials=config.credentials)
+        with pytest.raises(ValueError) as exc:
+            _ = await session_manager.get_session(snowflake_feature_store)
+        assert 'Credentials do not contain info for the feature store "sf_featurestore"' in str(
+            exc.value
+        )


### PR DESCRIPTION
## Description

This test `test_session_manager__wrong_configuration_file` creates a file in `non/existent/path` but never removes it after the test is done. This updates it to use tempfile module to ensure proper clean up.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
