### PR TITLE
Increase tablesample percentage buffer

### DIFF
--- a/featurebyte/models/observation_table.py
+++ b/featurebyte/models/observation_table.py
@@ -97,7 +97,7 @@ class BaseObservationInput(FeatureByteBaseModel):
         """
         # Sample a bit above the theoretical sample percentage since bernoulli sampling doesn't
         # guarantee an exact number of rows.
-        return min(100.0, 100.0 * desired_row_count / total_row_count * 1.2)
+        return min(100.0, 100.0 * desired_row_count / total_row_count * 1.4)
 
     async def materialize(
         self, session: BaseSession, destination: TableDetails, sample_rows: Optional[int]

--- a/tests/unit/api/test_event_view.py
+++ b/tests/unit/api/test_event_view.py
@@ -857,7 +857,7 @@ def test_create_observation_table_from_event_view(snowflake_event_table, snowfla
             "cust_id" AS "cust_id",
             "event_timestamp" AS "POINT_IN_TIME"
           FROM "sf_database"."sf_schema"."sf_table"
-        ) TABLESAMPLE(12.0)
+        ) TABLESAMPLE(14.0)
         LIMIT 100
         """,
     )

--- a/tests/unit/api/test_source_table.py
+++ b/tests/unit/api/test_source_table.py
@@ -240,7 +240,7 @@ def test_create_observation_table_with_sample_rows(
           SELECT
             *
           FROM "sf_database"."sf_schema"."sf_table"
-        ) TABLESAMPLE(12.0)
+        ) TABLESAMPLE(14.0)
         LIMIT 100
         """,
     )


### PR DESCRIPTION
## Description

This increases the sampling percentage buffer used for `TABLESAMPLE` since the integration test is sometimes flaky, indicating the current buffer is not reliable enough to almost always produce sufficient number of rows.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
