### PR TITLE
[DEV-1744] Remove `dtype` from feature creation payload

### DIFF
--- a/.changelog/DEV-1744.yaml
+++ b/.changelog/DEV-1744.yaml
@@ -1,0 +1,16 @@
+# Type of change
+change_type: enhancement
+
+# The name of the component
+component: feature
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.
+note: "remove `dtype` from feature creation route payload"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/featurebyte/api/feature.py
+++ b/featurebyte/api/feature.py
@@ -128,21 +128,6 @@ class Feature(
         return values
 
     @property
-    def dtype(self) -> DBVarType:
-        """
-        Returns the database variable type of the Feature object.
-
-        Returns
-        -------
-        DBVarType
-        """
-        try:
-            return cast(FeatureModel, self.cached_model).dtype
-        except RecordRetrievalException:
-            operation_structure = self.graph.extract_operation_structure(self.node)
-            return operation_structure.aggregations[0].dtype
-
-    @property
     def version(self) -> str:
         """
         Returns the version identifier of a Feature object.

--- a/featurebyte/api/feature.py
+++ b/featurebyte/api/feature.py
@@ -32,7 +32,6 @@ from featurebyte.core.accessor.count_dict import CdAccessorMixin
 from featurebyte.core.accessor.feature_datetime import FeatureDtAccessorMixin
 from featurebyte.core.accessor.feature_string import FeatureStrAccessorMixin
 from featurebyte.core.series import FrozenSeries, FrozenSeriesT, Series
-from featurebyte.enum import DBVarType
 from featurebyte.exception import RecordCreationException, RecordRetrievalException
 from featurebyte.feature_manager.model import ExtendedFeatureModel
 from featurebyte.logging import get_logger

--- a/featurebyte/api/feature.py
+++ b/featurebyte/api/feature.py
@@ -32,6 +32,7 @@ from featurebyte.core.accessor.count_dict import CdAccessorMixin
 from featurebyte.core.accessor.feature_datetime import FeatureDtAccessorMixin
 from featurebyte.core.accessor.feature_string import FeatureStrAccessorMixin
 from featurebyte.core.series import FrozenSeries, FrozenSeriesT, Series
+from featurebyte.enum import DBVarType
 from featurebyte.exception import RecordCreationException, RecordRetrievalException
 from featurebyte.feature_manager.model import ExtendedFeatureModel
 from featurebyte.logging import get_logger
@@ -125,6 +126,21 @@ class Feature(
                 feature_store_id = TabularSource(**tabular_source).feature_store_id
                 values["feature_store"] = FeatureStore.get_by_id(id=feature_store_id)
         return values
+
+    @property
+    def dtype(self) -> DBVarType:
+        """
+        Returns the database variable type of the Feature object.
+
+        Returns
+        -------
+        DBVarType
+        """
+        try:
+            return cast(FeatureModel, self.cached_model).dtype
+        except RecordRetrievalException:
+            operation_structure = self.graph.extract_operation_structure(self.node)
+            return operation_structure.aggregations[0].dtype
 
     @property
     def version(self) -> str:

--- a/featurebyte/schema/feature.py
+++ b/featurebyte/schema/feature.py
@@ -10,7 +10,6 @@ from datetime import datetime
 from bson.objectid import ObjectId
 from pydantic import Field, StrictStr, validator
 
-from featurebyte.enum import DBVarType
 from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId, VersionIdentifier
 from featurebyte.models.feature import FeatureModel, FeatureReadiness
 from featurebyte.query_graph.graph import QueryGraph

--- a/featurebyte/schema/feature.py
+++ b/featurebyte/schema/feature.py
@@ -29,7 +29,6 @@ class FeatureCreate(FeatureByteBaseModel):
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
     name: StrictStr
-    dtype: DBVarType
     graph: QueryGraph
     node_name: str
     tabular_source: TabularSource

--- a/tests/fixtures/request_payloads/feature_iet.json
+++ b/tests/fixtures/request_payloads/feature_iet.json
@@ -5,7 +5,6 @@
         "Run `pytest --update-fixtures` to update it."
     ],
     "_id": "642db61e28e1dffe39df3558",
-    "dtype": "FLOAT",
     "feature_namespace_id": "642db61e28e1dffe39df3559",
     "graph": {
         "edges": [

--- a/tests/fixtures/request_payloads/feature_item_event.json
+++ b/tests/fixtures/request_payloads/feature_item_event.json
@@ -5,7 +5,6 @@
         "Run `pytest --update-fixtures` to update it."
     ],
     "_id": "642db61f28e1dffe39df355a",
-    "dtype": "INT",
     "feature_namespace_id": "642db61f28e1dffe39df355b",
     "graph": {
         "edges": [

--- a/tests/fixtures/request_payloads/feature_non_time_based.json
+++ b/tests/fixtures/request_payloads/feature_non_time_based.json
@@ -5,7 +5,6 @@
         "Run `pytest --update-fixtures` to update it."
     ],
     "_id": "6414004bc6834e5117ec1575",
-    "dtype": "FLOAT",
     "feature_namespace_id": "6414004bc6834e5117ec1576",
     "graph": {
         "edges": [

--- a/tests/fixtures/request_payloads/feature_sum_2h.json
+++ b/tests/fixtures/request_payloads/feature_sum_2h.json
@@ -5,7 +5,6 @@
         "Run `pytest --update-fixtures` to update it."
     ],
     "_id": "642db61e28e1dffe39df3544",
-    "dtype": "FLOAT",
     "feature_namespace_id": "642db61e28e1dffe39df3545",
     "graph": {
         "edges": [

--- a/tests/fixtures/request_payloads/feature_sum_30m.json
+++ b/tests/fixtures/request_payloads/feature_sum_30m.json
@@ -5,7 +5,6 @@
         "Run `pytest --update-fixtures` to update it."
     ],
     "_id": "642db61e28e1dffe39df3542",
-    "dtype": "FLOAT",
     "feature_namespace_id": "642db61e28e1dffe39df3543",
     "graph": {
         "edges": [

--- a/tests/unit/api/test_feature.py
+++ b/tests/unit/api/test_feature.py
@@ -23,6 +23,7 @@ from featurebyte.api.feature import Feature, FeatureNamespace
 from featurebyte.api.feature_group import FeatureGroup
 from featurebyte.api.feature_list import FeatureList
 from featurebyte.api.table import Table
+from featurebyte.enum import DBVarType
 from featurebyte.exception import (
     ObjectHasBeenSavedError,
     RecordCreationException,
@@ -1573,3 +1574,30 @@ def test_unsaved_feature_repr(
 
     # html representation for unsaved object should be the same as repr
     assert float_feature._repr_html_() == expected_value
+
+
+def test_feature_dtype(
+    float_feature,
+    bool_feature,
+    non_time_based_feature,
+    sum_per_category_feature,
+):
+    """Test feature dtype before and after save"""
+    bool_feature.name = "bool_feat"
+
+    # test feature dtype before save
+    assert float_feature.dtype == DBVarType.FLOAT
+    assert bool_feature.dtype == DBVarType.BOOL
+    assert non_time_based_feature.dtype == DBVarType.FLOAT
+    assert sum_per_category_feature.dtype == DBVarType.OBJECT
+
+    float_feature.save()
+    bool_feature.save()
+    non_time_based_feature.save()
+    sum_per_category_feature.save()
+
+    # test feature dtype after save
+    assert float_feature.dtype == DBVarType.FLOAT
+    assert bool_feature.dtype == DBVarType.BOOL
+    assert non_time_based_feature.dtype == DBVarType.FLOAT
+    assert sum_per_category_feature.dtype == DBVarType.OBJECT

--- a/tests/unit/routes/test_feature.py
+++ b/tests/unit/routes/test_feature.py
@@ -112,6 +112,13 @@ class TestFeatureApi(BaseCatalogApiTestSuite):
                 "feature: ['631161373527e8d21e4197ac'])."
             ),
         ),
+        (
+            {**payload, "node_name": "groupby_1"},
+            (
+                "1 validation error for FeatureModel\n__root__\n  "
+                "Feature graph must have exactly one aggregation output (type=value_error)"
+            ),
+        ),
     ]
 
     def setup_creation_route(self, api_client, catalog_id=DEFAULT_CATALOG_ID):


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR aims to remove `dtype` from feature creation payload.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
