### PR TITLE
api/series: simplify logic around binary_op_series_params

### DIFF
--- a/featurebyte/api/feature.py
+++ b/featurebyte/api/feature.py
@@ -20,6 +20,7 @@ from featurebyte.api.feature_job import FeatureJobMixin
 from featurebyte.api.feature_store import FeatureStore
 from featurebyte.api.feature_validation_util import assert_is_lookup_feature
 from featurebyte.common.doc_util import FBAutoDoc
+from featurebyte.common.typing import Scalar, ScalarSequence
 from featurebyte.common.utils import dataframe_from_json
 from featurebyte.config import Configurations
 from featurebyte.core.accessor.count_dict import CdAccessorMixin
@@ -403,15 +404,15 @@ class Feature(
         operation_structure = self.extract_operation_structure()
         return operation_structure.is_time_based
 
-    def binary_op_series_params(self, other: Series | None = None) -> dict[str, Any]:
+    def binary_op_series_params(self, other: Scalar | Series | ScalarSequence) -> dict[str, Any]:
         """
         Parameters that will be passed to series-like constructor in _binary_op method
 
 
         Parameters
         ----------
-        other: Series
-            Other Series object
+        other: other: Scalar | Series | ScalarSequence
+            Other object
 
         Returns
         -------
@@ -419,7 +420,7 @@ class Feature(
         """
         tabular_data_ids = set(self.tabular_data_ids)
         entity_ids = set(self.entity_ids)
-        if other is not None:
+        if isinstance(other, Series):
             tabular_data_ids = tabular_data_ids.union(getattr(other, "tabular_data_ids", []))
             entity_ids = entity_ids.union(getattr(other, "entity_ids", []))
         return {"tabular_data_ids": sorted(tabular_data_ids), "entity_ids": sorted(entity_ids)}

--- a/featurebyte/api/view.py
+++ b/featurebyte/api/view.py
@@ -25,6 +25,7 @@ from featurebyte.api.join_utils import (
 )
 from featurebyte.common.doc_util import FBAutoDoc
 from featurebyte.common.model_util import validate_offset_string
+from featurebyte.common.typing import Scalar, ScalarSequence
 from featurebyte.core.frame import Frame
 from featurebyte.core.generic import ProtectedColumnsQueryObject
 from featurebyte.core.mixin import SampleMixin
@@ -65,14 +66,14 @@ class ViewColumn(Series, SampleMixin):
             return None
         return self._parent.timestamp_column
 
-    def binary_op_series_params(self, other: Series | None = None) -> dict[str, Any]:
+    def binary_op_series_params(self, other: Scalar | Series | ScalarSequence) -> dict[str, Any]:
         """
         Parameters that will be passed to series-like constructor in _binary_op method
 
         Parameters
         ----------
-        other: Series
-            Other Series object
+        other: Scalar | Series | ScalarSequence
+            Other object
 
         Returns
         -------

--- a/featurebyte/core/accessor/count_dict.py
+++ b/featurebyte/core/accessor/count_dict.py
@@ -152,7 +152,7 @@ class CountDictAccessor:
         return series_operator.operate(
             node_type=NodeType.COSINE_SIMILARITY,
             output_var_type=DBVarType.FLOAT,
-            **self._feature_obj.binary_op_series_params(),
+            **self._feature_obj.binary_op_series_params(other),
         )
 
     def get_value(self, key: Union[Scalar, Feature]) -> Feature:

--- a/featurebyte/core/series.py
+++ b/featurebyte/core/series.py
@@ -106,15 +106,15 @@ class Series(QueryObject, OpsMixin, ParentMixin, StrAccessorMixin, DtAccessorMix
             **self.unary_op_series_params(),
         )
 
-    def binary_op_series_params(self, other: Series | None = None) -> dict[str, Any]:
+    def binary_op_series_params(self, other: Scalar | Series | ScalarSequence) -> dict[str, Any]:
         """
         Parameters that will be passed to series-like constructor in _binary_op method
 
 
         Parameters
         ----------
-        other: Series
-            Other Series object
+        other: Scalar | Series | ScalarSequence
+            Other object
 
         Returns
         -------
@@ -264,10 +264,7 @@ class Series(QueryObject, OpsMixin, ParentMixin, StrAccessorMixin, DtAccessorMix
         Series
             output of the binary operation
         """
-        if isinstance(other, Series):
-            binary_op_series_params = self.binary_op_series_params(other)
-        else:
-            binary_op_series_params = self.binary_op_series_params()
+        binary_op_series_params = self.binary_op_series_params(other)
         series_operator = DefaultSeriesBinaryOperator(self, other)
         return series_operator.operate(
             node_type=node_type,


### PR DESCRIPTION
## Description
This commit simplifies some of the logic around binary_op_series_params. We currently only really check the type in one of the overrides.

This change pushes the type checking to that relevant override. This makes it slightly easier to read as
- type signature of `other` is now consistent w/ the caller
- it will become easier to simplify `_binary_op` even more which is reused.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
