### PR TITLE
[DEV-1439] Add `default_feature_fraction` to `FeatureList` object

### DIFF
--- a/.changelog/DEV-1439.yaml
+++ b/.changelog/DEV-1439.yaml
@@ -1,0 +1,16 @@
+# Type of change
+change_type: enhancement
+
+# The name of the component
+component: feature-list
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.
+note: "add `default_feature_fraction` to feature list object"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/featurebyte/api/feature_list.py
+++ b/featurebyte/api/feature_list.py
@@ -496,6 +496,7 @@ class FeatureList(BaseFeatureGroup, DeletableApiObject, SavableApiObject, Featur
 
         - `version`: The version name.
         - `production_ready_fraction`: The percentage of features that are production-ready.
+        - `default_feature_fraction`: The percentage of features that are default features.
 
         This method is only available for FeatureList objects that are saved in the catalog.
 
@@ -560,6 +561,10 @@ class FeatureList(BaseFeatureGroup, DeletableApiObject, SavableApiObject, Featur
             'default': ...
           },
           'production_ready_fraction': {
+            'this': 1.0,
+            'default': 1.0
+          },
+          'default_feature_fraction': {
             'this': 1.0,
             'default': 1.0
           },
@@ -873,8 +878,35 @@ class FeatureList(BaseFeatureGroup, DeletableApiObject, SavableApiObject, Featur
         Returns
         -------
         Fraction of production ready feature
+
+        See Also
+        --------
+        - [FeatureList.info](/reference/featurebyte.api.feature_list.FeatureList.info/)
         """
         return self.readiness_distribution.derive_production_ready_fraction()
+
+    @property
+    def default_feature_fraction(self) -> float:
+        """
+        Retrieve fraction of default features in the feature list
+
+        Returns
+        -------
+        Fraction of default feature
+
+        See Also
+        --------
+        - [Feature.info](/reference/featurebyte.api.feature.Feature.info/)
+        - [Feature.is_default](/reference/featurebyte.api.feature.Feature.is_default/)
+        - [FeatureList.info](/reference/featurebyte.api.feature_list.FeatureList.info/)
+        """
+        namespace_info = self.feature_list_namespace.info()
+        default_feat_ids = set(namespace_info["default_feature_ids"])
+        default_feat_count = 0
+        for feat_id in self.feature_ids:
+            if str(feat_id) in default_feat_ids:
+                default_feat_count += 1
+        return default_feat_count / len(self.feature_ids)
 
     @property
     def deployed(self) -> bool:

--- a/featurebyte/common/documentation/documentation_layout.py
+++ b/featurebyte/common/documentation/documentation_layout.py
@@ -375,6 +375,7 @@ def _get_feature_list_layout() -> List[DocLayoutItem]:
         DocLayoutItem([FEATURE_LIST, INFO, "FeatureList.updated_at"]),
         DocLayoutItem([FEATURE_LIST, INFO, "FeatureList.is_default"]),
         DocLayoutItem([FEATURE_LIST, INFO, "FeatureList.production_ready_fraction"]),
+        DocLayoutItem([FEATURE_LIST, INFO, "FeatureList.default_feature_fraction"]),
         DocLayoutItem([FEATURE_LIST, INFO, "FeatureList.version"]),
         DocLayoutItem([FEATURE_LIST, LINEAGE, "FeatureList.catalog_id"]),
         DocLayoutItem([FEATURE_LIST, LINEAGE, "FeatureList.feature_ids"]),

--- a/featurebyte/schema/info.py
+++ b/featurebyte/schema/info.py
@@ -302,9 +302,9 @@ class FeatureListBriefInfoList(FeatureByteBaseModel):
         return FeatureListBriefInfoList(__root__=feature_list_project.project(paginated_data))
 
 
-class FeatureListNamespaceInfo(NamespaceInfo):
+class BaseFeatureListNamespaceInfo(NamespaceInfo):
     """
-    FeatureListNamespace info schema
+    BaseFeatureListNamespace info schema
     """
 
     dtype_distribution: List[FeatureTypeFeatureCount]
@@ -313,13 +313,32 @@ class FeatureListNamespaceInfo(NamespaceInfo):
     feature_count: int
 
 
-class FeatureListInfo(FeatureListNamespaceInfo):
+class FeatureListNamespaceInfo(BaseFeatureListNamespaceInfo):
+    """
+    FeatureListNamespace info schema
+    """
+
+    feature_namespace_ids: List[PydanticObjectId]
+    default_feature_ids: List[PydanticObjectId]
+
+
+class DefaultFeatureFractionComparison(FeatureByteBaseModel):
+    """
+    DefaultFeatureFractionComparison info schema
+    """
+
+    this: float
+    default: float
+
+
+class FeatureListInfo(BaseFeatureListNamespaceInfo):
     """
     FeatureList info schema
     """
 
     version: VersionComparison
     production_ready_fraction: ProductionReadyFractionComparison
+    default_feature_fraction: DefaultFeatureFractionComparison
     versions_info: Optional[FeatureListBriefInfoList]
     deployed: bool
 

--- a/tests/unit/api/test_feature_list.py
+++ b/tests/unit/api/test_feature_list.py
@@ -467,6 +467,7 @@ def test_info(saved_feature_list):
         "feature_count": 1,
         "version_count": 1,
         "production_ready_fraction": {"this": 0.0, "default": 0.0},
+        "default_feature_fraction": {"this": 1.0, "default": 1.0},
         "deployed": False,
         "catalog_name": "default",
         "default_feature_list_id": str(saved_feature_list.id),

--- a/tests/unit/api/test_version.py
+++ b/tests/unit/api/test_version.py
@@ -50,6 +50,9 @@ def test_feature_and_feature_list_version(feature_group, mock_api_object_cache):
     assert feature_list.version == get_version()
     assert feature_list.feature_list_namespace.default_feature_list_id == feature_list.id
 
+    # check default feature fraction
+    assert feature_list.info()["default_feature_fraction"] == {"this": 1.0, "default": 1.0}
+
     # create a new feature version
     amt_sum_30m = feature_list["amt_sum_30m"]
     assert amt_sum_30m.feature_namespace.default_feature_id == amt_sum_30m.id
@@ -77,6 +80,10 @@ def test_feature_and_feature_list_version(feature_group, mock_api_object_cache):
     assert feature_list_v1.version == f"{get_version()}_1"
     assert feature_list.feature_list_namespace.default_feature_list_id == feature_list_v1.id
 
+    # check default feature fraction
+    assert feature_list.info()["default_feature_fraction"] == {"this": 2 / 3, "default": 1.0}
+    assert feature_list_v1.info()["default_feature_fraction"] == {"this": 1.0, "default": 1.0}
+
     # create a new feature list version by specifying features
     feature_list_v2 = feature_list.create_new_version(
         features=[FeatureVersionInfo(name=amt_sum_30m_v1.name, version=amt_sum_30m_v1.version)],
@@ -86,6 +93,12 @@ def test_feature_and_feature_list_version(feature_group, mock_api_object_cache):
     assert feature_list.feature_list_namespace.default_feature_list_id == feature_list_v2.id
     assert feature_list.is_default is False
     assert feature_list_v2.is_default is True
+
+    # check default feature fraction
+    assert feature_list_v1.feature_ids == feature_list_v2.feature_ids
+    assert feature_list.info()["default_feature_fraction"] == {"this": 2 / 3, "default": 1.0}
+    assert feature_list_v1.info()["default_feature_fraction"] == {"this": 1.0, "default": 1.0}
+    assert feature_list_v2.info()["default_feature_fraction"] == {"this": 1.0, "default": 1.0}
 
     # check feature list ids in feature list namespace
     assert set(feature_list.feature_list_namespace.feature_list_ids) == {
@@ -99,6 +112,9 @@ def test_feature_list__as_default_version(feature_group):
     """Test feature list as_default_version method"""
     feature_list = FeatureList([feature_group], name="my_special_fl")
     feature_list.save()
+
+    # check default feature fraction
+    assert feature_list.info()["default_feature_fraction"] == {"this": 1.0, "default": 1.0}
 
     # create new feature version
     feature_list["amt_sum_30m"].create_new_version(
@@ -116,6 +132,13 @@ def test_feature_list__as_default_version(feature_group):
     # create new feature list version
     new_feature_list_version = feature_list.create_new_version()
     assert new_feature_list_version.is_default is True
+
+    # check default feature fraction
+    assert feature_list.info()["default_feature_fraction"] == {"this": 2 / 3, "default": 1.0}
+    assert new_feature_list_version.info()["default_feature_fraction"] == {
+        "this": 1.0,
+        "default": 1.0,
+    }
 
     # check setting default version fails when default version mode is not MANUAL
     with pytest.raises(RecordUpdateException) as exc:

--- a/tests/unit/api/test_version.py
+++ b/tests/unit/api/test_version.py
@@ -83,6 +83,8 @@ def test_feature_and_feature_list_version(feature_group, mock_api_object_cache):
     # check default feature fraction
     assert feature_list.info()["default_feature_fraction"] == {"this": 2 / 3, "default": 1.0}
     assert feature_list_v1.info()["default_feature_fraction"] == {"this": 1.0, "default": 1.0}
+    assert feature_list.default_feature_fraction == 2 / 3
+    assert feature_list_v1.default_feature_fraction == 1.0
 
     # create a new feature list version by specifying features
     feature_list_v2 = feature_list.create_new_version(
@@ -99,6 +101,9 @@ def test_feature_and_feature_list_version(feature_group, mock_api_object_cache):
     assert feature_list.info()["default_feature_fraction"] == {"this": 2 / 3, "default": 1.0}
     assert feature_list_v1.info()["default_feature_fraction"] == {"this": 1.0, "default": 1.0}
     assert feature_list_v2.info()["default_feature_fraction"] == {"this": 1.0, "default": 1.0}
+    assert feature_list.default_feature_fraction == 2 / 3
+    assert feature_list_v1.default_feature_fraction == 1.0
+    assert feature_list_v2.default_feature_fraction == 1.0
 
     # check feature list ids in feature list namespace
     assert set(feature_list.feature_list_namespace.feature_list_ids) == {
@@ -139,6 +144,8 @@ def test_feature_list__as_default_version(feature_group):
         "this": 1.0,
         "default": 1.0,
     }
+    assert feature_list.default_feature_fraction == 2 / 3
+    assert new_feature_list_version.default_feature_fraction == 1.0
 
     # check setting default version fails when default version mode is not MANUAL
     with pytest.raises(RecordUpdateException) as exc:

--- a/tests/unit/service/test_info.py
+++ b/tests/unit/service/test_info.py
@@ -580,6 +580,7 @@ async def test_get_feature_list_info(info_service, feature_list, feature_list_na
             this=feature_list.version.to_str(), default=feature_list.version.to_str()
         ),
         production_ready_fraction={"this": 0.0, "default": 0.0},
+        default_feature_fraction={"this": 1.0, "default": 1.0},
         created_at=feature_list_namespace.created_at,
         updated_at=None,
         deployed=False,
@@ -606,7 +607,7 @@ async def test_get_feature_list_info(info_service, feature_list, feature_list_na
 
 
 @pytest.mark.asyncio
-async def test_get_feature_list_namespace_info(info_service, feature_list_namespace):
+async def test_get_feature_list_namespace_info(info_service, feature_list_namespace, feature):
     """Test get_feature_list_namespace_info"""
     info = await info_service.get_feature_list_namespace_info(
         document_id=feature_list_namespace.id, verbose=False
@@ -626,6 +627,8 @@ async def test_get_feature_list_namespace_info(info_service, feature_list_namesp
         version_count=1,
         dtype_distribution=[{"dtype": "FLOAT", "count": 1}],
         default_feature_list_id=feature_list_namespace.default_feature_list_id,
+        feature_namespace_ids=feature_list_namespace.feature_namespace_ids,
+        default_feature_ids=[feature.id],
         status="DRAFT",
         feature_count=1,
         created_at=feature_list_namespace.created_at,


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR introduces `default_feature_fraction` property to `FeatureList` object & the corresponding field in `feature_list.info()` method output.
## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
