### PR TITLE
[chore] Fix migration persistent test fixture

### DIFF
--- a/.changelog/changelog-gen.py
+++ b/.changelog/changelog-gen.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 from enum import Enum

--- a/tests/unit/migration/conftest.py
+++ b/tests/unit/migration/conftest.py
@@ -23,19 +23,9 @@ def user():
 
 
 @pytest_asyncio.fixture(name="migration_persistent")
-async def persistent_fixture():
+async def persistent_fixture(persistent):
     """Persistent fixture"""
-    with patch("motor.motor_asyncio.AsyncIOMotorClient.__new__") as mock_new:
-        mongo_client = AsyncMongoMockClient()
-        mock_new.return_value = mongo_client
-        persistent = MongoDB(uri="mongodb://server.example.com:27017", database="test")
-
-        @asynccontextmanager
-        async def start_transaction():
-            yield persistent
-
-        with patch.object(persistent, "start_transaction", start_transaction):
-            yield persistent
+    yield persistent
 
 
 @pytest.fixture(name="schema_metadata_service")

--- a/tests/unit/migration/conftest.py
+++ b/tests/unit/migration/conftest.py
@@ -22,12 +22,6 @@ def user():
     return user
 
 
-@pytest_asyncio.fixture(name="migration_persistent")
-async def persistent_fixture(persistent):
-    """Persistent fixture"""
-    yield persistent
-
-
 @pytest.fixture(name="schema_metadata_service")
 def schema_metadata_service_fixture(user, persistent):
     """Schema metadata service fixture"""

--- a/tests/unit/migration/test_run.py
+++ b/tests/unit/migration/test_run.py
@@ -56,10 +56,10 @@ def test_retrieve_all_migration_methods__duplicated_version(mock_extract_method)
 
 
 @pytest.mark.asyncio
-async def test_migrate_method_generator(user, migration_persistent, get_credential):
+async def test_migrate_method_generator(user, persistent, get_credential):
     """Test migrate method generator"""
     schema_metadata_service = SchemaMetadataService(
-        user=user, persistent=migration_persistent, catalog_id=DEFAULT_CATALOG_ID
+        user=user, persistent=persistent, catalog_id=DEFAULT_CATALOG_ID
     )
     schema_metadata = await schema_metadata_service.get_or_create_document(
         name=MigrationMetadata.SCHEMA_METADATA.value
@@ -68,7 +68,7 @@ async def test_migrate_method_generator(user, migration_persistent, get_credenti
     expected_method_num = len(retrieve_all_migration_methods())
     method_generator = migrate_method_generator(
         user=user,
-        persistent=migration_persistent,
+        persistent=persistent,
         get_credential=get_credential,
         schema_metadata=schema_metadata,
         include_data_warehouse_migrations=True,
@@ -88,7 +88,7 @@ async def test_migrate_method_generator(user, migration_persistent, get_credenti
     )
     method_generator = migrate_method_generator(
         user=user,
-        persistent=migration_persistent,
+        persistent=persistent,
         get_credential=get_credential,
         schema_metadata=schema_metadata,
         include_data_warehouse_migrations=True,
@@ -101,12 +101,10 @@ async def test_migrate_method_generator(user, migration_persistent, get_credenti
 
 
 @pytest.mark.asyncio
-async def test_migrate_method_generator__exclude_warehouse(
-    user, migration_persistent, get_credential
-):
+async def test_migrate_method_generator__exclude_warehouse(user, persistent, get_credential):
     """Test migrate method generator with include_data_warehouse_migrations=False"""
     schema_metadata_service = SchemaMetadataService(
-        user=user, persistent=migration_persistent, catalog_id=DEFAULT_CATALOG_ID
+        user=user, persistent=persistent, catalog_id=DEFAULT_CATALOG_ID
     )
     schema_metadata = await schema_metadata_service.get_or_create_document(
         name=MigrationMetadata.SCHEMA_METADATA.value
@@ -116,7 +114,7 @@ async def test_migrate_method_generator__exclude_warehouse(
     expected_method_num = len(retrieve_all_migration_methods()) - expected_num_warehouse_migrations
     method_generator = migrate_method_generator(
         user=user,
-        persistent=migration_persistent,
+        persistent=persistent,
         get_credential=get_credential,
         schema_metadata=schema_metadata,
         include_data_warehouse_migrations=False,
@@ -125,22 +123,20 @@ async def test_migrate_method_generator__exclude_warehouse(
 
 
 @pytest_asyncio.fixture(name="migration_check_persistent")
-async def migration_check_user_persistent_fixture(test_dir, migration_persistent):
+async def migration_check_user_persistent_fixture(test_dir, persistent):
     """Insert testing samples into the persistent"""
     fixture_glob_pattern = os.path.join(test_dir, "fixtures/migration/*")
     for file_name in glob.glob(fixture_glob_pattern):
         records = json_util.loads(open(file_name).read())
         collection_name = os.path.basename(file_name)
-        await migration_persistent._insert_many(collection_name=collection_name, documents=records)
-    return migration_persistent
+        await persistent._insert_many(collection_name=collection_name, documents=records)
+    return persistent
 
 
 @pytest.mark.asyncio
-async def test_post_migration_sanity_check(migration_persistent, user):
+async def test_post_migration_sanity_check(persistent, user):
     """Test post_migration_sanity_check"""
-    service = EntityService(
-        user=user, persistent=migration_persistent, catalog_id=DEFAULT_CATALOG_ID
-    )
+    service = EntityService(user=user, persistent=persistent, catalog_id=DEFAULT_CATALOG_ID)
     docs = []
     for i in range(20):
         doc = await service.create_document(


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR aims to fix the test coupling issue due to calling
```
AsyncIOMotorClient(uri, uuidRepresentation="standard")
```
where there exists a running event loop.

Run the following command to reproduce the issue:
```
pytest -vv tests/unit/migration tests/unit/worker --pdb
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
