### PR TITLE
[DEV-1507] Fix query syntax error on features without entity columns

### DIFF
--- a/tests/integration/api/test_change_view_operations.py
+++ b/tests/integration/api/test_change_view_operations.py
@@ -89,7 +89,8 @@ def test_change_view__feature_no_entity(scd_table):
     df = FeatureList([count_1w_feature], name="mylist").get_historical_features(observations_set)
     assert df.iloc[0].to_dict() == expected
 
-    # run again with different time to trigger entity tracker update and it should work
+    # run again with different time to trigger entity tracker update, and it should work
+    expected = {"POINT_IN_TIME": pd.Timestamp("2001-12-15 10:00:00"), "count_1w": 24}
     observations_set = pd.DataFrame([{"POINT_IN_TIME": "2001-12-15 10:00:00"}])
     df = FeatureList([count_1w_feature], name="mylist").get_historical_features(observations_set)
     assert df.iloc[0].to_dict() == expected


### PR DESCRIPTION
## Description

This fixes a syntax error that occurs when updating entity tracking tables for features without any entity columns.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
