### PR TITLE
[DEV-1217] Fix the frame `columns_info` bug

### DIFF
--- a/featurebyte/core/frame.py
+++ b/featurebyte/core/frame.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import Any, List, Tuple, TypeVar, Union
 
 import pandas as pd
-from pydantic import Field
+from pydantic import Field, validator
 from typeguard import typechecked
 
 from featurebyte.core.generic import QueryObject
@@ -15,6 +15,7 @@ from featurebyte.core.series import FrozenSeries, Series
 from featurebyte.enum import DBVarType
 from featurebyte.query_graph.enum import NodeOutputType, NodeType
 from featurebyte.query_graph.model.column_info import ColumnInfo
+from featurebyte.query_graph.node.validator import construct_unique_name_validator
 
 
 class BaseFrame(QueryObject, SampleMixin):
@@ -28,6 +29,11 @@ class BaseFrame(QueryObject, SampleMixin):
     """
 
     columns_info: List[ColumnInfo] = Field(description="List of columns specifications")
+
+    # pydantic validator
+    _validate_column_names = validator("columns_info", allow_reuse=True)(
+        construct_unique_name_validator(field="name")
+    )
 
     @property
     def column_var_type_map(self) -> dict[str, DBVarType]:
@@ -242,7 +248,7 @@ class Frame(FrozenFrame):
                 node_output_type=NodeOutputType.FRAME,
                 input_nodes=[self.node, value.node],
             )
-            self.columns_info.append(ColumnInfo(name=key, dtype=value.dtype))
+            column_info = ColumnInfo(name=key, dtype=value.dtype)
         else:
             node = self.graph.add_operation(
                 node_type=NodeType.ASSIGN,
@@ -250,9 +256,12 @@ class Frame(FrozenFrame):
                 node_output_type=NodeOutputType.FRAME,
                 input_nodes=[self.node],
             )
-            self.columns_info.append(
-                ColumnInfo(name=key, dtype=self.pytype_dbtype_map[type(value)])
-            )
+            column_info = ColumnInfo(name=key, dtype=self.pytype_dbtype_map[type(value)])
+
+        # update columns_info
+        columns_info = [col for col in self.columns_info if col.name != key]
+        columns_info.append(column_info)
+        self.columns_info = columns_info
 
         # update node_name
         self.node_name = node.name

--- a/tests/unit/api/test_item_view.py
+++ b/tests/unit/api/test_item_view.py
@@ -1030,3 +1030,30 @@ def test_sdk_code_generation(saved_item_data, saved_event_data, update_fixtures)
         update_fixtures=update_fixtures,
         data_id=saved_item_data.id,
     )
+
+
+def test_join_event_data_attributes__with_multiple_assignments(snowflake_item_view):
+    """
+    Test joining more columns from EventData after creating ItemView with multiple assignments
+    """
+    view = snowflake_item_view
+
+    mask = snowflake_item_view.event_id_col > 100
+    view["new_col"] = "new_column"
+    view["new_col"][mask] = "some_value"
+    view["new_col"][~mask] = "another_value"
+    view.join_event_data_attributes(["col_float"])
+
+    expected_columns = [
+        "event_id_col",
+        "item_id_col",
+        "item_type",
+        "item_amount",
+        "created_at",
+        "event_timestamp",
+        "event_timestamp_event_table",
+        "cust_id_event_table",
+        "new_col",
+        "col_float",
+    ]
+    assert view.columns == expected_columns

--- a/tests/unit/core/test_frame.py
+++ b/tests/unit/core/test_frame.py
@@ -6,6 +6,7 @@ import pytest
 from featurebyte.core.frame import Frame, Series
 from featurebyte.enum import DBVarType
 from featurebyte.query_graph.enum import NodeOutputType, NodeType
+from featurebyte.query_graph.model.column_info import ColumnInfo
 from tests.util.helper import get_node
 
 
@@ -520,3 +521,46 @@ def test_frame__project_always_uses_current_node_as_input(dataframe):
         "output_type": "series",
         "parameters": {"columns": ["CUST_ID"]},
     }
+
+
+def test_frame__setitem_with_multiple_assignments(dataframe):
+    """Test frame setitem with multiple assignments"""
+    mask = dataframe["MASK"]
+    dataframe["new_column"] = "some_value"
+    dataframe.new_column[mask] = "some_other_value"
+    dataframe.new_column[~mask] = "other_value"
+
+    # check that there is no duplicated 'new_column' column info
+    assert dataframe.columns_info == [
+        ColumnInfo(
+            name="CUST_ID", dtype="INT", entity_id=None, semantic_id=None, critical_data_info=None
+        ),
+        ColumnInfo(
+            name="PRODUCT_ACTION",
+            dtype="VARCHAR",
+            entity_id=None,
+            semantic_id=None,
+            critical_data_info=None,
+        ),
+        ColumnInfo(
+            name="VALUE", dtype="FLOAT", entity_id=None, semantic_id=None, critical_data_info=None
+        ),
+        ColumnInfo(
+            name="MASK", dtype="BOOL", entity_id=None, semantic_id=None, critical_data_info=None
+        ),
+        ColumnInfo(
+            name="TIMESTAMP",
+            dtype="TIMESTAMP",
+            entity_id=None,
+            semantic_id=None,
+            critical_data_info=None,
+        ),
+        ColumnInfo(name="PROMOTION_START_DATE", dtype="DATE", entity_id=None, semantic_id=None),
+        ColumnInfo(
+            name="new_column",
+            dtype="VARCHAR",
+            entity_id=None,
+            semantic_id=None,
+            critical_data_info=None,
+        ),
+    ]


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR aims to fix the bug where `columns_info` contains multiple columns with the same column name.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
