### PR TITLE
[DEV-1721] Enforce time limits for periodic tasks scheduled based on intervals

### DIFF
--- a/.changelog/DEV-1721.yaml
+++ b/.changelog/DEV-1721.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: scheduler
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "implement soft time limit for io tasks using gevent celery worker pool"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/service/task_manager.py
+++ b/featurebyte/service/task_manager.py
@@ -204,6 +204,7 @@ class TaskManager(AbstractTaskManager):
         interval: Interval,
         time_modulo_frequency_second: Optional[int] = None,
         start_after: Optional[datetime.datetime] = None,
+        time_limit: Optional[int] = None,
     ) -> ObjectId:
         """
         Schedule task to run periodically
@@ -220,6 +221,8 @@ class TaskManager(AbstractTaskManager):
             Time modulo frequency in seconds
         start_after: Optional[datetime.datetime]
             Start after this time
+        time_limit: Optional[int]
+            Execution time limit in seconds
 
         Returns
         -------
@@ -232,6 +235,12 @@ class TaskManager(AbstractTaskManager):
         else:
             last_run_at = None
 
+        # if time limit is not set default to interval length
+        if not time_limit:
+            time_limit = int(
+                datetime.timedelta(**{str(interval.period): interval.every}).total_seconds()
+            )
+
         periodic_task = PeriodicTask(
             name=name,
             task=payload.task,
@@ -242,6 +251,7 @@ class TaskManager(AbstractTaskManager):
             start_after=start_after,
             last_run_at=last_run_at,
             queue=payload.queue,
+            soft_time_limit=time_limit,
         )
         periodic_task_service = PeriodicTaskService(
             user=self.user,
@@ -257,6 +267,7 @@ class TaskManager(AbstractTaskManager):
         payload: BaseTaskPayload,
         crontab: Crontab,
         start_after: Optional[datetime.datetime] = None,
+        time_limit: Optional[int] = None,
     ) -> ObjectId:
         """
         Schedule task to run on cron setting
@@ -271,6 +282,8 @@ class TaskManager(AbstractTaskManager):
             Cron specification
         start_after: Optional[datetime.datetime]
             Start after this time
+        time_limit: Optional[int]
+            Execution time limit in seconds
 
         Returns
         -------
@@ -285,6 +298,7 @@ class TaskManager(AbstractTaskManager):
             args=[],
             kwargs=payload.json_dict(),
             start_after=start_after,
