### PR TITLE
[DEV-1728] expose warehouse statstics of feature job analysis

### DIFF
--- a/featurebyte/schema/feature_job_setting_analysis.py
+++ b/featurebyte/schema/feature_job_setting_analysis.py
@@ -76,6 +76,49 @@ class FeatureJobSetting(FeatureByteBaseModel):
     feature_cutoff_modulo_frequency: int
 
 
+class FeatureJobSettingAnalysisWHJobFrequency(FeatureByteBaseModel):
+    """
+    FeatureJobSettingAnalysisWHJobFrequency Schema
+    """
+
+    best_estimate: int
+    confidence: str
+
+
+class FeatureJobSettingAnalysisWHJobInterval(FeatureByteBaseModel):
+    """
+    FeatureJobSettingAnalysisWHJobInterval Schema
+    """
+
+    avg: float
+    median: float
+    min: float
+    max: float
+
+
+class FeatureJobSettingAnalysisWHJobTimeModuloFrequency(FeatureByteBaseModel):
+    """
+    FeatureJobSettingAnalysisWHJobTimeModuloFrequency Schema
+    """
+
+    starts: int
+    ends: int
+    ends_wo_late: int
+    job_at_end_of_cycle: bool
+
+
+class FeatureJobSettingAnalysisWarehouseRecord(FeatureByteBaseDocumentModel):
+    """
+    FeatureJobSettingAnalysis persistent record with warehouse jobs info
+    """
+
+    job_frequency: FeatureJobSettingAnalysisWHJobFrequency
+    job_interval: FeatureJobSettingAnalysisWHJobInterval
+    job_time_modulo_frequency: FeatureJobSettingAnalysisWHJobTimeModuloFrequency
+    jobs_count: int
+    missing_jobs_count: int
+
+
 class FeatureJobSettingAnalysisRecord(FeatureByteBaseDocumentModel):
     """
     FeatureJobSettingAnalysis persistent record without report
@@ -84,6 +127,7 @@ class FeatureJobSettingAnalysisRecord(FeatureByteBaseDocumentModel):
     event_table_id: PydanticObjectId
     analysis_options: AnalysisOptions
     recommended_feature_job_setting: FeatureJobSetting
+    stats_on_wh_jobs: FeatureJobSettingAnalysisWarehouseRecord
 
     @root_validator(pre=True)
     @classmethod
@@ -92,6 +136,11 @@ class FeatureJobSettingAnalysisRecord(FeatureByteBaseDocumentModel):
             values["recommended_feature_job_setting"] = values["analysis_result"][
                 "recommended_feature_job_setting"
             ]
+
+        # expose statistics on warehouse jobs
+        if "stats_on_wh_jobs" not in values:
+            values["stats_on_wh_jobs"] = values["analysis_result"]["stats_on_wh_jobs"]
+
         return values
 
 


### PR DESCRIPTION
## Description

Current feature_job_analysis route does not expose warehouse info of a feature job analysis. This change exposes warehouse info of feature job analysis without potentially long fields of missing/late job list

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
