### PR TITLE
[DEV-1013] Fix row index lineage contains proxy input node bug

### DIFF
--- a/featurebyte/query_graph/node/nested.py
+++ b/featurebyte/query_graph/node/nested.py
@@ -47,7 +47,7 @@ class ProxyInputNode(BaseNode):
             ],
             output_type=operation_structure.output_type,
             output_category=operation_structure.output_category,
-            row_index_lineage=(self.name,),
+            row_index_lineage=operation_structure.row_index_lineage,
         )
 
 

--- a/tests/unit/query_graph/test_graph_node.py
+++ b/tests/unit/query_graph/test_graph_node.py
@@ -166,7 +166,7 @@ def test_graph_node_create__non_empty_input_nodes(input_node_params):
         ],
         "output_category": "view",
         "output_type": "series",
-        "row_index_lineage": ("proxy_input_1",),
+        "row_index_lineage": ("input_1",),
         "is_time_based": False,
     }
     # check graph pruning
@@ -303,7 +303,7 @@ def nested_output_graph_fixture(input_node_params):
         ],
         "output_category": "view",
         "output_type": "series",
-        "row_index_lineage": ("proxy_input_1",),
+        "row_index_lineage": ("input_1",),
         "is_time_based": False,
     }
     # check graph pruning
@@ -644,7 +644,7 @@ def test_graph_node__redundant_graph_node(input_node_params):
         ],
         "output_category": "view",
         "output_type": "series",
-        "row_index_lineage": ("proxy_input_1",),
+        "row_index_lineage": ("input_1",),
         "is_time_based": False,
     }
     # TODO: [DEV-868] Make graph node prunable


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

The `row_index_lineage` attribute in operation structure is used to indicate list of nodes that contribute to the table row index. Due to the introduction of the critical data info, the data node could be a graph node. In this case, the `row_index_lineage` may contains proxy input node (input node in the nested graph) and it causes issue when doing row index checking. This PR aims to fix the bug by converting the proxy input node to the non-nested node.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
