### PR TITLE
[DEV-1686] Remove background color for code string html

### DIFF
--- a/featurebyte/common/utils.py
+++ b/featurebyte/common/utils.py
@@ -412,7 +412,9 @@ class CodeStr(str):
     def _repr_html_(self) -> str:
         lexer = pygments.lexers.get_lexer_by_name("python")
         highlighted_code = pygments.highlight(
-            str(self).strip(), lexer=lexer, formatter=HtmlFormatter(noclasses=True)
+            str(self).strip(),
+            lexer=lexer,
+            formatter=HtmlFormatter(noclasses=True, nobackground=True),
         )
         return (
             '<div style="margin:30px; padding: 20px; border:1px solid #aaa">'

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -96,7 +96,7 @@ def test_codestr_format():
     assert str(code) == "import featurebyte"
     assert code._repr_html_() == (
         '<div style="margin:30px; padding: 20px; border:1px solid #aaa">'
-        '<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span>'
+        '<div class="highlight"><pre style="line-height: 125%;"><span></span>'
         '<span style="color: #008000; font-weight: bold">import</span> '
         '<span style="color: #0000FF; font-weight: bold">featurebyte</span>\n'
         "</pre></div>\n</div>"


### PR DESCRIPTION
## Description

Exclude background color for code string html as it makes text unreadable in documentation in dark mode.

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-1686

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
