### PR TITLE
[release/0.2][DEV-1674] Move preview_sql() to SampleMixin (#1265)

### DIFF
--- a/featurebyte/api/request_column.py
+++ b/featurebyte/api/request_column.py
@@ -3,10 +3,9 @@ RequestColumn related classes for on-demand features
 """
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Optional
 
 from pydantic import Field
-from typeguard import typechecked
 
 from featurebyte.common.doc_util import FBAutoDoc
 from featurebyte.core.series import Series
@@ -107,11 +106,3 @@ class RequestColumn(Series):
     @property
     def binary_op_output_class_priority(self) -> int:
         return 1
-
-    @typechecked
-    def preview_sql(self, limit: int = 10, **kwargs: Any) -> str:
-        # preview_sql() is provided by QueryObject and requires feature_store. Ideally, it would be
-        # better to move preview_sql() out of QueryObject so RequestColumn doesn't have this method.
-        # But there are many tests that require Series to have preview_sql(), so the change is not
-        # trivial. Raising NotImplementedError() specifically for RequestColumn for now.
-        raise NotImplementedError("preview_sql is not supported for RequestColumn")

--- a/featurebyte/common/documentation/documentation_layout.py
+++ b/featurebyte/common/documentation/documentation_layout.py
@@ -277,7 +277,7 @@ def _get_feature_layout() -> List[DocLayoutItem]:
         DocLayoutItem([FEATURE, LINEAGE, "Feature.graph"]),
         DocLayoutItem([FEATURE, LINEAGE, "Feature.id"]),
         DocLayoutItem([FEATURE, LINEAGE, "Feature.definition"]),
-        DocLayoutItem([FEATURE, LINEAGE, "Feature.preview_sql"]),
+        DocLayoutItem([FEATURE, LINEAGE, "Feature.sql"]),
         DocLayoutItem([FEATURE, LINEAGE, "Feature.catalog_id"]),
         DocLayoutItem([FEATURE, MANAGE, "Feature.get_feature_jobs_status"]),
         DocLayoutItem([FEATURE, MANAGE, "Feature.as_default_version"]),

--- a/featurebyte/core/generic.py
+++ b/featurebyte/core/generic.py
@@ -12,7 +12,6 @@ from abc import abstractmethod
 from cachetools import LRUCache, cachedmethod
 from cachetools.keys import hashkey
 from pydantic import Field, root_validator
-from typeguard import typechecked
 
 from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
 from featurebyte.models.feature_store import FeatureStoreModel
@@ -23,7 +22,6 @@ from featurebyte.query_graph.model.common_table import TabularSource
 from featurebyte.query_graph.model.graph import QueryGraphModel
 from featurebyte.query_graph.node import Node
 from featurebyte.query_graph.node.metadata.operation import NodeOutputCategory, OperationStructure
-from featurebyte.query_graph.sql.interpreter import GraphInterpreter
 from featurebyte.query_graph.transform.flattening import GraphFlatteningTransformer
 from featurebyte.query_graph.transform.sdk_code import SDKCodeExtractor
 
@@ -207,30 +205,6 @@ class QueryObject(FeatureByteBaseModel):
         }
         state = SDKCodeExtractor(graph=pruned_graph).extract(node=node, **extract_kwargs)
         return state.code_generator.generate(to_format=to_format)
-
-    def _preview_sql(self, limit: int = 10, **kwargs: Any) -> str:
-        pruned_graph, mapped_node = self.extract_pruned_graph_and_node(**kwargs)
-        return GraphInterpreter(
-            pruned_graph, source_type=self.feature_store.type
-        ).construct_preview_sql(node_name=mapped_node.name, num_rows=limit)[0]
-
-    @typechecked
-    def preview_sql(self, limit: int = 10, **kwargs: Any) -> str:
-        """
-        Generate SQL query to preview the transformation output
-
-        Parameters
-        ----------
-        limit: int
-            maximum number of return rows
-        **kwargs: Any
-            Additional keyword parameters
-
-        Returns
-        -------
-        str
-        """
-        return self._preview_sql(limit=limit, **kwargs)
 
     def copy(
         self: QueryObjectT,

--- a/tests/unit/api/test_request_column.py
+++ b/tests/unit/api/test_request_column.py
@@ -66,14 +66,6 @@ def test_point_in_time_minus_timestamp_feature(latest_event_timestamp_feature, u
     )
 
 
-def test_request_column_preview_sql_blocked():
-    """
-    Test preview_sql() is blocked for RequestColumn
-    """
-    with pytest.raises(NotImplementedError):
-        _ = RequestColumn.point_in_time().preview_sql()
-
-
 def test_request_column_non_point_in_time_blocked():
     """
     Test non-point-in-time request column is blocked

--- a/tests/unit/core/accessor/test_datetime.py
+++ b/tests/unit/core/accessor/test_datetime.py
@@ -6,6 +6,7 @@ import pytest
 from featurebyte.core.accessor.datetime import DatetimeAccessor
 from featurebyte.enum import DBVarType
 from featurebyte.query_graph.enum import NodeOutputType, NodeType
+from tests.util.helper import get_preview_sql_for_series
 
 
 @pytest.mark.parametrize(
@@ -43,7 +44,7 @@ def test_datetime_property_extraction__timestamp(
     assert series.node.type == NodeType.DT_EXTRACT
     assert series.node.output_type == NodeOutputType.SERIES
     expected_sql = expression_sql_template.format(expression=exp_expression)
-    assert series.preview_sql() == expected_sql
+    assert get_preview_sql_for_series(series) == expected_sql
 
 
 def test_accessor_getattr__timestamp(timestamp_series):
@@ -138,7 +139,7 @@ def test_datetime_property_extraction__timedelta(
     assert series.node.type == NodeType.TIMEDELTA_EXTRACT
     assert series.node.output_type == NodeOutputType.SERIES
     expected_sql = expression_sql_template.format(expression=exp_expression)
-    assert series.preview_sql() == expected_sql
+    assert get_preview_sql_for_series(series) == expected_sql
 
 
 def test_accessor_getattr__timedelta(timedelta_series):
@@ -230,7 +231,7 @@ def test_datetime_property_extraction__timedelta_from_int(
     assert series.node.type == NodeType.TIMEDELTA_EXTRACT
     assert series.node.output_type == NodeOutputType.SERIES
     expected_sql = expression_sql_template.format(expression=exp_expression)
-    assert series.preview_sql() == expected_sql
+    assert get_preview_sql_for_series(series) == expected_sql
 
 
 @pytest.mark.parametrize("property_name", ["millisecond", "microsecond"])

--- a/tests/unit/core/accessor/test_string.py
+++ b/tests/unit/core/accessor/test_string.py
@@ -5,6 +5,7 @@ import pytest
 
 from featurebyte.enum import DBVarType
 from featurebyte.query_graph.enum import NodeOutputType, NodeType
+from tests.util.helper import get_preview_sql_for_series
 
 
 def test_length_expression(varchar_series, expression_sql_template):
@@ -16,7 +17,7 @@ def test_length_expression(varchar_series, expression_sql_template):
     assert str_len.node.type == NodeType.LENGTH
     assert str_len.node.output_type == NodeOutputType.SERIES
     expected_sql = expression_sql_template.format(expression='LENGTH("PRODUCT_ACTION")')
-    assert str_len.preview_sql() == expected_sql
+    assert get_preview_sql_for_series(str_len) == expected_sql
 
 
 @pytest.mark.parametrize(
@@ -40,7 +41,7 @@ def test_str_case_expression(
     assert series.node.type == NodeType.STR_CASE
     assert series.node.output_type == NodeOutputType.SERIES
     expected_sql = expression_sql_template.format(expression=exp_expression)
-    assert series.preview_sql() == expected_sql
+    assert get_preview_sql_for_series(series) == expected_sql
 
 
 @pytest.mark.parametrize(
@@ -68,7 +69,7 @@ def test_strip_expression(
     assert series.node.type == NodeType.TRIM
     assert series.node.output_type == NodeOutputType.SERIES
     expected_sql = expression_sql_template.format(expression=exp_expression)
-    assert series.preview_sql() == expected_sql
+    assert get_preview_sql_for_series(series) == expected_sql
 
 
 def test_replace_expression(
@@ -85,7 +86,7 @@ def test_replace_expression(
     expected_sql = expression_sql_template.format(
         expression="REPLACE(\"PRODUCT_ACTION\", 'hello', 'kitty')"
     )
-    assert str_replace.preview_sql() == expected_sql
+    assert get_preview_sql_for_series(str_replace) == expected_sql
 
 
 @pytest.mark.parametrize(
@@ -135,7 +136,7 @@ def test_pad_expression(
     assert series.node.type == NodeType.PAD
     assert series.node.output_type == NodeOutputType.SERIES
     expected_sql = expression_sql_template.format(expression=exp_expression)
-    assert series.preview_sql() == expected_sql
+    assert get_preview_sql_for_series(series) == expected_sql
 
 
 @pytest.mark.parametrize(
@@ -163,7 +164,7 @@ def test_contains_expression(
     assert series.node.type == NodeType.STR_CONTAINS
     assert series.node.output_type == NodeOutputType.SERIES
     expected_sql = expression_sql_template.format(expression=exp_expression)
-    assert series.preview_sql() == expected_sql
+    assert get_preview_sql_for_series(series) == expected_sql
 
 
 @pytest.mark.parametrize(
@@ -191,7 +192,7 @@ def test_slice_expression(
     assert series.node.type == NodeType.SUBSTRING
     assert series.node.output_type == NodeOutputType.SERIES
     expected_sql = expression_sql_template.format(expression=exp_expression)
-    assert series.preview_sql() == expected_sql
+    assert get_preview_sql_for_series(series) == expected_sql
 
 
 def test_slice_expression__step_size_not_supported_or_exception(varchar_series):

--- a/tests/unit/core/test_series.py
+++ b/tests/unit/core/test_series.py
@@ -13,7 +13,7 @@ from featurebyte.enum import DBVarType
 from featurebyte.query_graph.enum import NodeOutputType, NodeType
 from featurebyte.query_graph.graph import OperationStructureExtractor
 from featurebyte.query_graph.node import construct_node
-from tests.util.helper import get_node
+from tests.util.helper import get_node, get_preview_sql_for_series
 
 
 def test__getitem__series_key(int_series, bool_series):
@@ -894,7 +894,7 @@ def test_notnull(bool_series, expression_sql_template):
             """
         ).strip()
     )
-    assert expected_sql == result.preview_sql()
+    assert expected_sql == get_preview_sql_for_series(result)
 
 
 def test_fillna(float_series):
@@ -947,7 +947,7 @@ def test_varchar_series_concat(varchar_series, scalar_input, expected_literal):
         output_series = varchar_series + "scalar_value"
     else:
         output_series = varchar_series + varchar_series
-    output_sql = output_series.preview_sql()
+    output_sql = get_preview_sql_for_series(output_series)
     assert (
         output_sql
         == textwrap.dedent(
@@ -1096,7 +1096,7 @@ def test_numeric_operations(
     assert new_series.node.type == expected_node_type
     assert new_series.node.output_type == NodeOutputType.SERIES
     expected_sql = expression_sql_template.format(expression=expected_expr)
-    assert expected_sql == new_series.preview_sql()
+    assert expected_sql == get_preview_sql_for_series(new_series)
 
 
 @pytest.mark.parametrize("method", ["sqrt", "abs", "floor", "ceil"])
@@ -1168,7 +1168,7 @@ def test_scalar_timestamp__valid(
         LIMIT 10
         """
     ).strip()
-    assert result.preview_sql() == expected
+    assert get_preview_sql_for_series(result) == expected
 
 
 def test_scalar_timestamp__with_tz(timestamp_series, scalar_timestamp_tz):
@@ -1190,7 +1190,7 @@ def test_scalar_timestamp__with_tz(timestamp_series, scalar_timestamp_tz):
         LIMIT 10
         """
     ).strip()
-    assert result.preview_sql() == expected
+    assert get_preview_sql_for_series(result) == expected
 
 
 def test_scalar_timestamp__invalid(timestamp_series, scalar_timestamp):

--- a/tests/util/helper.py
+++ b/tests/util/helper.py
@@ -17,6 +17,7 @@ from sqlglot import expressions
 from featurebyte import get_version
 from featurebyte.api.source_table import AbstractTableData
 from featurebyte.core.generic import QueryObject
+from featurebyte.core.mixin import SampleMixin
 from featurebyte.enum import AggFunc
 from featurebyte.query_graph.enum import NodeOutputType, NodeType
 from featurebyte.query_graph.graph import GlobalGraphState, GlobalQueryGraph, QueryGraph
@@ -419,3 +420,10 @@ def check_observation_table_creation_query(query, expected):
     query = re.sub(r"OBSERVATION_TABLE_\w{24}", "OBSERVATION_TABLE", query)
     expected = textwrap.dedent(expected).strip()
     assert query == expected
+
+
+def get_preview_sql_for_series(series_obj, *args, **kwargs):
+    """
+    Helper function to get the preview SQL for a series
+    """
+    return SampleMixin.preview_sql(series_obj, *args, **kwargs)


### PR DESCRIPTION
Backport #1265 to release/0.2.

This moves preview_sql() to SampleMixin so that it is only available to applicable objects such as View and Column, but not Feature and RequestColumn.

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
