### PR TITLE
[DEV-1311] Skip importing datasets that exists by default

### DIFF
--- a/featurebyte/__init__.py
+++ b/featurebyte/__init__.py
@@ -1,5 +1,5 @@
 """Python Library for FeatureOps"""
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from featurebyte.api.catalog import Catalog
 from featurebyte.api.change_view import ChangeView
@@ -52,6 +52,23 @@ from featurebyte.schema.feature_list import FeatureVersionInfo
 version: str = get_version()
 
 
+def use_profile(profile: str) -> Dict[str, str]:
+    """
+    Use service profile specified in configuration file
+
+    Parameters
+    ----------
+    profile: str
+        Profile name
+
+    Returns
+    -------
+    Dict[str, str]
+        Remote and local SDK versions
+    """
+    return Configurations().use_profile(profile)
+
+
 def start(local: bool = False) -> None:
     """
     Start featurebyte application
@@ -85,7 +102,10 @@ def stop() -> None:
 
 
 def playground(
-    local: bool = False, datasets: Optional[List[str]] = None, docs_enabled: bool = True
+    local: bool = False,
+    datasets: Optional[List[str]] = None,
+    docs_enabled: bool = True,
+    force_import: bool = False,
 ) -> None:
     """
     Start playground environment
@@ -98,8 +118,12 @@ def playground(
         List of datasets to import, by default None (import all datasets)
     docs_enabled: bool
         Enable featurebyte-docs, by default True
+    force_import: bool
+        Import datasets even if they are already imported, by default False
     """
-    _start_playground(local=local, datasets=datasets, docs_enabled=docs_enabled)
+    _start_playground(
+        local=local, datasets=datasets, docs_enabled=docs_enabled, force_import=force_import
+    )
 
 
 __all__ = [

--- a/featurebyte/__main__.py
+++ b/featurebyte/__main__.py
@@ -38,9 +38,10 @@ def start(
 @app.command(name="playground")
 def playground(
     local: bool = typer.Option(default=False, help="Do not pull new images from registry"),
+    force_import: bool = typer.Option(default=False, help="Import datasets even if they exist"),
 ) -> None:
     """Start playground environment"""
-    start_playground(local)
+    start_playground(local, force_import=force_import)
 
 
 @app.callback(invoke_without_command=True)
@@ -52,13 +53,10 @@ def default(ctx: typer.Context) -> None:
 
 
 @app.command(name="stop")
-def stop(
-    app_name: ApplicationName = typer.Argument(
-        default="featurebyte", help="Name of application to stop"
-    )
-) -> None:
-    """Stop application"""
-    stop_app(app_name)
+def stop() -> None:
+    """Stop all applications"""
+    for app_name in ApplicationName:
+        stop_app(app_name)
 
 
 @app.command(name="logs")

--- a/featurebyte/docker/featurebyte.yml
+++ b/featurebyte/docker/featurebyte.yml
@@ -67,6 +67,8 @@ services:
       - "LOCAL_GID=${LOCAL_GID}"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8088/status"]
+      interval: 30s
+      start_period: 60s
     volumes:
       - ./migration.py:/scripts/migration.py
       - ~/.featurebyte/config.yaml:/app/.featurebyte/config.yaml


### PR DESCRIPTION
## Description

Skip datasets import if the dataset exists in the Spark datawarehouse to make playground setup faster on subsequent calls

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-1311

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
