### PR TITLE
[DEV-1672] Fix bug in production ready readiness check

### DIFF
--- a/tests/unit/api/test_change_view.py
+++ b/tests/unit/api/test_change_view.py
@@ -13,6 +13,7 @@ import pytest
 from featurebyte.api.change_view import ChangeView
 from featurebyte.api.entity import Entity
 from featurebyte.enum import SourceType
+from featurebyte.models.feature import FeatureReadiness
 from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
 from featurebyte.query_graph.model.table import SCDTableData
@@ -736,3 +737,9 @@ def test_change_view_column_lag(snowflake_change_view):
         """
     ).strip()
     assert snowflake_change_view.preview_sql() == expected
+
+
+def test_update_to_production_ready(feature_from_change_view):
+    """Test updating a feature generated from change view to production ready"""
+    feature_from_change_view.update_readiness(readiness=FeatureReadiness.PRODUCTION_READY)
+    assert feature_from_change_view.readiness == FeatureReadiness.PRODUCTION_READY

--- a/tests/unit/api/test_item_view.py
+++ b/tests/unit/api/test_item_view.py
@@ -10,6 +10,7 @@ from featurebyte.api.item_view import ItemView
 from featurebyte.core.series import Series
 from featurebyte.enum import AggFunc, DBVarType
 from featurebyte.exception import RecordCreationException, RepeatedColumnNamesError
+from featurebyte.models.feature import FeatureReadiness
 from featurebyte.query_graph.enum import NodeOutputType, NodeType
 from featurebyte.query_graph.model.feature_job_setting import (
     FeatureJobSetting,
@@ -1097,3 +1098,9 @@ def test_join_event_table_attributes__with_multiple_assignments(snowflake_item_v
         "col_float",
     ]
     assert joined_view.columns == expected_columns
+
+
+def test_update_to_production_ready(item_event_saved_feature):
+    """Test updating feature to production ready"""
+    item_event_saved_feature.update_readiness(readiness=FeatureReadiness.PRODUCTION_READY)
+    assert item_event_saved_feature.readiness == FeatureReadiness.PRODUCTION_READY


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

Current feature readiness production readiness check makes an assumption that `GroupbyNode`'s timestamp column source table must come from EventTable. This causes error when the feature is created from change view and the timestamp column is from SCDTable but not EventTable. Since there is no default feature job setting at the SCDTable, the logic is updated so that we only use the default feature job settings when the table is `EventTable`.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
