### PR TITLE
[DEV-1088] Add metadata to join node for SDK code generation

### DIFF
--- a/featurebyte/api/item_view.py
+++ b/featurebyte/api/item_view.py
@@ -29,7 +29,7 @@ from featurebyte.query_graph.graph import GlobalQueryGraph, QueryGraph
 from featurebyte.query_graph.graph_node.base import GraphNode
 from featurebyte.query_graph.model.column_info import ColumnInfo
 from featurebyte.query_graph.node import Node
-from featurebyte.query_graph.node.generic import JoinNodeParameters
+from featurebyte.query_graph.node.generic import JoinEventDataAttributesMetadata, JoinNodeParameters
 from featurebyte.query_graph.node.metadata.operation import DerivedDataColumn
 
 
@@ -150,6 +150,10 @@ class ItemView(View, GroupByMixin):
             right_input_columns=right_input_columns,
             right_output_columns=right_output_columns,
             join_type="inner",
+            metadata=JoinEventDataAttributesMetadata(
+                columns=columns_to_join,
+                event_suffix=event_suffix,
+            ),
         )
 
     @classmethod

--- a/featurebyte/api/view.py
+++ b/featurebyte/api/view.py
@@ -56,7 +56,7 @@ from featurebyte.query_graph.graph import GlobalQueryGraph
 from featurebyte.query_graph.graph_node.base import GraphNode
 from featurebyte.query_graph.model.column_info import ColumnInfo
 from featurebyte.query_graph.node import Node
-from featurebyte.query_graph.node.generic import ProjectNode
+from featurebyte.query_graph.node.generic import JoinMetadata, ProjectNode
 from featurebyte.query_graph.node.input import InputNode
 
 if TYPE_CHECKING:
@@ -775,6 +775,7 @@ class View(ProtectedColumnsQueryObject, Frame, ABC):
             "right_input_columns": right_input_columns,
             "right_output_columns": right_output_columns,
             "join_type": how,
+            "metadata": JoinMetadata(on=on, rsuffix=rsuffix),
         }
         node_params.update(
             other_view._get_join_parameters(self)  # pylint: disable=protected-access

--- a/tests/unit/api/test_item_view.py
+++ b/tests/unit/api/test_item_view.py
@@ -136,6 +136,11 @@ def test_from_item_data__auto_join_columns(
                                 "event_timestamp",
                             ],
                             "scd_parameters": None,
+                            "metadata": {
+                                "type": "join_event_data_attributes",
+                                "columns": ["event_timestamp", "cust_id"],
+                                "event_suffix": "_event_table",
+                            },
                         },
                         "type": "join",
                     },
@@ -294,6 +299,11 @@ def test_join_event_data_attributes__more_columns(
             ],
             "join_type": "inner",
             "scd_parameters": None,
+            "metadata": {
+                "type": "join_event_data_attributes",
+                "columns": ["col_float"],
+                "event_suffix": None,
+            },
         },
     }
 
@@ -461,6 +471,11 @@ def test_item_view__item_data_same_event_id_column_as_event_data(snowflake_item_
                             "right_output_columns": ["col_int", "item_id_col", "created_at"],
                             "join_type": "inner",
                             "scd_parameters": None,
+                            "metadata": {
+                                "type": "join_event_data_attributes",
+                                "event_suffix": None,
+                                "columns": ["event_timestamp", "cust_id"],
+                            },
                         },
                     },
                 ],

--- a/tests/unit/api/test_scd_view.py
+++ b/tests/unit/api/test_scd_view.py
@@ -93,6 +93,7 @@ def test_event_view_join_scd_view(snowflake_event_view, snowflake_scd_view):
             "end_timestamp_column": "end_timestamp",
             "left_timestamp_column": "event_timestamp",
         },
+        "metadata": {"type": "join", "on": None, "rsuffix": "_scd"},
     }
 
 

--- a/tests/unit/api/test_view.py
+++ b/tests/unit/api/test_view.py
@@ -372,6 +372,7 @@ def test_join__left_join(generic_input_node_params, join_type_param):
             "right_on": "colC",
             "right_output_columns": ["colDsuffix", "colEsuffix"],
             "scd_parameters": None,
+            "metadata": {"type": "join", "on": "colA", "rsuffix": "suffix"},
         },
         "type": "join",
     }

--- a/tests/unit/query_graph/test_graph_pruning.py
+++ b/tests/unit/query_graph/test_graph_pruning.py
@@ -201,6 +201,7 @@ def test_join_with_assign_node__join_node_parameters_pruning(
         "right_output_columns": ["item_type", "item_name"],
         "join_type": "inner",
         "scd_parameters": None,
+        "metadata": {"type": "join", "on": None, "rsuffix": ""},
     }
     join_node = global_graph.add_operation(
         node_type=NodeType.JOIN,
@@ -285,6 +286,7 @@ def test_join_with_assign_node__join_node_parameters_pruning(
         "right_on": "order_id",
         "right_output_columns": ["item_type", "item_name"],
         "scd_parameters": None,
+        "metadata": join_node_parameters["metadata"],
     }
     assert pruned_join_node.parameters == expected_pruned_join_node_params
 

--- a/tests/unit/query_graph/test_join.py
+++ b/tests/unit/query_graph/test_join.py
@@ -164,7 +164,7 @@ def test_item_data_join_event_data_attributes_on_demand_tile_gen(
           ) AS __FB_TILE_START_DATE_COLUMN,
           "cust_id",
           "item_type",
-          COUNT(*) AS value_count_7ae9b63c27e9f4f0a013cd6ec230f5a7a6b6fa62
+          COUNT(*) AS value_count_d3aca2b274b8253dd5a2aa41d62f55757aa2f2ce
         FROM (
           SELECT
             *,

--- a/tests/unit/service/test_context.py
+++ b/tests/unit/service/test_context.py
@@ -122,6 +122,11 @@ def join_node_fixture():
             "right_output_columns": ["event_id_col", "item_type", "item_amount"],
             "join_type": "inner",
             "scd_parameters": None,
+            "metadata": {
+                "type": "join_event_data_attributes",
+                "columns": ["item_type", "item_amount"],
+                "event_suffix": None,
+            },
         },
     }
 


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR adds metadata to `JoinNode` parameters so that we could track whether the join node is initiated from the left input node or right input node. The metadata is mainly used for SDK code generation.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
