### PR TITLE
[DEV-1346] documentation_layout: simplify declaration of docs

### DIFF
--- a/featurebyte/common/documentation/documentation_layout.py
+++ b/featurebyte/common/documentation/documentation_layout.py
@@ -81,34 +81,10 @@ def _get_table_layout() -> List[DocLayoutItem]:
         DocLayoutItem([TABLE, CREATE, "SourceTable.create_event_table"]),
         DocLayoutItem([TABLE, CREATE, "SourceTable.create_item_table"]),
         DocLayoutItem([TABLE, CREATE, "SourceTable.create_scd_table"]),
-        DocLayoutItem(
-            [
-                TABLE,
-                ADD_METADATA,
-                "EventTable.create_new_feature_job_setting_analysis",
-            ],
-        ),
-        DocLayoutItem(
-            [
-                TABLE,
-                ADD_METADATA,
-                "EventTable.initialize_default_feature_job_setting",
-            ],
-        ),
-        DocLayoutItem(
-            [
-                TABLE,
-                ADD_METADATA,
-                "EventTable.list_feature_job_setting_analysis",
-            ],
-        ),
-        DocLayoutItem(
-            [
-                TABLE,
-                ADD_METADATA,
-                "EventTable.update_default_feature_job_setting",
-            ],
-        ),
+        DocLayoutItem([TABLE, ADD_METADATA, "EventTable.create_new_feature_job_setting_analysis"]),
+        DocLayoutItem([TABLE, ADD_METADATA, "EventTable.initialize_default_feature_job_setting"]),
+        DocLayoutItem([TABLE, ADD_METADATA, "EventTable.list_feature_job_setting_analysis"]),
+        DocLayoutItem([TABLE, ADD_METADATA, "EventTable.update_default_feature_job_setting"]),
         DocLayoutItem(
             [TABLE, EXPLORE, "Table.describe"],
             doc_path_override="api.base_table.TableApiObject.describe.md",
@@ -194,9 +170,7 @@ def _get_table_layout() -> List[DocLayoutItem]:
             [TABLE, LINEAGE, "Table.tabular_source"],
             doc_path_override="api.base_table.TableApiObject.tabular_source.md",
         ),
-        DocLayoutItem(
-            [TABLE, LINEAGE, "ItemTable.event_table_id"],
-        ),
+        DocLayoutItem([TABLE, LINEAGE, "ItemTable.event_table_id"]),
         DocLayoutItem([TABLE, TYPE, "DimensionTable"]),
         DocLayoutItem([TABLE, TYPE, "EventTable"]),
         DocLayoutItem([TABLE, TYPE, "ItemTable"]),
@@ -220,9 +194,7 @@ def _get_table_column_layout() -> List[DocLayoutItem]:
     return [
         DocLayoutItem([TABLE_COLUMN]),
         DocLayoutItem([TABLE_COLUMN, ADD_METADATA, "TableColumn.as_entity"]),
-        DocLayoutItem(
-            [TABLE_COLUMN, ADD_METADATA, "TableColumn.update_critical_data_info"],
-        ),
+        DocLayoutItem([TABLE_COLUMN, ADD_METADATA, "TableColumn.update_critical_data_info"]),
         DocLayoutItem([TABLE_COLUMN, EXPLORE, "TableColumn.describe"]),
         DocLayoutItem([TABLE_COLUMN, EXPLORE, "TableColumn.preview"]),
         DocLayoutItem([TABLE_COLUMN, EXPLORE, "TableColumn.sample"]),
@@ -645,7 +617,7 @@ def _get_catalog_layout() -> List[DocLayoutItem]:
     """
     return [
         DocLayoutItem([CATALOG]),
-        DocLayoutItem([CATALOG, "Activate", "Catalog.activate"]),
+        DocLayoutItem([CATALOG, ACTIVATE, "Catalog.activate"]),
         DocLayoutItem([CATALOG, GET, "Catalog.get"]),
         DocLayoutItem([CATALOG, GET, "Catalog.get_active"]),
         DocLayoutItem([CATALOG, GET, "Catalog.get_by_id"]),


### PR DESCRIPTION
## Description
There was a bit of redundancy in the way we declared the `DocLayoutItem`. This was previously used when we had some discrepancies with the menu header, and the API path. Now that they're all the same, we can simplify the declaration here.

If we need to de-couple the two again, we can easily add back an optional parameter, but will remove it entirely for now to keep it simple.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-1346

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
