### PR TITLE
[DEV-1074] Fix spark register table with nanosecond precision timestamps

### DIFF
--- a/.github/spark/docker-compose.yml
+++ b/.github/spark/docker-compose.yml
@@ -11,6 +11,12 @@ services:
     environment:
       - SPARK_MASTER=local
       - SPARK_LOCAL_IP=spark-thrift
+    healthcheck:
+      test: netstat -ltn | grep -c 10000
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     command:
       - /bin/sh
       - -c

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ test-routes:
 #* Docker
 spark-start:
 	mkdir -p ~/.spark/data
-	cd .github/spark && docker compose up -d
+	cd .github/spark && docker compose up --wait -d
 
 spark-stop:
 	cd .github/spark && docker compose down

--- a/tests/integration/session/test_spark.py
+++ b/tests/integration/session/test_spark.py
@@ -71,7 +71,7 @@ async def test_register_table(config, spark_session):
     df_training_events = pd.DataFrame(
         {
             "POINT_IN_TIME": pd.to_datetime(
-                ["2001-01-02 10:00:00"] * 2 + ["2001-01-03 10:00:00"] * 3
+                ["2001-01-02 10:00:00.123456789"] * 2 + ["2001-01-03 10:00:00.123456789"] * 3
             ),
             "üser id": [1, 2, 3, 4, 5],
         }


### PR DESCRIPTION
## Description

- Spark and parquet do not support nanoseconds precision in timestamps well
-  Add healthcheck for spark service in docker compose

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-1074

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
