### PR TITLE
Deps: hive-udf needs >=11 java version

### DIFF
--- a/hive-udf/lib/build.gradle
+++ b/hive-udf/lib/build.gradle
@@ -37,32 +37,32 @@ tasks.named('test') {
 }
 
 java {
-    sourceCompatibility = "1.8"
-    targetCompatibility = "1.8"
+    sourceCompatibility = "1.11"
+    targetCompatibility = "1.11"
 }
 
 shadowJar {
-archivesBaseName = 'featurebyte-hive-udf'
-zip64 = true
+    archivesBaseName = 'featurebyte-hive-udf'
+    zip64 = true
 }
 
 spotless {
-format 'misc', {
-    // define the files to apply `misc` to
-    target '*.gradle', '*.md', '.gitignore'
+    format 'misc', {
+        // define the files to apply `misc` to
+        target '*.gradle', '*.md', '.gitignore'
 
-    // define the steps to apply to those files
-    trimTrailingWhitespace()
-    indentWithSpaces()
-    endWithNewline()
-}
-java {
-    removeUnusedImports()
-    // apply a specific flavor of google-java-format
-    googleJavaFormat('1.16.0')
-    // fix formatting of type annotations
-    formatAnnotations()
-}
+        // define the steps to apply to those files
+        trimTrailingWhitespace()
+        indentWithSpaces()
+        endWithNewline()
+    }
+    java {
+        removeUnusedImports()
+        // apply a specific flavor of google-java-format
+        googleJavaFormat('1.16.0')
+        // fix formatting of type annotations
+        formatAnnotations()
+    }
 }
 
 group = 'com.featurebyte.hive.udf'


### PR DESCRIPTION
## Description

```
(featurebyte-py3.10) chenyanhui@CHENs-MacBook-Pro featurebyte % cd hive-udf && ./gradlew clean

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':lib'.
> Could not resolve all files for configuration ':lib:classpath'.
   > Could not resolve com.diffplug.spotless:spotless-plugin-gradle:6.18.0.
     Required by:
         project :lib > com.diffplug.spotless:com.diffplug.spotless.gradle.plugin:6.18.0
      > No matching variant of com.diffplug.spotless:spotless-plugin-gradle:6.18.0 was found. The consumer was configured to find a runtime of a library compatible with Java 8, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '7.6' but:
          - Variant 'apiElements' capability com.diffplug.spotless:spotless-plugin-gradle:6.18.0 declares a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares an API of a component compatible with Java 11 and the consumer needed a runtime of a component compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '7.6')
          - Variant 'javadocElements' capability com.diffplug.spotless:spotless-plugin-gradle:6.18.0 declares a runtime of a component, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '7.6')
          - Variant 'runtimeElements' capability com.diffplug.spotless:spotless-plugin-gradle:6.18.0 declares a runtime of a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares a component compatible with Java 11 and the consumer needed a component compatible with Java 8
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '7.6')
          - Variant 'sourcesElements' capability com.diffplug.spotless:spotless-plugin-gradle:6.18.0 declares a runtime of a component, and its dependencies declared externally:
              - Incompatible because this component declares documentation and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them packaged as a jar)
                  - Doesn't say anything about org.gradle.plugin.api-version (required '7.6')

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org/

BUILD FAILED in 1s
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
