### PR TITLE
docs: create debug folder if it doesn't exist

### DIFF
--- a/.changelog/jevon-create-debug-folder-for-docs.yaml
+++ b/.changelog/jevon-create-debug-folder-for-docs.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+
+component: docs
+
+issues: []
+
+note: "automatically create `debug` folder if it doesn't exist when running docs"
+
+subtext:

--- a/featurebyte/common/documentation/gen_ref_pages_docs_builder.py
+++ b/featurebyte/common/documentation/gen_ref_pages_docs_builder.py
@@ -788,7 +788,11 @@ class DocsBuilder:
         with self.gen_files_open(filepath, "w") as fd:
             fd.writelines(output)
         if DEBUG_MODE:
-            with open(f"debug/{local_path}_local.txt", "w") as local_file:
+            debug_folder = "debug"
+            file_exists = os.path.exists(debug_folder)
+            if not file_exists:
+                os.makedirs(debug_folder)
+            with open(f"{debug_folder}/{local_path}_local.txt", "w") as local_file:
                 local_file.writelines(output)
 
     def _build_and_write_to_file(


### PR DESCRIPTION
## Description
Small fix to docs to create the `debug` folder automatically during initialization.
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
