### PR TITLE
[chore] fix publish-public workflow missing runs_on

### DIFF
--- a/.github/workflows/changelog_gen.yaml
+++ b/.github/workflows/changelog_gen.yaml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   changelog:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
     steps:
     - uses: actions/checkout@v3
       with:
@@ -39,12 +39,12 @@ jobs:
     - name: Ensure no changes to the CHANGELOG
       run: |-
         if [[ $(git diff --name-only $(git merge-base origin/main ${{ github.event.pull_request.head.sha }}) ${{ github.event.pull_request.head.sha }} ./CHANGELOG.md) ]]; then
-          echo "The CHANGELOG.md was not modified."
-          echo "See CONTRIBUTING.md for more details"
+          echo "The CHANGELOG.md was modified."
           echo "Alternately, add either \"[chore]\" to the title of the pull request or add the \"Skip Changelog\" label if this job should be skipped."
+          echo "See CONTRIBUTING.md for more details"
           exit 1
         else
-          echo "The CHANGELOG.md was modified."
+          echo "The CHANGELOG.md was not modified."
         fi
     - name: Ensure addition of at least 1 changelog entry
       run: task changelog-pr-files

--- a/.github/workflows/publish-public_gen.yaml
+++ b/.github/workflows/publish-public_gen.yaml
@@ -158,6 +158,7 @@ jobs:
         cache-to: type=inline
   slack:
     if: ${{ always() }}
+    runs-on: ubuntu-latest
     needs:
     - publish
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,7 @@ Before submitting your code please do the following steps:
 3. Edit documentation if you have changed something significant
 4. Run `task format` to format your changes.
 5. Run `task lint` to ensure that types, security and docstrings are okay.
+6. Add a changelog file in .changelog/ folder. Refer to `.changelog/TEMPLATE.yaml`.
 
 
 ### Checking documentation


### PR DESCRIPTION
## Description

missing `runs_on` property on public_public workflow.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
