### PR TITLE
[DEV-1346] gen_ref_pages_docs_builder: add test for missing docs

### DIFF
--- a/featurebyte/common/documentation/gen_ref_pages_docs_builder.py
+++ b/featurebyte/common/documentation/gen_ref_pages_docs_builder.py
@@ -787,7 +787,7 @@ class DocsBuilder:
         logger.info("Writing API Reference SUMMARY")
         self.write_nav_to_file("reference/SUMMARY.md", "summary", nav)
 
-    def build_docs(self) -> None:
+    def build_docs(self) -> Nav:
         """
         In order to generate the documentation, we perform the following steps:
 
@@ -811,6 +811,7 @@ class DocsBuilder:
         proxied_path_to_markdown_path = self.generate_documentation_for_docs(doc_groups_to_use)
         updated_nav = populate_nav(nav_to_use, proxied_path_to_markdown_path)
         self.write_summary_page(updated_nav)
+        return updated_nav
 
 
 def build_docs(set_edit_path_fn: Any, gen_files_open_fn: Any) -> None:

--- a/tests/unit/common/documentation/test_gen_ref_pages_docs_builder.py
+++ b/tests/unit/common/documentation/test_gen_ref_pages_docs_builder.py
@@ -1,10 +1,19 @@
 """
 Test gen ref pages docs builder.
 """
+from typing import Any, Set
+
+import re
+from contextlib import contextmanager
+from dataclasses import dataclass
+
 import pytest
 
 from featurebyte.common.doc_util import FBAutoDoc
-from featurebyte.common.documentation.gen_ref_pages_docs_builder import DocsBuilder
+from featurebyte.common.documentation.gen_ref_pages_docs_builder import (
+    MISSING_DEBUG_MARKDOWN,
+    DocsBuilder,
+)
 
 
 class TestClassWithAutodoc:
@@ -41,3 +50,95 @@ def test_get_section_from_class_obj(test_class, expected_output, gen_docs_overri
     docs_builder = DocsBuilder(None, None, gen_docs_override)
     section = docs_builder.get_section_from_class_obj(test_class)
     assert section == expected_output
+
+
+class NoopLinesWriter:
+    """
+    Noop lines writer class.
+    """
+
+    def writelines(self, lines):
+        pass
+
+
+class GenFilesOpenWrapper:
+    """
+    Simple wrapper class to help track all files that are opened.
+    """
+
+    def __init__(self):
+        self.all_file_names = set()
+
+    @contextmanager
+    def gen_files_open(self, filename: str, mode: str = "w"):
+        """
+        Context manager that opens a file in memory.
+        """
+        _ = filename, mode
+        self.all_file_names.add(str(filename))
+        writer = NoopLinesWriter()
+        yield writer
+
+
+@pytest.fixture(name="noop_set_edit_path")
+def noop_set_edit_path_fixture():
+    """
+    Noop set edit path fixture.
+    """
+
+    def _noop_set_edit_path(param1: Any, param2: Any):
+        pass
+
+    return _noop_set_edit_path
+
+
+@dataclass
+class NavItem:
+    """
+    Data class to represent a nav item.
+    """
+
+    property: str
+    markdown_filename: str
+
+    def is_missing(self, all_markdown_files: Set[str]):
+        reference_file = f"reference/{self.markdown_filename}"
+        return (
+            MISSING_DEBUG_MARKDOWN in self.markdown_filename
+            or reference_file not in all_markdown_files
+        )
+
+
+def _extract_nav_item(nav_item):
+    if nav_item is None:
+        return None
+    # example line to extract info from: [EventTable.initialize_default_feature_job_settings](missing.md)
+    regex = r"\[(.*)\]\((.*)\)"
+    result = re.search(regex, nav_item)
+    if result is None:
+        return None
+    return NavItem(result.group(1), result.group(2))
+
+
+def test_all_docs(noop_set_edit_path):
+    """
+    Test that all docs are generated.
+
+    There are 2 ways in which docs could go missing:
+    - we are unable to infer the object path from the API path in the doc layout. This will result in the markdown file
+      being `missing.md`
+    - the doc_path_override is not generated. This means that the markdown file is not generated and the explicit
+      override will be empty.
+    These errors are likely to occur if we refactored the code, without updating the doc layout.
+    """
+    files_open_wrapper = GenFilesOpenWrapper()
+    docs_builder = DocsBuilder(files_open_wrapper.gen_files_open, noop_set_edit_path)
+    nav = docs_builder.build_docs()
+    failed_items = []
+    for nav_item in nav.build_literate_nav():
+        extracted_nav_item = _extract_nav_item(nav_item)
+        if extracted_nav_item is None:
+            continue
+        if extracted_nav_item.is_missing(files_open_wrapper.all_file_names):
+            failed_items.append(extracted_nav_item)
+    assert len(failed_items) == 0, f"Missing docs: {failed_items}"


### PR DESCRIPTION
## Description
This test will help us catch if we are missing docs in the documentation automatically.

Example
![Screenshot 2023-03-30 at 11 56 06 AM](https://user-images.githubusercontent.com/2313101/228725331-8b19d554-132c-4298-b109-4b475f7c751a.png)


## Related Issue
https://featurebyte.atlassian.net/browse/DEV-1346

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
