### PR TITLE
[DEV-1686] Use embedded styles for code html formatting

### DIFF
--- a/featurebyte/common/utils.py
+++ b/featurebyte/common/utils.py
@@ -412,9 +412,9 @@ class CodeStr(str):
     def _repr_html_(self) -> str:
         lexer = pygments.lexers.get_lexer_by_name("python")
         highlighted_code = pygments.highlight(
-            str(self).strip(), lexer=lexer, formatter=HtmlFormatter(full=True)
+            str(self).strip(), lexer=lexer, formatter=HtmlFormatter(noclasses=True)
         )
         return (
-            '<div style="margin:30px; padding: 20px; border:1px solid #aaa">\n\n'
-            f"{highlighted_code}\n\n</div>"
+            '<div style="margin:30px; padding: 20px; border:1px solid #aaa">'
+            f"{highlighted_code}</div>"
         )

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -8,6 +8,7 @@ import toml
 from pandas.testing import assert_frame_equal
 
 from featurebyte.common.utils import (
+    CodeStr,
     dataframe_from_arrow_stream,
     dataframe_from_json,
     dataframe_to_arrow_bytes,
@@ -85,3 +86,18 @@ def test_get_version():
     """
     data = toml.load("pyproject.toml")
     assert get_version() == data["tool"]["poetry"]["version"]
+
+
+def test_codestr_format():
+    """
+    Test CodeStr formatting
+    """
+    code = CodeStr("import featurebyte")
+    assert str(code) == "import featurebyte"
+    assert code._repr_html_() == (
+        '<div style="margin:30px; padding: 20px; border:1px solid #aaa">'
+        '<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span>'
+        '<span style="color: #008000; font-weight: bold">import</span> '
+        '<span style="color: #0000FF; font-weight: bold">featurebyte</span>\n'
+        "</pre></div>\n</div>"
+    )


### PR DESCRIPTION
## Description

Usage of css classes breaks css formatting in documentation pages.

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-1686

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
