### PR TITLE
[release/0.2][DEV-1657] Derive available columns from graph for view input when materialising

### DIFF
--- a/featurebyte/models/request_input.py
+++ b/featurebyte/models/request_input.py
@@ -3,7 +3,7 @@ RequestInput is the base class for all request input types.
 """
 from __future__ import annotations
 
-from typing import Dict, List, Literal, Optional
+from typing import Dict, List, Literal, Optional, cast
 
 from abc import abstractmethod
 
@@ -24,6 +24,7 @@ from featurebyte.query_graph.sql.materialisation import (
     get_view_expr,
     select_and_rename_columns,
 )
+from featurebyte.query_graph.transform.operation_structure import OperationStructureExtractor
 from featurebyte.session.base import BaseSession
 
 
@@ -79,8 +80,8 @@ class BaseRequestInput(FeatureByteBaseModel):
         result = await session.execute_query(query)
         return int(result.iloc[0]["row_count"])  # type: ignore[union-attr]
 
-    @staticmethod
-    async def get_column_names(session: BaseSession, query_expr: Select) -> list[str]:
+    @abstractmethod
+    async def get_column_names(self, session: BaseSession) -> list[str]:
         """
         Get the column names of the table query
 
@@ -88,16 +89,11 @@ class BaseRequestInput(FeatureByteBaseModel):
         ----------
         session: BaseSession
             The session to use to get the column names
-        query_expr: Select
-            The query expression to get the column names for
 
         Returns
         -------
         list[str]
         """
-        query = sql_to_string(query_expr.limit(1), source_type=session.source_type)
-        result = await session.execute_query(query)
-        return list(result.columns)  # type: ignore[union-attr]
 
     @staticmethod
     def get_sample_percentage_from_row_count(total_row_count: int, desired_row_count: int) -> float:
@@ -140,7 +136,7 @@ class BaseRequestInput(FeatureByteBaseModel):
         query_expr = self.get_query_expr(source_type=session.source_type)
 
         if self.columns is not None or self.columns_rename_mapping is not None:
-            available_columns = await self.get_column_names(session=session, query_expr=query_expr)
+            available_columns = await self.get_column_names(session=session)
             self._validate_columns_and_rename_mapping(available_columns)
             if self.columns is None:
                 columns = available_columns
@@ -196,6 +192,12 @@ class ViewRequestInput(BaseRequestInput):
     def get_query_expr(self, source_type: SourceType) -> Select:
         return get_view_expr(graph=self.graph, node_name=self.node_name, source_type=source_type)
 
+    async def get_column_names(self, session: BaseSession) -> List[str]:
+        node = self.graph.get_node_by_name(self.node_name)
+        op_struct_info = OperationStructureExtractor(graph=self.graph).extract(node=node)
+        op_struct = op_struct_info.operation_structure_map[node.name]
+        return cast(List[str], [column.name for column in op_struct.columns])
+
 
 class SourceTableRequestInput(BaseRequestInput):
     """
@@ -213,3 +215,11 @@ class SourceTableRequestInput(BaseRequestInput):
     def get_query_expr(self, source_type: SourceType) -> Select:
         _ = source_type
         return get_source_expr(source=self.source.table_details)
+
+    async def get_column_names(self, session: BaseSession) -> list[str]:
+        table_schema = await session.list_table_schema(
+            table_name=self.source.table_details.table_name,
+            database_name=self.source.table_details.database_name,
+            schema_name=self.source.table_details.schema_name,
+        )
+        return list(table_schema.keys())

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,7 +7,7 @@ import tempfile
 import traceback
 from datetime import datetime
 from unittest import mock
-from unittest.mock import AsyncMock, Mock, PropertyMock, patch
+from unittest.mock import Mock, PropertyMock, patch
 from uuid import uuid4
 
 import pandas as pd
@@ -797,9 +797,6 @@ def patched_observation_table_service():
     with patch(
         "featurebyte.service.observation_table.ObservationTableService.validate_materialized_table_and_get_metadata",
         Mock(side_effect=mocked_get_additional_metadata),
-    ), patch(
-        "featurebyte.models.request_input.BaseRequestInput.get_column_names",
-        AsyncMock(return_value=["event_timestamp", "cust_id", "extra_col"]),
     ):
         yield
 

--- a/tests/unit/models/test_request_input.py
+++ b/tests/unit/models/test_request_input.py
@@ -4,12 +4,12 @@ Unit tests related to RequestInput
 import textwrap
 from unittest.mock import AsyncMock, Mock, call
 
-import pandas as pd
 import pytest
 
 from featurebyte import SourceType
+from featurebyte.enum import DBVarType
 from featurebyte.exception import ColumnNotFoundError
-from featurebyte.models.request_input import SourceTableRequestInput
+from featurebyte.models.request_input import SourceTableRequestInput, ViewRequestInput
 from featurebyte.query_graph.node.schema import TableDetails
 from featurebyte.session.snowflake import SnowflakeSession
 
@@ -23,7 +23,7 @@ def session_fixture():
         name="mock_snowflake_session",
         spec=SnowflakeSession,
         source_type=SourceType.SNOWFLAKE,
-        execute_query=AsyncMock(return_value=pd.DataFrame({"a": [1], "b": [2]})),
+        list_table_schema=AsyncMock(return_value={"a": DBVarType.INT, "b": DBVarType.INT}),
     )
 
 
