### PR TITLE
Update credentials_mapping_fixture to be more permissive

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -166,8 +166,8 @@ def credentials_mapping_fixture():
                 access_token=os.getenv("DATABRICKS_ACCESS_TOKEN", ""),
             ),
             storage_credential=S3StorageCredential(
-                s3_access_key_id=os.getenv("DATABRICKS_STORAGE_ACCESS_KEY_ID"),
-                s3_secret_access_key=os.getenv("DATABRICKS_STORAGE_ACCESS_KEY_SECRET"),
+                s3_access_key_id=os.getenv("DATABRICKS_STORAGE_ACCESS_KEY_ID", ""),
+                s3_secret_access_key=os.getenv("DATABRICKS_STORAGE_ACCESS_KEY_SECRET", ""),
             ),
         ),
         "spark_featurestore": CredentialModel(


### PR DESCRIPTION
## Description

This updates the Databricks related credential fixture to be more permissive if the required environment variables are unset, instead of failing immediately with a validation error.

I think this is useful because currently all my existing PyCharm integration test profiles are broken due to these variables being unset, but I wanted to run non-Databricks integration tests.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
