### PR TITLE
[chore] docs: add test to catch methods without examples

### DIFF
--- a/featurebyte/common/documentation/extract_csv.py
+++ b/featurebyte/common/documentation/extract_csv.py
@@ -1,7 +1,7 @@
 """
 Extract documentation into a CSV file.
 """
-from typing import Dict, List
+from typing import Dict, List, Literal
 
 import csv
 from dataclasses import dataclass
@@ -30,9 +30,11 @@ class DocItemToRender:
     """
 
     menu_item: str
+    # eg. class, method, property
+    item_type: Literal["class", "property", "method", "missing"]
     # eg. FeatureStore, FeatureStore.list
     class_method_or_attribute: str
-    # ilnk to docs, eg: http://127.0.0.1:8000/reference/featurebyte.api.feature_store.FeatureStore/
+    # link to docs, eg: http://127.0.0.1:8000/reference/featurebyte.api.feature_store.FeatureStore/
     link: str
     # the current docstring
     docstring_description: str
@@ -169,6 +171,7 @@ def _generate_items_to_render(doc_items: DocItems) -> List[DocItemToRender]:
             all_doc_items_to_generate.append(
                 DocItemToRender(
                     menu_item=" > ".join(layout_item.menu_header),
+                    item_type=resource_details.type,
                     class_method_or_attribute=link_without_md,
                     link=f"http://127.0.0.1:8000/reference/{link_without_md}",
                     **extract_details_for_rendering(resource_details),
@@ -180,6 +183,7 @@ def _generate_items_to_render(doc_items: DocItems) -> List[DocItemToRender]:
             all_doc_items_to_generate.append(
                 DocItemToRender(
                     menu_item=" > ".join(layout_item.menu_header),
+                    item_type=doc_item.resource_details.type,
                     class_method_or_attribute=doc_item.class_method_or_attribute,
                     link=doc_item.link,
                     **extract_details_for_rendering(doc_item.resource_details),
@@ -191,6 +195,7 @@ def _generate_items_to_render(doc_items: DocItems) -> List[DocItemToRender]:
         all_doc_items_to_generate.append(
             DocItemToRender(
                 menu_item=" > ".join(layout_item.menu_header),
+                item_type="missing",
                 class_method_or_attribute="missing",
                 link="missing",
                 docstring_description="missing",

--- a/tests/unit/common/documentation/test_extract_csv.py
+++ b/tests/unit/common/documentation/test_extract_csv.py
@@ -1,0 +1,122 @@
+"""
+Test extract CSV
+"""
+from typing import List
+
+from dataclasses import dataclass
+
+from featurebyte.common.documentation.extract_csv import _generate_items_to_render
+from featurebyte.common.documentation.gen_ref_pages_docs_builder import (
+    generate_documentation_for_docs,
+    get_doc_groups,
+)
+
+
+@dataclass
+class FailureMode:
+    """
+    Dataclass to capture various failure modes for a given menu item.
+    """
+
+    missing_docstring: bool = False
+    missing_examples: bool = False
+
+    def is_failure(self):
+        """
+        Check if any of the failure modes are true.
+        """
+        return self.missing_docstring or self.missing_examples
+
+    def __repr__(self):
+        failures: List[str] = []
+        if self.missing_docstring:
+            failures.append("docstring")
+        if self.missing_examples:
+            failures.append("examples")
+        return ",".join(failures)
+
+
+@dataclass
+class Failure:
+    """
+    Dataclass to capture a failure reason for a given menu item.
+    """
+
+    menu_item: str
+    item_name: str
+    failure_mode: FailureMode
+
+
+# These methods currently don't have examples in the documentation. We should update the documentation to include
+# some examples.
+methods_without_examples = {
+    "featurebyte.table.info",
+    "featurebyte.api.base_table.TableApiObject.preview_sql",
+    "featurebyte.tablecolumn.preview_sql",
+    "featurebyte.entity.info",
+    "featurebyte.feature.save",
+    "featurebyte.feature.info",
+    "featurebyte.feature.get_feature_jobs_status",
+    "featurebyte.Feature.dt.tz_offset",
+    "featurebyte.featurelist.save",
+    "featurebyte.featurelist.get_feature_jobs_status",
+    "featurebyte.view.get_join_column",
+    "featurebyte.view.preview_sql",
+    "featurebyte.viewcolumn.preview_sql",
+    "featurebyte.ViewColumn.dt.tz_offset",
+    "featurebyte.batchfeaturetable.describe",
+    "featurebyte.batchfeaturetable.preview",
+    "featurebyte.batchfeaturetable.sample",
+    "featurebyte.batchfeaturetable.download",
+    "featurebyte.batchfeaturetable.delete",
+    "featurebyte.batchrequesttable.describe",
+    "featurebyte.batchrequesttable.preview",
+    "featurebyte.batchrequesttable.sample",
+    "featurebyte.batchrequesttable.download",
+    "featurebyte.batchrequesttable.delete",
+    "featurebyte.observationtable.describe",
+    "featurebyte.observationtable.preview",
+    "featurebyte.observationtable.sample",
+    "featurebyte.observationtable.download",
+    "featurebyte.observationtable.delete",
+    "featurebyte.historicalfeaturetable.describe",
+    "featurebyte.historicalfeaturetable.preview",
+    "featurebyte.historicalfeaturetable.sample",
+    "featurebyte.historicalfeaturetable.download",
+    "featurebyte.historicalfeaturetable.delete",
+}
+
+
+def test_attributes_populated():
+    """
+    Test that various attributes in the docs are populated.
+
+    If an attribute is missing, you should consider updating the docs to include it.
+    """
+    doc_groups_to_use = get_doc_groups()
+    _, doc_items = generate_documentation_for_docs(doc_groups_to_use)
+    all_doc_items_to_generate = _generate_items_to_render(doc_items)
+    failures: List[Failure] = []
+    for item in all_doc_items_to_generate:
+        failure_mode = FailureMode()
+        # Perform checks
+        if not item.docstring_description:
+            failure_mode.missing_docstring = True
+        if (
+            item.item_type == "method"
+            and not item.examples
+            and item.class_method_or_attribute not in methods_without_examples
+        ):
+            # All methods should have an example
+            failure_mode.missing_examples = True
+
+        # Add to failures if necessary
+        if failure_mode.is_failure():
+            failures.append(
+                Failure(
+                    menu_item=item.menu_item,
+                    item_name=item.class_method_or_attribute,
+                    failure_mode=failure_mode,
+                )
+            )
+    assert len(failures) == 0, f"Failures: {failures}"


### PR DESCRIPTION
## Description
This adds a simple test to catch methods that are public facing in our documentation, but do not include any examples. 

Ideally, all our methods should have some simple examples on how to use them.
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