@@ -50,16 +50,11 @@ async def test_materialize__with_columns_only(session, snowflake_database_table,
     )
     await request_input.materialize(session, destination_table, None)
 
-    expected_query_1 = textwrap.dedent(
-        """
-        SELECT
-          *
-        FROM "sf_database"."sf_schema"."sf_table"
-        LIMIT 1
-        """
-    ).strip()
+    assert session.list_table_schema.call_args_list == [
+        call(table_name="sf_table", database_name="sf_database", schema_name="sf_schema")
+    ]
 
-    expected_query_2 = textwrap.dedent(
+    expected_query = textwrap.dedent(
         """
         CREATE TABLE "sf_database"."sf_schema"."my_materialized_table" AS
         SELECT
@@ -72,8 +67,7 @@ async def test_materialize__with_columns_only(session, snowflake_database_table,
         )
         """
     ).strip()
-
-    assert session.execute_query.call_args_list == [call(expected_query_1), call(expected_query_2)]
+    assert session.execute_query.call_args_list == [call(expected_query)]
 
 
 @pytest.mark.asyncio
@@ -90,16 +84,11 @@ async def test_materialize__with_columns_and_renames(
     )
     await request_input.materialize(session, destination_table, None)
 
-    expected_query_1 = textwrap.dedent(
-        """
-        SELECT
-          *
-        FROM "sf_database"."sf_schema"."sf_table"
-        LIMIT 1
-        """
-    ).strip()
+    assert session.list_table_schema.call_args_list == [
+        call(table_name="sf_table", database_name="sf_database", schema_name="sf_schema")
+    ]
 
-    expected_query_2 = textwrap.dedent(
+    expected_query = textwrap.dedent(
         """
         CREATE TABLE "sf_database"."sf_schema"."my_materialized_table" AS
         SELECT
@@ -112,7 +101,7 @@ async def test_materialize__with_columns_and_renames(
         )
         """
     ).strip()
-    assert session.execute_query.call_args_list == [call(expected_query_1), call(expected_query_2)]
+    assert session.execute_query.call_args_list == [call(expected_query)]
 
 
 @pytest.mark.asyncio
@@ -126,18 +115,11 @@ async def test_materialize__with_renames_only(session, snowflake_database_table,
     )
     await request_input.materialize(session, destination_table, None)
 
-    # First query retrieves the schema of the table / view
-    expected_query_1 = textwrap.dedent(
-        """
-        SELECT
-          *
-        FROM "sf_database"."sf_schema"."sf_table"
-        LIMIT 1
-        """
-    ).strip()
+    assert session.list_table_schema.call_args_list == [
+        call(table_name="sf_table", database_name="sf_database", schema_name="sf_schema")
+    ]
 
-    # Second query materializes the table
-    expected_query_2 = textwrap.dedent(
+    expected_query = textwrap.dedent(
         """
         CREATE TABLE "sf_database"."sf_schema"."my_materialized_table" AS
         SELECT
@@ -150,7 +132,7 @@ async def test_materialize__with_renames_only(session, snowflake_database_table,
         )
         """
     ).strip()
-    assert session.execute_query.call_args_list == [call(expected_query_1), call(expected_query_2)]
+    assert session.execute_query.call_args_list == [call(expected_query)]
 
 
 @pytest.mark.asyncio
@@ -181,3 +163,46 @@ async def test_materialize__invalid_rename_mapping(
     with pytest.raises(ColumnNotFoundError) as exc:
         await request_input.materialize(session, destination_table, None)
     assert "Columns ['unknown_column'] not found" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_materialize__from_view_with_columns_and_renames(
+    session, destination_table, snowflake_event_table
+):
+    """
+    Test materializing from view
+    """
+    view = snowflake_event_table.get_view()
+    pruned_graph, mapped_node = view.extract_pruned_graph_and_node()
+    request_input = ViewRequestInput(
+        columns=["event_timestamp", "col_int"],
+        columns_rename_mapping={"event_timestamp": "POINT_IN_TIME"},
+        graph=pruned_graph,
+        node_name=mapped_node.name,
+    )
+    await request_input.materialize(session, destination_table, None)
+
+    # No need to query database to get column names
+    assert session.list_table_schema.call_args_list == []
+
+    expected_query = textwrap.dedent(
+        """
+        CREATE TABLE "sf_database"."sf_schema"."my_materialized_table" AS
+        SELECT
+          "event_timestamp" AS "POINT_IN_TIME",
+          "col_int" AS "col_int"
+        FROM (
+          SELECT
+            "col_int" AS "col_int",
+            "col_float" AS "col_float",
+            "col_char" AS "col_char",
+            "col_text" AS "col_text",
+            "col_binary" AS "col_binary",
+            "col_boolean" AS "col_boolean",
+            "event_timestamp" AS "event_timestamp",
+            "cust_id" AS "cust_id"
+          FROM "sf_database"."sf_schema"."sf_table"
+        )
+        """
+    ).strip()
+    assert session.execute_query.call_args_list == [call(expected_query)]


### PR DESCRIPTION
Backport #1263 to release/0.2.

This updates the observation table / batch request table materialisation logic to derive the available column names from graph when applicable. This helps avoid an unnecessary warehouse query which can be expensive when the underlying view is complex.

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
