### PR TITLE
Revert "[DEV-1208] Use tablesample for sampling"

### DIFF
--- a/featurebyte/api/source_table.py
+++ b/featurebyte/api/source_table.py
@@ -258,6 +258,7 @@ class AbstractTableData(ConstructGraphMixin, FeatureByteBaseModel, ABC):
     def sample(
         self,
         size: int = 10,
+        seed: int = 1234,
         from_timestamp: Optional[Union[datetime, str]] = None,
         to_timestamp: Optional[Union[datetime, str]] = None,
         after_cleaning: bool = False,
@@ -270,6 +271,8 @@ class AbstractTableData(ConstructGraphMixin, FeatureByteBaseModel, ABC):
         ----------
         size: int
             Maximum number of rows to sample
+        seed: int
+            Seed to use for random sampling
         from_timestamp: Optional[datetime]
             Start of date range to sample from
         to_timestamp: Optional[datetime]
@@ -285,6 +288,7 @@ class AbstractTableData(ConstructGraphMixin, FeatureByteBaseModel, ABC):
         """
         return self.frame.sample(  # type: ignore[misc]
             size=size,
+            seed=seed,
             from_timestamp=from_timestamp,
             to_timestamp=to_timestamp,
             after_cleaning=after_cleaning,
@@ -295,6 +299,7 @@ class AbstractTableData(ConstructGraphMixin, FeatureByteBaseModel, ABC):
     def describe(
         self,
         size: int = 0,
+        seed: int = 1234,
         from_timestamp: Optional[Union[datetime, str]] = None,
         to_timestamp: Optional[Union[datetime, str]] = None,
         after_cleaning: bool = False,
@@ -307,6 +312,8 @@ class AbstractTableData(ConstructGraphMixin, FeatureByteBaseModel, ABC):
         ----------
         size: int
             Maximum number of rows to sample
+        seed: int
+            Seed to use for random sampling
         from_timestamp: Optional[datetime]
             Start of date range to sample from
         to_timestamp: Optional[datetime]
@@ -322,6 +329,7 @@ class AbstractTableData(ConstructGraphMixin, FeatureByteBaseModel, ABC):
         """
         return self.frame.describe(  # type: ignore[misc]
             size=size,
+            seed=seed,
             from_timestamp=from_timestamp,
             to_timestamp=to_timestamp,
             after_cleaning=after_cleaning,

--- a/featurebyte/core/mixin.py
+++ b/featurebyte/core/mixin.py
@@ -244,6 +244,7 @@ class SampleMixin:
     def sample(
         self: HasExtractPrunedGraphAndNode,
         size: int = 10,
+        seed: int = 1234,
         from_timestamp: Optional[Union[datetime, str]] = None,
         to_timestamp: Optional[Union[datetime, str]] = None,
         **kwargs: Any,
@@ -255,6 +256,8 @@ class SampleMixin:
         ----------
         size: int
             Maximum number of rows to sample
+        seed: int
+            Seed to use for random sampling
         from_timestamp: Optional[datetime]
             Start of date range to sample from
         to_timestamp: Optional[datetime]
@@ -284,7 +287,9 @@ class SampleMixin:
             timestamp_column=self.timestamp_column,
         )
         client = Configurations().get_client()
-        response = client.post(url=f"/feature_store/sample?size={size}", json=payload.json_dict())
+        response = client.post(
+            url=f"/feature_store/sample?size={size}&seed={seed}", json=payload.json_dict()
+        )
         if response.status_code != HTTPStatus.OK:
             raise RecordRetrievalException(response)
         return dataframe_from_json(response.json())
@@ -293,6 +298,7 @@ class SampleMixin:
     def describe(
         self: HasExtractPrunedGraphAndNode,
         size: int = 0,
+        seed: int = 1234,
         from_timestamp: Optional[Union[datetime, str]] = None,
         to_timestamp: Optional[Union[datetime, str]] = None,
         **kwargs: Any,
@@ -304,6 +310,8 @@ class SampleMixin:
         ----------
         size: int
             Maximum number of rows to sample
+        seed: int
+            Seed to use for random sampling
         from_timestamp: Optional[datetime]
             Start of date range to sample from
         to_timestamp: Optional[datetime]
@@ -334,7 +342,7 @@ class SampleMixin:
         )
         client = Configurations().get_client()
         response = client.post(
-            url=f"/feature_store/description?size={size}", json=payload.json_dict()
+            url=f"/feature_store/description?size={size}&seed={seed}", json=payload.json_dict()
         )
         if response.status_code != HTTPStatus.OK:
             raise RecordRetrievalException(response)

--- a/featurebyte/query_graph/sql/interpreter.py
+++ b/featurebyte/query_graph/sql/interpreter.py
@@ -274,6 +274,7 @@ class GraphInterpreter:
         self,
         node_name: str,
         num_rows: int = 10,
+        seed: int = 1234,
         from_timestamp: Optional[datetime] = None,
         to_timestamp: Optional[datetime] = None,
         timestamp_column: Optional[str] = None,
@@ -287,6 +288,8 @@ class GraphInterpreter:
             Query graph node name
         num_rows : int
             Number of rows to sample, no sampling if None
+        seed: int
+            Random seed to use for sampling
         from_timestamp: Optional[datetime]
             Start of date range to filter on
         to_timestamp: Optional[datetime]
@@ -352,21 +355,10 @@ class GraphInterpreter:
 
         if num_rows > 0:
             # apply random sampling
-            sql_tree = (
-                expressions.Select()
-                .select(
-                    *[
-                        quoted_identifier(col_expr.alias or col_expr.name)
-                        for col_expr in sql_tree.expressions
-                    ]
-                )
-                .from_(
-                    expressions.TableSample(
-                        this=expressions.Subquery(this=sql_tree),
-                        rows=make_literal_value(num_rows),
-                    )
-                )
+            sql_tree = sql_tree.order_by(
+                expressions.Anonymous(this="RANDOM", expressions=[make_literal_value(seed)])
             )
+            sql_tree = sql_tree.limit(num_rows)
 
         return sql_tree, type_conversions
 
@@ -397,6 +389,7 @@ class GraphInterpreter:
         self,
         node_name: str,
         num_rows: int = 10,
+        seed: int = 1234,
         from_timestamp: Optional[datetime] = None,
         to_timestamp: Optional[datetime] = None,
         timestamp_column: Optional[str] = None,
@@ -409,6 +402,8 @@ class GraphInterpreter:
             Query graph node name
         num_rows : int
             Number of rows to include in the preview
+        seed: int
+            Random seed to use for sampling
         from_timestamp: Optional[datetime]
             Start of date range to filter on
         to_timestamp: Optional[datetime]
@@ -425,6 +420,7 @@ class GraphInterpreter:
         sql_tree, type_conversions = self._construct_sample_sql(
             node_name=node_name,
             num_rows=num_rows,
+            seed=seed,
             from_timestamp=from_timestamp,
             to_timestamp=to_timestamp,
             timestamp_column=timestamp_column,
@@ -910,6 +906,7 @@ class GraphInterpreter:
         self,
         node_name: str,
         num_rows: int = 10,
+        seed: int = 1234,
         from_timestamp: Optional[datetime] = None,
         to_timestamp: Optional[datetime] = None,
         timestamp_column: Optional[str] = None,
@@ -922,6 +919,8 @@ class GraphInterpreter:
             Query graph node name
         num_rows : int
             Number of rows to include in the preview
+        seed: int
+            Random seed to use for sampling
         from_timestamp: Optional[datetime]
             Start of date range to filter on
         to_timestamp: Optional[datetime]
@@ -941,6 +940,7 @@ class GraphInterpreter:
         sql_tree, type_conversions = self._construct_sample_sql(
             node_name=node_name,
             num_rows=num_rows,
+            seed=seed,
             from_timestamp=from_timestamp,
             to_timestamp=to_timestamp,
             timestamp_column=timestamp_column,

--- a/featurebyte/routes/feature_store/api.py
+++ b/featurebyte/routes/feature_store/api.py
@@ -226,6 +226,7 @@ async def get_data_sample(
     request: Request,
     sample: FeatureStoreSample,
     size: int = Query(default=10, gt=0, le=10000),
+    seed: int = Query(default=1234),
 ) -> Dict[str, Any]:
     """
     Retrieve data sample for query graph node
@@ -234,7 +235,7 @@ async def get_data_sample(
     return cast(
         Dict[str, Any],
         await controller.sample(
-            sample=sample, size=size, get_credential=request.state.get_credential
+            sample=sample, size=size, seed=seed, get_credential=request.state.get_credential
         ),
     )
 
@@ -244,6 +245,7 @@ async def get_data_description(
     request: Request,
     sample: FeatureStoreSample,
     size: int = Query(default=0, gte=0, le=1000000),
+    seed: int = Query(default=1234),
 ) -> Dict[str, Any]:
     """
     Retrieve data description for query graph node
@@ -252,6 +254,6 @@ async def get_data_description(
     return cast(
         Dict[str, Any],
         await controller.describe(
-            sample=sample, size=size, get_credential=request.state.get_credential
+            sample=sample, size=size, seed=seed, get_credential=request.state.get_credential
         ),
     )

--- a/featurebyte/routes/feature_store/controller.py
+++ b/featurebyte/routes/feature_store/controller.py
@@ -316,7 +316,7 @@ class FeatureStoreController(
         )
 
     async def sample(
-        self, sample: FeatureStoreSample, size: int, get_credential: Any
+        self, sample: FeatureStoreSample, size: int, seed: int, get_credential: Any
     ) -> dict[str, Any]:
         """
         Retrieve data sample for query graph node
@@ -327,6 +327,8 @@ class FeatureStoreController(
             FeatureStoreSample object
         size: int
             Maximum rows to sample
+        seed: int
+            Random seed to use for sampling
         get_credential: Any
             Get credential handler function
 
@@ -336,11 +338,11 @@ class FeatureStoreController(
             Dataframe converted to json string
         """
         return await self.preview_service.sample(
-            sample=sample, size=size, get_credential=get_credential
+            sample=sample, size=size, seed=seed, get_credential=get_credential
         )
 
     async def describe(
-        self, sample: FeatureStoreSample, size: int, get_credential: Any
+        self, sample: FeatureStoreSample, size: int, seed: int, get_credential: Any
     ) -> dict[str, Any]:
         """
         Retrieve data description for query graph node
@@ -351,6 +353,8 @@ class FeatureStoreController(
             FeatureStoreSample object
         size: int
             Maximum rows to sample
+        seed: int
+            Random seed to use for sampling
         get_credential: Any
             Get credential handler function
 
@@ -360,7 +364,7 @@ class FeatureStoreController(
             Dataframe converted to json string
         """
         return await self.preview_service.describe(
-            sample=sample, size=size, get_credential=get_credential
+            sample=sample, size=size, seed=seed, get_credential=get_credential
         )
 
     async def get_info(

--- a/featurebyte/service/preview.py
+++ b/featurebyte/service/preview.py
@@ -124,7 +124,7 @@ class PreviewService(BaseService):
         return dataframe_to_json(result, type_conversions)
 
     async def sample(
-        self, sample: FeatureStoreSample, size: int, get_credential: Any
+        self, sample: FeatureStoreSample, size: int, seed: int, get_credential: Any
     ) -> dict[str, Any]:
         """
         Sample a QueryObject that is not a Feature (e.g. SourceTable, EventTable, EventView, etc)
@@ -135,6 +135,8 @@ class PreviewService(BaseService):
             FeatureStoreSample object
         size: int
             Maximum rows to sample
+        seed: int
+            Random seed to use for sampling
         get_credential: Any
             Get credential handler function
 
@@ -154,6 +156,7 @@ class PreviewService(BaseService):
         ).construct_sample_sql(
             node_name=sample.node_name,
             num_rows=size,
+            seed=seed,
             from_timestamp=sample.from_timestamp,
             to_timestamp=sample.to_timestamp,
             timestamp_column=sample.timestamp_column,
@@ -162,7 +165,7 @@ class PreviewService(BaseService):
         return dataframe_to_json(result, type_conversions)
 
     async def describe(
-        self, sample: FeatureStoreSample, size: int, get_credential: Any
+        self, sample: FeatureStoreSample, size: int, seed: int, get_credential: Any
     ) -> dict[str, Any]:
         """
         Sample a QueryObject that is not a Feature (e.g. SourceTable, EventTable, EventView, etc)
@@ -173,6 +176,8 @@ class PreviewService(BaseService):
             FeatureStoreSample object
         size: int
             Maximum rows to sample
+        seed: int
+            Random seed to use for sampling
         get_credential: Any
             Get credential handler function
 
@@ -193,6 +198,7 @@ class PreviewService(BaseService):
         ).construct_describe_sql(
             node_name=sample.node_name,
             num_rows=size,
+            seed=seed,
             from_timestamp=sample.from_timestamp,
             to_timestamp=sample.to_timestamp,
             timestamp_column=sample.timestamp_column,

--- a/tests/integration/api/feature_preview_utils.py
+++ b/tests/integration/api/feature_preview_utils.py
@@ -11,10 +11,3 @@ def convert_preview_param_dict_to_feature_preview_resp(input_dict):
     output_dict = input_dict
     output_dict["POINT_IN_TIME"] = pd.Timestamp(input_dict["POINT_IN_TIME"])
     return output_dict
-
-
-def _to_utc_no_offset(date):
-    """
-    Comvert timestamp to timezone naive UTC
-    """
-    return pd.to_datetime(date, utc=True).tz_localize(None)

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -1055,7 +1055,6 @@ def test_add_feature_on_view_with_join(event_view, scd_table, non_time_based_fea
 
     # ensure the updated view continues to work as expected
     event_view["User Status New"] = event_view["User Status"] + "_suffix"
-    event_view = event_view[event_view["User Status"].notnull()]
 
     # test columns are updated as expected
     event_view_preview = event_view.sample()

--- a/tests/integration/api/test_table_column_critical_data_info.py
+++ b/tests/integration/api/test_table_column_critical_data_info.py
@@ -65,8 +65,8 @@ def test_event_table_update_critical_data_info(event_table):
     clean_df = event_table.preview(after_cleaning=True)
     pd.testing.assert_frame_equal(view_df, clean_df)
 
-    view_sample_df = event_view.preview()
-    clean_sample_df = event_table.preview(after_cleaning=True)
+    view_sample_df = event_view.sample()
+    clean_sample_df = event_table.sample(after_cleaning=True)
     pd.testing.assert_frame_equal(view_sample_df, clean_sample_df)
 
     # check describe operation between post-clean event table & event view

--- a/tests/integration/api/test_view_describe.py
+++ b/tests/integration/api/test_view_describe.py
@@ -4,7 +4,12 @@ Test API View objects describe function
 import pandas as pd
 from pandas.testing import assert_series_equal
 
-from tests.integration.api.feature_preview_utils import _to_utc_no_offset
+
+def _to_utc_no_offset(date):
+    """
+    Comvert timestamp to timezone naive UTC
+    """
+    return pd.to_datetime(date, utc=True).tz_localize(None)
 
 
 def test_event_view_describe(event_table):

--- a/tests/integration/api/test_view_sample.py
+++ b/tests/integration/api/test_view_sample.py
@@ -6,32 +6,24 @@ import pytest
 from pandas.testing import assert_series_equal
 from pydantic.error_wrappers import ValidationError
 
-from tests.integration.api.feature_preview_utils import _to_utc_no_offset
 
-
+@pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
 def test_event_table_sample(event_table):
     """
     Test event table sample & event table column sample
     """
-    sample_df = event_table.sample()
-    assert sample_df.columns.tolist() == [
-        "ËVENT_TIMESTAMP",
-        "CREATED_AT",
-        "CUST_ID",
-        "ÜSER ID",
-        "PRODUCT_ACTION",
-        "SESSION_ID",
-        "ÀMOUNT",
-        "TRANSACTION_ID",
-    ]
-    assert sample_df.shape == (10, 8)
+    event_table_df = event_table.sample()
+    ts_col = "ËVENT_TIMESTAMP"
+    ev_ts = event_table[ts_col].sample()
+    pd.testing.assert_frame_equal(event_table_df[[ts_col]], ev_ts)
 
 
+@pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
 def test_event_view_sample(event_table):
     """
     Test sample for EventView
     """
-    sample_kwargs = {"size": 10}
+    sample_kwargs = {"size": 10, "seed": 1234}
     event_view = event_table.get_view()
     sample_df = event_view.sample(**sample_kwargs)
     assert sample_df.columns.tolist() == [
@@ -46,8 +38,28 @@ def test_event_view_sample(event_table):
     ]
 
     assert sample_df.shape == (10, 8)
+    assert sample_df["ËVENT_TIMESTAMP"].min() == pd.Timestamp("2001-01-06 03:42:00.000640+10:00")
+    assert sample_df["ËVENT_TIMESTAMP"].max() == pd.Timestamp("2001-10-14 13:57:21.000525+06:00")
+
+    # test view column
+    ts_col = "ËVENT_TIMESTAMP"
+    ev_ts = event_view[ts_col].sample(**sample_kwargs)
+    pd.testing.assert_frame_equal(sample_df[[ts_col]], ev_ts)
 
 
+@pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
+def test_event_view_sample_seed(event_table):
+    """
+    Test sample for EventView using a different seed
+    """
+    event_view = event_table.get_view()
+    sample_df = event_view.sample(size=10, seed=4321)
+    assert sample_df.shape == (10, 8)
+    assert sample_df["ËVENT_TIMESTAMP"].min() == pd.Timestamp("2001-01-01 22:23:02.000349+22:00")
+    assert sample_df["ËVENT_TIMESTAMP"].max() == pd.Timestamp("2001-10-05 14:34:01.000068+10:00")
+
+
+@pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
 def test_event_view_sample_with_date_range(event_table):
     """
     Test sample for EventView with date range
@@ -55,25 +67,26 @@ def test_event_view_sample_with_date_range(event_table):
     event_view = event_table.get_view()
     sample_params = {
         "size": 15,
+        "seed": 1234,
         "from_timestamp": "2001-10-10",
         "to_timestamp": "2001-10-14",
     }
     sample_df = event_view.sample(**sample_params)
     assert sample_df.shape == (15, 8)
-    assert _to_utc_no_offset(sample_df["ËVENT_TIMESTAMP"].min()) >= pd.Timestamp(
-        "2001-10-10 00:00:00"
-    )
-    assert _to_utc_no_offset(sample_df["ËVENT_TIMESTAMP"].max()) <= pd.Timestamp(
-        "2001-10-14 00:00:00"
-    )
+    assert sample_df["ËVENT_TIMESTAMP"].min() == pd.Timestamp("2001-10-10 18:58:16.000637+13:00")
+    assert sample_df["ËVENT_TIMESTAMP"].max() == pd.Timestamp("2001-10-13 13:12:06.000903+09:00")
+
+    col_sample_df = event_view["TRANSACTION_ID"].sample(**sample_params)
+    assert_series_equal(col_sample_df["TRANSACTION_ID"], sample_df["TRANSACTION_ID"])
 
 
+@pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
 def test_item_view_sample(item_table):
     """
     Test sample for ItemView
     """
     item_view = item_table.get_view()
-    sample_df = item_view.sample(size=10)
+    sample_df = item_view.sample(size=10, seed=1234)
     assert sample_df.columns.tolist() == [
         "ËVENT_TIMESTAMP",
         "CUST_ID",
@@ -85,8 +98,11 @@ def test_item_view_sample(item_table):
     ]
 
     assert sample_df.shape == (10, 7)
+    assert sample_df["ËVENT_TIMESTAMP"].min() == pd.Timestamp("2001-01-02 21:55:20.000561+1000")
+    assert sample_df["ËVENT_TIMESTAMP"].max() == pd.Timestamp("2001-12-27 14:51:49.000824+1300")
 
 
+@pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
 def test_item_view_sample_with_date_range(item_table):
     """
     Test sample for ItemView with date range
@@ -94,25 +110,26 @@ def test_item_view_sample_with_date_range(item_table):
     item_view = item_table.get_view()
     sample_params = {
         "size": 15,
+        "seed": 1234,
         "from_timestamp": "2001-10-10",
         "to_timestamp": "2001-10-14",
     }
     sample_df = item_view.sample(**sample_params)
     assert sample_df.shape == (15, 7)
-    assert _to_utc_no_offset(sample_df["ËVENT_TIMESTAMP"].min()) >= pd.Timestamp(
-        "2001-10-10 00:00:00"
-    )
-    assert _to_utc_no_offset(sample_df["ËVENT_TIMESTAMP"].max()) <= pd.Timestamp(
-        "2001-10-14 00:00:00"
-    )
+    assert sample_df["ËVENT_TIMESTAMP"].min() == pd.Timestamp("2001-10-10 18:12:15.000088+1400")
+    assert sample_df["ËVENT_TIMESTAMP"].max() == pd.Timestamp("2001-10-14 16:08:02.000346+2200")
+
+    col_sample_df = item_view["item_id"].sample(**sample_params)
+    assert_series_equal(col_sample_df["item_id"], sample_df["item_id"])
 
 
+@pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
 def test_dimension_view_sample(dimension_table):
     """
     Test sample for DimensionView
     """
     dimension_view = dimension_table.get_view()
-    sample_df = dimension_view.sample(size=10)
+    sample_df = dimension_view.sample(size=10, seed=1234)
     assert sample_df.columns.tolist() == [
         "created_at",
         "item_id",
@@ -123,11 +140,14 @@ def test_dimension_view_sample(dimension_table):
     assert sample_df.shape == (10, 4)
 
 
+@pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
 def test_dimension_view_sample_with_date_range(dimension_table):
     """
     Test sample for DimensionView with date range
     """
     dimension_view = dimension_table.get_view()
     with pytest.raises(ValidationError) as exc:
-        dimension_view.sample(size=15, from_timestamp="2001-10-10", to_timestamp="2001-10-14")
+        dimension_view.sample(
+            size=15, seed=1234, from_timestamp="2001-10-10", to_timestamp="2001-10-14"
+        )
         assert "timestamp_column must be specified." in str(exc)

--- a/tests/unit/query_graph/test_interpreter.py
+++ b/tests/unit/query_graph/test_interpreter.py
@@ -1121,24 +1121,19 @@ def test_graph_interpreter_sample(simple_graph):
     graph, node = simple_graph
     interpreter = GraphInterpreter(graph, SourceType.SNOWFLAKE)
 
-    sql_code = interpreter.construct_sample_sql(node.name, num_rows=10)[0]
+    sql_code = interpreter.construct_sample_sql(node.name, num_rows=10, seed=1234)[0]
     expected = textwrap.dedent(
         """
         SELECT
-          "ts",
-          "cust_id",
-          "a",
-          "b",
-          "a_copy"
-        FROM (
-          SELECT
-            "ts" AS "ts",
-            "cust_id" AS "cust_id",
-            "a" AS "a",
-            "b" AS "b",
-            "a" AS "a_copy"
-          FROM "db"."public"."event_table"
-        ) TABLESAMPLE(10 ROWS)
+          "ts" AS "ts",
+          "cust_id" AS "cust_id",
+          "a" AS "a",
+          "b" AS "b",
+          "a" AS "a_copy"
+        FROM "db"."public"."event_table"
+        ORDER BY
+          RANDOM(1234)
+        LIMIT 10
         """
     ).strip()
     assert sql_code == expected
@@ -1152,6 +1147,7 @@ def test_graph_interpreter_sample_date_range(simple_graph):
     sql_code = interpreter.construct_sample_sql(
         node.name,
         num_rows=10,
+        seed=10,
         timestamp_column="ts",
         from_timestamp=pd.to_datetime("2020-01-01"),
         to_timestamp=pd.to_datetime("2020-01-03"),
@@ -1159,23 +1155,18 @@ def test_graph_interpreter_sample_date_range(simple_graph):
     expected = textwrap.dedent(
         """
         SELECT
-          "ts",
-          "cust_id",
-          "a",
-          "b",
-          "a_copy"
-        FROM (
-          SELECT
-            "ts" AS "ts",
-            "cust_id" AS "cust_id",
-            "a" AS "a",
-            "b" AS "b",
-            "a" AS "a_copy"
-          FROM "db"."public"."event_table"
-          WHERE
-            "ts" >= CAST('2020-01-01T00:00:00' AS TIMESTAMPNTZ)
-            AND "ts" < CAST('2020-01-03T00:00:00' AS TIMESTAMPNTZ)
-        ) TABLESAMPLE(10 ROWS)
+          "ts" AS "ts",
+          "cust_id" AS "cust_id",
+          "a" AS "a",
+          "b" AS "b",
+          "a" AS "a_copy"
+        FROM "db"."public"."event_table"
+        WHERE
+          "ts" >= CAST('2020-01-01T00:00:00' AS TIMESTAMPNTZ)
+          AND "ts" < CAST('2020-01-03T00:00:00' AS TIMESTAMPNTZ)
+        ORDER BY
+          RANDOM(10)
+        LIMIT 10
         """
     ).strip()
     assert sql_code == expected
@@ -1189,6 +1180,7 @@ def test_graph_interpreter_sample_date_range_no_timestamp_column(simple_graph):
     sql_code = interpreter.construct_sample_sql(
         node.name,
         num_rows=30,
+        seed=20,
         timestamp_column=None,
         from_timestamp=pd.to_datetime("2020-01-01"),
         to_timestamp=pd.to_datetime("2020-01-03"),
@@ -1196,20 +1188,15 @@ def test_graph_interpreter_sample_date_range_no_timestamp_column(simple_graph):
     expected = textwrap.dedent(
         """
         SELECT
-          "ts",
-          "cust_id",
-          "a",
-          "b",
-          "a_copy"
-        FROM (
-          SELECT
-            "ts" AS "ts",
-            "cust_id" AS "cust_id",
-            "a" AS "a",
-            "b" AS "b",
-            "a" AS "a_copy"
-          FROM "db"."public"."event_table"
-        ) TABLESAMPLE(30 ROWS)
+          "ts" AS "ts",
+          "cust_id" AS "cust_id",
+          "a" AS "a",
+          "b" AS "b",
+          "a" AS "a_copy"
+        FROM "db"."public"."event_table"
+        ORDER BY
+          RANDOM(20)
+        LIMIT 30
         """
     ).strip()
     assert sql_code == expected

--- a/tests/unit/routes/test_feature_store.py
+++ b/tests/unit/routes/test_feature_store.py
@@ -349,31 +349,22 @@ class TestFeatureStoreApi(BaseApiTestSuite):
             == textwrap.dedent(
                 """
                 SELECT
-                  "col_int",
-                  "col_float",
-                  "col_char",
-                  "col_text",
-                  "col_binary",
-                  "col_boolean",
-                  "event_timestamp",
-                  "created_at",
-                  "cust_id"
-                FROM (
-                  SELECT
-                    "col_int" AS "col_int",
-                    "col_float" AS "col_float",
-                    "col_char" AS "col_char",
-                    "col_text" AS "col_text",
-                    "col_binary" AS "col_binary",
-                    "col_boolean" AS "col_boolean",
-                    "event_timestamp" AS "event_timestamp",
-                    "created_at" AS "created_at",
-                    "cust_id" AS "cust_id"
-                  FROM "sf_database"."sf_schema"."sf_table"
-                  WHERE
-                    "event_timestamp" >= CAST('2012-11-24T11:00:00' AS TIMESTAMPNTZ)
-                    AND "event_timestamp" < CAST('2019-11-24T11:00:00' AS TIMESTAMPNTZ)
-                ) TABLESAMPLE(10 ROWS)
+                  "col_int" AS "col_int",
+                  "col_float" AS "col_float",
+                  "col_char" AS "col_char",
+                  "col_text" AS "col_text",
+                  "col_binary" AS "col_binary",
+                  "col_boolean" AS "col_boolean",
+                  "event_timestamp" AS "event_timestamp",
+                  "created_at" AS "created_at",
+                  "cust_id" AS "cust_id"
+                FROM "sf_database"."sf_schema"."sf_table"
+                WHERE
+                  "event_timestamp" >= CAST('2012-11-24T11:00:00' AS TIMESTAMPNTZ)
+                  AND "event_timestamp" < CAST('2019-11-24T11:00:00' AS TIMESTAMPNTZ)
+                ORDER BY
+                  RANDOM(1234)
+                LIMIT 10
                 """
             ).strip()
         )


### PR DESCRIPTION
Reverts featurebyte/featurebyte#930

Using tablesample with rows simply performs limit per partition and does not sample uniformly.
Reverting this for now.