### PR TITLE
[DEV-1367] Remove usage of AsyncMongoMockClient in integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -213,7 +213,7 @@ def event_loop():
 @pytest.fixture(name="persistent", scope="session")
 def persistent_fixture():
     """
-    Mock mongodb persistent used by most of the integration tests
+    Mongo persistent fixture used by most of the integration tests
     """
     database_name = f"test_{ObjectId()}"
     client = AsyncIOMotorClient(MONGO_CONNECTION)
@@ -227,7 +227,8 @@ def persistent_fixture():
 @pytest.fixture(name="mongo_persistent")
 def mongo_persistent_fixture():
     """
-    Mongo persistent fixture used by some tests that need to access the database directly
+    Mongo persistent fixture that uses a non-async client. Used by some integration tests that
+    interact with the persistent directly.
     """
     database_name = f"test_{ObjectId()}"
     client = pymongo.MongoClient(MONGO_CONNECTION)


### PR DESCRIPTION
## Description

This removes usage of `AsyncMongoMockClient` in integration tests, which is causing the `RecursionError: maximum recursion depth exceeded while calling a Python object` error in some cases: https://github.com/featurebyte/featurebyte/actions/runs/4559089912/jobs/8042663173?pr=1025

Since we always start an actual test mongo server when running integration tests, we can update the persistent fixture to use that instead. One dev facing change is that in order to run the integration tests locally, we need to run

```
make test-setup
```

to start the test mongo server first. I think this is already the standard workflow anyway, though previously that was not required if only running a subset of the integration tests.

## Related Issue
Related PR that made this necessary: https://github.com/featurebyte/featurebyte/pull/1025

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
