### PR TITLE
[DEV-994] Fix rsuffix validation when joining views

### DIFF
--- a/featurebyte/api/view.py
+++ b/featurebyte/api/view.py
@@ -511,21 +511,20 @@ class View(ProtectedColumnsQueryObject, Frame, ABC):
             raised when the on column provided, is not present in the columns
         """
         # Validate whether there are overlapping column names
-        if rsuffix == "":
-            left_join_key, _ = self._get_join_keys(other_view, on)
-            current_column_names = {col.name for col in self.columns_info}
-            repeated_column_names = []
-            for other_col in other_view.columns_info:
-                # Raise an error if the name is repeated, but it is not a join key
-                if other_col.name in current_column_names and other_col.name != left_join_key:
-                    repeated_column_names.append(other_col.name)
-            if len(repeated_column_names) > 0:
-                raise RepeatedColumnNamesError(
-                    f"Duplicate column names {repeated_column_names} found between the "
-                    "calling view, and the target view.\nTo resolve this error, do consider "
-                    "setting the rsuffix parameter in `join()` to disambiguate the "
-                    "resulting columns in the joined view."
-                )
+        left_join_key, _ = self._get_join_keys(other_view, on)
+        current_column_names = {col.name for col in self.columns_info}
+        repeated_column_names = []
+        for other_col in append_rsuffix_to_column_info(other_view.columns_info, rsuffix):
+            # Raise an error if the name is repeated, but it is not a join key
+            if other_col.name in current_column_names and other_col.name != left_join_key:
+                repeated_column_names.append(other_col.name)
+        if len(repeated_column_names) > 0:
+            raise RepeatedColumnNamesError(
+                f"Duplicate column names {repeated_column_names} found between the "
+                "calling view, and the target view.\nTo resolve this error, do consider "
+                "setting the rsuffix parameter in `join()` to disambiguate the "
+                "resulting columns in the joined view."
+            )
 
         # Validate whether the join column provided is present in the columns
         if on is not None:

--- a/tests/unit/api/test_view.py
+++ b/tests/unit/api/test_view.py
@@ -399,7 +399,7 @@ def test_validate_join__no_overlapping_columns():
     assert "Unable to automatically find a default join column key" in str(exc_info)
 
     # no overlap should have no error with suffix, since we'll use primary keys to join
-    base_view._validate_join(view_without_overlap, rsuffix="suffix")
+    base_view._validate_join(view_without_overlap, on="colA", rsuffix="suffix")
 
 
 def test_validate_join__one_overlapping_column():
@@ -467,10 +467,6 @@ def test_validate_join__check_on_column():
     )
     base_view = SimpleTestView(columns_info=[col_info_a, col_info_b], join_col=col_info_a.name)
     other_view = SimpleTestView(columns_info=[col_info_c], join_col=col_info_c.name)
-
-    # no `on` provided, should have no error in this method. However, this will still throw an error down the line
-    # when we try to get_join_keys since the other join key column is not present in the calling view.
-    base_view._validate_join(other_view, rsuffix="_suffix")
 
     # `on` provided for column in calling view should have no error
     base_view._validate_join(other_view, on=col_info_a.name, rsuffix="_suffix")


### PR DESCRIPTION
## Description

This fixes a bug in `rsuffix` validation of joins which is caused by the validation not being done as long as any rsuffix is provided, but in practice it could happen that the provided `rsuffix` doesn't resolve the name conflicts (or causes them).

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
