### PR TITLE
ci: update lint check to not run safety on every PR

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           sudo apt-get install libsasl2-dev gcc
       - name: Lint Checks
-        run: task lint
+        run: task lint-pr
   slack:
     runs-on: ubuntu-latest
     if: ${{ always() }}

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -55,6 +55,8 @@ jobs:
       - name: Install dependencies
         run: |
           task install
+      - name: Lint Safety Check
+        run: task lint-safety
       - name: Authenticate to Google Cloud
         id: 'auth'
         uses: 'google-github-actions/auth@v1'

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -77,15 +77,22 @@ tasks:
       - poetry run black .
       - poetry run toml-sort --all --in-place pyproject.toml poetry.lock
 
-  lint:
-    desc: "Run the linter"
+  lint-pr:
+    desc: "Run the linter, but without the safety check. This is run on every PR. Safety check will be run on deploy."
     deps:
       - task: install
     cmds:
       - task: lint-style
       - task: lint-type
-      - task: lint-safety
       - task: lint-bandit
+
+  lint:
+    desc: "Run ALL the linter checks."
+    deps:
+      - task: install
+    cmds:
+      - task: lint-pr
+      - task: lint-safety
 
   lint-style:
     desc: "Run the linter[style]"


### PR DESCRIPTION
## Description
This commit updates the lint workflow to not run lint-safety on every PR. This is because most of the failures that come from this check are not caused by the PR itself, but by changes that are outside of our control (eg. a new vulnerability is introduced).

The current state will result in situations in which a new vulnerability introduced externally will cause us to not be able to merge any PRs - which is a loss in developer productivity.

Instead, we move this check to before we deploy a new staging environment. If a failure happens here, we won't update our staging environment, and a failure message will get pushed to slack. We can then triage accordingly.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
