### PR TITLE
[DEV-1260] fbautodoc/extension: rm links from exceptions

### DIFF
--- a/docs/css/code_select.css
+++ b/docs/css/code_select.css
@@ -101,3 +101,7 @@ div.autodoc-content li div {
   padding: 10px;
   font-size: 14px;
 }
+
+.autodoc-overflow-wrap-break-word {
+  overflow-wrap: break-word;
+}

--- a/docs/extensions/fbautodoc/extension.py
+++ b/docs/extensions/fbautodoc/extension.py
@@ -572,6 +572,7 @@ class FBAutoDocProcessor(AutoDocProcessor):
             # populate resource path and name as autodoc title
             parent.clear()
             title_elem = etree.SubElement(parent, "h1")
+            title_elem.set("class", "autodoc-overflow-wrap-break-word")
 
             # add div for autodoc body
             autodoc_div = etree.SubElement(parent, "div")


### PR DESCRIPTION
## Description
Remove links from exceptions. We don't generate pages for each of these exceptions so the links are broken right now. Further, each exception should already have its own description under which might vary based on the method that is raising them.

As such, a centralized exception doc page will not be too useful.

Also convert headers to H1 for simplicity and consistency w/ rest of docs.

**Screenshot of changes**
![Screenshot 2023-03-22 at 4 32 12 PM](https://user-images.githubusercontent.com/2313101/226844519-5da3e6f3-9a96-490d-ba85-146ecd0968ff.png)
![Screenshot 2023-03-22 at 4 23 12 PM](https://user-images.githubusercontent.com/2313101/226844546-56b8e4c8-a659-4013-af75-2af41e2707e3.png)
nshots**


<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-1260
<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
