### PR TITLE
[BETA] fixing user without ~/.docker/config.json

### DIFF
--- a/featurebyte/docker/manager.py
+++ b/featurebyte/docker/manager.py
@@ -172,6 +172,11 @@ def print_logs(app_name: ApplicationName, service_name: str, tail: int) -> None:
 
 ### WARNING THIS NEEDS TO BE REMOVED AFTER BETA ###
 def __backup_docker_conf() -> None:
+    # If docker folder does not exist, create it
+    docker_folder = os.path.expanduser("~/.docker")
+    if not os.path.isdir(docker_folder):
+        os.mkdir(docker_folder)
+
     docker_cfg = os.path.expanduser("~/.docker/config.json")
     docker_cfg_old = os.path.expanduser("~/.docker/config.json.old")
 


### PR DESCRIPTION
## Description

Fixes the case when user does not even have a docker folder `~/.docker`
Fixes the case when user has docker but does not have a `~/.docker/config.json`

This section of code will be removed after beta. We only need to check for docker.config to replace when our images are not public.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
