### PR TITLE
api/base_view_test: lazily instantiate fixtures

### DIFF
--- a/tests/unit/api/base_view_test.py
+++ b/tests/unit/api/base_view_test.py
@@ -34,24 +34,19 @@ class BaseViewTestSuite:
     bool_col = col
 
     @pytest.fixture(name="view_under_test")
-    def get_view_under_test_fixture(
-        self,
-        snowflake_event_view,
-        snowflake_item_view,
-        snowflake_dimension_view,
-        snowflake_scd_view,
-    ):
+    def get_view_under_test_fixture(self, request):
         view_type_map = {
-            ViewType.DIMENSION_VIEW: snowflake_dimension_view,
-            ViewType.EVENT_VIEW: snowflake_event_view,
-            ViewType.ITEM_VIEW: snowflake_item_view,
-            ViewType.SLOWLY_CHANGING_VIEW: snowflake_scd_view,
+            ViewType.DIMENSION_VIEW: "snowflake_dimension_view",
+            ViewType.EVENT_VIEW: "snowflake_event_view",
+            ViewType.ITEM_VIEW: "snowflake_item_view",
+            ViewType.SLOWLY_CHANGING_VIEW: "snowflake_scd_view",
         }
         if self.view_type not in view_type_map:
             pytest.fail(
                 f"Invalid view type `{self.view_type}` found. Please use (or map) a valid ViewType."
             )
-        return view_type_map[self.view_type]
+        view_name = view_type_map[self.view_type]
+        return request.getfixturevalue(view_name)
 
     @pytest.fixture(name="data_under_test")
     def get_data_under_test_fixture(self, request):

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -171,11 +171,13 @@ def snowflake_item_data_fixture(
     snowflake_item_data_id,
     saved_event_data,
     cust_id_entity,
+    arbitrary_default_feature_job_setting,
 ):
     """
     Snowflake ItemData object fixture (using config object)
     """
     _ = mock_get_persistent
