### PR TITLE
[DEV-1201] gen_ref_pages: simplify accessor logic for reuse

### DIFF
--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -355,13 +355,19 @@ def get_paths_to_document():
 
 def get_api_path_to_use(doc_path, base_path, accessor_property_name):
     """
-    doc_path -> featurebyte.core.accessor.string.StringAccessor.lower.md
-    base_path_of_class -> featurebyte.ViewColumn
-    accessor_property_name -> str, cd
+    Returns
+    -------
+    str
+        API path to use
 
-    returns api_to_use
-
-    caller will know what accessor it is, and pass the base_path_of_class in accordingly
+    Parameters
+    ---------
+    doc_path
+        Example: featurebyte.core.accessor.string.StringAccessor.lower.md
+    base_path
+        Example: featurebyte.ViewColumn
+    accessor_property_name
+        Example: str, cd
     """
     removed_md_path = doc_path.replace(".md", "")
     function_name = removed_md_path.rsplit(".", 1)[-1]


### PR DESCRIPTION
## Description
This commit simplifies the accessor logic to make it easier to reuse,
and also fixes some bugs.

This commit will now generate a markdown page for each class
that uses the accessor. This will allow us to display the
API path properly, and also not have some link issues that was
previously occurring in the docs.

**Before**
![Screenshot 2023-03-22 at 5 43 10 PM](https://user-images.githubusercontent.com/2313101/226863964-a64accbf-77b2-4039-adae-89a09f158092.png)

**After**
![Screenshot 2023-03-22 at 5 42 33 PM](https://user-images.githubusercontent.com/2313101/226864004-86b9bdb7-67fa-4466-b1c1-9a79500b8d1c.png)


<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-1201

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
