### PR TITLE
Fix test_get_view_entity_column__no_entity_col_provided to work standalone

### DIFF
--- a/tests/unit/api/test_event_view.py
+++ b/tests/unit/api/test_event_view.py
@@ -443,24 +443,15 @@ def test_get_feature_entity_col(production_ready_feature):
 
 
 @pytest.fixture(name="feature_with_entity_ids")
-def get_feature_with_entity_ids(snowflake_feature_store):
+def get_feature_with_entity_ids(float_feature):
     """
     Get a function that helps us create test features with configurable entity IDs.
     """
 
     def get_feature(entity_ids):
-        return Feature(
-            entity_ids=entity_ids,
-            dtype=DBVarType.INT,
-            node_name="input_1",
-            tabular_source=TabularSource(
-                feature_store_id=PydanticObjectId(ObjectId()),
-                table_details=TableDetails(
-                    table_name="random",
-                ),
-            ),
-            feature_store=snowflake_feature_store,
-        )
+        feature = float_feature.copy()
+        feature.__dict__.update({"entity_ids": entity_ids[:]})
+        return feature
 
     return get_feature
 


### PR DESCRIPTION
## Description

This fixes the `test_get_view_entity_column__no_entity_col_provided` test which fails when running standalone or in the wrong order with other tests:

```
FAILED tests/unit/api/test_event_view.py::test_get_view_entity_column__no_entity_col_provided - KeyError: 'input_1'
```

by creating the test feature using existing fixtures that are guaranteed to be valid.


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
