### PR TITLE
[DEV-1138] Avoid deepcopy when copying TableNode

### DIFF
--- a/featurebyte/query_graph/sql/ast/base.py
+++ b/featurebyte/query_graph/sql/ast/base.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import Optional, Type, TypeVar, cast
 
 from abc import ABC, abstractmethod
-from copy import deepcopy
+from copy import copy
 from dataclasses import dataclass, field
 
 from sqlglot import expressions
@@ -334,7 +334,10 @@ class TableNode(SQLNode, ABC):
         -------
         TableNode
         """
-        return deepcopy(self)
+        new_table = copy(self)
+        new_table.columns_map = copy(self.columns_map)
+        new_table.columns_node = copy(self.columns_node)
+        return new_table
 
 
 @dataclass  # type: ignore


### PR DESCRIPTION
## Description

This avoids unnecessary deepcopy when copying a `TableNode` since it contains recursive structures like `SQLNodeContext` which can be very expensive to deepcopy but can be shared. It is now part of https://github.com/featurebyte/featurebyte/pull/797, but curious to see its effect standalone.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
