### PR TITLE
[DEV-1699] Avoid performing Spark storage connection check for every session creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ### 🚩 Deprecations 🚩
 ### 💡 Enhancements 💡
 + Support overriding default log level using environment variable `LOG_LEVEL`
++ Support streamed records fetching for DataBricks session
++ Support GCS storage for Spark and DataBricks sessions
 
 ### 🧰 Bug fixes 🧰
 
@@ -17,8 +19,6 @@
 ### 💡 Enhancements 💡
 
 + Update healthcare demo dataset to include timezone columns
-+ Support streamed records fetching for DataBricks session
-+ Support GCS storage for Spark and DataBricks sessions
 
 ### 🧰 Bug fixes 🧰
 

--- a/featurebyte/models/credential.py
+++ b/featurebyte/models/credential.py
@@ -73,6 +73,15 @@ class BaseCredential(FeatureByteBaseModel):
         for field in self.__fields__.values():
             if field.type_ == StrictStr:
                 setattr(self, field.name, encrypt_value(getattr(self, field.name)))
+            elif field.type_ == str:
+                field_value = getattr(self, field.name)
+                if isinstance(field_value, dict):
+                    # Encrypt each value in the dict
+                    setattr(
+                        self,
+                        field.name,
+                        {key: encrypt_value(value) for key, value in field_value.items()},
+                    )
 
     def decrypt(self) -> None:
         """
@@ -81,6 +90,15 @@ class BaseCredential(FeatureByteBaseModel):
         for field in self.__fields__.values():
             if field.type_ == StrictStr:
                 setattr(self, field.name, decrypt_value(getattr(self, field.name)))
+            elif field.type_ == str:
+                field_value = getattr(self, field.name)
+                if isinstance(field_value, dict):
+                    # Decrypt each value in the dict
+                    setattr(
+                        self,
+                        field.name,
+                        {key: decrypt_value(value) for key, value in field_value.items()},
+                    )
 
 
 # Database Credentials

--- a/featurebyte/models/credential.py
+++ b/featurebyte/models/credential.py
@@ -74,6 +74,7 @@ class BaseCredential(FeatureByteBaseModel):
             if field.type_ == StrictStr:
                 setattr(self, field.name, encrypt_value(getattr(self, field.name)))
             elif field.type_ == str:
+                # pydantic captures dict field type as str
                 field_value = getattr(self, field.name)
                 if isinstance(field_value, dict):
                     # Encrypt each value in the dict
@@ -91,6 +92,7 @@ class BaseCredential(FeatureByteBaseModel):
             if field.type_ == StrictStr:
                 setattr(self, field.name, decrypt_value(getattr(self, field.name)))
             elif field.type_ == str:
+                # pydantic captures dict field type as str
                 field_value = getattr(self, field.name)
                 if isinstance(field_value, dict):
                     # Decrypt each value in the dict

--- a/tests/unit/models/test_credential.py
+++ b/tests/unit/models/test_credential.py
@@ -12,6 +12,7 @@ from featurebyte.models.credential import (
     AccessTokenCredential,
     CredentialModel,
     DatabaseCredentialType,
+    GCSStorageCredential,
     S3StorageCredential,
     StorageCredentialType,
     UsernamePasswordCredential,
@@ -19,7 +20,9 @@ from featurebyte.models.credential import (
 from featurebyte.models.feature_store import FeatureStoreModel
 
 
-@pytest.fixture(name="storage_credential", params=[None, StorageCredentialType.S3])
+@pytest.fixture(
+    name="storage_credential", params=[None] + list(StorageCredentialType.__members__.values())
+)
 def storage_credential_fixture(request):
     """
     Fixture for a StorageCredential object
@@ -31,6 +34,13 @@ def storage_credential_fixture(request):
             s3_access_key_id="access_key_id",
             s3_secret_access_key="secret_access_key",
         )
+    elif request.param == StorageCredentialType.GCS:
+        credential = GCSStorageCredential(
+            service_account_info={
+                "type": "service_account",
+                "private_key": "private_key",
+            }
+        )
     else:
         raise ValueError("Invalid storage credential type")
     return credential.json_dict()
@@ -38,7 +48,7 @@ def storage_credential_fixture(request):
 
 @pytest.fixture(
     name="database_credential",
-    params=[None, DatabaseCredentialType.USERNAME_PASSWORD, DatabaseCredentialType.ACCESS_TOKEN],
+    params=[None] + list(DatabaseCredentialType.__members__.values()),
 )
 def database_credential_fixture(request):
     """

--- a/tests/unit/session/test_spark.py
+++ b/tests/unit/session/test_spark.py
@@ -10,6 +10,7 @@ from featurebyte.models.credential import GCSStorageCredential
 from featurebyte.session.spark import SparkSession
 
 
+@patch("featurebyte.session.spark.HiveConnection.__new__")
 def test_s3_storage(config):
     """
     Test initializing session with s3 storage
@@ -47,6 +48,7 @@ def test_s3_storage(config):
     )
 
 
+@patch("featurebyte.session.spark.HiveConnection.__new__")
 def test_gcs_storage(config):
     """
     Test initializing session with gcs storage

--- a/tests/unit/session/test_spark.py
+++ b/tests/unit/session/test_spark.py
@@ -1,6 +1,8 @@
 """
 Test SparkSession
 """
+from unittest.mock import patch
+
 import pytest
 
 from featurebyte import S3StorageCredential, StorageType
@@ -36,13 +38,13 @@ def test_s3_storage(config):
     assert "Unsupported storage credential for S3: GCSStorageCredential" in str(exc)
 
     # Success
-    with pytest.raises(ValueError) as exc:
-        SparkSession(
-            storage_credential=S3StorageCredential(
-                s3_access_key_id="test", s3_secret_access_key="test"
-            ),
-            **params,
-        )
+    # with pytest.raises(ValueError):
+    SparkSession(
+        storage_credential=S3StorageCredential(
+            s3_access_key_id="test", s3_secret_access_key="test"
+        ),
+        **params,
+    )
 
 
 def test_gcs_storage(config):
@@ -78,5 +80,14 @@ def test_gcs_storage(config):
     assert "Unsupported storage credential for GCS: S3StorageCredential" in str(exc)
 
     # Success
-    with pytest.raises(ValueError) as exc:
-        SparkSession(storage_credential=GCSStorageCredential(service_account_info={}), **params)
+    with patch("featurebyte.session.simple_storage.GCSClient.from_service_account_info"):
+        SparkSession(
+            storage_credential=GCSStorageCredential(
+                service_account_info={
+                    "client_email": "test",
+                    "token_uri": "test",
+                    "private_key": "test",
+                }
+            ),
+            **params,
+        )


### PR DESCRIPTION
## Description

- Connection check is expensive - do it only when registering objects instead of each time a session is created.
- Fix GCS credentials not encrypted for storage

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-1699

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