+            soft_time_limit=time_limit,
         )
         periodic_task_service = PeriodicTaskService(
             user=self.user,

--- a/featurebyte/worker/task_executor.py
+++ b/featurebyte/worker/task_executor.py
@@ -60,7 +60,7 @@ def run_async(coro: Awaitable[Any], timeout: Optional[int] = None) -> Any:
         timeout is exceeded
     """
     try:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         logger.debug("Use existing async loop", extra={"loop": loop})
     except RuntimeError:
         loop = asyncio.new_event_loop()

--- a/featurebyte/worker/task_executor.py
+++ b/featurebyte/worker/task_executor.py
@@ -3,7 +3,7 @@ This module contains TaskExecutor class
 """
 from __future__ import annotations
 
-from typing import Any, Awaitable
+from typing import Any, Awaitable, Optional
 
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
@@ -11,6 +11,7 @@ from threading import Thread
 from uuid import UUID
 
 import gevent
+from celery.exceptions import SoftTimeLimitExceeded
 
 from featurebyte.enum import WorkerCommand
 from featurebyte.logging import get_logger
@@ -38,18 +39,25 @@ def start_background_loop(loop: asyncio.AbstractEventLoop) -> None:
     loop.run_forever()
 
 
-def run_async(coro: Awaitable[Any]) -> Any:
+def run_async(coro: Awaitable[Any], timeout: Optional[int] = None) -> Any:
     """
     Run async function in both async and non-async context
     Parameters
     ----------
     coro: Coroutine
         Coroutine to run
+    timeout: Optional[int]
+        Timeout in seconds, default to None (no timeout)
 
     Returns
     -------
     Any
         result from function call
+
+    Raises
+    ------
+    SoftTimeLimitExceeded
+        timeout is exceeded
     """
     try:
         loop = asyncio.get_event_loop()
@@ -61,13 +69,20 @@ def run_async(coro: Awaitable[Any]) -> Any:
         thread = Thread(target=start_background_loop, args=(loop,), daemon=True)
         thread.start()
 
-    tasks = asyncio.all_tasks()
-    logger.debug("Asyncio tasks", extra={"num_tasks": len(tasks)})
+    logger.debug("Asyncio tasks", extra={"num_tasks": len(asyncio.all_tasks(loop=loop))})
+
+    logger.info("Start task", extra={"timeout": timeout})
     future = asyncio.run_coroutine_threadsafe(coro, loop)
-    event = gevent.event.Event()
-    future.add_done_callback(lambda _: event.set())
-    event.wait()
-    return future.result()
+    try:
+        with gevent.Timeout(seconds=timeout, exception=TimeoutError):
+            event = gevent.event.Event()
+            future.add_done_callback(lambda _: event.set())
+            event.wait()
+            return future.result()
+    except TimeoutError as exc:
+        # try to cancel the job if it has not started
+        future.cancel()
+        raise SoftTimeLimitExceeded(f"Task timed out after {timeout}s") from exc
 
 
 class TaskExecutor:
@@ -142,7 +157,9 @@ def execute_io_task(self: Any, **payload: Any) -> Any:
     -------
     Any
     """
-    return run_async(execute_task(self.request.id, **payload))
+    # gevent celery worker pool does not support soft time limit,
+    # so we let "run_async" handle the timeout enforcement
+    return run_async(execute_task(self.request.id, **payload), timeout=self.request.timelimit[1])
 
 
 @celery.task(bind=True)

--- a/tests/unit/service/test_task_manager.py
+++ b/tests/unit/service/test_task_manager.py
@@ -162,6 +162,7 @@ async def test_task_manager__schedule_interval_task(task_manager, user_id):
     assert periodic_task.name == "test_interval_task"
     assert periodic_task.kwargs == payload.json_dict()
     assert periodic_task.interval == interval
+    assert periodic_task.soft_time_limit == 60
 
     await task_manager.delete_periodic_task(periodic_task_id)
     with pytest.raises(DocumentNotFoundError):

--- a/tests/unit/worker/test_task_executor.py
+++ b/tests/unit/worker/test_task_executor.py
@@ -185,7 +185,7 @@ def run_process_task(state: Value, exception_value: Value, timeout: int):
     greenlet.greenlet(run_greenlet_task).switch()
 
 
-@pytest.mark.parametrize("timeout", [10, 1])
+@pytest.mark.parametrize("timeout", [30, 1])
 def test_run_async(timeout):
     """
     Test run async task in a separate thread

--- a/tests/unit/worker/test_task_executor.py
+++ b/tests/unit/worker/test_task_executor.py
@@ -185,7 +185,7 @@ def run_process_task(state: Value, exception_value: Value, timeout: int):
     greenlet.greenlet(run_greenlet_task).switch()
 
 
-@pytest.mark.parametrize("timeout", [30, 1])
+@pytest.mark.parametrize("timeout", [10, 1])
 def test_run_async(timeout):
     """
     Test run async task in a separate thread


### PR DESCRIPTION
## Description

Periodic tasks scheduled based on intervals can pile up if such task does not complete within the interval.

Changes made in this PR:

- Always specify soft time limit for scheduled tasks (defaults to interval length), can be overriden
- Support enforcement of soft time limit for io-intensive tasks executed in gevent workers (soft limit is not supported by celery for gevent worker pool)

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-1721

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [x] I have written tests for the changes made.
- [x] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [x] I have labeled my Pull Request correctly
