### PR TITLE
[DEV-961] core/util: extract series binary operaator

### DIFF
--- a/featurebyte/core/accessor/count_dict.py
+++ b/featurebyte/core/accessor/count_dict.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 from typeguard import typechecked
 
 from featurebyte.common.doc_util import FBAutoDoc
-from featurebyte.core.util import series_binary_operation, series_unary_operation
+from featurebyte.core.util import SeriesBinaryOperator, series_unary_operation
 from featurebyte.enum import DBVarType
 from featurebyte.query_graph.enum import NodeType
 
@@ -33,6 +33,29 @@ class CdAccessorMixin:
         CountDictAccessor
         """
         return CountDictAccessor(self)
+
+
+class CountDictSeriesOperator(SeriesBinaryOperator):
+    """
+    CountDict series operator that has specialized handling for input validation.
+    """
+
+    def validate_inputs(self) -> None:
+        """
+        Validate the input series, and other parameter.
+
+        Raises
+        ------
+        TypeError
+            If the the current or the other Feature is not of dictionary type
+        """
+        if not isinstance(self.other, type(self.input_series)):
+            raise TypeError(f"cosine_similarity is only available for Feature; got {self.other}")
+        if self.other.dtype != DBVarType.OBJECT:
+            raise TypeError(
+                f"cosine_similarity is only available for Feature of dictionary type; got "
+                f"{self.other.dtype}"
+            )
 
 
 class CountDictAccessor:
@@ -121,22 +144,9 @@ class CountDictAccessor:
         Returns
         -------
         Feature
-
-        Raises
-        ------
-        TypeError
-            If the the current or the other Feature is not of dictionary type
         """
-        if not isinstance(other, type(self._obj)):
-            raise TypeError(f"cosine_similarity is only available for Feature; got {other}")
-        if other.dtype != DBVarType.OBJECT:
-            raise TypeError(
-                f"cosine_similarity is only available for Feature of dictionary type; got "
-                f"{other.dtype}"
-            )
-        return series_binary_operation(
-            input_series=self._obj,
-            other=other,
+        series_operator = CountDictSeriesOperator(self._obj, other)
+        return series_operator.operate(
             node_type=NodeType.COSINE_SIMILARITY,
             output_var_type=DBVarType.FLOAT,
             **self._obj.binary_op_series_params(),

--- a/featurebyte/core/util.py
+++ b/featurebyte/core/util.py
@@ -57,6 +57,63 @@ def series_unary_operation(
     )
 
 
+class SeriesBinaryOperator:
+    """
+    Perform a binary operation between a Series, and another value.
+    """
+
+    def __init__(self, input_series: SeriesT, other: int | float | str | bool | SeriesT):
+        self.input_series = input_series
+        self.other = other
+
+    def validate_inputs(self) -> None:
+        """
+        Validate the input series, and other parameter.
+
+        Override this for any custom validation that is needed.
+        """
+        return
+
+    def operate(
+        self,
+        node_type: NodeType,
+        output_var_type: DBVarType,
+        right_op: bool = False,
+        additional_node_params: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> SeriesT:
+        """
+        Perform the series binary operation.
+
+        Parameters
+        ----------
+        node_type: NodeType
+            binary operator node type
+        output_var_type: DBVarType
+            output of the variable type
+        right_op: bool
+            whether the binary operation is from right object or not
+        additional_node_params: dict[str, Any] | None
+            additional parameters to include as node parameters
+        kwargs : Any
+            Other series parameters
+
+        Returns
+        -------
+        SeriesT
+        """
+        self.validate_inputs()
+        return series_binary_operation(
+            input_series=self.input_series,
+            other=self.other,
+            node_type=node_type,
+            output_var_type=output_var_type,
+            right_op=right_op,
+            additional_node_params=additional_node_params,
+            **kwargs,
+        )
+
+
 def series_binary_operation(
     input_series: SeriesT,
     other: int | float | str | bool | SeriesT,


### PR DESCRIPTION
## Description
Refactor the series binary operator into a class to allow for extensibility. Also refactors a couple of the callers to move validation into this operator class.

This will help us add some validation as part of the work to enable us to derive features from multiple features.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-961

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
