### PR TITLE
[DEV-1414] core/mixin: add after_cleaning param to describe, sample, preview

### DIFF
--- a/featurebyte/core/mixin.py
+++ b/featurebyte/core/mixin.py
@@ -196,7 +196,12 @@ class SampleMixin:
     """
 
     @typechecked
-    def preview(self: HasExtractPrunedGraphAndNode, limit: int = 10, **kwargs: Any) -> pd.DataFrame:
+    def preview(
+        self: HasExtractPrunedGraphAndNode,
+        limit: int = 10,
+        after_cleaning: bool = False,
+        **kwargs: Any,
+    ) -> pd.DataFrame:
         """
         Retrieve a preview of the view / column.
 
@@ -204,6 +209,8 @@ class SampleMixin:
         ----------
         limit: int
             Maximum number of return rows.
+        after_cleaning: bool
+            Whether to apply cleaning operations.
         **kwargs: Any
             Additional keyword parameters.
 
@@ -240,7 +247,9 @@ class SampleMixin:
         - [View.describe](/reference/featurebyte.api.view.View.describe/):
           Retrieve a summary of a view.
         """
-        pruned_graph, mapped_node = self.extract_pruned_graph_and_node(**kwargs)
+        pruned_graph, mapped_node = self.extract_pruned_graph_and_node(
+            after_cleaning=after_cleaning, **kwargs
+        )
         payload = FeatureStorePreview(
             feature_store_name=self.feature_store.name,
             graph=pruned_graph,
@@ -272,6 +281,7 @@ class SampleMixin:
         seed: int = 1234,
         from_timestamp: Optional[Union[datetime, str]] = None,
         to_timestamp: Optional[Union[datetime, str]] = None,
+        after_cleaning: bool = False,
         **kwargs: Any,
     ) -> pd.DataFrame:
         """
@@ -287,6 +297,8 @@ class SampleMixin:
             Start of date range to sample from.
         to_timestamp: Optional[datetime]
             End of date range to sample from.
+        after_cleaning: bool
+            Whether to apply cleaning operations.
         **kwargs: Any
             Additional keyword parameters.
 
@@ -326,7 +338,9 @@ class SampleMixin:
         from_timestamp = validate_datetime_input(from_timestamp) if from_timestamp else None
         to_timestamp = validate_datetime_input(to_timestamp) if to_timestamp else None
 
-        pruned_graph, mapped_node = self.extract_pruned_graph_and_node(**kwargs)
+        pruned_graph, mapped_node = self.extract_pruned_graph_and_node(
+            after_cleaning=after_cleaning, **kwargs
+        )
         payload = FeatureStoreSample(
             feature_store_name=self.feature_store.name,
             graph=pruned_graph,
@@ -350,6 +364,7 @@ class SampleMixin:
         seed: int = 1234,
         from_timestamp: Optional[Union[datetime, str]] = None,
         to_timestamp: Optional[Union[datetime, str]] = None,
+        after_cleaning: bool = False,
         **kwargs: Any,
     ) -> pd.DataFrame:
         """
@@ -365,6 +380,8 @@ class SampleMixin:
             Start of date range to sample from.
         to_timestamp: Optional[datetime]
             End of date range to sample from.
+        after_cleaning: bool
+            Whether to apply cleaning operations.
         **kwargs: Any
             Additional keyword parameters.
 
@@ -412,7 +429,9 @@ class SampleMixin:
         from_timestamp = validate_datetime_input(from_timestamp) if from_timestamp else None
         to_timestamp = validate_datetime_input(to_timestamp) if to_timestamp else None
 
-        pruned_graph, mapped_node = self.extract_pruned_graph_and_node(**kwargs)
+        pruned_graph, mapped_node = self.extract_pruned_graph_and_node(
+            after_cleaning=after_cleaning, **kwargs
+        )
         payload = FeatureStoreSample(
             feature_store_name=self.feature_store.name,
             graph=pruned_graph,


### PR DESCRIPTION
## Description
This will allow us to get the docstring on after_cleaning on TableColumn.

Note that this also causes the param to appear on `View#describe,sample,preview`.

![Screenshot 2023-04-05 at 4 40 10 PM](https://user-images.githubusercontent.com/2313101/230028814-e9009c69-c0db-412a-b835-5d1bed4aa7b5.png)

![Screenshot 2023-04-05 at 4 39 37 PM](https://user-images.githubusercontent.com/2313101/230028949-2cc80aa9-30a6-4cff-863a-8f001f86ceb6.png)



<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-1414

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
