### PR TITLE
[DEV-1712] Ensure html repr for unsaved objects is not empty

### DIFF
--- a/featurebyte/api/api_object.py
+++ b/featurebyte/api/api_object.py
@@ -121,14 +121,11 @@ class ApiObject(FeatureByteBaseDocumentModel):
         -------
         str
         """
-        info_repr = ""
         try:
-            info_repr = InfoDict(self.info()).to_html()
+            return InfoDict(self.info()).to_html()
         except (RecordCreationException, RecordRetrievalException):
             # object has not been saved yet
-            pass
-
-        return info_repr
+            return repr(self)
 
     def __repr__(self) -> str:
         info_repr = ""
@@ -136,7 +133,7 @@ class ApiObject(FeatureByteBaseDocumentModel):
             info_repr = repr(self.info())
         except (RecordCreationException, RecordRetrievalException):
             # object has not been saved yet
-            pass
+            info_repr = super().__repr__()
 
         return construct_repr_string(self, info_repr)
 

--- a/featurebyte/api/api_object.py
+++ b/featurebyte/api/api_object.py
@@ -128,7 +128,6 @@ class ApiObject(FeatureByteBaseDocumentModel):
             return repr(self)
 
     def __repr__(self) -> str:
-        info_repr = ""
         try:
             info_repr = repr(self.info())
         except (RecordCreationException, RecordRetrievalException):

--- a/tests/unit/api/test_feature.py
+++ b/tests/unit/api/test_feature.py
@@ -1567,7 +1567,7 @@ def test_list_unsaved_features(
 def test_unsaved_feature_repr(
     float_feature,
 ):
-    expected_value = "Feature[FLOAT](name=sum_1d, node_name=project_3)"
+    expected_value = f"Feature[FLOAT](name=sum_1d, node_name={float_feature.node_name})"
     assert repr(float_feature) == expected_value
 
     # html representation for unsaved object should be the same as repr

--- a/tests/unit/api/test_feature.py
+++ b/tests/unit/api/test_feature.py
@@ -1562,3 +1562,13 @@ def test_list_unsaved_features(
         )
     finally:
         activate_and_get_catalog("default")
+
+
+def test_unsaved_feature_repr(
+    float_feature,
+):
+    expected_value = "Feature[FLOAT](name=sum_1d, node_name=project_3)"
+    assert repr(float_feature) == expected_value
+
+    # html representation for unsaved object should be the same as repr
+    assert float_feature._repr_html_() == expected_value


### PR DESCRIPTION
## Description

Fix bug introduced by unreleased implementation of object info html representation https://github.com/featurebyte/featurebyte/pull/1307

The html representation of unsaved API objects returns an empty string. This PR will fix that to return the non-html repr instead.

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-1712

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [x] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [x] I have labeled my Pull Request correctly
