### PR TITLE
[DEV-976] Convert numeric columns to float before comparing

### DIFF
--- a/tests/integration/api/test_feature_correctness.py
+++ b/tests/integration/api/test_feature_correctness.py
@@ -1,11 +1,11 @@
 import json
 import time
 from collections import defaultdict
-from decimal import Decimal
 
 import numpy as np
 import pandas as pd
 import pytest
+from pandas.api.types import is_numeric_dtype
 
 from featurebyte.api.event_view import EventView
 from featurebyte.api.feature_list import FeatureList
@@ -244,8 +244,8 @@ def fb_assert_frame_equal(df, df_expected, dict_like_columns=None):
 
     if regular_columns:
         for col in regular_columns:
-            if isinstance(df[col].iloc[0], Decimal):
-                df[col] = df[col].astype(int)
+            if is_numeric_dtype(df_expected[col]):
+                df[col] = df[col].astype(float)
         pd.testing.assert_frame_equal(
             df[regular_columns], df_expected[regular_columns], check_dtype=False
         )
@@ -454,11 +454,6 @@ def test_aggregate_over(
     df_expected["POINT_IN_TIME"] = pd.to_datetime(
         df_expected["POINT_IN_TIME"], utc=True
     ).dt.tz_localize(None)
-
-    # DEV-976: temporary fix for the type discrepancies
-    # historical features of the affected type has the object type
-    fix_col = "event_interval_avg_24h"
-    df_historical_features[fix_col] = df_historical_features[fix_col].astype(float)
 
     fb_assert_frame_equal(df_historical_features, df_expected, dict_like_columns)
 


### PR DESCRIPTION
## Description

This fixes an issue in integration test where sometimes comparison can fail because of type mismatch (Decimal vs floating point). It refactors the existing type conversion to be more flexible.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
