### PR TITLE
[FIX] Do not run migration on import

### DIFF
--- a/featurebyte/docker/migration.py
+++ b/featurebyte/docker/migration.py
@@ -9,6 +9,10 @@ from featurebyte.migration.run import run_migration
 from featurebyte.utils.credential import get_credential
 from featurebyte.utils.persistent import get_persistent
 
-logger.info("Running database migration")
-asyncio.run(run_migration(user=User(), persistent=get_persistent(), get_credential=get_credential))
-logger.info("Database migration completed")
+if __name__ == "__main__":
+    logger.info("Running database migration")
+    asyncio.run(
+        run_migration(user=User(), persistent=get_persistent(), get_credential=get_credential)
+    )
+
+    logger.info("Database migration completed")


### PR DESCRIPTION
## Description

A code block in `documentation` repo,  `gen_ref_pages.py` does an import like this. 

```
module = importlib.import_module(module_str)
```

As a result, when not in `if __name__ == "__main__"` block, migration will try to run leading to build failure in documentation.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
