### PR TITLE
[DEV-1084] Fix `Data.get_by_id` not working

### DIFF
--- a/featurebyte/routes/tabular_data/api.py
+++ b/featurebyte/routes/tabular_data/api.py
@@ -7,6 +7,8 @@ from typing import Optional
 
 from fastapi import APIRouter, Request
 
+from featurebyte.models.base import PydanticObjectId
+from featurebyte.models.tabular_data import TabularDataModel
 from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
@@ -43,3 +45,15 @@ async def list_tabular_data(
         name=name,
     )
     return tabular_data_list
+
+
+@router.get("/{tabular_data_id}", response_model=TabularDataModel)
+async def get_tabular_data(request: Request, tabular_data_id: PydanticObjectId) -> TabularDataModel:
+    """
+    Retrieve Tabular Data
+    """
+    controller = request.state.app_container.tabular_data_controller
+    tabular_data: TabularDataModel = await controller.get(
+        document_id=tabular_data_id,
+    )
+    return tabular_data

--- a/tests/unit/api/test_data.py
+++ b/tests/unit/api/test_data.py
@@ -27,6 +27,10 @@ def test_get_event_data(saved_event_data, snowflake_event_data):
     assert loaded_event_data == snowflake_event_data
     assert EventData.get_by_id(id=snowflake_event_data.id) == snowflake_event_data
 
+    # load the event data use get_by_id
+    loaded_data = Data.get_by_id(snowflake_event_data.id)
+    assert loaded_data == loaded_event_data
+
     with pytest.raises(RecordRetrievalException) as exc:
         lazy_event_data = Data.get("unknown_event_data")
         _ = lazy_event_data.name

--- a/tests/unit/routes/base.py
+++ b/tests/unit/routes/base.py
@@ -907,6 +907,15 @@ class BaseDataApiTestSuite(BaseApiTestSuite):
         assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
         assert response.json()["detail"] == expected_message
 
+    def test_tabular_data_get_200(self, test_api_client_persistent, create_success_response):
+        """Test tabular get (success)"""
+        test_api_client, _ = test_api_client_persistent
+        success_response_dict = create_success_response.json()
+
+        # check that tabular_data route can be used to retrieve the created data
+        response = test_api_client.get(f"/tabular_data/{success_response_dict['_id']}")
+        assert response.json() == success_response_dict
+
     def test_tabular_data_list_200(
         self, test_api_client_persistent, create_multiple_success_responses
     ):


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR aims to fix the issue where `Data.get_by_id` not working by exposing `/tabular_data/<tabular_data_id>` route.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
