### PR TITLE
[DEV-1431] Add `default_feature_list_id` to `feature_list.info()` output

### DIFF
--- a/.changelog/DEV-1431.yaml
+++ b/.changelog/DEV-1431.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: feature-list
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "add `default_feature_list_id` to `feature_list.info()` output"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,6 +5,9 @@
 #   - PR title contains text '[chore]'
 
 name: changelog
+permissions:
+  contents: write
+  pull-requests: write
 on:
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled]

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -380,7 +380,7 @@ tasks:
     desc: "Generate changelog for PR"
     vars:
       clogs:
-        sh: git diff main\:./ --numstat | awk '{if ($3 ~ /^.changelog/ && $3 ~ /.yaml$/ && $3 !~ /TEMPLATE[.]yaml$/) { print $3 }}' | sed 's-.changelog/--g' | xargs
+        sh: git diff origin/main\:./ --numstat | awk '{if ($3 ~ /^.changelog/ && $3 ~ /.yaml$/ && $3 !~ /TEMPLATE[.]yaml$/) { print $3 }}' | sed 's-.changelog/--g' | xargs
     cmds:
       - python .changelog/changelog-gen.py {{.clogs}}
 
@@ -388,6 +388,6 @@ tasks:
     desc: "View changelog files in pr"
     vars:
       clogs:
-        sh: git diff main...HEAD --numstat | awk '{if ($3 ~ /^.changelog/ && $3 ~ /.yaml$/ && $3 !~ /TEMPLATE[.]yaml$/) { print $3 }}' | sed 's-.changelog/--g' | xargs
+        sh: git diff origin/main\:./ --numstat | awk '{if ($3 ~ /^.changelog/ && $3 ~ /.yaml$/ && $3 !~ /TEMPLATE[.]yaml$/) { print $3 }}' | sed 's-.changelog/--g' | xargs
     cmds:
       - python .changelog/changelog-gen.py --file-mode {{.clogs}}

--- a/featurebyte/api/feature_list.py
+++ b/featurebyte/api/feature_list.py
@@ -486,6 +486,7 @@ class FeatureList(
               'count': 1
             }
           ],
+          'default_feature_list_id': ...,
           'status': 'DRAFT',
           'feature_count': 1,
           'version': {

--- a/featurebyte/schema/info.py
+++ b/featurebyte/schema/info.py
@@ -302,20 +302,6 @@ class FeatureListBriefInfoList(FeatureByteBaseModel):
         return FeatureListBriefInfoList(__root__=feature_list_project.project(paginated_data))
 
 
-class FeatureListInfo(NamespaceInfo):
-    """
-    FeatureList info schema
-    """
-
-    dtype_distribution: List[FeatureTypeFeatureCount]
-    status: FeatureListStatus
-    feature_count: int
-    version: VersionComparison
-    production_ready_fraction: ProductionReadyFractionComparison
-    versions_info: Optional[FeatureListBriefInfoList]
-    deployed: bool
-
-
 class FeatureListNamespaceInfo(NamespaceInfo):
     """
     FeatureListNamespace info schema
@@ -325,6 +311,17 @@ class FeatureListNamespaceInfo(NamespaceInfo):
     default_feature_list_id: PydanticObjectId
     status: FeatureListStatus
     feature_count: int
+
+
+class FeatureListInfo(FeatureListNamespaceInfo):
+    """
+    FeatureList info schema
+    """
+
+    version: VersionComparison
+    production_ready_fraction: ProductionReadyFractionComparison
+    versions_info: Optional[FeatureListBriefInfoList]
+    deployed: bool
 
 
 class FeatureJobSettingAnalysisInfo(FeatureByteBaseModel):

--- a/tests/unit/api/test_feature_list.py
+++ b/tests/unit/api/test_feature_list.py
@@ -1,7 +1,6 @@
 """
 Tests for featurebyte.api.feature_list
 """
-import pdb
 import textwrap
 from unittest.mock import patch
 

--- a/tests/unit/api/test_feature_list.py
+++ b/tests/unit/api/test_feature_list.py
@@ -1,6 +1,7 @@
 """
 Tests for featurebyte.api.feature_list
 """
+import pdb
 import textwrap
 from unittest.mock import patch
 
@@ -476,25 +477,25 @@ def test_info(saved_feature_list):
         "production_ready_fraction": {"this": 0.0, "default": 0.0},
         "deployed": False,
         "catalog_name": "default",
+        "default_feature_list_id": str(saved_feature_list.id),
+        "created_at": info_dict["created_at"],
+        "version": info_dict["version"],
+        "updated_at": info_dict["updated_at"],
+        "versions_info": None,
     }
-    assert info_dict.items() > expected_info.items(), info_dict
-    assert "created_at" in info_dict, info_dict
-    assert "version" in info_dict, info_dict
-    assert set(info_dict["version"]) == {"this", "default"}, info_dict["version"]
+    assert info_dict == expected_info, info_dict
 
     verbose_info_dict = saved_feature_list.info(verbose=True)
-    assert verbose_info_dict.items() > expected_info.items(), verbose_info_dict
-    assert "created_at" in verbose_info_dict, verbose_info_dict
-    assert "version" in verbose_info_dict, verbose_info_dict
-    assert set(verbose_info_dict["version"]) == {"this", "default"}, verbose_info_dict["version"]
-
-    assert "versions_info" in verbose_info_dict, verbose_info_dict
-    assert len(verbose_info_dict["versions_info"]) == 1, verbose_info_dict
-    assert set(verbose_info_dict["versions_info"][0]) == {
-        "version",
-        "readiness_distribution",
-        "created_at",
-        "production_ready_fraction",
+    assert verbose_info_dict == {
+        **expected_info,
+        "versions_info": [
+            {
+                "production_ready_fraction": 0.0,
+                "readiness_distribution": [{"readiness": "DRAFT", "count": 1}],
+                "created_at": verbose_info_dict["versions_info"][0]["created_at"],
+                "version": verbose_info_dict["versions_info"][0]["version"],
+            }
+        ],
     }, verbose_info_dict
 
 

--- a/tests/unit/service/test_info.py
+++ b/tests/unit/service/test_info.py
@@ -585,6 +585,7 @@ async def test_get_feature_list_info(info_service, feature_list, feature_list_na
         deployed=False,
         serving_endpoint=None,
         catalog_name="default",
+        default_feature_list_id=feature_list_namespace.default_feature_list_id,
     )
     assert info == expected_info
 


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

As per title suggests, this PR fixes inconsistencies between `feature.info()` & `feature_list.info()` by minor refactoring feature & feature list info schema.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
