### PR TITLE
[DEV-1096] Handle the case when entity_ids is None when updating Aggregator

### DIFF
--- a/featurebyte/query_graph/sql/aggregator/base.py
+++ b/featurebyte/query_graph/sql/aggregator/base.py
@@ -121,7 +121,8 @@ class Aggregator(Generic[AggregationSpecT], ABC):
             Aggregation specification
         """
         self.required_serving_names.update(aggregation_spec.serving_names)
-        self.required_entity_ids.update(aggregation_spec.entity_ids)
+        if aggregation_spec.entity_ids is not None:
+            self.required_entity_ids.update(aggregation_spec.entity_ids)
         self.additional_update(aggregation_spec)
 
     @abstractmethod
@@ -315,7 +316,7 @@ class TileBasedAggregator(Aggregator[TileBasedAggregationSpec], ABC):
         super().update(aggregation_spec)
         if self.is_online_serving:
             table_name = get_online_store_table_name_from_entity_ids(
-                set(aggregation_spec.entity_ids)
+                set(aggregation_spec.entity_ids if aggregation_spec.entity_ids is not None else [])
             )
             self.agg_result_names_by_online_store_table[table_name].add(
                 aggregation_spec.agg_result_name

--- a/featurebyte/query_graph/sql/online_serving.py
+++ b/featurebyte/query_graph/sql/online_serving.py
@@ -184,7 +184,9 @@ class OnlineStorePrecomputePlan:
             exclude_post_aggregation=True,
         )
         sql = sql_to_string(sql_expr, source_type)
-        table_name = get_online_store_table_name_from_entity_ids(set(params.agg_spec.entity_ids))
+        table_name = get_online_store_table_name_from_entity_ids(
+            set(params.agg_spec.entity_ids if params.agg_spec.entity_ids is not None else [])
+        )
 
         op_struct = (
             OperationStructureExtractor(graph=params.pruned_graph)

--- a/featurebyte/query_graph/sql/specs.py
+++ b/featurebyte/query_graph/sql/specs.py
@@ -55,7 +55,7 @@ class AggregationSpec(ABC):
     Base class of all aggregation specifications
     """
 
-    entity_ids: list[ObjectId]
+    entity_ids: list[ObjectId] | None  # DEV-556: should not be None for new features
     serving_names: list[str]
     serving_names_mapping: Optional[dict[str, str]]
 

--- a/tests/unit/query_graph/conftest.py
+++ b/tests/unit/query_graph/conftest.py
@@ -332,6 +332,20 @@ def query_graph_with_groupby_fixture(query_graph_and_assign_node, groupby_node_p
     return graph
 
 
+@pytest.fixture(name="query_graph_with_groupby_no_entity_ids")
+def query_graph_with_groupby_fixture_no_entity_ids(
+    query_graph_and_assign_node, groupby_node_params
+):
+    """
+    Fixture of a query graph with a groupby operation (DEV-556: old version without entity_ids)
+    """
+    graph, assign_node = query_graph_and_assign_node
+    node_params = copy.deepcopy(groupby_node_params)
+    node_params.pop("entity_ids")
+    add_groupby_operation(graph, node_params, assign_node)
+    return graph
+
+
 @pytest.fixture(name="query_graph_with_groupby_and_feature_nodes")
 def query_graph_with_groupby_and_feature_nodes_fixture(query_graph_with_groupby):
     graph = query_graph_with_groupby

--- a/tests/unit/query_graph/test_feature_compute.py
+++ b/tests/unit/query_graph/test_feature_compute.py
@@ -289,6 +289,7 @@ def test_feature_execution_planner(query_graph_with_groupby, groupby_node_aggreg
             feature_expr=f'"agg_w172800_avg_{groupby_node_aggregation_id}"',
         ),
     }
+    assert plan.required_entity_ids == {ObjectId("637516ebc9c18f5a277a78db")}
 
 
 def test_feature_execution_planner__serving_names_mapping(
@@ -420,3 +421,20 @@ def test_feature_execution_planner__query_graph_with_graph_node(
             feature_expr=f'"agg_w172800_avg_{groupby_node_aggregation_id}"',
         ),
     }
+
+
+def test_feature_execution_planner__feature_no_entity_ids(
+    query_graph_with_groupby_no_entity_ids,
+    groupby_node_aggregation_id,
+):
+    """
+    Test FeatureExecutionPlanner when feature node has no entity_ids
+    """
+    groupby_node = query_graph_with_groupby_no_entity_ids.get_node_by_name("groupby_1")
+    planner = FeatureExecutionPlanner(
+        query_graph_with_groupby_no_entity_ids,
+        source_type=SourceType.SNOWFLAKE,
+        is_online_serving=False,
+    )
+    plan = planner.generate_plan([groupby_node])
+    assert plan.required_entity_ids == set()


### PR DESCRIPTION
## Description

This prevents internal server errors when attempting to interact with old features created before the `entity_ids` parameter was added to `BaseGroupbyParameters`, such as retrieving feature sql.

Addresses the error:
```
File \"/app/.venv/lib/python3.8/site-packages/featurebyte/query
_graph/sql/feature_compute.py\", line 110, in add_aggregation_spec
    aggregator.update(aggregation_spec)  # type: ignore

  File \"/app/.venv/lib/python3.8/site-packages/featurebyte/
query_graph/sql/aggregator/base.py\", line 315, in update
    super().update(aggregation_spec)

  File \"/app/.venv/lib/python3.8/site-packages/featurebyte/query_graph/sql/aggregator/b
ase.py\", line 124, in update
    self.required_entity_ids.update(aggregation_spec.entity_ids)
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
