### PR TITLE
[DEV-1557] docs: add ability to skip rendering of params

### DIFF
--- a/featurebyte/api/change_view.py
+++ b/featurebyte/api/change_view.py
@@ -59,7 +59,7 @@ class ChangeView(View, GroupByMixin):
     # documentation metadata
     __fbautodoc__ = FBAutoDoc(
         proxy_class="featurebyte.ChangeView",
-        skip_params_in_docs=True,
+        skip_params_in_class_docs=True,
     )
 
     # class variables

--- a/featurebyte/api/dimension_table.py
+++ b/featurebyte/api/dimension_table.py
@@ -47,7 +47,9 @@ class DimensionTable(TableApiObject):
     """
 
     # documentation metadata
-    __fbautodoc__ = FBAutoDoc(proxy_class="featurebyte.DimensionTable", skip_params_in_docs=True)
+    __fbautodoc__ = FBAutoDoc(
+        proxy_class="featurebyte.DimensionTable", skip_params_in_class_docs=True
+    )
 
     # class variables
     _route = "/dimension_table"

--- a/featurebyte/api/dimension_view.py
+++ b/featurebyte/api/dimension_view.py
@@ -41,7 +41,7 @@ class DimensionView(View, RawMixin):
     # documentation metadata
     __fbautodoc__ = FBAutoDoc(
         proxy_class="featurebyte.DimensionView",
-        skip_params_in_docs=True,
+        skip_params_in_class_docs=True,
     )
 
     # class variables

--- a/featurebyte/api/event_table.py
+++ b/featurebyte/api/event_table.py
@@ -56,7 +56,7 @@ class EventTable(TableApiObject):
     """
 
     # documentation metadata
-    __fbautodoc__ = FBAutoDoc(proxy_class="featurebyte.EventTable", skip_params_in_docs=True)
+    __fbautodoc__ = FBAutoDoc(proxy_class="featurebyte.EventTable", skip_params_in_class_docs=True)
 
     # class variables
     _route = "/event_table"

--- a/featurebyte/api/event_view.py
+++ b/featurebyte/api/event_view.py
@@ -49,7 +49,7 @@ class EventView(View, GroupByMixin, RawMixin):
     """
 
     # documentation metadata
-    __fbautodoc__ = FBAutoDoc(proxy_class="featurebyte.EventView", skip_params_in_docs=True)
+    __fbautodoc__ = FBAutoDoc(proxy_class="featurebyte.EventView", skip_params_in_class_docs=True)
 
     # class variables
     _series_class = EventViewColumn

--- a/featurebyte/api/item_table.py
+++ b/featurebyte/api/item_table.py
@@ -54,7 +54,7 @@ class ItemTable(TableApiObject):
     """
 
     # documentation metadata
-    __fbautodoc__ = FBAutoDoc(proxy_class="featurebyte.ItemTable", skip_params_in_docs=True)
+    __fbautodoc__ = FBAutoDoc(proxy_class="featurebyte.ItemTable", skip_params_in_class_docs=True)
 
     # class variables
     _route = "/item_table"

--- a/featurebyte/api/item_view.py
+++ b/featurebyte/api/item_view.py
@@ -51,7 +51,7 @@ class ItemView(View, GroupByMixin, RawMixin):
     # documentation metadata
     __fbautodoc__ = FBAutoDoc(
         proxy_class="featurebyte.ItemView",
-        skip_params_in_docs=True,
+        skip_params_in_class_docs=True,
     )
 
     # class variables

