### PR TITLE
[chore] changelog module dependency and formatting fix

### DIFF
--- a/.changelog/changelog-gen.py
+++ b/.changelog/changelog-gen.py
@@ -168,7 +168,7 @@ class ChangelogRenderer:
                 display += clog.render()
             display += "\n"
 
-        return display
+        return display.rstrip()
 
 
 if __name__ == "__main__":

--- a/.changelog/chester-starlette-vuln.yaml
+++ b/.changelog/chester-starlette-vuln.yaml
@@ -16,7 +16,7 @@ component: dependencies
 issues: []
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "fixed vulnerability in starlette dependency"
+note: "fixed vulnerability in starlette"
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -374,15 +374,18 @@ tasks:
   changelog:
     desc: "Generate all changelog entries in .changelog"
     cmds:
-      - python .changelog/changelog-gen.py
+      - poetry run python .changelog/changelog-gen.py
 
   changelog-pr:
     desc: "Generate changelog for PR"
     vars:
       clogs:
         sh: git diff origin/main\:./ --numstat | awk '{if ($3 ~ /^.changelog/ && $3 ~ /.yaml$/ && $3 !~ /TEMPLATE[.]yaml$/) { print $3 }}' | sed 's-.changelog/--g' | xargs
+    preconditions:
+      - sh: bash -c '[[ "" != "{{.clogs}}" ]]'
+        msg: "No changelog files found in PR"
     cmds:
-      - python .changelog/changelog-gen.py {{.clogs}}
+      - poetry run python .changelog/changelog-gen.py {{.clogs}}
 
   changelog-pr-files:
     desc: "View changelog files in pr"


### PR DESCRIPTION
## Description

+ changelog needs pyyaml which might not be present in default env
+ rstrip() on final text render.

![image](https://github.com/featurebyte/featurebyte/assets/28699647/874f1c44-899b-41dc-b2f5-b73d7fc570d7)


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
