### PR TITLE
expose catalog_id for entity and relationship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 + Support streamed records fetching for DataBricks session
 + Support GCS storage for Spark and DataBricks sessions
 + Update feature definition by explicitly specifying `on` parameter in `join` operation
++ Expose `catalog_id` property in the Entity and Relationship API objects
 + Remove unused statement from `feature.definition`
 + Improve error handling and messaging for Docker exceptions
 + Support `scheduler`, `worker:io`, `worker:cpu` in startup command to start different services

--- a/featurebyte/api/entity.py
+++ b/featurebyte/api/entity.py
@@ -16,6 +16,7 @@ from featurebyte.api.savable_api_object import SavableApiObject
 from featurebyte.common.doc_util import FBAutoDoc
 from featurebyte.config import Configurations
 from featurebyte.exception import RecordRetrievalException, RecordUpdateException
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.entity import EntityModel, ParentEntity
 from featurebyte.schema.entity import EntityCreate, EntityUpdate
 
@@ -80,6 +81,22 @@ class Entity(NameAttributeUpdatableMixin, SavableApiObject):
             return self.cached_model.serving_names
         except RecordRetrievalException:
             return self.internal_serving_names
+
+    @property
+    def catalog_id(self) -> PydanticObjectId:
+        """
+        Returns the unique identifier (ID) of the Catalog that is associated with the Entity object.
+
+        Returns
+        -------
+        ObjectId
+            Catalog ID of the entity.
+
+        See Also
+        --------
+        - [Catalog](/reference/featurebyte.api.catalog.Catalog)
+        """
+        return self.cached_model.catalog_id  # pylint: disable=no-member
 
     @property
     def serving_name(self) -> str:

--- a/featurebyte/api/entity.py
+++ b/featurebyte/api/entity.py
@@ -89,7 +89,7 @@ class Entity(NameAttributeUpdatableMixin, SavableApiObject):
 
         Returns
         -------
-        ObjectId
+        PydanticObjectId
             Catalog ID of the entity.
 
         See Also

--- a/featurebyte/api/relationship.py
+++ b/featurebyte/api/relationship.py
@@ -95,6 +95,22 @@ class Relationship(ApiObject):
         except RecordRetrievalException:
             return self.internal_updated_by
 
+    @property
+    def catalog_id(self) -> PydanticObjectId:
+        """
+        Returns the unique identifier (ID) of the Catalog that is associated with the Relationship object.
+
+        Returns
+        -------
+        ObjectId
+            Catalog ID of the relationship.
+
+        See Also
+        --------
+        - [Catalog](/reference/featurebyte.api.catalog.Catalog)
+        """
+        return self.cached_model.catalog_id  # pylint: disable=no-member
+
     @classmethod
     @typechecked
     def list(

--- a/featurebyte/api/relationship.py
+++ b/featurebyte/api/relationship.py
@@ -102,7 +102,7 @@ class Relationship(ApiObject):
 
         Returns
         -------
-        ObjectId
+        PydanticObjectId
             Catalog ID of the relationship.
 
         See Also

--- a/featurebyte/common/documentation/documentation_layout.py
+++ b/featurebyte/common/documentation/documentation_layout.py
@@ -248,6 +248,7 @@ def _get_entity_layout() -> List[DocLayoutItem]:
         DocLayoutItem([ENTITY, INFO, "Entity.serving_names"]),
         DocLayoutItem([ENTITY, INFO, "Entity.updated_at"]),
         DocLayoutItem([ENTITY, LINEAGE, "Entity.id"]),
+        DocLayoutItem([ENTITY, LINEAGE, "Entity.catalog_id"]),
         DocLayoutItem([ENTITY, MANAGE, "Entity.update_name"]),
     ]
 
@@ -453,6 +454,7 @@ def _get_relationship_layout() -> List[DocLayoutItem]:
         DocLayoutItem([RELATIONSHIP, INFO, "Relationship.name"]),
         DocLayoutItem([RELATIONSHIP, INFO, "Relationship.updated_at"]),
         DocLayoutItem([RELATIONSHIP, LINEAGE, "Relationship.id"]),
+        DocLayoutItem([RELATIONSHIP, LINEAGE, "Relationship.catalog_id"]),
         DocLayoutItem([RELATIONSHIP, MANAGE, "Relationship.enable"]),
         DocLayoutItem([RELATIONSHIP, MANAGE, "Relationship.disable"]),
     ]

--- a/tests/unit/api/test_entity.py
+++ b/tests/unit/api/test_entity.py
@@ -11,6 +11,7 @@ from bson import ObjectId
 from pandas.testing import assert_frame_equal
 from pydantic import ValidationError
 
+from featurebyte.api.catalog import Catalog
 from featurebyte.api.entity import Entity
 from featurebyte.enum import DBVarType, TableDataType
 from featurebyte.exception import (
@@ -398,3 +399,12 @@ def test_entity_name_synchronization_issue(entity):
     cloned_entity.update_name("customer")
     assert entity.name == "customer"
     assert cloned_entity.name == "customer"
+
+
+def test_catalog_id(entity):
+    """
+    Test catalog_id
+    """
+    entity = Entity.get_by_id(entity.id)
+    catalog = Catalog.get_active()
+    assert entity.catalog_id == catalog.id

--- a/tests/unit/api/test_relationship.py
+++ b/tests/unit/api/test_relationship.py
@@ -6,6 +6,7 @@ import pytest_asyncio
 from bson import ObjectId
 
 from featurebyte import Entity
+from featurebyte.api.catalog import Catalog
 from featurebyte.api.relationship import Relationship
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.relationship import RelationshipInfoModel, RelationshipType
@@ -181,3 +182,12 @@ async def test_enable(persisted_relationship_info):
     # verify that relationship is now enabled
     relationship = Relationship.get_by_id(persisted_relationship_info.id)
     assert not relationship.enabled
+
+
+def test_catalog_id(persisted_relationship_info):
+    """
+    Test catalog_id
+    """
+    relationship = Relationship.get_by_id(persisted_relationship_info.id)
+    catalog = Catalog.get_active()
+    assert relationship.catalog_id == catalog.id


### PR DESCRIPTION
## Description
Expose `catalog_id` for the entity and relationship API objects.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-1505
https://featurebyte.atlassian.net/browse/DEV-1506

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
