### PR TITLE
Fix logical conflict

### DIFF
--- a/tests/unit/api/test_scd_data.py
+++ b/tests/unit/api/test_scd_data.py
@@ -33,34 +33,36 @@ class TestSlowChangingDataTestSuite(BaseDataTestSuite):
     SELECT
       "col_int" AS "col_int",
       "col_float" AS "col_float",
-      "col_char" AS "col_char",
+      "is_active" AS "is_active",
       "col_text" AS "col_text",
       "col_binary" AS "col_binary",
       "col_boolean" AS "col_boolean",
-      CAST("event_timestamp" AS VARCHAR) AS "event_timestamp",
+      CAST("effective_timestamp" AS VARCHAR) AS "effective_timestamp",
+      CAST("end_timestamp" AS VARCHAR) AS "end_timestamp",
       CAST("created_at" AS VARCHAR) AS "created_at",
       "cust_id" AS "cust_id"
-    FROM "sf_database"."sf_schema"."sf_table"
+    FROM "sf_database"."sf_schema"."scd_table"
     LIMIT 10
     """
     expected_data_column_sql = """
     SELECT
       "col_int" AS "col_int"
-    FROM "sf_database"."sf_schema"."sf_table"
+    FROM "sf_database"."sf_schema"."scd_table"
     LIMIT 10
     """
     expected_clean_data_sql = """
     SELECT
       CAST(CASE WHEN "col_int" IS NULL THEN 0 ELSE "col_int" END AS BIGINT) AS "col_int",
       "col_float" AS "col_float",
-      "col_char" AS "col_char",
+      "is_active" AS "is_active",
       "col_text" AS "col_text",
       "col_binary" AS "col_binary",
       "col_boolean" AS "col_boolean",
-      CAST("event_timestamp" AS VARCHAR) AS "event_timestamp",
+      CAST("effective_timestamp" AS VARCHAR) AS "effective_timestamp",
+      CAST("end_timestamp" AS VARCHAR) AS "end_timestamp",
       CAST("created_at" AS VARCHAR) AS "created_at",
       "cust_id" AS "cust_id"
-    FROM "sf_database"."sf_schema"."sf_table"
+    FROM "sf_database"."sf_schema"."scd_table"
     LIMIT 10
     """
 


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

Fix logical conflict between https://github.com/featurebyte/featurebyte/commit/935064476c6fd9ecf69a203785058bcd887ccdf4 and https://github.com/featurebyte/featurebyte/commit/3176706c62826ff9a0fbc3c2795132d9e2cc0002 in `tests/unit/api/test_scd_data.py` test module.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