+    saved_event_data.update_default_feature_job_setting(arbitrary_default_feature_job_setting)
     saved_event_data["cust_id"].as_entity(cust_id_entity.name)
     item_data = ItemData.from_tabular_source(
         tabular_source=snowflake_database_table_item_data,
@@ -242,17 +244,15 @@ def snowflake_change_view(snowflake_scd_data):
 
 
 @pytest.fixture(name="snowflake_event_view")
-def snowflake_event_view_fixture(snowflake_event_data, config):
+def snowflake_event_view_fixture(
+    snowflake_event_data, config, arbitrary_default_feature_job_setting
+):
     """
     EventData object fixture
     """
     _ = config
     snowflake_event_data.update_default_feature_job_setting(
-        feature_job_setting=FeatureJobSetting(
-            blind_spot="1m30s",
-            frequency="6m",
-            time_modulo_frequency="3m",
-        )
+        feature_job_setting=arbitrary_default_feature_job_setting
     )
     event_view = EventView.from_event_data(event_data=snowflake_event_data)
     yield event_view

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -491,16 +491,24 @@ def snowflake_event_data_with_entity_fixture(snowflake_event_data, cust_id_entit
     yield snowflake_event_data
 
 
+@pytest.fixture(name="arbitrary_default_feature_job_setting")
+def arbitrary_default_feature_job_setting_fixture():
+    """
+    Get arbitrary default feature job setting
+    """
+    return FeatureJobSetting(blind_spot="1m30s", frequency="6m", time_modulo_frequency="3m")
+
+
 @pytest.fixture(name="snowflake_event_data_with_entity_and_feature_job")
-def snowflake_event_data_with_entity_and_feature_job_fixture(snowflake_event_data, cust_id_entity):
+def snowflake_event_data_with_entity_and_feature_job_fixture(
+    snowflake_event_data, cust_id_entity, arbitrary_default_feature_job_setting
+):
     """
     Entity fixture that sets cust_id in snowflake_event_data as an Entity
     """
     snowflake_event_data.cust_id.as_entity(cust_id_entity.name)
     snowflake_event_data.update_default_feature_job_setting(
-        feature_job_setting=FeatureJobSetting(
-            blind_spot="1m30s", frequency="6m", time_modulo_frequency="3m"
-        )
+        feature_job_setting=arbitrary_default_feature_job_setting
     )
     yield snowflake_event_data
 


### PR DESCRIPTION
## Description
From test runs, we can see that a lot of time is spent on the `setup` of `test_*_view` tests. This presumably comes from a lot of the `view_under_test` and `data_under_test` initialization which was previously done eagerly.

Hopefully this change to lazy instantiation helps to reduce test run time a bit.

Example - before
```
Required test coverage of 50.0% reached. Total coverage: 96.85%
============================= slowest 50 durations =============================
258.01s call     tests/integration/api/test_event_view_operations.py::test_feature_operations
157.32s call     tests/integration/api/test_feature_correctness.py::test_aggregation
100.24s call     tests/integration/api/test_event_view_operations.py::test_event_view_ops
29.62s call     tests/integration/query_graph/test_online_serving.py::test_online_serving_sql
23.91s setup    tests/integration/api/test_change_view_operations.py::test_change_view
21.46s call     tests/integration/tile/snowflake/test_tile_cache.py::test_snowflake_tile_cache[PRODUCT_ACTION]
20.87s call     tests/integration/tile/snowflake/test_tile_cache.py::test_snowflake_tile_cache[None]
18.82s call     tests/unit/test_app.py::test_get_app__loading_time
17.81s call     tests/integration/tile/snowflake/test_sql_schedule_generate_tile.py::test_schedule_monitor_tile_all_new_column
14.92s call     tests/integration/api/test_event_view_operations.py::test_get_historical_features
11.47s call     tests/integration/tile/snowflake/test_sql_schedule_generate_tile.py::test_schedule_monitor_tile_existing_new_column
11.37s call     tests/integration/tile/snowflake/test_sql_schedule_generate_tile.py::test_schedule_monitor_tile_online
11.18s call     tests/integration/api/test_item_view_operations.py::test_item_view_ops
10.99s setup    tests/integration/backward_compatibility/test_get_route.py::test_get_route[/context]
10.74s setup    tests/unit/api/test_item_data.py::test_get_item_data
9.72s setup    tests/unit/api/test_item_data.py::test_list_filter
9.70s setup    tests/unit/api/test_item_data.py::test_info
9.61s setup    tests/unit/api/test_item_data.py::test_update_record_creation_date_column__saved_object
9.54s setup    tests/unit/api/test_item_data.py::test_item_data__save__exceptions
9.39s setup    tests/unit/api/test_item_data.py::test_from_tabular_source__duplicated_record
8.47s setup    tests/integration/api/test_event_view_operations.py::test_add_feature
8.01s call     tests/integration/api/test_event_view_operations.py::test_feature_operations__test_conditional_assign
7.42s call     tests/integration/api/test_item_view_operations.py::test_item_view_joined_with_dimension_view[snowflake]
7.41s call     tests/integration/api/test_item_view_operations.py::test_expected_rows_and_columns[snowflake]
7.34s setup    tests/unit/api/test_item_view.py::test_item_view__item_data_same_event_id_column_as_event_data
7.26s setup    tests/unit/api/test_scd_view.py::TestSlowlyChangingView::test_unary_op_params
7.23s setup    tests/unit/api/test_scd_view.py::TestSlowlyChangingView::test_join_column_is_part_of_inherited_columns
7.19s setup    tests/unit/api/test_scd_view.py::TestSlowlyChangingView::test_view_column_getitem_series
7.14s setup    tests/unit/api/test_scd_view.py::TestSlowlyChangingView::test_getitem__series_key
7.11s setup    tests/unit/api/test_scd_view.py::TestSlowlyChangingView::test_getitem__str
7.02s setup    tests/unit/api/test_scd_view.py::TestSlowlyChangingView::test_setitem__str_key_series_value
7.02s setup    tests/unit/api/test_scd_view.py::TestSlowlyChangingView::test_setitem__override_protected_column
6.68s setup    tests/unit/api/test_item_view.py::test_validate_join
6.55s setup    tests/unit/api/test_item_view.py::test_item_view_groupby__event_data_column_derived
6.41s setup    tests/unit/api/test_item_view.py::TestItemView::test_setitem__str_key_series_value
6.39s setup    tests/unit/api/test_item_view.py::TestItemView::test_join_column_is_part_of_inherited_columns
6.37s call     tests/integration/tile/snowflake/test_sql_schedule_generate_tile.py::test_schedule_generate_tile_online
6.36s setup    tests/unit/api/test_item_view.py::TestItemView::test_unary_op_params
6.28s setup    tests/unit/api/test_item_view.py::TestItemView::test_view_column_getitem_series
6.25s setup    tests/unit/api/test_item_view.py::TestItemView::test_getitem__series_key
6.20s setup    tests/unit/api/test_item_view.py::TestItemView::test_getitem__str
6.15s setup    tests/unit/api/test_item_view.py::TestItemView::test_setitem__override_protected_column
5.65s setup    tests/unit/worker/task/test_feature_job_setting_analysis_backtest.py::TestFeatureJobSettingAnalysisBacktestTask::test_execute_success
5.64s setup    tests/unit/api/test_scd_data.py::TestEventDataTestSuite::test_data_column__not_exists
5.61s setup    tests/unit/api/test_item_view.py::test_item_view_groupby__event_data_column_derived_mixed
5.57s setup    tests/unit/api/test_item_view.py::test_item_view_groupby__no_value_column
5.57s setup    tests/unit/api/test_item_view.py::test_item_view_groupby__event_data_column
5.52s setup    tests/unit/api/test_item_view.py::test_item_view_groupby__item_data_column
5.46s call     tests/integration/tile/snowflake/test_snowflake_tile.py::test_update_tile_entity_tracker
5.42s setup    tests/unit/api/test_item_view.py::test_join_event_data_attributes__invalid_columns
```

Example - after
Most of the `test_scd_view` test setups have dropped off the top 50. We still see `test_item_view` in the top 50 as they are generally the slowest to setup due to the extra dependency on event data/event views.
```
Required test coverage of 50.0% reached. Total coverage: 96.80%
============================= slowest 50 durations =============================
179.76s call     tests/integration/api/test_event_view_operations.py::test_feature_operations
174.87s call     tests/integration/api/test_feature_correctness.py::test_aggregation
117.97s call     tests/integration/api/test_event_view_operations.py::test_event_view_ops
32.10s call     tests/integration/query_graph/test_online_serving.py::test_online_serving_sql
23.93s setup    tests/integration/api/test_change_view_operations.py::test_change_view
23.89s call     tests/integration/tile/snowflake/test_tile_cache.py::test_snowflake_tile_cache[PRODUCT_ACTION]
22.97s call     tests/integration/tile/snowflake/test_tile_cache.py::test_snowflake_tile_cache[None]
20.82s call     tests/unit/test_app.py::test_get_app__loading_time
18.32s call     tests/integration/tile/snowflake/test_sql_schedule_generate_tile.py::test_schedule_monitor_tile_all_new_column
15.76s call     tests/integration/api/test_event_view_operations.py::test_get_historical_features
11.99s call     tests/integration/tile/snowflake/test_sql_schedule_generate_tile.py::test_schedule_monitor_tile_online
11.78s call     tests/integration/tile/snowflake/test_sql_schedule_generate_tile.py::test_schedule_monitor_tile_existing_new_column
11.45s call     tests/integration/api/test_item_view_operations.py::test_item_view_ops
11.24s setup    tests/unit/api/test_item_data.py::test_info
11.22s setup    tests/unit/api/test_item_data.py::test_update_record_creation_date_column__saved_object
11.09s setup    tests/unit/api/test_item_data.py::test_item_data__save__exceptions
10.99s setup    tests/unit/api/test_item_data.py::test_list_filter
10.98s setup    tests/unit/api/test_item_data.py::test_get_item_data
10.62s setup    tests/unit/api/test_item_data.py::test_from_tabular_source__duplicated_record
10.47s setup    tests/integration/backward_compatibility/test_get_route.py::test_get_route[/context]
9.20s setup    tests/unit/api/test_item_view.py::test_item_view__item_data_same_event_id_column_as_event_data
9.17s setup    tests/integration/api/test_event_view_operations.py::test_add_feature
8.76s call     tests/integration/api/test_item_view_operations.py::test_expected_rows_and_columns[snowflake]
7.95s setup    tests/unit/api/test_item_view.py::test_validate_join
7.68s call     tests/integration/api/test_item_view_operations.py::test_item_view_joined_with_dimension_view[snowflake]
7.32s call     tests/unit/api/test_feature_list.py::test_deploy
7.20s call     tests/integration/tile/snowflake/test_sql_schedule_generate_tile.py::test_schedule_generate_tile_online
6.78s setup    tests/unit/api/test_scd_data.py::TestEventDataTestSuite::test_data_column__not_exists
6.61s setup    tests/unit/api/test_item_data.py::test_event_data__record_creation_exception
6.58s setup    tests/unit/api/test_item_view.py::test_item_view_groupby__event_data_column_derived_mixed
6.56s setup    tests/unit/api/test_item_view.py::test_item_view_groupby__event_data_column_derived
6.47s setup    tests/unit/api/test_item_view.py::test_item_view_groupby__no_value_column
6.40s setup    tests/unit/api/test_item_view.py::test_item_view_groupby__event_data_column
6.24s setup    tests/unit/api/test_item_view.py::TestItemView::test_view_column_getitem_series
6.21s setup    tests/unit/api/test_item_view.py::TestItemView::test_join_column_is_part_of_inherited_columns
6.20s setup    tests/unit/api/test_item_view.py::test_item_view_groupby__event_id_column
6.17s setup    tests/unit/api/test_item_view.py::TestItemView::test_setitem__str_key_series_value
6.16s setup    tests/unit/api/test_item_view.py::test_setitem__str_key_series_value
6.16s setup    tests/unit/api/test_item_view.py::test_has_event_timestamp_column
6.14s setup    tests/unit/api/test_item_view.py::test_item_view_groupby__item_data_column
6.13s setup    tests/unit/api/test_item_view.py::TestItemView::test_setitem__override_protected_column
6.13s setup    tests/unit/api/test_item_view.py::test_join_event_data_attributes__invalid_columns
6.12s setup    tests/unit/api/test_item_view.py::test_default_feature_job_setting
6.11s setup    tests/unit/api/test_item_view.py::test_join_event_data_attributes__more_columns
6.10s setup    tests/unit/api/test_item_view.py::TestItemView::test_unary_op_params
6.05s setup    tests/unit/api/test_item_view.py::TestItemView::test_getitem__series_key
6.01s setup    tests/unit/api/test_item_view.py::TestItemView::test_getitem__str
5.99s call     tests/integration/api/test_scd_view_operations.py::test_scd_join_small
5.94s setup    tests/unit/api/test_item_data.py::TestItemDataTestSuite::test_data_column__not_exists
5.60s setup    tests/unit/api/test_item_view.py::test_from_item_data__auto_join_columns
```

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
