### PR TITLE
[DEV-1726] Add guardrail to make sure `SCDTable`'s effective timestamp & end timestamp column differs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 + Update feature's & feature list's version format from dictionary to string
 + Implement HTML representation for API objects `.info()` result
 + Add `column_cleaning_operations` to view object
++ Add guardrail to make sure `SCDTable`'s `effective_timestamp_column` differs from `end_timestamp_column`
 
 ### 🧰 Bug fixes 🧰
 

--- a/featurebyte/schema/scd_table.py
+++ b/featurebyte/schema/scd_table.py
@@ -3,9 +3,9 @@ SCDTable API payload schema
 """
 from __future__ import annotations
 
-from typing import List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import Field, StrictStr
+from pydantic import Field, StrictStr, root_validator
 
 from featurebyte.enum import TableDataType
 from featurebyte.models.base import FeatureByteBaseModel
@@ -25,6 +25,21 @@ class SCDTableCreate(TableCreate):
     effective_timestamp_column: StrictStr
     end_timestamp_column: Optional[StrictStr]
     current_flag_column: Optional[StrictStr]
+
+    @root_validator
+    @classmethod
+    def _validate_scd_table_settings(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Validate SCDTable settings
+        """
+        effective_timestamp_column = values.get("effective_timestamp_column")
+        end_timestamp_column = values.get("end_timestamp_column")
+        if effective_timestamp_column and end_timestamp_column:
+            if effective_timestamp_column == end_timestamp_column:
+                raise ValueError(
+                    "effective_timestamp_column and end_timestamp_column cannot be same"
+                )
+        return values
 
 
 class SCDTableList(PaginationMixin):

--- a/tests/unit/api/test_scd_table.py
+++ b/tests/unit/api/test_scd_table.py
@@ -259,6 +259,27 @@ def test_create_scd_table__retrieval_exception(snowflake_database_table_scd_tabl
             )
 
 
+def test_create_scd_table__effective_timestamp_column_same_as_end_timestamp_column(
+    snowflake_database_table_scd_table,
+):
+    """
+    Test SCDTable creation failure due to effective_timestamp_column same as end_timestamp_column
+    """
+    # test when effective_timestamp_column is same as end_timestamp_column
+    with pytest.raises(ValueError) as exc:
+        snowflake_database_table_scd_table.create_scd_table(
+            name="sf_scd_table",
+            natural_key_column="col_text",
+            surrogate_key_column="col_int",
+            effective_timestamp_column="effective_timestamp",
+            end_timestamp_column="effective_timestamp",
+            current_flag_column="is_active",
+            record_creation_timestamp_column="created_at",
+        )
+    expected_error_message = "effective_timestamp_column and end_timestamp_column cannot be same"
+    assert expected_error_message in str(exc.value)
+
+
 def assert_info_helper(scd_table_info):
     """
     Helper function to assert info from SCD table.


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
