### PR TITLE
[DEV-1712] Implement HTML representation for API Object information result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 + Improve error handling and messaging for Docker exceptions
 + Support `scheduler`, `worker:io`, `worker:cpu` in startup command to start different services
 + Update feature's & feature list's version format from dictionary to string
++ Implement HTML representation for API objects `.info()` result
 
 ### 🧰 Bug fixes 🧰
 

--- a/featurebyte/api/api_object.py
+++ b/featurebyte/api/api_object.py
@@ -21,9 +21,9 @@ from pandas import DataFrame
 from requests.models import Response
 from typeguard import typechecked
 
-from featurebyte.api.api_object_util import PrettyDict, ProgressThread
+from featurebyte.api.api_object_util import ProgressThread
 from featurebyte.common.env_util import get_alive_bar_additional_params
-from featurebyte.common.utils import construct_repr_string
+from featurebyte.common.utils import InfoDict, construct_repr_string
 from featurebyte.config import Configurations
 from featurebyte.exception import (
     DuplicatedRecordException,
@@ -720,7 +720,9 @@ class ApiObject(FeatureByteBaseDocumentModel):
         client = Configurations().get_client()
         response = client.get(url=f"{self._route}/{self.id}/info", params={"verbose": verbose})
         if response.status_code == HTTPStatus.OK:
-            return PrettyDict(response.json())
+            info = response.json()
+            info["class_name"] = self.__class__.__name__
+            return InfoDict(info)
         raise RecordRetrievalException(response, "Failed to retrieve object info.")
 
     @classmethod

--- a/featurebyte/api/api_object.py
+++ b/featurebyte/api/api_object.py
@@ -23,13 +23,12 @@ from typeguard import typechecked
 
 from featurebyte.api.api_object_util import ProgressThread
 from featurebyte.common.env_util import get_alive_bar_additional_params
-from featurebyte.common.utils import InfoDict, construct_repr_string
+from featurebyte.common.formatting_util import InfoDict
+from featurebyte.common.utils import construct_repr_string
 from featurebyte.config import Configurations
 from featurebyte.exception import (
     DuplicatedRecordException,
-    ObjectHasBeenSavedError,
     RecordCreationException,
-    RecordDeletionException,
     RecordRetrievalException,
     RecordUpdateException,
 )
@@ -113,6 +112,23 @@ class ApiObject(FeatureByteBaseDocumentModel):
 
     # global api object cache shared by all the ApiObject class & its child classes
     _cache: Any = TTLCache(maxsize=1024, ttl=1)
+
+    def _repr_html_(self) -> str:
+        """
+        HTML representation of the object
+
+        Returns
+        -------
+        str
+        """
+        info_repr = ""
+        try:
+            info_repr = InfoDict(self.info()).to_html()
+        except (RecordCreationException, RecordRetrievalException):
+            # object has not been saved yet
+            pass
+
+        return info_repr
 
     def __repr__(self) -> str:
         info_repr = ""
@@ -871,117 +887,3 @@ class ApiObject(FeatureByteBaseDocumentModel):
             self._poll_async_task(task_response=update_response, delay=delay, retrieve_result=False)
         # call get to update the object cache as retrieve result is False
         self.get_by_id(self.id)
-
-
-class SavableApiObject(ApiObject):
-    """
-    ApiObject contains common methods used to interact with API routes
-    """
-
-    def _get_create_payload(self) -> dict[str, Any]:
-        """
-        Construct payload used for post route
-
-        Returns
-        -------
-        dict[str, Any]
-        """
-        return self.json_dict(exclude_none=True)
-
-    def _pre_save_operations(self, conflict_resolution: ConflictResolution) -> None:
-        """
-        Operations to be executed before saving the api object
-
-        Parameters
-        ----------
-        conflict_resolution: ConflictResolution
-            "raise" raises error when then counters conflict error (default)
-            "retrieve" handle conflict error by retrieving object with the same name
-        """
-        _ = conflict_resolution
-
-    @typechecked
-    def save(self, conflict_resolution: ConflictResolution = "raise") -> None:
-        """
-        Save an object to the persistent data store.
-
-        A conflict could be triggered when the object being saved has violated a uniqueness check at the persistent
-        data store. For example, the same object ID could have been used by another record that is already stored.
-
-        In these scenarios, we can either raise an error or retrieve the object with the same name, depending on the
-        conflict resolution parameter passed in. The default behavior is to raise an error.
-
-        Parameters
-        ----------
-        conflict_resolution: ConflictResolution
-            "raise" will raise an error when we encounter a conflict error.
-            "retrieve" will handle the conflict error by retrieving the object with the same name.
-
-        Raises
-        ------
-        ObjectHasBeenSavedError
-            If the object has been saved before.
-        DuplicatedRecordException
-            When a record with the same key exists at the persistent data store.
-        RecordCreationException
-            When we fail to save the new object (general failure).
-
-        Examples
-        --------
-        Note that the examples below are not exhaustive.
-
-        Save a new Entity object.
-
-        >>> entity = fb.Entity(name="grocerycustomer_example", serving_names=["GROCERYCUSTOMERGUID"])  # doctest: +SKIP
-        >>> entity.save()  # doctest: +SKIP
-        None
-
-        Calling save again returns an error.
-
-        >>> entity = fb.Entity(name="grocerycustomer", serving_names=["GROCERYCUSTOMERGUID"])  # doctest: +SKIP
-        >>> entity.save()  # doctest: +SKIP
-        >>> entity.save()  # doctest: +SKIP
-        Entity (id: <entity.id>) has been saved before.
-        """
-        if self.saved and conflict_resolution == "raise":
-            raise ObjectHasBeenSavedError(
-                f'{type(self).__name__} (id: "{self.id}") has been saved before.'
-            )
-
-        self._pre_save_operations(conflict_resolution=conflict_resolution)
-        client = Configurations().get_client()
-        response = client.post(url=self._route, json=self._get_create_payload())
-        retrieve_object = False
-        if response.status_code != HTTPStatus.CREATED:
-            if response.status_code == HTTPStatus.CONFLICT:
-                if conflict_resolution == "retrieve":
-                    retrieve_object = True
-                else:
-                    raise DuplicatedRecordException(response=response)
-            if not retrieve_object:
-                raise RecordCreationException(response=response)
-
-        if retrieve_object:
-            assert self.name is not None
-            object_dict = self._get_object_dict_by_name(name=self.name)
-        else:
-            object_dict = response.json()
-
-        self._update_cache(object_dict)  # update api object cache store
-        type(self).__init__(
-            self,
-            **object_dict,
-            **self._get_init_params_from_object(),
-        )
-
-
-class DeletableApiObject(ApiObject):
-    """
-    DeleteMixin contains common methods used to delete an object
-    """
-
-    def _delete(self) -> None:
-        client = Configurations().get_client()
-        response = client.delete(url=f"{self._route}/{self.id}")
-        if response.status_code != HTTPStatus.OK:
-            raise RecordDeletionException(response, "Failed to delete the specified object.")

--- a/featurebyte/api/api_object_util.py
+++ b/featurebyte/api/api_object_util.py
@@ -1,12 +1,10 @@
 """
 API Object Util
 """
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import ctypes
 import threading
-
-from rich.pretty import pretty_repr
 
 from featurebyte.config import Configurations
 from featurebyte.exception import RecordRetrievalException
@@ -82,15 +80,6 @@ class ProgressThread(threading.Thread):
             if res > 1:
                 ctypes.pythonapi.PyThreadState_SetAsyncExc(thread_id, 0)
                 logger.warning("Exception raise failure")
-
-
-class PrettyDict(Dict[str, Any]):
-    """
-    Dict with prettified representation
-    """
-
-    def __repr__(self) -> str:
-        return pretty_repr(dict(self), expand_all=True, indent_size=2)
 
 
 class NameAttributeUpdatableMixin:

--- a/featurebyte/api/base_table.py
+++ b/featurebyte/api/base_table.py
@@ -15,8 +15,9 @@ from pandas import DataFrame
 from pydantic import Field
 from typeguard import typechecked
 
-from featurebyte.api.api_object import ApiObject, ForeignKeyMapping, SavableApiObject
+from featurebyte.api.api_object import ApiObject, ForeignKeyMapping
 from featurebyte.api.entity import Entity
+from featurebyte.api.savable_api_object import SavableApiObject
 from featurebyte.api.source_table import AbstractTableData, SourceTable
 from featurebyte.common.doc_util import FBAutoDoc
 from featurebyte.config import Configurations

--- a/featurebyte/api/catalog.py
+++ b/featurebyte/api/catalog.py
@@ -11,7 +11,6 @@ from bson import ObjectId
 from pydantic import Field
 from typeguard import typechecked
 
-from featurebyte.api.api_object import SavableApiObject
 from featurebyte.api.api_object_util import NameAttributeUpdatableMixin
 from featurebyte.api.batch_feature_table import BatchFeatureTable
 from featurebyte.api.batch_request_table import BatchRequestTable
@@ -28,6 +27,7 @@ from featurebyte.api.historical_feature_table import HistoricalFeatureTable
 from featurebyte.api.observation_table import ObservationTable
 from featurebyte.api.periodic_task import PeriodicTask
 from featurebyte.api.relationship import Relationship
+from featurebyte.api.savable_api_object import SavableApiObject
 from featurebyte.api.table import Table
 from featurebyte.api.view import View
 from featurebyte.common.doc_util import FBAutoDoc

--- a/featurebyte/api/credential.py
+++ b/featurebyte/api/credential.py
@@ -8,8 +8,9 @@ from typing import Any, Dict, Optional
 from pydantic import Field
 from typeguard import typechecked
 
-from featurebyte.api.api_object import DeletableApiObject, ForeignKeyMapping, SavableApiObject
+from featurebyte.api.api_object import ForeignKeyMapping
 from featurebyte.api.feature_store import FeatureStore
+from featurebyte.api.savable_api_object import DeletableApiObject, SavableApiObject
 from featurebyte.common.doc_util import FBAutoDoc
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.credential import (

--- a/featurebyte/api/deployment.py
+++ b/featurebyte/api/deployment.py
@@ -21,7 +21,7 @@ from featurebyte.api.feature_job import FeatureJobStatusResult
 from featurebyte.api.feature_list import FeatureList
 from featurebyte.api.table import Table
 from featurebyte.common.doc_util import FBAutoDoc
-from featurebyte.common.utils import CodeStr
+from featurebyte.common.formatting_util import CodeStr
 from featurebyte.config import Configurations
 from featurebyte.exception import FeatureListNotOnlineEnabledError
 from featurebyte.models.base import PydanticObjectId

--- a/featurebyte/api/entity.py
+++ b/featurebyte/api/entity.py
@@ -11,8 +11,8 @@ from bson import ObjectId
 from pydantic import Field
 from typeguard import typechecked
 
-from featurebyte.api.api_object import SavableApiObject
 from featurebyte.api.api_object_util import NameAttributeUpdatableMixin
+from featurebyte.api.savable_api_object import SavableApiObject
 from featurebyte.common.doc_util import FBAutoDoc
 from featurebyte.config import Configurations
 from featurebyte.exception import RecordRetrievalException, RecordUpdateException

--- a/featurebyte/api/feature.py
+++ b/featurebyte/api/feature.py
@@ -14,17 +14,19 @@ from bson import ObjectId
 from pydantic import Field, root_validator
 from typeguard import typechecked
 
-from featurebyte.api.api_object import ConflictResolution, DeletableApiObject, SavableApiObject
+from featurebyte.api.api_object import ConflictResolution
 from featurebyte.api.entity import Entity
 from featurebyte.api.feature_job import FeatureJobMixin
 from featurebyte.api.feature_namespace import FeatureNamespace
 from featurebyte.api.feature_store import FeatureStore
 from featurebyte.api.feature_util import FEATURE_COMMON_LIST_FIELDS, FEATURE_LIST_FOREIGN_KEYS
 from featurebyte.api.feature_validation_util import assert_is_lookup_feature
+from featurebyte.api.savable_api_object import DeletableApiObject, SavableApiObject
 from featurebyte.common.descriptor import ClassInstanceMethodDescriptor
 from featurebyte.common.doc_util import FBAutoDoc
+from featurebyte.common.formatting_util import CodeStr
 from featurebyte.common.typing import Scalar, ScalarSequence
-from featurebyte.common.utils import CodeStr, dataframe_from_json, enforce_observation_set_row_order
+from featurebyte.common.utils import dataframe_from_json, enforce_observation_set_row_order
 from featurebyte.config import Configurations
 from featurebyte.core.accessor.count_dict import CdAccessorMixin
 from featurebyte.core.accessor.feature_datetime import FeatureDtAccessorMixin

--- a/featurebyte/api/feature_list.py
+++ b/featurebyte/api/feature_list.py
@@ -33,9 +33,7 @@ from featurebyte.api.api_object import (
     PAGINATED_CALL_PAGE_SIZE,
     ApiObject,
     ConflictResolution,
-    DeletableApiObject,
     ForeignKeyMapping,
-    SavableApiObject,
 )
 from featurebyte.api.base_table import TableApiObject
 from featurebyte.api.entity import Entity
@@ -45,6 +43,7 @@ from featurebyte.api.feature_job import FeatureJobMixin, FeatureJobStatusResult
 from featurebyte.api.feature_store import FeatureStore
 from featurebyte.api.historical_feature_table import HistoricalFeatureTable
 from featurebyte.api.observation_table import ObservationTable
+from featurebyte.api.savable_api_object import DeletableApiObject, SavableApiObject
 from featurebyte.common.descriptor import ClassInstanceMethodDescriptor
 from featurebyte.common.doc_util import FBAutoDoc
 from featurebyte.common.env_util import get_alive_bar_additional_params

--- a/featurebyte/api/feature_store.py
+++ b/featurebyte/api/feature_store.py
@@ -8,8 +8,8 @@ from typing import Any, Dict, Optional
 from bson import ObjectId
 from pandas import DataFrame
 
-from featurebyte.api.api_object import SavableApiObject
 from featurebyte.api.data_source import DataSource
+from featurebyte.api.savable_api_object import SavableApiObject
 from featurebyte.common.doc_util import FBAutoDoc
 from featurebyte.enum import SourceType
 from featurebyte.exception import RecordRetrievalException

--- a/featurebyte/api/periodic_task.py
+++ b/featurebyte/api/periodic_task.py
@@ -3,7 +3,7 @@ PeriodicTask class
 """
 from __future__ import annotations
 
-from featurebyte.api.api_object import SavableApiObject
+from featurebyte.api.savable_api_object import SavableApiObject
 from featurebyte.common.doc_util import FBAutoDoc
 from featurebyte.models.periodic_task import PeriodicTask as PeriodicTaskModel
 

--- a/featurebyte/api/savable_api_object.py
+++ b/featurebyte/api/savable_api_object.py
@@ -1,0 +1,133 @@
+"""
+SavableApiObject class
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from http import HTTPStatus
+
+from typeguard import typechecked
+
+from featurebyte.api.api_object import ApiObject, ConflictResolution
+from featurebyte.config import Configurations
+from featurebyte.exception import (
+    DuplicatedRecordException,
+    ObjectHasBeenSavedError,
+    RecordCreationException,
+    RecordDeletionException,
+)
+
+
+class SavableApiObject(ApiObject):
+    """
+    ApiObject contains common methods used to interact with API routes
+    """
+
+    def _get_create_payload(self) -> dict[str, Any]:
+        """
+        Construct payload used for post route
+
+        Returns
+        -------
+        dict[str, Any]
+        """
+        return self.json_dict(exclude_none=True)
+
+    def _pre_save_operations(self, conflict_resolution: ConflictResolution) -> None:
+        """
+        Operations to be executed before saving the api object
+
+        Parameters
+        ----------
+        conflict_resolution: ConflictResolution
+            "raise" raises error when then counters conflict error (default)
+            "retrieve" handle conflict error by retrieving object with the same name
+        """
+        _ = conflict_resolution
+
+    @typechecked
+    def save(self, conflict_resolution: ConflictResolution = "raise") -> None:
+        """
+        Save an object to the persistent data store.
+
+        A conflict could be triggered when the object being saved has violated a uniqueness check at the persistent
+        data store. For example, the same object ID could have been used by another record that is already stored.
+
+        In these scenarios, we can either raise an error or retrieve the object with the same name, depending on the
+        conflict resolution parameter passed in. The default behavior is to raise an error.
+
+        Parameters
+        ----------
+        conflict_resolution: ConflictResolution
+            "raise" will raise an error when we encounter a conflict error.
+            "retrieve" will handle the conflict error by retrieving the object with the same name.
+
+        Raises
+        ------
+        ObjectHasBeenSavedError
+            If the object has been saved before.
+        DuplicatedRecordException
+            When a record with the same key exists at the persistent data store.
+        RecordCreationException
+            When we fail to save the new object (general failure).
+
+        Examples
+        --------
+        Note that the examples below are not exhaustive.
+
+        Save a new Entity object.
+
+        >>> entity = fb.Entity(name="grocerycustomer_example", serving_names=["GROCERYCUSTOMERGUID"])  # doctest: +SKIP
+        >>> entity.save()  # doctest: +SKIP
+        None
+
+        Calling save again returns an error.
+
+        >>> entity = fb.Entity(name="grocerycustomer", serving_names=["GROCERYCUSTOMERGUID"])  # doctest: +SKIP
+        >>> entity.save()  # doctest: +SKIP
+        >>> entity.save()  # doctest: +SKIP
+        Entity (id: <entity.id>) has been saved before.
+        """
+        if self.saved and conflict_resolution == "raise":
+            raise ObjectHasBeenSavedError(
+                f'{type(self).__name__} (id: "{self.id}") has been saved before.'
+            )
+
+        self._pre_save_operations(conflict_resolution=conflict_resolution)
+        client = Configurations().get_client()
+        response = client.post(url=self._route, json=self._get_create_payload())
+        retrieve_object = False
+        if response.status_code != HTTPStatus.CREATED:
+            if response.status_code == HTTPStatus.CONFLICT:
+                if conflict_resolution == "retrieve":
+                    retrieve_object = True
+                else:
+                    raise DuplicatedRecordException(response=response)
+            if not retrieve_object:
+                raise RecordCreationException(response=response)
+
+        if retrieve_object:
+            assert self.name is not None
+            object_dict = self._get_object_dict_by_name(name=self.name)
+        else:
+            object_dict = response.json()
+
+        self._update_cache(object_dict)  # update api object cache store
+        type(self).__init__(
+            self,
+            **object_dict,
+            **self._get_init_params_from_object(),
+        )
+
+
+class DeletableApiObject(ApiObject):
+    """
+    DeleteMixin contains common methods used to delete an object
+    """
+
+    def _delete(self) -> None:
+        client = Configurations().get_client()
+        response = client.delete(url=f"{self._route}/{self.id}")
+        if response.status_code != HTTPStatus.OK:
+            raise RecordDeletionException(response, "Failed to delete the specified object.")

--- a/featurebyte/common/formatting_util.py
+++ b/featurebyte/common/formatting_util.py
@@ -1,0 +1,192 @@
+"""
+Utility functions for formatting data in Jupyter notebooks
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Union
+
+import copy
+import re
+from datetime import datetime
+from xml.dom import getDOMImplementation
+from xml.dom.minidom import Document, Element
+
+import pandas as pd
+import pygments
+from bson import ObjectId
+from pygments.formatters.html import HtmlFormatter
+
+
+class CodeStr(str):
+    """
+    Code string content that can be displayed in markdown format
+    """
+
+    def _repr_html_(self) -> str:
+        lexer = pygments.lexers.get_lexer_by_name("python")
+        highlighted_code = pygments.highlight(
+            str(self).strip(),
+            lexer=lexer,
+            formatter=HtmlFormatter(noclasses=True, nobackground=True),
+        )
+        return (
+            '<div style="margin:30px; padding: 20px; border:1px solid #aaa">'
+            f"{highlighted_code}</div>"
+        )
+
+
+class InfoDict(Dict[str, Any]):
+    """
+    Featurebyte asset information dictionary that can be displayed in HTML
+    """
+
+    def __init__(self, data: Union[Dict[str, Any], InfoDict]) -> None:
+        self.class_name: str = "Unknown"
+        if isinstance(data, InfoDict):
+            self.class_name = data.class_name
+        else:
+            self.class_name = data.pop("class_name", "Unknown")
+
+        super().__init__(data)
+
+    def _repr_html_(self) -> str:
+        """
+        HTML representation of the info dictionary
+
+        Returns
+        -------
+        str
+        """
+        return self.to_html()
+
+    def to_html(self) -> str:
+        """
+        Get HTML representation of the info dictionary
+
+        Returns
+        -------
+        str
+        """
+
+        def _set_element_style(elem: Element, style: Dict[str, Any]) -> None:
+            """
+            Set style of dom element
+
+            Parameters
+            ----------
+            elem: Element
+                Element to set style for.
+            style: Dict[str, Any]
+                Style dictionary
+            """
+            elem.setAttribute("style", ";".join(f"{key}:{value}" for key, value in style.items()))
+
+        def _populate_html_elem(
+            data: Dict[str, Any], doc: Document, elem: Element, html_content: Dict[str, str]
+        ) -> None:
+            """
+            Populate html document with data dict
+
+            Parameters
+            ----------
+            data: Dict[str, str]
+                Data dictionary
+            doc: Document
+                HTML document
+            elem: Element
+                HTML element to populate into
+            html_content: Dict[str, str]
+                Dictionary referencing HTML content in the document
+            """
+            # create html table
+            table = doc.createElement("table")
+            _set_element_style(
+                table, {"table-layout": "auto", "width": "100%", "padding": 0, "margin": 0}
+            )
+
+            # determine max key length for computing column width
+            max_key_len = max([len(key) for key in data.keys()] + [0])
+
+            for key, value in data.items():
+                # add row to table
+                row = doc.createElement("tr")
+                table.appendChild(row)
+
+                # populate key column
+                key_column = doc.createElement("td")
+                _set_element_style(
+                    key_column,
+                    {
+                        "font-weight": "bold",
+                        "vertical-align": "top",
+                        "width": f"{max_key_len * 8 + 5}px",
+                        "over-flow": "overflow-wrap",
+                        "word-break": "break-all",
+                    },
+                )
+                key_column.appendChild(doc.createTextNode(key))
+                row.appendChild(key_column)
+
+                # populate value column
+                if isinstance(value, dict):
+                    # process dictionaries recursively
+                    value_elem = doc.createElement("div")
+                    _set_element_style(value_elem, {"border": "0", "padding": "0", "margin": "0"})
+                    _populate_html_elem(
+                        data=value, doc=doc, elem=value_elem, html_content=html_content
+                    )
+                elif isinstance(value, list) and len(value) > 0 and isinstance(value[0], dict):
+                    # list of dictionaries
+                    value_elem = doc.createElement("div")
+                    _set_element_style(value_elem, {"border": "0", "padding": "0", "margin": "0"})
+                    df_key = str(ObjectId())
+                    html_content[df_key] = pd.DataFrame(value).to_html()
+                    value_elem.appendChild(doc.createTextNode(f"{{{df_key}}}"))
+                else:
+                    # nicer datetime formatting
+                    try:
+                        value = datetime.fromisoformat(value).strftime("%Y-%m-%d %H:%M:%S")
+                    except (ValueError, TypeError):
+                        pass
+                    value_elem = doc.createTextNode(str(value))
+
+                val_column = doc.createElement("td")
+                _set_element_style(val_column, {"width": "auto", "text-align": "left"})
+                val_column.appendChild(value_elem)
+                row.appendChild(val_column)
+
+            elem.appendChild(table)
+
+        # create html document
+        impl = getDOMImplementation()
+        assert impl
+        doc_type = impl.createDocumentType(
+            "html",
+            "-//W3C//DTD XHTML 1.0 Strict//EN",
+            "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd",
+        )
+        doc = impl.createDocument("http://www.w3.org/1999/xhtml", "html", doc_type)
+        doc_elem = doc.documentElement
+
+        # add title for the table
+        data = copy.deepcopy(self)
+        class_name = re.sub(r"([A-Z]+[a-z]+)", r" \1", self.class_name).strip()
+        title_div = doc.createElement("div")
+        title_div.appendChild(doc.createTextNode(class_name))
+        _set_element_style(
+            elem=title_div,
+            style={
+                "font-weight": "bold",
+                "text-align": "center",
+                "border-bottom": "1px solid black",
+                "width": "100%",
+                "padding-top": "20px",
+            },
+        )
+        doc_elem.appendChild(title_div)
+
+        # add info table
+        html_content: Dict[str, str] = {}
+        _populate_html_elem(data=data, doc=doc, elem=doc_elem, html_content=html_content)
+        html = str(doc.toprettyxml())
+        return html.format(**html_content)

--- a/featurebyte/common/formatting_util.py
+++ b/featurebyte/common/formatting_util.py
@@ -15,6 +15,7 @@ import pandas as pd
 import pygments
 from bson import ObjectId
 from pygments.formatters.html import HtmlFormatter
+from rich.pretty import pretty_repr
 
 
 class CodeStr(str):
@@ -48,6 +49,9 @@ class InfoDict(Dict[str, Any]):
             self.class_name = data.pop("class_name", "Unknown")
 
         super().__init__(data)
+
+    def __repr__(self) -> str:
+        return pretty_repr(dict(self), expand_all=True, indent_size=2)
 
     def _repr_html_(self) -> str:
         """

--- a/featurebyte/common/utils.py
+++ b/featurebyte/common/utils.py
@@ -420,3 +420,63 @@ class CodeStr(str):
             '<div style="margin:30px; padding: 20px; border:1px solid #aaa">'
             f"{highlighted_code}</div>"
         )
+
+
+class InfoDict(dict):
+    """
+    Featurebyte asset information dictionary that can be displayed in HTML
+    """
+
+    def _repr_html_(self) -> str:
+        def dict_to_html(data):
+            """
+            Convert dict to html using basic html tags
+            """
+            content = []
+            if "class_name" in data:
+                # info table title
+                content.append(
+                    '<div style="font-weight:bold; text-align:center; border-bottom:1px solid black; width: 100%; padding-top:20px">'
+                    f'{data["class_name"]}</div>'
+                )
+
+            if isinstance(data, list):
+                return pd.DataFrame(data)._repr_html_()
+                # # list of dictionaries
+                # data = pd.DataFrame(data).to_dict(orient="list")
+                # header = "</th><th>".join([
+                #     " ".join(key.split("_")).title() for key in data.keys()
+                # ])
+                # content.append(
+                #     f'<thead><tr style="height:35px; border-bottom: 1px solid lightgray"><th>{header}</th></tr></thead><tbody>'
+                # )
+                # for row in zip(*data.values()):
+                #     row_content = "</td><td>".join([str(value) for value in row])
+                #     content.append(f"<tr><td>{row_content}</td></tr>")
+                # content.append("</tbody>")
+            else:
+                for key, value in data.items():
+                    if isinstance(value, dict):
+                        # process dictionaries recursively
+                        value = (
+                            f'<div style="border:0;padding:0;margin:0">{dict_to_html(value)}</div>'
+                        )
+                    elif isinstance(value, list):
+                        if value and isinstance(value[0], dict):
+                            # list of dictionaries
+                            value = f'<div style="border:0;padding:0;margin:0">{dict_to_html(value)}</div>'
+                    else:
+                        # nicer datetime formatting
+                        try:
+                            value = datetime.fromisoformat(value).strftime("%Y-%m-%d %H:%M:%S")
+                        except:
+                            pass
+
+                    key = " ".join(key.split("_")).title()
+                    content.append(
+                        f'<tr><td style="font-weight:bold; vertical-align:top; width:200px; over-flow:wrap">{key}</td>'
+                        f'<td style="width:80%; text-align: left">{value}</td></tr>'
+                    )
+            return f'<table style="width:100%;padding:0;margin:0">{"".join(content)}</table>'
+
+        return dict_to_html(self)

--- a/featurebyte/common/utils.py
+++ b/featurebyte/common/utils.py
@@ -431,6 +431,10 @@ class InfoDict(Dict[str, Any]):
     Featurebyte asset information dictionary that can be displayed in HTML
     """
 
+    def __init__(self, data: Dict[str, Any]) -> None:
+        self.class_name = data.pop("class_name", "Unknown")
+        super().__init__(data)
+
     def _repr_html_(self) -> str:
         def _set_element_style(elem: Element, style: Dict[str, Any]) -> None:
             """
@@ -529,8 +533,7 @@ class InfoDict(Dict[str, Any]):
 
         # add title for the table
         data = copy.deepcopy(self)
-        class_name = data.pop("class_name", "Unknown")
-        class_name = re.sub(r"([A-Z]+[a-z]+)", r" \1", class_name).strip()
+        class_name = re.sub(r"([A-Z]+[a-z]+)", r" \1", self.class_name).strip()
         title_div = doc.createElement("div")
         title_div.appendChild(doc.createTextNode(class_name))
         _set_element_style(

--- a/featurebyte/common/utils.py
+++ b/featurebyte/common/utils.py
@@ -3,14 +3,17 @@ Utility functions for API Objects
 """
 from __future__ import annotations
 
-from typing import Any, Iterator, List, Optional, Union
+from typing import Any, Dict, Iterator, List, Optional, Union
 
+import copy
 import functools
+import re
 from datetime import datetime
 from decimal import Decimal
 from importlib import metadata as importlib_metadata
 from io import BytesIO
 from pathlib import Path
+from xml.dom.minidom import Document, Element, getDOMImplementation
 
 import numpy as np
 import pandas as pd
@@ -18,6 +21,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pygments
 from alive_progress import alive_bar
+from bson import ObjectId
 from dateutil import parser
 from pygments.formatters.html import HtmlFormatter
 from requests import Response
@@ -422,61 +426,127 @@ class CodeStr(str):
         )
 
 
-class InfoDict(dict):
+class InfoDict(Dict[str, Any]):
     """
     Featurebyte asset information dictionary that can be displayed in HTML
     """
 
     def _repr_html_(self) -> str:
-        def dict_to_html(data):
+        def _set_element_style(elem: Element, style: Dict[str, Any]) -> None:
             """
-            Convert dict to html using basic html tags
+            Set style of dom element
+
+            Parameters
+            ----------
+            elem: Element
+                Element to set style for.
+            style: Dict[str, Any]
+                Style dictionary
             """
-            content = []
-            if "class_name" in data:
-                # info table title
-                content.append(
-                    '<div style="font-weight:bold; text-align:center; border-bottom:1px solid black; width: 100%; padding-top:20px">'
-                    f'{data["class_name"]}</div>'
+            elem.setAttribute("style", ";".join(f"{key}:{value}" for key, value in style.items()))
+
+        def _populate_html_elem(
+            data: Dict[str, Any], doc: Document, elem: Element, html_content: Dict[str, str]
+        ) -> None:
+            """
+            Populate html document with data dict
+
+            Parameters
+            ----------
+            data: Dict[str, str]
+                Data dictionary
+            doc: Document
+                HTML document
+            elem: Element
+                HTML element to populate into
+            html_content: Dict[str, str]
+                Dictionary referencing HTML content in the document
+            """
+            # create html table
+            table = doc.createElement("table")
+            _set_element_style(table, {"width": "100%", "padding": 0, "margin": 0})
+
+            for key, value in data.items():
+                # add row to table
+                row = doc.createElement("tr")
+                table.appendChild(row)
+
+                # populate key column
+                key_column = doc.createElement("td")
+                _set_element_style(
+                    key_column,
+                    {
+                        "font-weight": "bold",
+                        "vertical-align": "top",
+                        "width": "200px",
+                        "over-flow": "overflow-wrap",
+                        "word-break": "break-all",
+                    },
                 )
+                key_column.appendChild(doc.createTextNode(key))
+                row.appendChild(key_column)
 
-            if isinstance(data, list):
-                return pd.DataFrame(data)._repr_html_()
-                # # list of dictionaries
-                # data = pd.DataFrame(data).to_dict(orient="list")
-                # header = "</th><th>".join([
-                #     " ".join(key.split("_")).title() for key in data.keys()
-                # ])
-                # content.append(
-                #     f'<thead><tr style="height:35px; border-bottom: 1px solid lightgray"><th>{header}</th></tr></thead><tbody>'
-                # )
-                # for row in zip(*data.values()):
-                #     row_content = "</td><td>".join([str(value) for value in row])
-                #     content.append(f"<tr><td>{row_content}</td></tr>")
-                # content.append("</tbody>")
-            else:
-                for key, value in data.items():
-                    if isinstance(value, dict):
-                        # process dictionaries recursively
-                        value = (
-                            f'<div style="border:0;padding:0;margin:0">{dict_to_html(value)}</div>'
-                        )
-                    elif isinstance(value, list):
-                        if value and isinstance(value[0], dict):
-                            # list of dictionaries
-                            value = f'<div style="border:0;padding:0;margin:0">{dict_to_html(value)}</div>'
-                    else:
-                        # nicer datetime formatting
-                        try:
-                            value = datetime.fromisoformat(value).strftime("%Y-%m-%d %H:%M:%S")
-                        except:
-                            pass
-
-                    key = " ".join(key.split("_")).title()
-                    content.append(
-                        f'<tr><td style="font-weight:bold; vertical-align:top; width:200px; over-flow:wrap">{key}</td>'
-                        f'<td style="width:80%; text-align: left">{value}</td></tr>'
+                # populate value column
+                if isinstance(value, dict):
+                    # process dictionaries recursively
+                    value_elem = doc.createElement("div")
+                    _set_element_style(value_elem, {"border": "0", "padding": "0", "margin": "0"})
+                    _populate_html_elem(
+                        data=value, doc=doc, elem=value_elem, html_content=html_content
                     )
-            return f'<table style="width:100%;padding:0;margin:0">{"".join(content)}</table>'
+                elif isinstance(value, list) and isinstance(value[0], dict):
+                    # list of dictionaries
+                    value_elem = doc.createElement("div")
+                    _set_element_style(value_elem, {"border": "0", "padding": "0", "margin": "0"})
+                    df_key = str(ObjectId())
+                    html_content[df_key] = pd.DataFrame(value).to_html()
+                    value_elem.appendChild(doc.createTextNode(f"{{{df_key}}}"))
+                else:
+                    # nicer datetime formatting
+                    try:
+                        value = datetime.fromisoformat(value).strftime("%Y-%m-%d %H:%M:%S")
+                    except (ValueError, TypeError):
+                        pass
+                    value_elem = doc.createTextNode(str(value))
 
-        return dict_to_html(self)
+                val_column = doc.createElement("td")
+                _set_element_style(val_column, {"width": "80%", "text-align": "left"})
+                val_column.appendChild(value_elem)
+                row.appendChild(val_column)
+
+            elem.appendChild(table)
+
+        # create html document
+        impl = getDOMImplementation()
+        assert impl
+        doc_type = impl.createDocumentType(
+            "html",
+            "-//W3C//DTD XHTML 1.0 Strict//EN",
+            "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd",
+        )
+        doc = impl.createDocument("http://www.w3.org/1999/xhtml", "html", doc_type)
+        doc_elem = doc.documentElement
+
+        # add title for the table
+        data = copy.deepcopy(self)
+        class_name = data.pop("class_name", "Unknown")
+        class_name = re.sub(r"([A-Z]+[a-z]+)", r" \1", class_name).strip()
+        title_div = doc.createElement("div")
+        title_div.appendChild(doc.createTextNode(class_name))
+        _set_element_style(
+            elem=title_div,
+            style={
+                "font-weight": "bold",
+                "text-align": "center",
+                "border-bottom": "1px solid black",
+                "width": "100%",
+                "padding-top": "20px",
+            },
+        )
+        doc_elem.appendChild(title_div)
+
+        # add info table
+        html_content: Dict[str, str] = {}
+        _populate_html_elem(data=data, doc=doc, elem=doc_elem, html_content=html_content)
+        html = str(doc.toprettyxml())
+        return html.format(**html_content)

--- a/tests/fixtures/feature_info.html
+++ b/tests/fixtures/feature_info.html
@@ -1,0 +1,417 @@
+<?xml version="1.0" ?>
+<!DOCTYPE html
+  PUBLIC '-//W3C//DTD XHTML 1.0 Strict//EN'
+  'http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd'>
+<html>
+	<div style="font-weight:bold;text-align:center;border-bottom:1px solid black;width:100%;padding-top:20px">Feature</div>
+	<table style="table-layout:auto;width:100%;padding:0;margin:0">
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">name</td>
+			<td style="width:auto;text-align:left">CustomerSpendingStability_7d28d</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">created_at</td>
+			<td style="width:auto;text-align:left">2023-05-16 01:35:13</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">updated_at</td>
+			<td style="width:auto;text-align:left">None</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">entities</td>
+			<td style="width:auto;text-align:left">
+				<div style="border:0;padding:0;margin:0"><table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>name</th>
+      <th>serving_names</th>
+      <th>catalog_name</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>grocerycustomer</td>
+      <td>[GROCERYCUSTOMERGUID]</td>
+      <td>Grocery V31 - playground (spark)</td>
+    </tr>
+  </tbody>
+</table></div>
+			</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">primary_entity</td>
+			<td style="width:auto;text-align:left">
+				<div style="border:0;padding:0;margin:0"><table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>name</th>
+      <th>serving_names</th>
+      <th>catalog_name</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>grocerycustomer</td>
+      <td>[GROCERYCUSTOMERGUID]</td>
+      <td>Grocery V31 - playground (spark)</td>
+    </tr>
+  </tbody>
+</table></div>
+			</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">tables</td>
+			<td style="width:auto;text-align:left">
+				<div style="border:0;padding:0;margin:0"><table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>name</th>
+      <th>status</th>
+      <th>catalog_name</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>INVOICEITEMS</td>
+      <td>PUBLIC_DRAFT</td>
+      <td>Grocery V31 - playground (spark)</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>GROCERYINVOICE</td>
+      <td>PUBLIC_DRAFT</td>
+      <td>Grocery V31 - playground (spark)</td>
+    </tr>
+  </tbody>
+</table></div>
+			</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">default_version_mode</td>
+			<td style="width:auto;text-align:left">AUTO</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">version_count</td>
+			<td style="width:auto;text-align:left">1</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">catalog_name</td>
+			<td style="width:auto;text-align:left">Grocery V31 - playground (spark)</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">dtype</td>
+			<td style="width:auto;text-align:left">FLOAT</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">primary_table</td>
+			<td style="width:auto;text-align:left">
+				<div style="border:0;padding:0;margin:0"><table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>name</th>
+      <th>status</th>
+      <th>catalog_name</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>INVOICEITEMS</td>
+      <td>PUBLIC_DRAFT</td>
+      <td>Grocery V31 - playground (spark)</td>
+    </tr>
+  </tbody>
+</table></div>
+			</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">default_feature_id</td>
+			<td style="width:auto;text-align:left">6462dd287b12204e7e1c2ba6</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">version</td>
+			<td style="width:auto;text-align:left">
+				<div style="border:0;padding:0;margin:0">
+					<table style="table-layout:auto;width:100%;padding:0;margin:0">
+						<tr>
+							<td style="font-weight:bold;vertical-align:top;width:61px;over-flow:overflow-wrap;word-break:break-all">this</td>
+							<td style="width:auto;text-align:left">V230516</td>
+						</tr>
+						<tr>
+							<td style="font-weight:bold;vertical-align:top;width:61px;over-flow:overflow-wrap;word-break:break-all">default</td>
+							<td style="width:auto;text-align:left">V230516</td>
+						</tr>
+					</table>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">readiness</td>
+			<td style="width:auto;text-align:left">
+				<div style="border:0;padding:0;margin:0">
+					<table style="table-layout:auto;width:100%;padding:0;margin:0">
+						<tr>
+							<td style="font-weight:bold;vertical-align:top;width:61px;over-flow:overflow-wrap;word-break:break-all">this</td>
+							<td style="width:auto;text-align:left">DRAFT</td>
+						</tr>
+						<tr>
+							<td style="font-weight:bold;vertical-align:top;width:61px;over-flow:overflow-wrap;word-break:break-all">default</td>
+							<td style="width:auto;text-align:left">DRAFT</td>
+						</tr>
+					</table>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">table_feature_job_setting</td>
+			<td style="width:auto;text-align:left">
+				<div style="border:0;padding:0;margin:0">
+					<table style="table-layout:auto;width:100%;padding:0;margin:0">
+						<tr>
+							<td style="font-weight:bold;vertical-align:top;width:61px;over-flow:overflow-wrap;word-break:break-all">this</td>
+							<td style="width:auto;text-align:left">
+								<div style="border:0;padding:0;margin:0"><table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>table_name</th>
+      <th>feature_job_setting</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>GROCERYINVOICE</td>
+      <td>{'blind_spot': '3600s', 'frequency': '3600s', 'time_modulo_frequency': '60s'}</td>
+    </tr>
+  </tbody>
+</table></div>
+							</td>
+						</tr>
+						<tr>
+							<td style="font-weight:bold;vertical-align:top;width:61px;over-flow:overflow-wrap;word-break:break-all">default</td>
+							<td style="width:auto;text-align:left">
+								<div style="border:0;padding:0;margin:0"><table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>table_name</th>
+      <th>feature_job_setting</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>GROCERYINVOICE</td>
+      <td>{'blind_spot': '3600s', 'frequency': '3600s', 'time_modulo_frequency': '60s'}</td>
+    </tr>
+  </tbody>
+</table></div>
+							</td>
+						</tr>
+					</table>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">table_cleaning_operation</td>
+			<td style="width:auto;text-align:left">
+				<div style="border:0;padding:0;margin:0">
+					<table style="table-layout:auto;width:100%;padding:0;margin:0">
+						<tr>
+							<td style="font-weight:bold;vertical-align:top;width:61px;over-flow:overflow-wrap;word-break:break-all">this</td>
+							<td style="width:auto;text-align:left">[]</td>
+						</tr>
+						<tr>
+							<td style="font-weight:bold;vertical-align:top;width:61px;over-flow:overflow-wrap;word-break:break-all">default</td>
+							<td style="width:auto;text-align:left">[]</td>
+						</tr>
+					</table>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">versions_info</td>
+			<td style="width:auto;text-align:left">None</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">metadata</td>
+			<td style="width:auto;text-align:left">
+				<div style="border:0;padding:0;margin:0">
+					<table style="table-layout:auto;width:100%;padding:0;margin:0">
+						<tr>
+							<td style="font-weight:bold;vertical-align:top;width:133px;over-flow:overflow-wrap;word-break:break-all">input_columns</td>
+							<td style="width:auto;text-align:left">
+								<div style="border:0;padding:0;margin:0">
+									<table style="table-layout:auto;width:100%;padding:0;margin:0">
+										<tr>
+											<td style="font-weight:bold;vertical-align:top;width:53px;over-flow:overflow-wrap;word-break:break-all">Input0</td>
+											<td style="width:auto;text-align:left">
+												<div style="border:0;padding:0;margin:0">
+													<table style="table-layout:auto;width:100%;padding:0;margin:0">
+														<tr>
+															<td style="font-weight:bold;vertical-align:top;width:93px;over-flow:overflow-wrap;word-break:break-all">data</td>
+															<td style="width:auto;text-align:left">INVOICEITEMS</td>
+														</tr>
+														<tr>
+															<td style="font-weight:bold;vertical-align:top;width:93px;over-flow:overflow-wrap;word-break:break-all">column_name</td>
+															<td style="width:auto;text-align:left">GroceryProductGuid</td>
+														</tr>
+														<tr>
+															<td style="font-weight:bold;vertical-align:top;width:93px;over-flow:overflow-wrap;word-break:break-all">semantic</td>
+															<td style="width:auto;text-align:left">None</td>
+														</tr>
+													</table>
+												</div>
+											</td>
+										</tr>
+										<tr>
+											<td style="font-weight:bold;vertical-align:top;width:53px;over-flow:overflow-wrap;word-break:break-all">Input1</td>
+											<td style="width:auto;text-align:left">
+												<div style="border:0;padding:0;margin:0">
+													<table style="table-layout:auto;width:100%;padding:0;margin:0">
+														<tr>
+															<td style="font-weight:bold;vertical-align:top;width:93px;over-flow:overflow-wrap;word-break:break-all">data</td>
+															<td style="width:auto;text-align:left">INVOICEITEMS</td>
+														</tr>
+														<tr>
+															<td style="font-weight:bold;vertical-align:top;width:93px;over-flow:overflow-wrap;word-break:break-all">column_name</td>
+															<td style="width:auto;text-align:left">TotalCost</td>
+														</tr>
+														<tr>
+															<td style="font-weight:bold;vertical-align:top;width:93px;over-flow:overflow-wrap;word-break:break-all">semantic</td>
+															<td style="width:auto;text-align:left">None</td>
+														</tr>
+													</table>
+												</div>
+											</td>
+										</tr>
+									</table>
+								</div>
+							</td>
+						</tr>
+						<tr>
+							<td style="font-weight:bold;vertical-align:top;width:133px;over-flow:overflow-wrap;word-break:break-all">derived_columns</td>
+							<td style="width:auto;text-align:left">
+								<div style="border:0;padding:0;margin:0">
+									<table style="table-layout:auto;width:100%;padding:0;margin:0"/>
+								</div>
+							</td>
+						</tr>
+						<tr>
+							<td style="font-weight:bold;vertical-align:top;width:133px;over-flow:overflow-wrap;word-break:break-all">aggregations</td>
+							<td style="width:auto;text-align:left">
+								<div style="border:0;padding:0;margin:0">
+									<table style="table-layout:auto;width:100%;padding:0;margin:0">
+										<tr>
+											<td style="font-weight:bold;vertical-align:top;width:21px;over-flow:overflow-wrap;word-break:break-all">F0</td>
+											<td style="width:auto;text-align:left">
+												<div style="border:0;padding:0;margin:0">
+													<table style="table-layout:auto;width:100%;padding:0;margin:0">
+														<tr>
+															<td style="font-weight:bold;vertical-align:top;width:69px;over-flow:overflow-wrap;word-break:break-all">name</td>
+															<td style="width:auto;text-align:left">CustomerSpending_7d</td>
+														</tr>
+														<tr>
+															<td style="font-weight:bold;vertical-align:top;width:69px;over-flow:overflow-wrap;word-break:break-all">column</td>
+															<td style="width:auto;text-align:left">Input1</td>
+														</tr>
+														<tr>
+															<td style="font-weight:bold;vertical-align:top;width:69px;over-flow:overflow-wrap;word-break:break-all">function</td>
+															<td style="width:auto;text-align:left">sum</td>
+														</tr>
+														<tr>
+															<td style="font-weight:bold;vertical-align:top;width:69px;over-flow:overflow-wrap;word-break:break-all">keys</td>
+															<td style="width:auto;text-align:left">['GroceryCustomerGuid']</td>
+														</tr>
+														<tr>
+															<td style="font-weight:bold;vertical-align:top;width:69px;over-flow:overflow-wrap;word-break:break-all">window</td>
+															<td style="width:auto;text-align:left">7d</td>
+														</tr>
+														<tr>
+															<td style="font-weight:bold;vertical-align:top;width:69px;over-flow:overflow-wrap;word-break:break-all">category</td>
+															<td style="width:auto;text-align:left">GroceryProductGuid</td>
+														</tr>
+														<tr>
+															<td style="font-weight:bold;vertical-align:top;width:69px;over-flow:overflow-wrap;word-break:break-all">filter</td>
+															<td style="width:auto;text-align:left">False</td>
+														</tr>
+													</table>
+												</div>
+											</td>
+										</tr>
+										<tr>
+											<td style="font-weight:bold;vertical-align:top;width:21px;over-flow:overflow-wrap;word-break:break-all">F1</td>
+											<td style="width:auto;text-align:left">
+												<div style="border:0;padding:0;margin:0">
+													<table style="table-layout:auto;width:100%;padding:0;margin:0">
+														<tr>
+															<td style="font-weight:bold;vertical-align:top;width:69px;over-flow:overflow-wrap;word-break:break-all">name</td>
+															<td style="width:auto;text-align:left">CustomerSpending_28d</td>
+														</tr>
+														<tr>
+															<td style="font-weight:bold;vertical-align:top;width:69px;over-flow:overflow-wrap;word-break:break-all">column</td>
+															<td style="width:auto;text-align:left">Input1</td>
+														</tr>
+														<tr>
+															<td style="font-weight:bold;vertical-align:top;width:69px;over-flow:overflow-wrap;word-break:break-all">function</td>
+															<td style="width:auto;text-align:left">sum</td>
+														</tr>
+														<tr>
+															<td style="font-weight:bold;vertical-align:top;width:69px;over-flow:overflow-wrap;word-break:break-all">keys</td>
+															<td style="width:auto;text-align:left">['GroceryCustomerGuid']</td>
+														</tr>
+														<tr>
+															<td style="font-weight:bold;vertical-align:top;width:69px;over-flow:overflow-wrap;word-break:break-all">window</td>
+															<td style="width:auto;text-align:left">28d</td>
+														</tr>
+														<tr>
+															<td style="font-weight:bold;vertical-align:top;width:69px;over-flow:overflow-wrap;word-break:break-all">category</td>
+															<td style="width:auto;text-align:left">GroceryProductGuid</td>
+														</tr>
+														<tr>
+															<td style="font-weight:bold;vertical-align:top;width:69px;over-flow:overflow-wrap;word-break:break-all">filter</td>
+															<td style="width:auto;text-align:left">False</td>
+														</tr>
+													</table>
+												</div>
+											</td>
+										</tr>
+									</table>
+								</div>
+							</td>
+						</tr>
+						<tr>
+							<td style="font-weight:bold;vertical-align:top;width:133px;over-flow:overflow-wrap;word-break:break-all">post_aggregation</td>
+							<td style="width:auto;text-align:left">
+								<div style="border:0;padding:0;margin:0">
+									<table style="table-layout:auto;width:100%;padding:0;margin:0">
+										<tr>
+											<td style="font-weight:bold;vertical-align:top;width:85px;over-flow:overflow-wrap;word-break:break-all">name</td>
+											<td style="width:auto;text-align:left">CustomerSpendingStability_7d28d</td>
+										</tr>
+										<tr>
+											<td style="font-weight:bold;vertical-align:top;width:85px;over-flow:overflow-wrap;word-break:break-all">inputs</td>
+											<td style="width:auto;text-align:left">['F0', 'F1']</td>
+										</tr>
+										<tr>
+											<td style="font-weight:bold;vertical-align:top;width:85px;over-flow:overflow-wrap;word-break:break-all">transforms</td>
+											<td style="width:auto;text-align:left">['cosine_similarity']</td>
+										</tr>
+									</table>
+								</div>
+							</td>
+						</tr>
+					</table>
+				</div>
+			</td>
+		</tr>
+	</table>
+</html>

--- a/tests/fixtures/feature_list_info.html
+++ b/tests/fixtures/feature_list_info.html
@@ -1,0 +1,195 @@
+<?xml version="1.0" ?>
+<!DOCTYPE html
+  PUBLIC '-//W3C//DTD XHTML 1.0 Strict//EN'
+  'http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd'>
+<html>
+	<div style="font-weight:bold;text-align:center;border-bottom:1px solid black;width:100%;padding-top:20px">Feature List</div>
+	<table style="width:100%;padding:0;margin:0">
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">name</td>
+			<td style="width:80%;text-align:left">Small List</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">created_at</td>
+			<td style="width:80%;text-align:left">2023-05-03 14:30:54</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">updated_at</td>
+			<td style="width:80%;text-align:left">2023-05-13 06:55:12</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">entities</td>
+			<td style="width:80%;text-align:left">
+				<div style="border:0;padding:0;margin:0"><table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>name</th>
+      <th>serving_names</th>
+      <th>catalog_name</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>grocerycustomer</td>
+      <td>[GROCERYCUSTOMERGUID]</td>
+      <td>Grocery - playground (spark)</td>
+    </tr>
+  </tbody>
+</table></div>
+			</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">primary_entity</td>
+			<td style="width:80%;text-align:left">
+				<div style="border:0;padding:0;margin:0"><table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>name</th>
+      <th>serving_names</th>
+      <th>catalog_name</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>grocerycustomer</td>
+      <td>[GROCERYCUSTOMERGUID]</td>
+      <td>Grocery - playground (spark)</td>
+    </tr>
+  </tbody>
+</table></div>
+			</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">tables</td>
+			<td style="width:80%;text-align:left">
+				<div style="border:0;padding:0;margin:0"><table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>name</th>
+      <th>status</th>
+      <th>catalog_name</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>GROCERYPRODUCT</td>
+      <td>PUBLIC_DRAFT</td>
+      <td>Grocery - playground (spark)</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>INVOICEITEMS</td>
+      <td>PUBLIC_DRAFT</td>
+      <td>Grocery - playground (spark)</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>GROCERYINVOICE</td>
+      <td>PUBLIC_DRAFT</td>
+      <td>Grocery - playground (spark)</td>
+    </tr>
+  </tbody>
+</table></div>
+			</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">default_version_mode</td>
+			<td style="width:80%;text-align:left">AUTO</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">version_count</td>
+			<td style="width:80%;text-align:left">1</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">catalog_name</td>
+			<td style="width:80%;text-align:left">Grocery - playground (spark)</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">dtype_distribution</td>
+			<td style="width:80%;text-align:left">
+				<div style="border:0;padding:0;margin:0"><table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>dtype</th>
+      <th>count</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>OBJECT</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>FLOAT</td>
+      <td>8</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>VARCHAR</td>
+      <td>1</td>
+    </tr>
+  </tbody>
+</table></div>
+			</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">status</td>
+			<td style="width:80%;text-align:left">PUBLIC_DRAFT</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">feature_count</td>
+			<td style="width:80%;text-align:left">10</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">version</td>
+			<td style="width:80%;text-align:left">
+				<div style="border:0;padding:0;margin:0">
+					<table style="width:100%;padding:0;margin:0">
+						<tr>
+							<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">this</td>
+							<td style="width:80%;text-align:left">V230503</td>
+						</tr>
+						<tr>
+							<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">default</td>
+							<td style="width:80%;text-align:left">V230503</td>
+						</tr>
+					</table>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">production_ready_fraction</td>
+			<td style="width:80%;text-align:left">
+				<div style="border:0;padding:0;margin:0">
+					<table style="width:100%;padding:0;margin:0">
+						<tr>
+							<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">this</td>
+							<td style="width:80%;text-align:left">1.0</td>
+						</tr>
+						<tr>
+							<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">default</td>
+							<td style="width:80%;text-align:left">1.0</td>
+						</tr>
+					</table>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">versions_info</td>
+			<td style="width:80%;text-align:left">None</td>
+		</tr>
+		<tr>
+			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">deployed</td>
+			<td style="width:80%;text-align:left">False</td>
+		</tr>
+	</table>
+</html>

--- a/tests/fixtures/feature_list_info.html
+++ b/tests/fixtures/feature_list_info.html
@@ -4,22 +4,22 @@
   'http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd'>
 <html>
 	<div style="font-weight:bold;text-align:center;border-bottom:1px solid black;width:100%;padding-top:20px">Feature List</div>
-	<table style="width:100%;padding:0;margin:0">
+	<table style="table-layout:auto;width:100%;padding:0;margin:0">
 		<tr>
-			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">name</td>
-			<td style="width:80%;text-align:left">Small List</td>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">name</td>
+			<td style="width:auto;text-align:left">Small List</td>
 		</tr>
 		<tr>
-			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">created_at</td>
-			<td style="width:80%;text-align:left">2023-05-03 14:30:54</td>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">created_at</td>
+			<td style="width:auto;text-align:left">2023-05-03 14:30:54</td>
 		</tr>
 		<tr>
-			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">updated_at</td>
-			<td style="width:80%;text-align:left">2023-05-13 06:55:12</td>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">updated_at</td>
+			<td style="width:auto;text-align:left">2023-05-13 06:55:12</td>
 		</tr>
 		<tr>
-			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">entities</td>
-			<td style="width:80%;text-align:left">
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">entities</td>
+			<td style="width:auto;text-align:left">
 				<div style="border:0;padding:0;margin:0"><table border="1" class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -41,8 +41,8 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">primary_entity</td>
-			<td style="width:80%;text-align:left">
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">primary_entity</td>
+			<td style="width:auto;text-align:left">
 				<div style="border:0;padding:0;margin:0"><table border="1" class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -64,8 +64,8 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">tables</td>
-			<td style="width:80%;text-align:left">
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">tables</td>
+			<td style="width:auto;text-align:left">
 				<div style="border:0;padding:0;margin:0"><table border="1" class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -99,20 +99,20 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">default_version_mode</td>
-			<td style="width:80%;text-align:left">AUTO</td>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">default_version_mode</td>
+			<td style="width:auto;text-align:left">AUTO</td>
 		</tr>
 		<tr>
-			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">version_count</td>
-			<td style="width:80%;text-align:left">1</td>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">version_count</td>
+			<td style="width:auto;text-align:left">1</td>
 		</tr>
 		<tr>
-			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">catalog_name</td>
-			<td style="width:80%;text-align:left">Grocery - playground (spark)</td>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">catalog_name</td>
+			<td style="width:auto;text-align:left">Grocery - playground (spark)</td>
 		</tr>
 		<tr>
-			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">dtype_distribution</td>
-			<td style="width:80%;text-align:left">
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">dtype_distribution</td>
+			<td style="width:auto;text-align:left">
 				<div style="border:0;padding:0;margin:0"><table border="1" class="dataframe">
   <thead>
     <tr style="text-align: right;">
@@ -142,54 +142,54 @@
 			</td>
 		</tr>
 		<tr>
-			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">status</td>
-			<td style="width:80%;text-align:left">PUBLIC_DRAFT</td>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">status</td>
+			<td style="width:auto;text-align:left">PUBLIC_DRAFT</td>
 		</tr>
 		<tr>
-			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">feature_count</td>
-			<td style="width:80%;text-align:left">10</td>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">feature_count</td>
+			<td style="width:auto;text-align:left">10</td>
 		</tr>
 		<tr>
-			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">version</td>
-			<td style="width:80%;text-align:left">
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">version</td>
+			<td style="width:auto;text-align:left">
 				<div style="border:0;padding:0;margin:0">
-					<table style="width:100%;padding:0;margin:0">
+					<table style="table-layout:auto;width:100%;padding:0;margin:0">
 						<tr>
-							<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">this</td>
-							<td style="width:80%;text-align:left">V230503</td>
+							<td style="font-weight:bold;vertical-align:top;width:61px;over-flow:overflow-wrap;word-break:break-all">this</td>
+							<td style="width:auto;text-align:left">V230503</td>
 						</tr>
 						<tr>
-							<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">default</td>
-							<td style="width:80%;text-align:left">V230503</td>
+							<td style="font-weight:bold;vertical-align:top;width:61px;over-flow:overflow-wrap;word-break:break-all">default</td>
+							<td style="width:auto;text-align:left">V230503</td>
 						</tr>
 					</table>
 				</div>
 			</td>
 		</tr>
 		<tr>
-			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">production_ready_fraction</td>
-			<td style="width:80%;text-align:left">
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">production_ready_fraction</td>
+			<td style="width:auto;text-align:left">
 				<div style="border:0;padding:0;margin:0">
-					<table style="width:100%;padding:0;margin:0">
+					<table style="table-layout:auto;width:100%;padding:0;margin:0">
 						<tr>
-							<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">this</td>
-							<td style="width:80%;text-align:left">1.0</td>
+							<td style="font-weight:bold;vertical-align:top;width:61px;over-flow:overflow-wrap;word-break:break-all">this</td>
+							<td style="width:auto;text-align:left">1.0</td>
 						</tr>
 						<tr>
-							<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">default</td>
-							<td style="width:80%;text-align:left">1.0</td>
+							<td style="font-weight:bold;vertical-align:top;width:61px;over-flow:overflow-wrap;word-break:break-all">default</td>
+							<td style="width:auto;text-align:left">1.0</td>
 						</tr>
 					</table>
 				</div>
 			</td>
 		</tr>
 		<tr>
-			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">versions_info</td>
-			<td style="width:80%;text-align:left">None</td>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">versions_info</td>
+			<td style="width:auto;text-align:left">None</td>
 		</tr>
 		<tr>
-			<td style="font-weight:bold;vertical-align:top;width:200px;over-flow:overflow-wrap;word-break:break-all">deployed</td>
-			<td style="width:80%;text-align:left">False</td>
+			<td style="font-weight:bold;vertical-align:top;width:205px;over-flow:overflow-wrap;word-break:break-all">deployed</td>
+			<td style="width:auto;text-align:left">False</td>
 		</tr>
 	</table>
 </html>

--- a/tests/unit/api/test_catalog.py
+++ b/tests/unit/api/test_catalog.py
@@ -19,7 +19,7 @@ from bson import ObjectId
 from pandas.testing import assert_frame_equal
 from pydantic import ValidationError
 
-from featurebyte.api.api_object import ApiObject, DeletableApiObject, SavableApiObject
+from featurebyte.api.api_object import ApiObject
 from featurebyte.api.base_table import TableApiObject, TableListMixin
 from featurebyte.api.batch_feature_table import BatchFeatureTable
 from featurebyte.api.batch_request_table import BatchRequestTable
@@ -40,6 +40,7 @@ from featurebyte.api.item_table import ItemTable
 from featurebyte.api.observation_table import ObservationTable
 from featurebyte.api.periodic_task import PeriodicTask
 from featurebyte.api.relationship import Relationship
+from featurebyte.api.savable_api_object import DeletableApiObject, SavableApiObject
 from featurebyte.api.scd_table import SCDTable
 from featurebyte.api.table import Table
 from featurebyte.exception import (

--- a/tests/unit/api/test_entity.py
+++ b/tests/unit/api/test_entity.py
@@ -114,7 +114,7 @@ def test_entity_creation(entity):
     )
     assert expected_msg in str(exc.value)
 
-    with mock.patch("featurebyte.api.api_object.Configurations"):
+    with mock.patch("featurebyte.api.savable_api_object.Configurations"):
         with pytest.raises(RecordCreationException):
             Entity(name="Customer", serving_names=["cust_id"]).save()
 

--- a/tests/unit/api/test_event_table.py
+++ b/tests/unit/api/test_event_table.py
@@ -426,7 +426,7 @@ def test_event_table__record_creation_exception(snowflake_database_table, snowfl
     """
     # check unhandled response status code
     with pytest.raises(RecordCreationException):
-        with patch("featurebyte.api.api_object.Configurations"):
+        with patch("featurebyte.api.savable_api_object.Configurations"):
             snowflake_database_table.create_event_table(
                 name="sf_event_table",
                 event_id_column="col_int",

--- a/tests/unit/api/test_item_table.py
+++ b/tests/unit/api/test_item_table.py
@@ -303,7 +303,7 @@ def test_item_table__record_creation_exception(
     """
     # check unhandled response status code
     with pytest.raises(RecordCreationException):
-        with patch("featurebyte.api.api_object.Configurations"):
+        with patch("featurebyte.api.savable_api_object.Configurations"):
             with patch("featurebyte.api.api_object.ApiObject.get") as mock_get:
                 mock_get.return_value = snowflake_event_table
                 snowflake_database_table_item_table.create_item_table(

--- a/tests/unit/common/test_formatting_util.py
+++ b/tests/unit/common/test_formatting_util.py
@@ -1,0 +1,210 @@
+"""
+Test utility functions for formatting data in Jupyter notebooks
+"""
+from featurebyte.common.formatting_util import CodeStr, InfoDict
+
+
+def test_codestr_formatting():
+    """
+    Test CodeStr formatting
+    """
+    code = CodeStr("import featurebyte")
+    assert str(code) == "import featurebyte"
+    assert code._repr_html_() == (
+        '<div style="margin:30px; padding: 20px; border:1px solid #aaa">'
+        '<div class="highlight"><pre style="line-height: 125%;"><span></span>'
+        '<span style="color: #008000; font-weight: bold">import</span> '
+        '<span style="color: #0000FF; font-weight: bold">featurebyte</span>\n'
+        "</pre></div>\n</div>"
+    )
+
+
+def test_feature_list_info_dict_formatting(update_fixtures):
+    """
+    Test InfoDict formatting for feature list
+    """
+    feature_list_info = {
+        "name": "Small List",
+        "created_at": "2023-05-03T14:30:54.217000",
+        "updated_at": "2023-05-13T06:55:12.110000",
+        "entities": [
+            {
+                "name": "grocerycustomer",
+                "serving_names": ["GROCERYCUSTOMERGUID"],
+                "catalog_name": "Grocery - playground (spark)",
+            }
+        ],
+        "primary_entity": [
+            {
+                "name": "grocerycustomer",
+                "serving_names": ["GROCERYCUSTOMERGUID"],
+                "catalog_name": "Grocery - playground (spark)",
+            }
+        ],
+        "tables": [
+            {
+                "name": "GROCERYPRODUCT",
+                "status": "PUBLIC_DRAFT",
+                "catalog_name": "Grocery - playground (spark)",
+            },
+            {
+                "name": "INVOICEITEMS",
+                "status": "PUBLIC_DRAFT",
+                "catalog_name": "Grocery - playground (spark)",
+            },
+            {
+                "name": "GROCERYINVOICE",
+                "status": "PUBLIC_DRAFT",
+                "catalog_name": "Grocery - playground (spark)",
+            },
+        ],
+        "default_version_mode": "AUTO",
+        "version_count": 1,
+        "catalog_name": "Grocery - playground (spark)",
+        "dtype_distribution": [
+            {"dtype": "OBJECT", "count": 1},
+            {"dtype": "FLOAT", "count": 8},
+            {"dtype": "VARCHAR", "count": 1},
+        ],
+        "status": "PUBLIC_DRAFT",
+        "feature_count": 10,
+        "version": {"this": "V230503", "default": "V230503"},
+        "production_ready_fraction": {"this": 1.0, "default": 1.0},
+        "versions_info": None,
+        "deployed": False,
+        "class_name": "FeatureList",
+    }
+
+    feature_list_info_html = InfoDict(feature_list_info)._repr_html_()
+    feature_list_info_fixture_path = "tests/fixtures/feature_list_info.html"
+    if update_fixtures:
+        with open(feature_list_info_fixture_path, "w") as file_obj:
+            file_obj.write(feature_list_info_html)
+    else:
+        # check report
+        with open(feature_list_info_fixture_path, "r") as file_obj:
+            expected_html = file_obj.read()
+        assert feature_list_info_html == expected_html
+
+
+def test_feature_info_dict_formatting(update_fixtures):
+    """
+    Test InfoDict formatting for feature
+    """
+    feature_info = {
+        "name": "CustomerSpendingStability_7d28d",
+        "created_at": "2023-05-16T01:35:13.757000",
+        "updated_at": None,
+        "entities": [
+            {
+                "name": "grocerycustomer",
+                "serving_names": ["GROCERYCUSTOMERGUID"],
+                "catalog_name": "Grocery V31 - playground (spark)",
+            }
+        ],
+        "primary_entity": [
+            {
+                "name": "grocerycustomer",
+                "serving_names": ["GROCERYCUSTOMERGUID"],
+                "catalog_name": "Grocery V31 - playground (spark)",
+            }
+        ],
+        "tables": [
+            {
+                "name": "INVOICEITEMS",
+                "status": "PUBLIC_DRAFT",
+                "catalog_name": "Grocery V31 - playground (spark)",
+            },
+            {
+                "name": "GROCERYINVOICE",
+                "status": "PUBLIC_DRAFT",
+                "catalog_name": "Grocery V31 - playground (spark)",
+            },
+        ],
+        "default_version_mode": "AUTO",
+        "version_count": 1,
+        "catalog_name": "Grocery V31 - playground (spark)",
+        "dtype": "FLOAT",
+        "primary_table": [
+            {
+                "name": "INVOICEITEMS",
+                "status": "PUBLIC_DRAFT",
+                "catalog_name": "Grocery V31 - playground (spark)",
+            }
+        ],
+        "default_feature_id": "6462dd287b12204e7e1c2ba6",
+        "version": {"this": "V230516", "default": "V230516"},
+        "readiness": {"this": "DRAFT", "default": "DRAFT"},
+        "table_feature_job_setting": {
+            "this": [
+                {
+                    "table_name": "GROCERYINVOICE",
+                    "feature_job_setting": {
+                        "blind_spot": "3600s",
+                        "frequency": "3600s",
+                        "time_modulo_frequency": "60s",
+                    },
+                }
+            ],
+            "default": [
+                {
+                    "table_name": "GROCERYINVOICE",
+                    "feature_job_setting": {
+                        "blind_spot": "3600s",
+                        "frequency": "3600s",
+                        "time_modulo_frequency": "60s",
+                    },
+                }
+            ],
+        },
+        "table_cleaning_operation": {"this": [], "default": []},
+        "versions_info": None,
+        "metadata": {
+            "input_columns": {
+                "Input0": {
+                    "data": "INVOICEITEMS",
+                    "column_name": "GroceryProductGuid",
+                    "semantic": None,
+                },
+                "Input1": {"data": "INVOICEITEMS", "column_name": "TotalCost", "semantic": None},
+            },
+            "derived_columns": {},
+            "aggregations": {
+                "F0": {
+                    "name": "CustomerSpending_7d",
+                    "column": "Input1",
+                    "function": "sum",
+                    "keys": ["GroceryCustomerGuid"],
+                    "window": "7d",
+                    "category": "GroceryProductGuid",
+                    "filter": False,
+                },
+                "F1": {
+                    "name": "CustomerSpending_28d",
+                    "column": "Input1",
+                    "function": "sum",
+                    "keys": ["GroceryCustomerGuid"],
+                    "window": "28d",
+                    "category": "GroceryProductGuid",
+                    "filter": False,
+                },
+            },
+            "post_aggregation": {
+                "name": "CustomerSpendingStability_7d28d",
+                "inputs": ["F0", "F1"],
+                "transforms": ["cosine_similarity"],
+            },
+        },
+        "class_name": "Feature",
+    }
+
+    feature_info_html = InfoDict(feature_info)._repr_html_()
+    feature_info_fixture_path = "tests/fixtures/feature_info.html"
+    if update_fixtures:
+        with open(feature_info_fixture_path, "w") as file_obj:
+            file_obj.write(feature_info_html)
+    else:
+        # check report
+        with open(feature_info_fixture_path, "r") as file_obj:
+            expected_html = file_obj.read()
+        assert feature_info_html == expected_html

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -8,8 +8,6 @@ import toml
 from pandas.testing import assert_frame_equal
 
 from featurebyte.common.utils import (
-    CodeStr,
-    InfoDict,
     dataframe_from_arrow_stream,
     dataframe_from_json,
     dataframe_to_arrow_bytes,
@@ -87,86 +85,3 @@ def test_get_version():
     """
     data = toml.load("pyproject.toml")
     assert get_version() == data["tool"]["poetry"]["version"]
-
-
-def test_codestr_formatting():
-    """
-    Test CodeStr formatting
-    """
-    code = CodeStr("import featurebyte")
-    assert str(code) == "import featurebyte"
-    assert code._repr_html_() == (
-        '<div style="margin:30px; padding: 20px; border:1px solid #aaa">'
-        '<div class="highlight"><pre style="line-height: 125%;"><span></span>'
-        '<span style="color: #008000; font-weight: bold">import</span> '
-        '<span style="color: #0000FF; font-weight: bold">featurebyte</span>\n'
-        "</pre></div>\n</div>"
-    )
-
-
-def test_info_dict_formatting(update_fixtures):
-    """
-    Test InfoDict formatting
-    """
-    feature_list_info = {
-        "name": "Small List",
-        "created_at": "2023-05-03T14:30:54.217000",
-        "updated_at": "2023-05-13T06:55:12.110000",
-        "entities": [
-            {
-                "name": "grocerycustomer",
-                "serving_names": ["GROCERYCUSTOMERGUID"],
-                "catalog_name": "Grocery - playground (spark)",
-            }
-        ],
-        "primary_entity": [
-            {
-                "name": "grocerycustomer",
-                "serving_names": ["GROCERYCUSTOMERGUID"],
-                "catalog_name": "Grocery - playground (spark)",
-            }
-        ],
-        "tables": [
-            {
-                "name": "GROCERYPRODUCT",
-                "status": "PUBLIC_DRAFT",
-                "catalog_name": "Grocery - playground (spark)",
-            },
-            {
-                "name": "INVOICEITEMS",
-                "status": "PUBLIC_DRAFT",
-                "catalog_name": "Grocery - playground (spark)",
-            },
-            {
-                "name": "GROCERYINVOICE",
-                "status": "PUBLIC_DRAFT",
-                "catalog_name": "Grocery - playground (spark)",
-            },
-        ],
-        "default_version_mode": "AUTO",
-        "version_count": 1,
-        "catalog_name": "Grocery - playground (spark)",
-        "dtype_distribution": [
-            {"dtype": "OBJECT", "count": 1},
-            {"dtype": "FLOAT", "count": 8},
-            {"dtype": "VARCHAR", "count": 1},
-        ],
-        "status": "PUBLIC_DRAFT",
-        "feature_count": 10,
-        "version": {"this": "V230503", "default": "V230503"},
-        "production_ready_fraction": {"this": 1.0, "default": 1.0},
-        "versions_info": None,
-        "deployed": False,
-        "class_name": "FeatureList",
-    }
-
-    feature_list_info_html = InfoDict(feature_list_info)._repr_html_()
-    feature_list_info_fixture_path = "tests/fixtures/feature_list_info.html"
-    if update_fixtures:
-        with open(feature_list_info_fixture_path, "w") as file_obj:
-            file_obj.write(feature_list_info_html)
-    else:
-        # check report
-        with open(feature_list_info_fixture_path, "r") as file_obj:
-            expected_html = file_obj.read()
-        assert feature_list_info_html == expected_html

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -9,6 +9,7 @@ from pandas.testing import assert_frame_equal
 
 from featurebyte.common.utils import (
     CodeStr,
+    InfoDict,
     dataframe_from_arrow_stream,
     dataframe_from_json,
     dataframe_to_arrow_bytes,
@@ -88,7 +89,7 @@ def test_get_version():
     assert get_version() == data["tool"]["poetry"]["version"]
 
 
-def test_codestr_format():
+def test_codestr_formatting():
     """
     Test CodeStr formatting
     """
@@ -101,3 +102,71 @@ def test_codestr_format():
         '<span style="color: #0000FF; font-weight: bold">featurebyte</span>\n'
         "</pre></div>\n</div>"
     )
+
+
+def test_info_dict_formatting(update_fixtures):
+    """
+    Test InfoDict formatting
+    """
+    feature_list_info = {
+        "name": "Small List",
+        "created_at": "2023-05-03T14:30:54.217000",
+        "updated_at": "2023-05-13T06:55:12.110000",
+        "entities": [
+            {
+                "name": "grocerycustomer",
+                "serving_names": ["GROCERYCUSTOMERGUID"],
+                "catalog_name": "Grocery - playground (spark)",
+            }
+        ],
+        "primary_entity": [
+            {
+                "name": "grocerycustomer",
+                "serving_names": ["GROCERYCUSTOMERGUID"],
+                "catalog_name": "Grocery - playground (spark)",
+            }
+        ],
+        "tables": [
+            {
+                "name": "GROCERYPRODUCT",
+                "status": "PUBLIC_DRAFT",
+                "catalog_name": "Grocery - playground (spark)",
+            },
+            {
+                "name": "INVOICEITEMS",
+                "status": "PUBLIC_DRAFT",
+                "catalog_name": "Grocery - playground (spark)",
+            },
+            {
+                "name": "GROCERYINVOICE",
+                "status": "PUBLIC_DRAFT",
+                "catalog_name": "Grocery - playground (spark)",
+            },
+        ],
+        "default_version_mode": "AUTO",
+        "version_count": 1,
+        "catalog_name": "Grocery - playground (spark)",
+        "dtype_distribution": [
+            {"dtype": "OBJECT", "count": 1},
+            {"dtype": "FLOAT", "count": 8},
+            {"dtype": "VARCHAR", "count": 1},
+        ],
+        "status": "PUBLIC_DRAFT",
+        "feature_count": 10,
+        "version": {"this": "V230503", "default": "V230503"},
+        "production_ready_fraction": {"this": 1.0, "default": 1.0},
+        "versions_info": None,
+        "deployed": False,
+        "class_name": "FeatureList",
+    }
+
+    feature_list_info_html = InfoDict(feature_list_info)._repr_html_()
+    feature_list_info_fixture_path = "tests/fixtures/feature_list_info.html"
+    if update_fixtures:
+        with open(feature_list_info_fixture_path, "w") as file_obj:
+            file_obj.write(feature_list_info_html)
+    else:
+        # check report
+        with open(feature_list_info_fixture_path, "r") as file_obj:
+            expected_html = file_obj.read()
+        assert feature_list_info_html == expected_html


### PR DESCRIPTION
## Description

Implement HTML representation for API Object `.info()` result for better readability.

![Screenshot 2023-05-15 at 2 38 17 PM](https://github.com/featurebyte/featurebyte/assets/9862154/298ff36e-f839-4aff-a489-ade3ed0cc738)
![Screenshot 2023-05-15 at 2 38 07 PM](https://github.com/featurebyte/featurebyte/assets/9862154/4755a39c-2f13-428e-b257-7647cc980a3e)



## Related Issue

https://featurebyte.atlassian.net/browse/DEV-1712

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
