### PR TITLE
[DEV-1423] relationship: ensure get_by_id works for None updated_by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 + Fixed bug in `feature.definition` so that it is consistent with the underlying query graph
 + Updated `pymdown-extensions` due to vuln `CVE-2023-32309`
++ Fixed bug that was causing an error when retrieving a `Relationship` with no `updated_by` set
 
 ## v0.2.2
 

--- a/featurebyte/api/relationship.py
+++ b/featurebyte/api/relationship.py
@@ -63,7 +63,7 @@ class Relationship(ApiObject):
 
     # pydantic instance variable (internal use)
     internal_enabled: bool = Field(alias="enabled")
-    internal_updated_by: PydanticObjectId = Field(alias="updated_by")
+    internal_updated_by: Optional[PydanticObjectId] = Field(alias="updated_by")
 
     @property
     def enabled(self) -> bool:
@@ -81,7 +81,7 @@ class Relationship(ApiObject):
             return self.internal_enabled
 
     @property
-    def updated_by(self) -> PydanticObjectId:
+    def updated_by(self) -> Optional[PydanticObjectId]:
         """
         Who the relationship was updated by
 


### PR DESCRIPTION
## Description
This PR fixes a small bug that was causing an error to be thrown when a `Relationship` was persisted with no `updated_by`. 

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-1423

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
