### PR TITLE
Re-direct spark docker logs to a file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,7 +221,13 @@ jobs:
           make test-setup
           set +e
           make test-integration-spark
+          # capture the exit code from the test run before stashing logs
+          EXIT_CODE=$?
           docker logs spark-thrift 2>&1 | tee spark-thrift.log
+          # bail out now if the test run was a failure
+          if [ $EXIT_CODE -ne 0 ]; then
+            exit $EXIT_CODE
+          fi
           make test-teardown
           mv .coverage .coverage.2
       - name: Upload spark-thrift log file


### PR DESCRIPTION
And use the upload-artifact action to save the log file on each workflow run. I set the retention to 5 days since these logs can get large and should really on be valuable when investigating failures.

With the logs saved as an artifact you can also download them from the details page on a single workflow run and search them locally using grep, ack, etc.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [x] I have labeled my Pull Request correctly
