### PR TITLE
[DEV-1428] doc_types: update to use first two instead of rsplit

### DIFF
--- a/featurebyte/common/documentation/doc_types.py
+++ b/featurebyte/common/documentation/doc_types.py
@@ -264,7 +264,8 @@ def get_docs_version() -> str:
     str
         Docs version
     """
-    return version.rsplit(".", 1)[0]
+    split_current_version = version.split(".")
+    return ".".join(split_current_version[:2])
 
 
 class Docstring(BaseDocstring):

--- a/tests/unit/common/documentation/test_doc_types.py
+++ b/tests/unit/common/documentation/test_doc_types.py
@@ -1,0 +1,17 @@
+"""
+Test doc types
+"""
+from featurebyte import version
+from featurebyte.common.documentation.doc_types import get_docs_version
+
+
+def test_get_docs_version():
+    """
+    Test get_docs_version
+    """
+    current_version = version
+    split_current_version = current_version.split(".")
+    # assert that the current version is in the format x.y.z
+    assert len(split_current_version) == 3
+    expected_version = ".".join(split_current_version[:2])
+    assert get_docs_version() == expected_version


### PR DESCRIPTION
## Description
This should handle both the 0.1.1, and 0.1.1.devX versions.

Without this change, the URLs in the `documentation` repo are currently getting a `0.1.1` prefix instead of a `0.1`.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-1428

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
