### PR TITLE
Fix combine_column_info_of_views logic when filtering on empty set

### DIFF
--- a/featurebyte/api/join_utils.py
+++ b/featurebyte/api/join_utils.py
@@ -102,7 +102,7 @@ def combine_column_info_of_views(
     """
     Combine two column info views.
 
-    If the filter_set provided is empty / not overridden, we'll not do any filtering.
+    If the filter_set is not provided, we'll not do any filtering.
 
     Parameters
     ----------
@@ -110,7 +110,7 @@ def combine_column_info_of_views(
         one list of columns
     columns_b: List[ColumnInfo]
         another list of columns
-    filter_set: Set[str]
+    filter_set: Optional[Set[str]]
         column names to filter columns_b on
 
     Returns
@@ -118,11 +118,10 @@ def combine_column_info_of_views(
     List[ColumnInfo]
         combined columns
     """
-    if filter_set is None:
-        filter_set = set()
     joined_columns_info = copy.deepcopy(columns_a)
+    columns_b = copy.deepcopy(columns_b)
     for column_info in columns_b:
-        if len(filter_set) == 0 or column_info.name in filter_set:
+        if filter_set is None or column_info.name in filter_set:
             joined_columns_info.append(column_info)
     return joined_columns_info
 

--- a/tests/unit/api/test_join_utils.py
+++ b/tests/unit/api/test_join_utils.py
@@ -173,10 +173,6 @@ def test_combine_column_info_of_views():
     result = combine_column_info_of_views(columns_a, columns_b, filter_set={col1.name})
     assert result == [col1, col2, col3]
 
-    # test that passing an empty filter set doesn't perform any filtering
-    result = combine_column_info_of_views(columns_a, columns_b, filter_set=set())
-    assert result == [col1, col2, col3, col4, col5, col6]
-
 
 def test_is_column_name_in_columns():
     """


### PR DESCRIPTION
## Description

I think skipping the filtering on empty set is not the intended behaviour.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