--- a/featurebyte/api/scd_table.py
+++ b/featurebyte/api/scd_table.py
@@ -55,7 +55,7 @@ class SCDTable(TableApiObject):
     """
 
     # documentation metadata
-    __fbautodoc__ = FBAutoDoc(proxy_class="featurebyte.SCDTable", skip_params_in_docs=True)
+    __fbautodoc__ = FBAutoDoc(proxy_class="featurebyte.SCDTable", skip_params_in_class_docs=True)
 
     # class variables
     _route = "/scd_table"

--- a/featurebyte/api/scd_view.py
+++ b/featurebyte/api/scd_view.py
@@ -42,7 +42,7 @@ class SCDView(View, GroupByMixin, RawMixin):
     # documentation metadata
     __fbautodoc__ = FBAutoDoc(
         proxy_class="featurebyte.SCDView",
-        skip_params_in_docs=True,
+        skip_params_in_class_docs=True,
     )
 
     # class variables

--- a/featurebyte/common/doc_util.py
+++ b/featurebyte/common/doc_util.py
@@ -50,7 +50,7 @@ class FBAutoDoc(BaseModel):
 
     skipped_members: List[str] = Field(default=COMMON_SKIPPED_ATTRIBUTES)
     proxy_class: Optional[str] = Field(default=None)
-    # Setting this to True will skip the rendering of the parameters in the documentation.
+    # Setting this to True will skip the rendering of the parameters in the documentation for the class.
     # This is typically used for class level parameters that should not be initialized directly, compared to say a
     # dataclass object.
-    skip_params_in_docs: bool = Field(default=False)
+    skip_params_in_class_docs: bool = Field(default=False)

--- a/featurebyte/common/documentation/autodoc_processor.py
+++ b/featurebyte/common/documentation/autodoc_processor.py
@@ -311,7 +311,10 @@ class FBAutoDocProcessor(AutoDocProcessor):
             self._render(elem, "Description", content)
 
         # Render parameters
-        if resource_details.parameters and not resource_details.should_skip_params:
+        should_not_render_params = (
+            resource_details.should_skip_params_in_class_docs and resource_details.type == "class"
+        )
+        if resource_details.parameters and not should_not_render_params:
             self._render(elem, "Parameters", _get_parameters_content(resource_details.parameters))
 
         if resource_details.enum_values:

--- a/featurebyte/common/documentation/doc_types.py
+++ b/featurebyte/common/documentation/doc_types.py
@@ -160,8 +160,8 @@ class ResourceDetails(BaseModel):
     see_also: Optional[str]
     enum_values: Optional[List[ParameterDetails]]
 
-    # Setting this param to True will not render the parameters in the documentation.
-    should_skip_params: bool
+    # Setting this param to True will not render the parameters for the class in the documentation.
+    should_skip_params_in_class_docs: bool
 
     @property
     def resource(self) -> Any:

--- a/featurebyte/common/documentation/resource_extractor.py
+++ b/featurebyte/common/documentation/resource_extractor.py
@@ -310,7 +310,7 @@ def get_resource_details(resource_descriptor: str) -> ResourceDetails:
     autodoc_config = resource_class.__dict__.get("__fbautodoc__", FBAutoDoc())
     if autodoc_config.proxy_class:
         proxy_path = autodoc_config.proxy_class
-    should_skip_params = autodoc_config.skip_params_in_docs
+    should_skip_params = autodoc_config.skip_params_in_class_docs
 
     # process signature
     parameters, return_type = get_params_from_signature(resource)
@@ -367,5 +367,5 @@ def get_resource_details(resource_descriptor: str) -> ResourceDetails:
         examples=[_format_example(example) for example in docstring.examples],
         see_also=docstring.see_also.description if docstring.see_also else None,
         enum_values=_get_param_details(enum_possible_values, enum_desc),
-        should_skip_params=should_skip_params,
+        should_skip_params_in_class_docs=should_skip_params,
     )

--- a/tests/unit/common/documentation/test_resource_extractor.py
+++ b/tests/unit/common/documentation/test_resource_extractor.py
@@ -95,7 +95,7 @@ class DocClassWithProxyPathAndSkipParams:
 
     __fbautodoc__ = FBAutoDoc(
         proxy_class="autodoc_proxy",
-        skip_params_in_docs=True,
+        skip_params_in_class_docs=True,
     )
 
 
@@ -141,7 +141,7 @@ def test_get_resource_details__enum_class():
                 description="Test documentation for enum classes.",
             ),
         ],
-        should_skip_params=False,
+        should_skip_params_in_class_docs=False,
     )
     assert resource_details == expected_resource_details
 
@@ -172,7 +172,7 @@ def test_get_resource_details__class():
         examples=["Some example code."],
         see_also="Some text that normally references other resources.",
         enum_values=[],
-        should_skip_params=False,
+        should_skip_params_in_class_docs=False,
     )
     assert resource_details == expected_resource_details
 
@@ -204,7 +204,7 @@ def test_get_resource_details__method():
         examples=["Some example code."],
         see_also=None,
         enum_values=[],
-        should_skip_params=False,
+        should_skip_params_in_class_docs=False,
     )
     assert resource_details == expected_resource_details
 
@@ -232,7 +232,7 @@ def test_get_resource_details__pydantic_field():
         examples=[],
         see_also=None,
         enum_values=[],
-        should_skip_params=False,
+        should_skip_params_in_class_docs=False,
     )
     assert resource_details == expected_resource_details
 
@@ -262,7 +262,7 @@ def test_get_resource_details__property():
         examples=[],
         see_also=None,
         enum_values=[],
-        should_skip_params=False,
+        should_skip_params_in_class_docs=False,
     )
     assert resource_details == expected_resource_details
 
@@ -282,4 +282,4 @@ def test_get_resource_details__proxy_paths():
         "tests.unit.common.documentation.test_resource_extractor.DocClassWithProxyPathAndSkipParams"
     )
     assert resource_details.proxy_path == "autodoc_proxy"
-    assert resource_details.should_skip_params
+    assert resource_details.should_skip_params_in_class_docs


### PR DESCRIPTION
## Description
We don't want to print the parameters for some of the classes as there's a lot of noise. This happens because some of these classes inherit a lot of properties and parameters from base classes that users should not need to know about. Further, these classes are never initialized directly via a constructor on the class, so these parameters aren't particularly useful for users to know about.

For the fields that are important to users, they'll be exposed as part of other pages directly, and shouldn't need to be reflected as part of the classes description.

However, we still want to render parameters for data-class like classes (eg. `FeatureJobSetting` etc), in which users would still have to construct a class directly.


<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-1557


<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
