### PR TITLE
Fix bug when register table with empty row dataframe

### DIFF
--- a/featurebyte/session/snowflake.py
+++ b/featurebyte/session/snowflake.py
@@ -255,7 +255,7 @@ class SnowflakeSession(BaseSession):
         schema = []
         for colname, dtype in dataframe.dtypes.to_dict().items():
 
-            if isinstance(dataframe[colname].iloc[0], datetime.datetime):
+            if dataframe.shape[0] > 0 and isinstance(dataframe[colname].iloc[0], datetime.datetime):
                 if dataframe[colname].iloc[0].tzinfo:
                     db_type = "TIMESTAMP_TZ"
                 else:

--- a/tests/unit/session/test_snowflake_session.py
+++ b/tests/unit/session/test_snowflake_session.py
@@ -543,6 +543,10 @@ def test_get_columns_schema_from_dataframe():
     expected_schema = list(expected_dict.items())
     assert schema == expected_schema
 
+    # test empty dataframe
+    schema = SnowflakeSession.get_columns_schema_from_dataframe(dataframe.iloc[:0])
+    assert schema == expected_schema
+
 
 @pytest.mark.parametrize("error_type", [DatabaseError, OperationalError])
 def test_constructor__credentials_error(snowflake_connector, error_type, snowflake_session_dict):


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR aims to fix data warehouse migration error when the migration script attempt to register table with 0-row (https://github.com/featurebyte/featurebyte/blob/main/featurebyte/migration/service/data_warehouse.py#L164-L167).


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
