### PR TITLE
docs/code_select.css: fix colour in dark mode

### DIFF
--- a/docs/css/code_select.css
+++ b/docs/css/code_select.css
@@ -102,7 +102,6 @@ div.autodoc-members {
 }
 
 div.autodoc-content li div {
-  background-color: #f0f0ff;
   padding: 10px;
   font-size: 14px;
 }


### PR DESCRIPTION
## Description
There was an issue with the colouration in dark mode on li>div elements. This removes the background colour override so that we can view these elements in dark mode.

**Before**
![Screenshot 2023-03-06 at 11 32 39 AM](https://user-images.githubusercontent.com/2313101/223013911-3573dd65-2b94-4c27-8532-c0e20031212b.png)
![Screenshot 2023-03-06 at 11 32 42 AM](https://user-images.githubusercontent.com/2313101/223013919-3486a087-591b-4289-b98a-7f4c21cc0967.png)

**After**
![Screenshot 2023-03-06 at 11 32 58 AM](https://user-images.githubusercontent.com/2313101/223013936-2beea827-901a-4cdb-86d8-838d75a61093.png)
![Screenshot 2023-03-06 at 11 32 56 AM](https://user-images.githubusercontent.com/2313101/223013940-c4a7b950-1c8f-45cc-a53f-b3d21fad369d.png)


<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
