### PR TITLE
[DEV-1258] fbautodoc/extension: fix return type

### DIFF
--- a/docs/extensions/fbautodoc/extension.py
+++ b/docs/extensions/fbautodoc/extension.py
@@ -13,7 +13,7 @@ from xml.etree import ElementTree as etree
 
 from docstring_parser import parse
 from docstring_parser.common import Docstring as BaseDocstring
-from docstring_parser.common import DocstringExample, DocstringMeta
+from docstring_parser.common import DocstringExample, DocstringMeta, DocstringReturns
 from markdown import Markdown
 from markdown.extensions import Extension
 from mkautodoc.extension import AutoDocProcessor, import_from_string, last_iter, trim_docstring
@@ -431,7 +431,9 @@ class FBAutoDocProcessor(AutoDocProcessor):
 
             return "\n".join(content)
 
-        def _get_return_param_details(docstring_returns, return_type_from_signature):
+        def _get_return_param_details(
+            docstring_returns: DocstringReturns, return_type_from_signature: Any
+        ) -> ParameterDetails:
             current_return_type = self.format_param_type(return_type_from_signature)
             if not current_return_type and docstring_returns:
                 current_return_type = docstring_returns.type_name


### PR DESCRIPTION
## Description
Return type values are sometimes missing from the signature. This is because the type checker doesn't find the type as we do some special type checking handling in the src code to workaround circular imports.

This commit updates the logic to fallback to the type found in the docstring instead if we cannot infer the type from the signature.

**Before**
![Screenshot 2023-03-22 at 11 16 38 AM](https://user-images.githubusercontent.com/2313101/226793313-8a34b17f-204d-4238-926c-5d1f7d9e4e74.png)

**After**
![Screenshot 2023-03-22 at 11 16 16 AM](https://user-images.githubusercontent.com/2313101/226793344-4c090279-770e-47d0-b0ec-de1151bc9160.png)


## Related Issue
https://featurebyte.atlassian.net/browse/DEV-1258
<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
