### PR TITLE
[release/0.2][DEV-1488] Support DataFrame as observation set in compute_historical_feature_table (#1238)

### DIFF
--- a/featurebyte/api/feature_list.py
+++ b/featurebyte/api/feature_list.py
@@ -1045,9 +1045,10 @@ class FeatureList(
 
         return pd.concat(output, ignore_index=True)
 
+    @typechecked
     def compute_historical_feature_table(
         self,
-        observation_table: ObservationTable,
+        observation_table: Union[ObservationTable, pd.DataFrame],
         historical_feature_table_name: str,
         serving_names_mapping: Optional[Dict[str, str]] = None,
     ) -> HistoricalFeatureTable:
@@ -1057,8 +1058,9 @@ class FeatureList(
 
         Parameters
         ----------
-        observation_table: ObservationTable
-            Observation table with `POINT_IN_TIME` and serving names columns
+        observation_table: Union[ObservationTable, pd.DataFrame]
+            Observation set with `POINT_IN_TIME` and serving names columns. This can be either an
+            ObservationTable of a pandas DataFrame.
         historical_feature_table_name: str
             Name of the historical feature table to be created
         serving_names_mapping : Optional[Dict[str, str]]
@@ -1074,14 +1076,24 @@ class FeatureList(
             serving_names_mapping=serving_names_mapping,
         )
         feature_store_id = featurelist_get_historical_features.feature_clusters[0].feature_store_id
-        payload = HistoricalFeatureTableCreate(
+        feature_table_create_params = HistoricalFeatureTableCreate(
             name=historical_feature_table_name,
-            observation_table_id=observation_table.id,
+            observation_table_id=(
+                observation_table.id if isinstance(observation_table, ObservationTable) else None
+            ),
             feature_store_id=feature_store_id,
             featurelist_get_historical_features=featurelist_get_historical_features,
         )
+        if isinstance(observation_table, ObservationTable):
+            files = None
+        else:
+            assert isinstance(observation_table, pd.DataFrame)
+            files = {"observation_set": dataframe_to_arrow_bytes(observation_table)}
         historical_feature_table_doc = self.post_async_task(
-            route="/historical_feature_table", payload=payload.json_dict()
+            route="/historical_feature_table",
+            payload={"payload": feature_table_create_params.json()},
+            is_payload_json=False,
+            files=files,
         )
         return HistoricalFeatureTable.get_by_id(historical_feature_table_doc["_id"])
 

--- a/featurebyte/models/historical_feature_table.py
+++ b/featurebyte/models/historical_feature_table.py
@@ -3,6 +3,8 @@ HistoricalFeatureTableModel
 """
 from __future__ import annotations
 
+from typing import Optional
+
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.materialized_table import MaterializedTableModel
 
@@ -12,7 +14,7 @@ class HistoricalFeatureTableModel(MaterializedTableModel):
     HistoricalFeatureTable is the result of asynchronous historical features requests
     """
 
-    observation_table_id: PydanticObjectId
+    observation_table_id: Optional[PydanticObjectId]
     feature_list_id: PydanticObjectId
 
     class Settings(MaterializedTableModel.Settings):

--- a/featurebyte/routes/historical_feature_table/api.py
+++ b/featurebyte/routes/historical_feature_table/api.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 
 from typing import Optional, cast
 
+import json
 from http import HTTPStatus
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Form, Request, UploadFile
 from starlette.responses import StreamingResponse
 
 from featurebyte.models.base import PydanticObjectId
@@ -36,14 +37,18 @@ router = APIRouter(prefix="/historical_feature_table")
 @router.post("", response_model=Task, status_code=HTTPStatus.CREATED)
 async def create_historical_feature_table(
     request: Request,
-    data: HistoricalFeatureTableCreate,
+    payload: str = Form(),
+    observation_set: Optional[UploadFile] = None,
 ) -> Task:
     """
     Create HistoricalFeatureTable by submitting a materialization task
     """
+    data = HistoricalFeatureTableCreate(**json.loads(payload))
     controller = request.state.app_container.historical_feature_table_controller
     task_submit: Task = await controller.create_historical_feature_table(
         data=data,
+        observation_set=observation_set,
+        temp_storage=request.state.get_temp_storage(),
     )
     return task_submit
 

--- a/featurebyte/routes/historical_feature_table/controller.py
+++ b/featurebyte/routes/historical_feature_table/controller.py
@@ -3,8 +3,14 @@ HistoricalTable API route controller
 """
 from __future__ import annotations
 
-from bson import ObjectId
+from typing import Optional
 
+from http import HTTPStatus
+
+from bson import ObjectId
+from fastapi import HTTPException, UploadFile
+
+from featurebyte.common.utils import dataframe_from_arrow_stream
 from featurebyte.models.historical_feature_table import HistoricalFeatureTableModel
 from featurebyte.routes.common.base_materialized_table import BaseMaterializedTableController
 from featurebyte.routes.task.controller import TaskController
@@ -20,6 +26,7 @@ from featurebyte.service.historical_feature_table import HistoricalFeatureTableS
 from featurebyte.service.info import InfoService
 from featurebyte.service.observation_table import ObservationTableService
 from featurebyte.service.preview import PreviewService
+from featurebyte.storage import Storage
 
 
 class HistoricalFeatureTableController(
@@ -53,6 +60,8 @@ class HistoricalFeatureTableController(
     async def create_historical_feature_table(
         self,
         data: HistoricalFeatureTableCreate,
+        observation_set: Optional[UploadFile],
+        temp_storage: Storage,
     ) -> Task:
         """
         Create HistoricalFeatureTable by submitting an async historical feature request task
@@ -61,17 +70,40 @@ class HistoricalFeatureTableController(
         ----------
         data: HistoricalFeatureTableCreate
             HistoricalFeatureTable creation payload
+        observation_set: Optional[UploadFile]
+            Observation set file
+        temp_storage: Storage
+            Storage instance
 
         Returns
         -------
         Task
-        """
-        # Validate the observation_table_id
-        observation_table = await self.observation_table_service.get_document(
-            document_id=data.observation_table_id
-        )
 
-        # feature cluster group feature graph by feature store ID, only single feature store is supported
+        Raises
+        ------
+        HTTPException
+            If both observation_set and observation_table_id are set
+        """
+        if data.observation_table_id is not None and observation_set is not None:
+            raise HTTPException(
+                status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                detail="Only one of observation_set file and observation_table_id can be set",
+            )
+
+        # Validate the observation_table_id
+        if data.observation_table_id is not None:
+            observation_table = await self.observation_table_service.get_document(
+                document_id=data.observation_table_id
+            )
+            observation_set_dataframe = None
+            request_column_names = {col.name for col in observation_table.columns_info}
+        else:
+            assert observation_set is not None
+            observation_set_dataframe = dataframe_from_arrow_stream(observation_set.file)
+            request_column_names = set(observation_set_dataframe.columns)
+
+        # feature cluster group feature graph by feature store ID, only single feature store is
+        # supported
         feature_cluster = data.featurelist_get_historical_features.feature_clusters[0]
         feature_store = await self.feature_store_service.get_document(
             document_id=feature_cluster.feature_store_id
@@ -79,13 +111,15 @@ class HistoricalFeatureTableController(
         await self.entity_validation_service.validate_entities_or_prepare_for_parent_serving(
             graph=feature_cluster.graph,
             nodes=feature_cluster.nodes,
-            request_column_names={col.name for col in observation_table.columns_info},
+            request_column_names=request_column_names,
             feature_store=feature_store,
             serving_names_mapping=data.featurelist_get_historical_features.serving_names_mapping,
         )
 
         # prepare task payload and submit task
-        payload = await self.service.get_historical_feature_table_task_payload(data=data)
+        payload = await self.service.get_historical_feature_table_task_payload(
+            data=data, storage=temp_storage, observation_set_dataframe=observation_set_dataframe
+        )
         task_id = await self.task_controller.task_manager.submit(payload=payload)
         return await self.task_controller.get_task(task_id=str(task_id))
 

--- a/featurebyte/schema/historical_feature_table.py
+++ b/featurebyte/schema/historical_feature_table.py
@@ -23,7 +23,7 @@ class HistoricalFeatureTableCreate(FeatureByteBaseModel):
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
     name: StrictStr
     feature_store_id: PydanticObjectId
-    observation_table_id: PydanticObjectId
+    observation_table_id: Optional[PydanticObjectId]
     featurelist_get_historical_features: FeatureListGetHistoricalFeatures
 
 

--- a/featurebyte/schema/info.py
+++ b/featurebyte/schema/info.py
@@ -384,7 +384,7 @@ class HistoricalFeatureTableInfo(BaseInfo):
     Schema for historical feature table info
     """
 
-    observation_table_name: str
+    observation_table_name: Optional[str]
     feature_list_name: str
     feature_list_version: str
     table_details: TableDetails

--- a/featurebyte/schema/worker/task/historical_feature_table.py
+++ b/featurebyte/schema/worker/task/historical_feature_table.py
@@ -3,6 +3,8 @@ HistoricalFeaturesTaskPayload schema
 """
 from __future__ import annotations
 
+from typing import Optional
+
 from featurebyte.enum import WorkerCommand
 from featurebyte.models.historical_feature_table import HistoricalFeatureTableModel
 from featurebyte.schema.historical_feature_table import HistoricalFeatureTableCreate
@@ -16,3 +18,4 @@ class HistoricalFeatureTableTaskPayload(BaseTaskPayload, HistoricalFeatureTableC
 
     output_collection_name = HistoricalFeatureTableModel.collection_name()
     command = WorkerCommand.HISTORICAL_FEATURE_TABLE_CREATE
+    observation_set_storage_path: Optional[str]

--- a/featurebyte/service/info.py
+++ b/featurebyte/service/info.py
@@ -965,9 +965,12 @@ class InfoService(BaseService):
         historical_feature_table = await self.historical_feature_table_service.get_document(
             document_id=document_id
         )
-        observation_table = await self.observation_table_service.get_document(
-            document_id=historical_feature_table.observation_table_id
-        )
+        if historical_feature_table.observation_table_id is not None:
+            observation_table = await self.observation_table_service.get_document(
+                document_id=historical_feature_table.observation_table_id
+            )
+        else:
+            observation_table = None
         feature_list = await self.feature_list_service.get_document(
             document_id=historical_feature_table.feature_list_id
         )
@@ -975,7 +978,7 @@ class InfoService(BaseService):
             name=historical_feature_table.name,
             feature_list_name=feature_list.name,
             feature_list_version=feature_list.version.to_str(),
-            observation_table_name=observation_table.name,
+            observation_table_name=observation_table.name if observation_table else None,
             table_details=historical_feature_table.location.table_details,
             created_at=historical_feature_table.created_at,
             updated_at=historical_feature_table.updated_at,

--- a/featurebyte/worker/task/historical_feature_table.py
+++ b/featurebyte/worker/task/historical_feature_table.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+from pathlib import Path
+
 from featurebyte.logging import get_logger
 from featurebyte.models.historical_feature_table import HistoricalFeatureTableModel
 from featurebyte.schema.worker.task.historical_feature_table import (
@@ -38,10 +40,21 @@ class HistoricalFeatureTableTask(DataWarehouseMixin, BaseTask):
 
         app_container = self.app_container
 
-        observation_table_service: ObservationTableService = app_container.observation_table_service
-        observation_table_model = await observation_table_service.get_document(
-            payload.observation_table_id
-        )
+        if payload.observation_table_id is not None:
+            # ObservationTable as observation set
+            assert payload.observation_set_storage_path is None
+            observation_table_service: ObservationTableService = (
+                app_container.observation_table_service
+            )
+            observation_set = await observation_table_service.get_document(
+                payload.observation_table_id
+            )
+        else:
+            # In-memory DataFrame as observation set
+            assert payload.observation_set_storage_path is not None
+            observation_set = await self.get_temp_storage().get_dataframe(
+                Path(payload.observation_set_storage_path)
+            )
 
         historical_feature_table_service: HistoricalFeatureTableService = (
             app_container.historical_feature_table_service
@@ -55,7 +68,7 @@ class HistoricalFeatureTableTask(DataWarehouseMixin, BaseTask):
         ):
             preview_service: PreviewService = app_container.preview_service
             await preview_service.compute_historical_features(
-                observation_set=observation_table_model,
+                observation_set=observation_set,
                 featurelist_get_historical_features=payload.featurelist_get_historical_features,
                 get_credential=self.get_credential,
                 output_table_details=location.table_details,

--- a/tests/unit/api/test_api_object.py
+++ b/tests/unit/api/test_api_object.py
@@ -93,9 +93,9 @@ def mock_clients_fixture():
         def json(self):
             return self.response_dict
 
-    def post_side_effect(url, json):
+    def post_side_effect(url, **kwargs):
         """Post side effect"""
-        _ = json
+        _ = kwargs
         return {
             "/success_task_pending": FakeResponse(
                 status_code=HTTPStatus.CREATED,

--- a/tests/unit/routes/base.py
+++ b/tests/unit/routes/base.py
@@ -37,6 +37,7 @@ class BaseApiTestSuite:
     class_name = None
     payload = None
     async_create = False
+    wrap_payload_on_create = False
     create_conflict_payload_expected_detail_pairs = []
     create_unprocessable_payload_expected_detail_pairs = []
     list_unprocessable_params_expected_detail_pairs = [
@@ -161,13 +162,25 @@ class BaseApiTestSuite:
     def setup_creation_route(self, api_client, catalog_id=DEFAULT_CATALOG_ID):
         """Setup for post route"""
 
+    def post(self, api_client, payload, **kwargs):
+        """Call post route with payload"""
+
+        if self.wrap_payload_on_create:
+            # When set, the payload is passed via data instead of json since the route expects
+            # multipart/form-data handling. Because of that, the payload is also wrapped in this
+            # format: {"payload": payload_in_json}.
+            data = {"payload": json.dumps(payload)}
+            return api_client.post(self.base_route, data=data, **kwargs)
+
+        return api_client.post(self.base_route, json=payload, **kwargs)
+
     @pytest_asyncio.fixture()
     async def create_success_response(self, test_api_client_persistent):
         """Post route success response object"""
         test_api_client, _ = test_api_client_persistent
         self.setup_creation_route(test_api_client)
         id_before = self.payload["_id"]
-        response = test_api_client.post(f"{self.base_route}", json=self.payload)
+        response = self.post(test_api_client, self.payload)
         response_dict = response.json()
         assert response.status_code == HTTPStatus.CREATED, response_dict
         assert response_dict["_id"] == id_before
@@ -186,7 +199,7 @@ class BaseApiTestSuite:
         output = []
         for _, payload in enumerate(self.multiple_success_payload_generator(test_api_client)):
             # payload name is set here as we need the exact name value for test_list_200 test
-            response = test_api_client.post(f"{self.base_route}", json=payload)
+            response = self.post(test_api_client, payload)
             assert response.status_code == HTTPStatus.CREATED, response.json()
             if self.async_create:
                 assert response.json()["status"] == "SUCCESS"
@@ -201,7 +214,7 @@ class BaseApiTestSuite:
         self.setup_creation_route(test_api_client)
         payload = {key: value for key, value in self.payload.items() if key != "_id"}
         assert "_id" not in payload
-        response = test_api_client.post(f"{self.base_route}", json=payload)
+        response = self.post(test_api_client, payload)
         assert response.status_code == HTTPStatus.CREATED
 
     def test_create_201__id_is_none(self, test_api_client_persistent):
@@ -210,7 +223,7 @@ class BaseApiTestSuite:
         self.setup_creation_route(test_api_client)
         payload = self.payload.copy()
         payload["_id"] = None
-        response = test_api_client.post(f"{self.base_route}", json=payload)
+        response = self.post(test_api_client, payload)
         assert response.status_code == HTTPStatus.CREATED
 
     def test_create_201(self, test_api_client_persistent, create_success_response, user_id):
@@ -242,7 +255,7 @@ class BaseApiTestSuite:
         test_api_client, _ = test_api_client_persistent
 
         conflict_payload, expected_message = create_conflict_payload_expected_detail
-        response = test_api_client.post(f"{self.base_route}", json=conflict_payload)
+        response = self.post(test_api_client, conflict_payload)
         assert response.status_code == HTTPStatus.CONFLICT
         assert response.json()["detail"] == expected_message
 
@@ -256,7 +269,7 @@ class BaseApiTestSuite:
         _ = create_success_response
         test_api_client, _ = test_api_client_persistent
         unprocessable_payload, expected_detail = create_unprocessable_payload_expected_detail
-        response = test_api_client.post(f"{self.base_route}", json=unprocessable_payload)
+        response = self.post(test_api_client, unprocessable_payload)
         assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
         assert response.json()["detail"] == expected_detail
 
@@ -452,7 +465,7 @@ class BaseAsyncApiTestSuite(BaseApiTestSuite):
         test_api_client, _ = test_api_client_persistent
         self.setup_creation_route(test_api_client)
         id_before = self.payload["_id"]
-        response = test_api_client.post(self.base_route, json=self.payload)
+        response = self.post(test_api_client, self.payload)
 
         response = self.wait_for_results(test_api_client, response)
         response_dict = response.json()

--- a/tests/unit/routes/test_historical_feature_table.py
+++ b/tests/unit/routes/test_historical_feature_table.py
@@ -5,10 +5,12 @@ import copy
 from http import HTTPStatus
 from unittest.mock import patch
 
+import pandas as pd
 import pytest
 from bson.objectid import ObjectId
 from sqlglot import expressions
 
+from featurebyte.common.utils import dataframe_to_arrow_bytes
 from featurebyte.models.base import DEFAULT_CATALOG_ID
 from tests.unit.routes.base import BaseMaterializedTableTestSuite
 
@@ -17,6 +19,8 @@ class TestHistoricalFeatureTableApi(BaseMaterializedTableTestSuite):
     """
     Tests for HistoricalFeatureTable route
     """
+
+    wrap_payload_on_create = True
 
     class_name = "HistoricalFeatureTable"
     base_route = "/historical_feature_table"
@@ -119,7 +123,7 @@ class TestHistoricalFeatureTableApi(BaseMaterializedTableTestSuite):
             "random_name": "random_name"
         }
 
-        response = test_api_client.post(self.base_route, json=payload)
+        response = self.post(test_api_client, payload)
         assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
         assert response.json()["detail"] == (
             "Unexpected serving names provided in serving_names_mapping: random_name"
@@ -187,4 +191,24 @@ class TestHistoricalFeatureTableApi(BaseMaterializedTableTestSuite):
             },
             "created_at": response_dict["created_at"],
             "updated_at": None,
+        }
+
+    def test_provide_both_observation_table_id_and_dataframe_not_allowed(
+        self, test_api_client_persistent
+    ):
+        """
+        Test that providing both observation_table_id and observation set DataFrame is not allowed
+        """
+        test_api_client, _ = test_api_client_persistent
+        df = pd.DataFrame(
+            {
+                "POINT_IN_TIME": ["2023-01-15 10:00:00"],
+                "CUST_ID": ["C1"],
+            }
+        )
+        files = {"observation_set": dataframe_to_arrow_bytes(df)}
+        response = self.post(test_api_client, self.payload, files=files)
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        assert response.json() == {
+            "detail": "Only one of observation_set file and observation_table_id can be set"
         }

--- a/tests/util/helper.py
+++ b/tests/util/helper.py
@@ -383,15 +383,19 @@ async def get_dataframe_from_materialized_table(session, materialized_table):
 
 
 async def compute_historical_feature_table_dataframe_helper(
-    feature_list, df_observation_set, session, data_source, **kwargs
+    feature_list, df_observation_set, session, data_source, input_format, **kwargs
 ):
     """
     Helper to call compute_historical_feature_table using DataFrame as input, converted to an
     intermediate observation table
     """
-    observation_table = await create_observation_table_from_dataframe(
-        session, df_observation_set, data_source
-    )
+    if input_format == "table":
+        observation_table = await create_observation_table_from_dataframe(
+            session, df_observation_set, data_source
+        )
+    else:
+        observation_table = df_observation_set
+
     historical_feature_table_name = f"historical_feature_table_{ObjectId()}"
     historical_feature_table = feature_list.compute_historical_feature_table(
         observation_table, historical_feature_table_name, **kwargs


### PR DESCRIPTION
Backport #1238 to release/0.2.

This adds support for using DataFrame as the observation set when calling `compute_historical_feature_table()`.

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
