### PR TITLE
Drop a materialized table only if it exists when cleaning up on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### 🧰 Bug fixes 🧰
 
++ Drop a materialized table only if it exists when cleaning up on error
+
 ## v0.2.1
 
 ### 🧰 Bug fixes 🧰

--- a/featurebyte/session/base.py
+++ b/featurebyte/session/base.py
@@ -437,6 +437,7 @@ class BaseSession(BaseModel):
         table_name: str,
         schema_name: str,
         database_name: str,
+        if_exists: bool = False,
     ) -> None:
         """
         Drop a table
@@ -449,12 +450,18 @@ class BaseSession(BaseModel):
             Schema name
         database_name : str
             Database name
+        if_exists : bool
+            If True, drop the table only if it exists
         """
         fully_qualified_table_name = get_fully_qualified_table_name(
             {"table_name": table_name, "schema_name": schema_name, "database_name": database_name}
         )
         query = sql_to_string(
-            expressions.Drop(this=expressions.Table(this=fully_qualified_table_name), kind="TABLE"),
+            expressions.Drop(
+                this=expressions.Table(this=fully_qualified_table_name),
+                kind="TABLE",
+                exists=if_exists,
+            ),
             source_type=self.source_type,
         )
         await self.execute_query(query)

--- a/featurebyte/worker/task/mixin.py
+++ b/featurebyte/worker/task/mixin.py
@@ -85,5 +85,6 @@ class DataWarehouseMixin:
                 table_name=table_details.table_name,
                 schema_name=table_details.schema_name,
                 database_name=table_details.database_name,
+                if_exists=True,
             )
             raise exc

--- a/tests/unit/api/test_source_table.py
+++ b/tests/unit/api/test_source_table.py
@@ -271,5 +271,5 @@ def test_bad_materialized_tables_cleaned_up(
 
     assert "RuntimeError: Something went wrong" in str(exc.value)
     assert snowflake_execute_query.call_args[0][0].startswith(
-        'DROP TABLE "sf_database"."sf_schema"."OBSERVATION_TABLE_'
+        'DROP TABLE IF EXISTS "sf_database"."sf_schema"."OBSERVATION_TABLE_'
     )


### PR DESCRIPTION
## Description

This updates the clean up of materialized tables on error to drop the table only when it exists to avoid masking actual errors.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
