### PR TITLE
[DEV-1064] fix typo in function signature

### DIFF
--- a/featurebyte/api/event_data.py
+++ b/featurebyte/api/event_data.py
@@ -213,17 +213,17 @@ class EventData(EventDataModel, DataApiObject):
         return analysis
 
     @typechecked
-    def initialise_default_feature_job_setting(self) -> None:
+    def initialize_default_feature_job_setting(self) -> None:
         """
-        Initialise default feature job setting by performing an analysis on the data
+        Initialize default feature job setting by performing an analysis on the data
 
         Raises
         ------
         InvalidSettingsError
-            Default feature job setting is already initialised
+            Default feature job setting is already initialized
         """
         if self.default_feature_job_setting:
-            raise InvalidSettingsError("Default feature job setting is already initialised")
+            raise InvalidSettingsError("Default feature job setting is already initialized")
 
         analysis = self.create_new_feature_job_setting_analysis()
         self.update_default_feature_job_setting(analysis.get_recommendation())

--- a/tests/unit/api/test_event_data.py
+++ b/tests/unit/api/test_event_data.py
@@ -505,7 +505,7 @@ def test_update_default_feature_job_setting__using_feature_job_analysis(
         time_modulo_frequency="0",
     )
     mock_get_by_id.return_value = analysis
-    saved_event_data.initialise_default_feature_job_setting()
+    saved_event_data.initialize_default_feature_job_setting()
 
     # should make a call to post_async_task
     mock_post_async_task.assert_called_once_with(
@@ -546,7 +546,7 @@ def test_update_default_feature_job_setting__using_feature_job_analysis_no_creat
     mock_get_document.return_value = Mock(record_creation_date_column=None)
 
     with pytest.raises(RecordCreationException) as exc:
-        saved_event_data.initialise_default_feature_job_setting()
+        saved_event_data.initialize_default_feature_job_setting()
     assert "Creation date column is not available for the event data." in str(exc)
 
 
@@ -570,7 +570,7 @@ def test_update_default_feature_job_setting__using_feature_job_analysis_high_fre
     )
 
     with pytest.raises(RecordCreationException) as exc:
-        saved_event_data.initialise_default_feature_job_setting()
+        saved_event_data.initialize_default_feature_job_setting()
     assert "HighUpdateFrequencyError" in str(exc)
 
 
@@ -594,7 +594,7 @@ def test_update_default_job_setting__feature_job_setting_analysis_failure__event
     Test update failure due to event data not saved
     """
     with pytest.raises(RecordCreationException) as exc:
-        snowflake_event_data.initialise_default_feature_job_setting()
+        snowflake_event_data.initialize_default_feature_job_setting()
     expected_msg = f'EventData (id: "{snowflake_event_data.id}") not found. Please save the EventData object first.'
     assert expected_msg in str(exc)
 
@@ -627,7 +627,7 @@ def test_update_default_job_setting__feature_job_setting_analysis_failure(
     mock_process_store.return_value.get = AsyncMock()
     mock_process_store.return_value.get.return_value = get_return
     with pytest.raises(RecordCreationException) as exc:
-        saved_event_data.initialise_default_feature_job_setting()
+        saved_event_data.initialize_default_feature_job_setting()
     assert "ValueError: Event Data not found" in str(exc.value)
 
 


### PR DESCRIPTION
## Description

Fix function signature to follow US en spelling.

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-1064

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
