### PR TITLE
[DEV-1045] Improve error message when feature_job_setting cannot be inferred

### DIFF
--- a/featurebyte/api/groupby.py
+++ b/featurebyte/api/groupby.py
@@ -334,11 +334,30 @@ class WindowAggregator(BaseAggregator):
         frequency = feature_job_setting.get("frequency")
         time_modulo_frequency = feature_job_setting.get("time_modulo_frequency")
         blind_spot = feature_job_setting.get("blind_spot")
-        default_setting = self.view.default_feature_job_setting
-        if default_setting:
-            frequency = frequency or default_setting.frequency
-            time_modulo_frequency = time_modulo_frequency or default_setting.time_modulo_frequency
-            blind_spot = blind_spot or default_setting.blind_spot
+
+        # Check that feature job setting is not specified partially (must be all or nothing)
+        settings_overridden = [
+            frequency is not None,
+            time_modulo_frequency is not None,
+            blind_spot is not None,
+        ]
+        is_settings_provided = any(settings_overridden)
+        if is_settings_provided and not all(settings_overridden):
+            raise ValueError(
+                "All of frequency, time_modulo_frequency and blind_spot must be specified in"
+                " feature_job_setting"
+            )
+
+        if not is_settings_provided:
+            default_setting = self.view.default_feature_job_setting
+            if default_setting is None:
+                raise ValueError(
+                    f"feature_job_setting is required as the {type(self.view).__name__} does not "
+                    "have a default feature job setting"
+                )
+            frequency = default_setting.frequency
+            time_modulo_frequency = default_setting.time_modulo_frequency
+            blind_spot = default_setting.blind_spot
 
         return FeatureJobSetting(
             frequency=frequency,

--- a/tests/unit/api/test_groupby.py
+++ b/tests/unit/api/test_groupby.py
@@ -127,7 +127,29 @@ def test_groupby__not_able_to_infer_feature_job_setting(snowflake_event_view_wit
             windows=["30m", "1h", "2h"],
             feature_names=["feat_30m", "feat_1h", "feat_2h"],
         )
-    assert "must be str; got NoneType instead" in str(exc.value)
+    assert str(exc.value) == (
+        "feature_job_setting is required as the EventView does not have a default feature job setting"
+    )
+
+
+def test_groupby__feature_job_setting_partially_specified(
+    snowflake_event_view_with_entity_and_feature_job, cust_id_entity
+):
+    """
+    Test when feature job setting is partially specified
+    """
+    with pytest.raises(ValueError) as exc:
+        _ = snowflake_event_view_with_entity_and_feature_job.groupby("cust_id").aggregate_over(
+            value_column="col_float",
+            method="sum",
+            windows=["30m", "1h", "2h"],
+            feature_names=["feat_30m", "feat_1h", "feat_2h"],
+            feature_job_setting={"frequency": "1h"},
+        )
+    assert (
+        str(exc.value)
+        == "All of frequency, time_modulo_frequency and blind_spot must be specified in feature_job_setting"
+    )
 
 
 def test_groupby__window_sizes_issue(snowflake_event_view_with_entity):


### PR DESCRIPTION
## Description

This updates the error message to be more informative when feature job setting cannot be inferred in `aggregate_over` when there is no default. The validation logic is also updated to ensure setting is not partially specified when provided.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
