### PR TITLE
[DEV-1684] Implement streamed records fetching for DataBricks session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Support `columns` and `columns_rename_mapping` parameters when creating observation table and
   batch feature table
 * Update healthcare demo dataset to include timezone columns
+* Support streamed records fetching for DataBricks session
 
 
 ### 🧰 Bug fixes 🧰

--- a/tests/unit/session/test_databricks_session.py
+++ b/tests/unit/session/test_databricks_session.py
@@ -104,6 +104,11 @@ class MockDatabricksConnection:
         mock_arrow_table.to_pandas.return_value = df
         return mock_arrow_table
 
+    def fetchmany_arrow(self, size):
+        mock_dataframe = self.fetchall_arrow().to_pandas()
+        for i in range(mock_dataframe.shape[0], size):
+            yield mock_dataframe.iloc[i:size]
+
     def execute(self, *args, **kwargs):
         self.description = [["a", "INT"], ["b", "INT"], ["c", "INT"]]
         self.result_rows = [

--- a/tests/unit/session/test_databricks_session.py
+++ b/tests/unit/session/test_databricks_session.py
@@ -6,6 +6,7 @@ from unittest import mock
 from unittest.mock import call
 
 import pandas as pd
+import pyarrow as pa
 import pytest
 
 from featurebyte.enum import DBVarType
@@ -45,6 +46,7 @@ class MockDatabricksConnection:
     def __init__(self, *args, **kwargs):
         self.description = None
         self.result_rows = None
+        self.returned_count = 0
 
     def cursor(self):
         return self
@@ -100,14 +102,16 @@ class MockDatabricksConnection:
         for row in self.result_rows:
             data.append({k: v for (k, v) in zip(columns, row)})
         df = pd.DataFrame(data)
-        mock_arrow_table = mock.Mock()
-        mock_arrow_table.to_pandas.return_value = df
-        return mock_arrow_table
+        return pa.Table.from_pandas(df)
 
     def fetchmany_arrow(self, size):
         mock_dataframe = self.fetchall_arrow().to_pandas()
-        for i in range(mock_dataframe.shape[0], size):
-            yield mock_dataframe.iloc[i:size]
+        if self.returned_count >= len(mock_dataframe):
+            mock_dataframe = pd.DataFrame(columns=mock_dataframe.columns)
+        else:
+            mock_dataframe = mock_dataframe.iloc[self.returned_count : self.returned_count + size]
+            self.returned_count += size
+        return pa.Table.from_pandas(mock_dataframe)
 
     def execute(self, *args, **kwargs):
         self.description = [["a", "INT"], ["b", "INT"], ["c", "INT"]]


### PR DESCRIPTION
## Description

Implement streamed records fetching for DataBricks session to support download of large tables.

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-1684

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
