### PR TITLE
integration/conftest: try to set event_loop on failure

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -41,6 +41,7 @@ from featurebyte.config import Configurations
 from featurebyte.enum import InternalName, SourceType, StorageType
 from featurebyte.feature_manager.manager import FeatureManager
 from featurebyte.feature_manager.model import ExtendedFeatureListModel
+from featurebyte.logger import logger
 from featurebyte.models.feature import FeatureModel, FeatureReadiness
 from featurebyte.models.feature_list import FeatureListStatus
 from featurebyte.persistent.mongo import MongoDB
@@ -189,6 +190,10 @@ def event_loop():
         loop.close()
     except Exception as e:  # pylint: disable=broad-except
         if "there is no current event loop in thread" in str(e):
+            logger.exception(
+                f"no event loop found. explicitly recreating and resetting new event loop.\n"
+                f"previous error: {str(e)}"
+            )
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
             yield loop


### PR DESCRIPTION
## Description
There's a bunch of errors of the form `RuntimeError: There is no current event loop in thread 'Dummy-1'.` that pop up once in a while on failing integration tests.

Example: https://github.com/featurebyte/featurebyte/actions/runs/4320831275/jobs/7541472752

Some googling suggests we can try to avoid this by having some extra handling around the event loop fixture.

Related links
- https://stackoverflow.com/questions/46727787/runtimeerror-there-is-no-current-event-loop-in-thread-in-async-apscheduler
- https://github.com/ultrafunkamsterdam/undetected-chromedriver/issues/373
- https://github.com/pytest-dev/pytest-asyncio/issues/257

I don't think this necessarily solves the underlying issue, but figured it might be worth a try to try to make a short-term patch to alleviate some flaky integration tests.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
