### PR TITLE
[DEV-1002] Fix online serving of features that do not use tile tables

### DIFF
--- a/featurebyte/models/online_store.py
+++ b/featurebyte/models/online_store.py
@@ -13,6 +13,7 @@ from featurebyte.query_graph.sql.online_serving import (
     get_entities_ids_and_serving_names,
     get_online_store_feature_compute_sql,
     get_online_store_table_name_from_graph,
+    is_online_store_eligible,
 )
 
 
@@ -108,6 +109,17 @@ class OnlineFeatureSpec(FeatureByteBaseModel):
             node=self.feature.node,
             source_type=self.feature.feature_store_type,
         )
+
+    @property
+    def is_online_store_eligible(self) -> bool:
+        """
+        Whether pre-computation with online store is eligible for the feature
+
+        Returns
+        -------
+        bool
+        """
+        return is_online_store_eligible(graph=self.feature.graph, node=self.feature.node)
 
     @property
     def feature_store_table_name(self) -> str:

--- a/featurebyte/query_graph/sql/online_serving.py
+++ b/featurebyte/query_graph/sql/online_serving.py
@@ -284,6 +284,9 @@ def is_online_store_eligible(graph: QueryGraph, node: Node) -> bool:
     -------
     bool
     """
+    op_struct = graph.extract_operation_structure(node)
+    if not op_struct.is_time_based:
+        return False
     has_point_in_time_groupby = False
     for _ in graph.iterate_nodes(node, NodeType.GROUPBY):
         has_point_in_time_groupby = True

--- a/featurebyte/service/online_enable.py
+++ b/featurebyte/service/online_enable.py
@@ -137,6 +137,10 @@ class OnlineEnableService(BaseService):
         extended_feature_model = ExtendedFeatureModel(**feature.dict())
 
         online_feature_spec = OnlineFeatureSpec(feature=extended_feature_model)
+
+        if not online_feature_spec.is_online_store_eligible:
+            return
+
         feature_store_model = await self.feature_store_service.get_document(
             document_id=feature.tabular_source.feature_store_id
         )

--- a/featurebyte/service/online_serving.py
+++ b/featurebyte/service/online_serving.py
@@ -84,7 +84,7 @@ class OnlineServingService(BaseService):
             feature_cluster.graph,
             feature_cluster.nodes,
             source_type=feature_store.type,
-            request_table_columns=df_request_table.columns,
+            request_table_columns=df_request_table.columns.tolist(),
             request_table_expr=df_expr,
         )
         logger.debug(f"OnlineServingService sql prep elapsed: {time.time() - tic:.6f}s")

--- a/tests/unit/query_graph/test_online_serving.py
+++ b/tests/unit/query_graph/test_online_serving.py
@@ -17,6 +17,7 @@ from featurebyte.query_graph.sql.online_serving import (
     get_entities_ids_and_serving_names,
     get_online_store_feature_compute_sql,
     get_online_store_retrieval_sql,
+    is_online_store_eligible,
 )
 from tests.util.helper import assert_equal_with_expected_fixture
 
@@ -110,6 +111,22 @@ def test_construct_universe_sql__unbounded_latest(
         """
     ).strip()
     assert expr.sql(pretty=True) == expected_sql
+
+
+def test_is_online_store_eligible__non_time_aware(global_graph, order_size_feature_node):
+    """
+    Test is_online_store_eligible for a non-time-aware feature node
+    """
+    assert not is_online_store_eligible(global_graph, order_size_feature_node)
+
+
+def test_is_online_store_eligible__time_aware(
+    global_graph, latest_value_without_window_feature_node
+):
+    """
+    Test is_online_store_eligible for a time-aware feature node
+    """
+    assert is_online_store_eligible(global_graph, latest_value_without_window_feature_node)
 
 
 def test_online_store_feature_compute_sql(query_graph_with_groupby, update_fixtures):


### PR DESCRIPTION
## Description

This fixes an incorrect `NotImplementedError` that arises when deploying features that do not use tile tables, such as simple aggregation features that are not time-based.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
