### PR TITLE
docs: ignore # noqa comment lines in docs

### DIFF
--- a/featurebyte/common/documentation/resource_extractor.py
+++ b/featurebyte/common/documentation/resource_extractor.py
@@ -262,7 +262,7 @@ def _get_docstring_for_resource(resource: Any) -> Docstring:
     lint checks.
 
     Parameters
-    –---------
+    ----------
     resource: Any
         Resource
 
@@ -275,7 +275,12 @@ def _get_docstring_for_resource(resource: Any) -> Docstring:
         docs = ""
     else:
         split_string = docstring.split("\n")
-        filtered_string = [string for string in split_string if "# noqa:" not in string]
+        filtered_string = []
+        for string in split_string:
+            stripped_string = string.strip()
+            if stripped_string.startswith("# noqa"):
+                continue
+            filtered_string.append(string)
         docs = trim_docstring("\n".join(filtered_string))
     return Docstring(parse(docs))
 


### PR DESCRIPTION
## Description
The `# noqa` lines will appear in our docstrings currently. This change filters it out during the parsing of docs so that it doesn't appear in our documentation.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
