### PR TITLE
Mock send telemetry in tests

### DIFF
--- a/featurebyte/middleware.py
+++ b/featurebyte/middleware.py
@@ -240,7 +240,7 @@ class TelemetryMiddleware(BaseHTTPMiddleware):
             [f"{(uuid.getnode() >> ele) & 0xff:02x}" for ele in range(0, 8 * 6, 8)][::-1]
         )
 
-    async def __send_telemetry(self, payload: Dict[str, Any]) -> None:
+    async def _send_telemetry(self, payload: Dict[str, Any]) -> None:
         try:
             requests.post(self.endpoint, json=payload, timeout=1)  # set timeout to 1 second
         except Exception:  # pylint: disable=broad-except
@@ -284,12 +284,12 @@ class TelemetryMiddleware(BaseHTTPMiddleware):
         }
         if response.background is None:
             background = BackgroundTasks()
-            background.add_task(self.__send_telemetry, payload)
+            background.add_task(self._send_telemetry, payload)
             response.background = background
         else:
             background = BackgroundTasks()
             background.add_task(response.background)
-            background.add_task(self.__send_telemetry, payload)
+            background.add_task(self._send_telemetry, payload)
             response.background = background
 
         return response

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,14 @@ def mock_settings_env_vars():
         yield
 
 
+@pytest.fixture(autouse=True)
+def mock_send_telemetry():
+    """Mock __send_telemetry in featurebyte.middleware"""
+
+    with patch("featurebyte.middleware.TelemetryMiddleware._send_telemetry") as mock_send_telemetry:
+        yield mock_send_telemetry
+
+
 @pytest.fixture(name="test_dir")
 def test_directory_fixture():
     """Test directory"""


### PR DESCRIPTION
## Description

The tests are still sending telemetry because correctly mocking the configurations in all tests is tricky. Patching the underlying `_send_telemetry` method to be a no-op for now.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
