### PR TITLE
task/base: make parameters non-optional

### DIFF
--- a/featurebyte/worker/task/base.py
+++ b/featurebyte/worker/task/base.py
@@ -11,7 +11,7 @@ from enum import Enum
 from featurebyte.schema.worker.progress import ProgressModel
 from featurebyte.schema.worker.task.base import BaseTaskPayload
 
-TASK_MAP: Dict[Enum, BaseTask] = {}
+TASK_MAP: Dict[Enum, type[BaseTask]] = {}
 
 
 class BaseTask:

--- a/tests/integration/worker/test_task_executor.py
+++ b/tests/integration/worker/test_task_executor.py
@@ -122,4 +122,11 @@ def test_task_has_been_implemented(command_class):
 
     # initiate BaseTask without override payload_class will trigger NotImplementedError
     with pytest.raises(NotImplementedError):
-        BaseTask(payload={})
+        BaseTask(
+            payload={},
+            progress=None,
+            get_persistent=None,
+            get_storage=None,
+            get_temp_storage=None,
+            get_credential=None,
+        )


### PR DESCRIPTION
## Description
Small changes to make these parameters non-optional since we always pass them in regardless. This would've help catch some small type/dependency issues on the `featurebyte-app` side where we accidentally removed an input thinking it was optional/not needed, when it actually was.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
