### PR TITLE
[DEV-1756] Improve columns batching logic to account for aggregation parameters

### DIFF
--- a/tests/fixtures/expected_historical_requests_multiple_batches_feature_set_0.sql
+++ b/tests/fixtures/expected_historical_requests_multiple_batches_feature_set_0.sql
@@ -1,123 +1,21 @@
 CREATE TABLE "__TEMP_646f1b781d1e7970788b32ec_0" AS
-WITH "REQUEST_TABLE_W7200_F3600_BS900_M1800_CUSTOMER_ID" AS (
-  SELECT
-    "POINT_IN_TIME",
-    "CUSTOMER_ID",
-    FLOOR((
-      DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 1800
-    ) / 3600) AS "__FB_LAST_TILE_INDEX",
-    FLOOR((
-      DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 1800
-    ) / 3600) - 2 AS "__FB_FIRST_TILE_INDEX"
-  FROM (
-    SELECT DISTINCT
-      "POINT_IN_TIME",
-      "CUSTOMER_ID"
-    FROM REQUEST_TABLE
-  )
-), "REQUEST_TABLE_W172800_F3600_BS900_M1800_CUSTOMER_ID" AS (
-  SELECT
-    "POINT_IN_TIME",
-    "CUSTOMER_ID",
-    FLOOR((
-      DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 1800
-    ) / 3600) AS "__FB_LAST_TILE_INDEX",
-    FLOOR((
-      DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 1800
-    ) / 3600) - 48 AS "__FB_FIRST_TILE_INDEX"
-  FROM (
-    SELECT DISTINCT
-      "POINT_IN_TIME",
-      "CUSTOMER_ID"
-    FROM REQUEST_TABLE
-  )
-), "REQUEST_TABLE_order_id" AS (
+WITH "REQUEST_TABLE_order_id" AS (
   SELECT DISTINCT
     "order_id"
+  FROM REQUEST_TABLE
+), "REQUEST_TABLE_POINT_IN_TIME_MEMBERSHIP_STATUS" AS (
+  SELECT DISTINCT
+    "POINT_IN_TIME",
+    "MEMBERSHIP_STATUS"
   FROM REQUEST_TABLE
 ), _FB_AGGREGATED AS (
   SELECT
     REQ."__FB_ROW_INDEX_FOR_JOIN",
     REQ."POINT_IN_TIME",
     REQ."CUSTOMER_ID",
-    "T0"."_fb_internal_window_w7200_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb" AS "_fb_internal_window_w7200_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb",
-    "T1"."_fb_internal_window_w172800_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb" AS "_fb_internal_window_w172800_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb",
-    "T2"."_fb_internal_item_count_None_order_id_None_input_1" AS "_fb_internal_item_count_None_order_id_None_input_1"
+    "T0"."_fb_internal_item_count_None_order_id_None_input_1" AS "_fb_internal_item_count_None_order_id_None_input_1",
+    "T1"."_fb_internal_as_at_count_None_membership_status_None_input_2" AS "_fb_internal_as_at_count_None_membership_status_None_input_2"
   FROM REQUEST_TABLE AS REQ
-  LEFT JOIN (
-    SELECT
-      "POINT_IN_TIME",
-      "CUSTOMER_ID",
-      SUM(sum_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb) / SUM(count_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb) AS "_fb_internal_window_w7200_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb"
-    FROM (
-      SELECT
-        REQ."POINT_IN_TIME",
-        REQ."CUSTOMER_ID",
-        TILE.INDEX,
-        TILE.count_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb,
-        TILE.sum_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb
-      FROM "REQUEST_TABLE_W7200_F3600_BS900_M1800_CUSTOMER_ID" AS REQ
-      INNER JOIN TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS TILE
-        ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 2) = FLOOR(TILE.INDEX / 2)
-        AND REQ."CUSTOMER_ID" = TILE."cust_id"
-      WHERE
-        TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
-      UNION ALL
-      SELECT
-        REQ."POINT_IN_TIME",
-        REQ."CUSTOMER_ID",
-        TILE.INDEX,
-        TILE.count_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb,
-        TILE.sum_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb
-      FROM "REQUEST_TABLE_W7200_F3600_BS900_M1800_CUSTOMER_ID" AS REQ
-      INNER JOIN TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS TILE
-        ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 2) - 1 = FLOOR(TILE.INDEX / 2)
-        AND REQ."CUSTOMER_ID" = TILE."cust_id"
-      WHERE
-        TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
-    )
-    GROUP BY
-      "POINT_IN_TIME",
-      "CUSTOMER_ID"
-  ) AS T0
-    ON REQ."POINT_IN_TIME" = T0."POINT_IN_TIME" AND REQ."CUSTOMER_ID" = T0."CUSTOMER_ID"
-  LEFT JOIN (
-    SELECT
-      "POINT_IN_TIME",
-      "CUSTOMER_ID",
-      SUM(sum_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb) / SUM(count_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb) AS "_fb_internal_window_w172800_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb"
-    FROM (
-      SELECT
-        REQ."POINT_IN_TIME",
-        REQ."CUSTOMER_ID",
-        TILE.INDEX,
-        TILE.count_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb,
-        TILE.sum_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb
-      FROM "REQUEST_TABLE_W172800_F3600_BS900_M1800_CUSTOMER_ID" AS REQ
-      INNER JOIN TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS TILE
-        ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 48) = FLOOR(TILE.INDEX / 48)
-        AND REQ."CUSTOMER_ID" = TILE."cust_id"
-      WHERE
-        TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
-      UNION ALL
-      SELECT
-        REQ."POINT_IN_TIME",
-        REQ."CUSTOMER_ID",
-        TILE.INDEX,
-        TILE.count_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb,
-        TILE.sum_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb
-      FROM "REQUEST_TABLE_W172800_F3600_BS900_M1800_CUSTOMER_ID" AS REQ
-      INNER JOIN TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS TILE
-        ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 48) - 1 = FLOOR(TILE.INDEX / 48)
-        AND REQ."CUSTOMER_ID" = TILE."cust_id"
-      WHERE
-        TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
-    )
-    GROUP BY
-      "POINT_IN_TIME",
-      "CUSTOMER_ID"
-  ) AS T1
-    ON REQ."POINT_IN_TIME" = T1."POINT_IN_TIME" AND REQ."CUSTOMER_ID" = T1."CUSTOMER_ID"
   LEFT JOIN (
     SELECT
       REQ."order_id" AS "order_id",
@@ -134,14 +32,44 @@ WITH "REQUEST_TABLE_W7200_F3600_BS900_M1800_CUSTOMER_ID" AS (
       ON REQ."order_id" = ITEM."order_id"
     GROUP BY
       REQ."order_id"
-  ) AS T2
-    ON REQ."order_id" = T2."order_id"
+  ) AS T0
+    ON REQ."order_id" = T0."order_id"
+  LEFT JOIN (
+    SELECT
+      REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
+      REQ."MEMBERSHIP_STATUS" AS "MEMBERSHIP_STATUS",
+      COUNT(*) AS "_fb_internal_as_at_count_None_membership_status_None_input_2"
+    FROM "REQUEST_TABLE_POINT_IN_TIME_MEMBERSHIP_STATUS" AS REQ
+    INNER JOIN (
+      SELECT
+        *,
+        LEAD("effective_ts") OVER (PARTITION BY "cust_id" ORDER BY "effective_ts") AS "__FB_END_TS"
+      FROM (
+        SELECT
+          "effective_ts" AS "effective_ts",
+          "cust_id" AS "cust_id",
+          "membership_status" AS "membership_status"
+        FROM "db"."public"."customer_profile_table"
+      )
+    ) AS SCD
+      ON REQ."MEMBERSHIP_STATUS" = SCD."membership_status"
+      AND (
+        SCD."effective_ts" <= REQ."POINT_IN_TIME"
+        AND (
+          SCD."__FB_END_TS" > REQ."POINT_IN_TIME" OR SCD."__FB_END_TS" IS NULL
+        )
+      )
+    GROUP BY
+      REQ."POINT_IN_TIME",
+      REQ."MEMBERSHIP_STATUS"
+  ) AS T1
+    ON REQ."POINT_IN_TIME" = T1."POINT_IN_TIME"
+    AND REQ."MEMBERSHIP_STATUS" = T1."MEMBERSHIP_STATUS"
 )
 SELECT
   AGG."__FB_ROW_INDEX_FOR_JOIN",
   AGG."POINT_IN_TIME",
   AGG."CUSTOMER_ID",
-  "_fb_internal_window_w7200_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb" AS "a_2h_average",
-  "_fb_internal_window_w172800_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb" AS "a_48h_average",
+  "_fb_internal_as_at_count_None_membership_status_None_input_2" AS "asat_feature",
   "_fb_internal_item_count_None_order_id_None_input_1" AS "order_size"
 FROM _FB_AGGREGATED AS AGG

--- a/tests/fixtures/expected_historical_requests_multiple_batches_feature_set_1.sql
+++ b/tests/fixtures/expected_historical_requests_multiple_batches_feature_set_1.sql
@@ -4,14 +4,14 @@ WITH _FB_AGGREGATED AS (
     REQ."__FB_ROW_INDEX_FOR_JOIN" AS "__FB_ROW_INDEX_FOR_JOIN",
     REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
     REQ."CUSTOMER_ID" AS "CUSTOMER_ID",
-    REQ."_fb_internal_lookup_membership_status_input_2" AS "_fb_internal_lookup_membership_status_input_2",
-    "T0"."_fb_internal_lookup_cust_value_1_input_4" AS "_fb_internal_lookup_cust_value_1_input_4",
-    "T0"."_fb_internal_lookup_cust_value_2_input_4" AS "_fb_internal_lookup_cust_value_2_input_4"
+    REQ."_fb_internal_latest_3b3c2a8389d7720826731fefb7060b6578050e04" AS "_fb_internal_latest_3b3c2a8389d7720826731fefb7060b6578050e04",
+    REQ."_fb_internal_lookup_membership_status_input_2" AS "_fb_internal_lookup_membership_status_input_2"
   FROM (
     SELECT
       L."__FB_ROW_INDEX_FOR_JOIN" AS "__FB_ROW_INDEX_FOR_JOIN",
       L."POINT_IN_TIME" AS "POINT_IN_TIME",
       L."CUSTOMER_ID" AS "CUSTOMER_ID",
+      L."_fb_internal_latest_3b3c2a8389d7720826731fefb7060b6578050e04" AS "_fb_internal_latest_3b3c2a8389d7720826731fefb7060b6578050e04",
       R."membership_status" AS "_fb_internal_lookup_membership_status_input_2"
     FROM (
       SELECT
@@ -19,7 +19,8 @@ WITH _FB_AGGREGATED AS (
         "__FB_LAST_TS",
         "__FB_ROW_INDEX_FOR_JOIN",
         "POINT_IN_TIME",
-        "CUSTOMER_ID"
+        "CUSTOMER_ID",
+        "_fb_internal_latest_3b3c2a8389d7720826731fefb7060b6578050e04"
       FROM (
         SELECT
           "__FB_KEY_COL_0",
@@ -27,6 +28,7 @@ WITH _FB_AGGREGATED AS (
           "__FB_ROW_INDEX_FOR_JOIN",
           "POINT_IN_TIME",
           "CUSTOMER_ID",
+          "_fb_internal_latest_3b3c2a8389d7720826731fefb7060b6578050e04",
           "__FB_EFFECTIVE_TS_COL"
         FROM (
           SELECT
@@ -36,13 +38,77 @@ WITH _FB_AGGREGATED AS (
             2 AS "__FB_TS_TIE_BREAKER_COL",
             "__FB_ROW_INDEX_FOR_JOIN" AS "__FB_ROW_INDEX_FOR_JOIN",
             "POINT_IN_TIME" AS "POINT_IN_TIME",
-            "CUSTOMER_ID" AS "CUSTOMER_ID"
+            "CUSTOMER_ID" AS "CUSTOMER_ID",
+            "_fb_internal_latest_3b3c2a8389d7720826731fefb7060b6578050e04" AS "_fb_internal_latest_3b3c2a8389d7720826731fefb7060b6578050e04"
           FROM (
             SELECT
-              REQ."__FB_ROW_INDEX_FOR_JOIN",
-              REQ."POINT_IN_TIME",
-              REQ."CUSTOMER_ID"
-            FROM REQUEST_TABLE AS REQ
+              REQ."__FB_ROW_INDEX_FOR_JOIN" AS "__FB_ROW_INDEX_FOR_JOIN",
+              REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
+              REQ."CUSTOMER_ID" AS "CUSTOMER_ID",
+              REQ."_fb_internal_latest_3b3c2a8389d7720826731fefb7060b6578050e04" AS "_fb_internal_latest_3b3c2a8389d7720826731fefb7060b6578050e04"
+            FROM (
+              SELECT
+                L."__FB_ROW_INDEX_FOR_JOIN" AS "__FB_ROW_INDEX_FOR_JOIN",
+                L."POINT_IN_TIME" AS "POINT_IN_TIME",
+                L."CUSTOMER_ID" AS "CUSTOMER_ID",
+                R.value_latest_3b3c2a8389d7720826731fefb7060b6578050e04 AS "_fb_internal_latest_3b3c2a8389d7720826731fefb7060b6578050e04"
+              FROM (
+                SELECT
+                  "__FB_KEY_COL_0",
+                  "__FB_KEY_COL_1",
+                  "__FB_LAST_TS",
+                  "__FB_ROW_INDEX_FOR_JOIN",
+                  "POINT_IN_TIME",
+                  "CUSTOMER_ID"
+                FROM (
+                  SELECT
+                    "__FB_KEY_COL_0",
+                    "__FB_KEY_COL_1",
+                    LAG("__FB_EFFECTIVE_TS_COL") IGNORE NULLS OVER (PARTITION BY "__FB_KEY_COL_0", "__FB_KEY_COL_1" ORDER BY "__FB_TS_COL", "__FB_TS_TIE_BREAKER_COL") AS "__FB_LAST_TS",
+                    "__FB_ROW_INDEX_FOR_JOIN",
+                    "POINT_IN_TIME",
+                    "CUSTOMER_ID",
+                    "__FB_EFFECTIVE_TS_COL"
+                  FROM (
+                    SELECT
+                      FLOOR((
+                        DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 1800
+                      ) / 3600) AS "__FB_TS_COL",
+                      "CUSTOMER_ID" AS "__FB_KEY_COL_0",
+                      "BUSINESS_ID" AS "__FB_KEY_COL_1",
+                      NULL AS "__FB_EFFECTIVE_TS_COL",
+                      0 AS "__FB_TS_TIE_BREAKER_COL",
+                      "__FB_ROW_INDEX_FOR_JOIN" AS "__FB_ROW_INDEX_FOR_JOIN",
+                      "POINT_IN_TIME" AS "POINT_IN_TIME",
+                      "CUSTOMER_ID" AS "CUSTOMER_ID"
+                    FROM (
+                      SELECT
+                        REQ."__FB_ROW_INDEX_FOR_JOIN",
+                        REQ."POINT_IN_TIME",
+                        REQ."CUSTOMER_ID"
+                      FROM REQUEST_TABLE AS REQ
+                    )
+                    UNION ALL
+                    SELECT
+                      "INDEX" AS "__FB_TS_COL",
+                      "cust_id" AS "__FB_KEY_COL_0",
+                      "biz_id" AS "__FB_KEY_COL_1",
+                      "INDEX" AS "__FB_EFFECTIVE_TS_COL",
+                      1 AS "__FB_TS_TIE_BREAKER_COL",
+                      NULL AS "__FB_ROW_INDEX_FOR_JOIN",
+                      NULL AS "POINT_IN_TIME",
+                      NULL AS "CUSTOMER_ID"
+                    FROM TILE_F3600_M1800_B900_AF1FD0AEE34EC80A96A6D5A486CE40F5A2267B4E
+                  )
+                )
+                WHERE
+                  "__FB_EFFECTIVE_TS_COL" IS NULL
+              ) AS L
+              LEFT JOIN TILE_F3600_M1800_B900_AF1FD0AEE34EC80A96A6D5A486CE40F5A2267B4E AS R
+                ON L."__FB_LAST_TS" = R."INDEX"
+                AND L."__FB_KEY_COL_0" = R."cust_id"
+                AND L."__FB_KEY_COL_1" = R."biz_id"
+            ) AS REQ
           )
           UNION ALL
           SELECT
@@ -52,7 +118,8 @@ WITH _FB_AGGREGATED AS (
             1 AS "__FB_TS_TIE_BREAKER_COL",
             NULL AS "__FB_ROW_INDEX_FOR_JOIN",
             NULL AS "POINT_IN_TIME",
-            NULL AS "CUSTOMER_ID"
+            NULL AS "CUSTOMER_ID",
+            NULL AS "_fb_internal_latest_3b3c2a8389d7720826731fefb7060b6578050e04"
           FROM (
             SELECT
               "effective_ts" AS "effective_ts",
@@ -74,27 +141,11 @@ WITH _FB_AGGREGATED AS (
     ) AS R
       ON L."__FB_LAST_TS" = R."event_timestamp" AND L."__FB_KEY_COL_0" = R."cust_id"
   ) AS REQ
-  LEFT JOIN (
-    SELECT
-      "cust_id" AS "CUSTOMER_ID",
-      "cust_value_1" AS "_fb_internal_lookup_cust_value_1_input_4",
-      "cust_value_2" AS "_fb_internal_lookup_cust_value_2_input_4"
-    FROM (
-      SELECT
-        "cust_id" AS "cust_id",
-        "cust_value_1" AS "cust_value_1",
-        "cust_value_2" AS "cust_value_2"
-      FROM "db"."public"."dimension_table"
-    )
-  ) AS T0
-    ON REQ."CUSTOMER_ID" = T0."CUSTOMER_ID"
 )
 SELECT
   AGG."__FB_ROW_INDEX_FOR_JOIN",
   AGG."POINT_IN_TIME",
   AGG."CUSTOMER_ID",
-  (
-    "_fb_internal_lookup_cust_value_1_input_4" + "_fb_internal_lookup_cust_value_2_input_4"
-  ) AS "MY FEATURE",
+  "_fb_internal_latest_3b3c2a8389d7720826731fefb7060b6578050e04" AS "a_latest_value",
   "_fb_internal_lookup_membership_status_input_2" AS "Current Membership Status"
 FROM _FB_AGGREGATED AS AGG

--- a/tests/fixtures/expected_historical_requests_multiple_batches_feature_set_2.sql
+++ b/tests/fixtures/expected_historical_requests_multiple_batches_feature_set_2.sql
@@ -1,5 +1,5 @@
 CREATE TABLE "__TEMP_646f1b781d1e7970788b32ec_2" AS
-WITH "REQUEST_TABLE_W7776000_F3600_BS900_M1800_CUSTOMER_ID" AS (
+WITH "REQUEST_TABLE_W7200_F3600_BS900_M1800_CUSTOMER_ID" AS (
   SELECT
     "POINT_IN_TIME",
     "CUSTOMER_ID",
@@ -8,7 +8,23 @@ WITH "REQUEST_TABLE_W7776000_F3600_BS900_M1800_CUSTOMER_ID" AS (
     ) / 3600) AS "__FB_LAST_TILE_INDEX",
     FLOOR((
       DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 1800
-    ) / 3600) - 2160 AS "__FB_FIRST_TILE_INDEX"
+    ) / 3600) - 2 AS "__FB_FIRST_TILE_INDEX"
+  FROM (
+    SELECT DISTINCT
+      "POINT_IN_TIME",
+      "CUSTOMER_ID"
+    FROM REQUEST_TABLE
+  )
+), "REQUEST_TABLE_W172800_F3600_BS900_M1800_CUSTOMER_ID" AS (
+  SELECT
+    "POINT_IN_TIME",
+    "CUSTOMER_ID",
+    FLOOR((
+      DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 1800
+    ) / 3600) AS "__FB_LAST_TILE_INDEX",
+    FLOOR((
+      DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 1800
+    ) / 3600) - 48 AS "__FB_FIRST_TILE_INDEX"
   FROM (
     SELECT DISTINCT
       "POINT_IN_TIME",
@@ -17,118 +33,110 @@ WITH "REQUEST_TABLE_W7776000_F3600_BS900_M1800_CUSTOMER_ID" AS (
   )
 ), _FB_AGGREGATED AS (
   SELECT
-    REQ."__FB_ROW_INDEX_FOR_JOIN" AS "__FB_ROW_INDEX_FOR_JOIN",
-    REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
-    REQ."CUSTOMER_ID" AS "CUSTOMER_ID",
-    REQ."_fb_internal_latest_3b3c2a8389d7720826731fefb7060b6578050e04" AS "_fb_internal_latest_3b3c2a8389d7720826731fefb7060b6578050e04",
-    "T0"."_fb_internal_window_w7776000_latest_2a1145d57c972a1eace23efb905e5f1e25ba5e73" AS "_fb_internal_window_w7776000_latest_2a1145d57c972a1eace23efb905e5f1e25ba5e73"
-  FROM (
-    SELECT
-      L."__FB_ROW_INDEX_FOR_JOIN" AS "__FB_ROW_INDEX_FOR_JOIN",
-      L."POINT_IN_TIME" AS "POINT_IN_TIME",
-      L."CUSTOMER_ID" AS "CUSTOMER_ID",
-      R.value_latest_3b3c2a8389d7720826731fefb7060b6578050e04 AS "_fb_internal_latest_3b3c2a8389d7720826731fefb7060b6578050e04"
-    FROM (
-      SELECT
-        "__FB_KEY_COL_0",
-        "__FB_KEY_COL_1",
-        "__FB_LAST_TS",
-        "__FB_ROW_INDEX_FOR_JOIN",
-        "POINT_IN_TIME",
-        "CUSTOMER_ID"
-      FROM (
-        SELECT
-          "__FB_KEY_COL_0",
-          "__FB_KEY_COL_1",
-          LAG("__FB_EFFECTIVE_TS_COL") IGNORE NULLS OVER (PARTITION BY "__FB_KEY_COL_0", "__FB_KEY_COL_1" ORDER BY "__FB_TS_COL", "__FB_TS_TIE_BREAKER_COL") AS "__FB_LAST_TS",
-          "__FB_ROW_INDEX_FOR_JOIN",
-          "POINT_IN_TIME",
-          "CUSTOMER_ID",
-          "__FB_EFFECTIVE_TS_COL"
-        FROM (
-          SELECT
-            FLOOR((
-              DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 1800
-            ) / 3600) AS "__FB_TS_COL",
-            "CUSTOMER_ID" AS "__FB_KEY_COL_0",
-            "BUSINESS_ID" AS "__FB_KEY_COL_1",
-            NULL AS "__FB_EFFECTIVE_TS_COL",
-            0 AS "__FB_TS_TIE_BREAKER_COL",
-            "__FB_ROW_INDEX_FOR_JOIN" AS "__FB_ROW_INDEX_FOR_JOIN",
-            "POINT_IN_TIME" AS "POINT_IN_TIME",
-            "CUSTOMER_ID" AS "CUSTOMER_ID"
-          FROM (
-            SELECT
-              REQ."__FB_ROW_INDEX_FOR_JOIN",
-              REQ."POINT_IN_TIME",
-              REQ."CUSTOMER_ID"
-            FROM REQUEST_TABLE AS REQ
-          )
-          UNION ALL
-          SELECT
-            "INDEX" AS "__FB_TS_COL",
-            "cust_id" AS "__FB_KEY_COL_0",
-            "biz_id" AS "__FB_KEY_COL_1",
-            "INDEX" AS "__FB_EFFECTIVE_TS_COL",
-            1 AS "__FB_TS_TIE_BREAKER_COL",
-            NULL AS "__FB_ROW_INDEX_FOR_JOIN",
-            NULL AS "POINT_IN_TIME",
-            NULL AS "CUSTOMER_ID"
-          FROM TILE_F3600_M1800_B900_AF1FD0AEE34EC80A96A6D5A486CE40F5A2267B4E
-        )
-      )
-      WHERE
-        "__FB_EFFECTIVE_TS_COL" IS NULL
-    ) AS L
-    LEFT JOIN TILE_F3600_M1800_B900_AF1FD0AEE34EC80A96A6D5A486CE40F5A2267B4E AS R
-      ON L."__FB_LAST_TS" = R."INDEX"
-      AND L."__FB_KEY_COL_0" = R."cust_id"
-      AND L."__FB_KEY_COL_1" = R."biz_id"
-  ) AS REQ
+    REQ."__FB_ROW_INDEX_FOR_JOIN",
+    REQ."POINT_IN_TIME",
+    REQ."CUSTOMER_ID",
+    "T0"."_fb_internal_lookup_cust_value_1_input_4" AS "_fb_internal_lookup_cust_value_1_input_4",
+    "T0"."_fb_internal_lookup_cust_value_2_input_4" AS "_fb_internal_lookup_cust_value_2_input_4",
+    "T1"."_fb_internal_window_w7200_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb" AS "_fb_internal_window_w7200_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb",
+    "T2"."_fb_internal_window_w172800_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb" AS "_fb_internal_window_w172800_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb"
+  FROM REQUEST_TABLE AS REQ
   LEFT JOIN (
     SELECT
-      *
+      "cust_id" AS "CUSTOMER_ID",
+      "cust_value_1" AS "_fb_internal_lookup_cust_value_1_input_4",
+      "cust_value_2" AS "_fb_internal_lookup_cust_value_2_input_4"
     FROM (
       SELECT
-        "POINT_IN_TIME",
-        "CUSTOMER_ID",
-        ROW_NUMBER() OVER (PARTITION BY "POINT_IN_TIME", "CUSTOMER_ID" ORDER BY INDEX DESC NULLS LAST) AS "__FB_ROW_NUMBER",
-        FIRST_VALUE(value_latest_2a1145d57c972a1eace23efb905e5f1e25ba5e73) OVER (PARTITION BY "POINT_IN_TIME", "CUSTOMER_ID" ORDER BY INDEX DESC NULLS LAST) AS "_fb_internal_window_w7776000_latest_2a1145d57c972a1eace23efb905e5f1e25ba5e73"
-      FROM (
-        SELECT
-          REQ."POINT_IN_TIME",
-          REQ."CUSTOMER_ID",
-          TILE.INDEX,
-          TILE.value_latest_2a1145d57c972a1eace23efb905e5f1e25ba5e73
-        FROM "REQUEST_TABLE_W7776000_F3600_BS900_M1800_CUSTOMER_ID" AS REQ
-        INNER JOIN TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS TILE
-          ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 2160) = FLOOR(TILE.INDEX / 2160)
-          AND REQ."CUSTOMER_ID" = TILE."cust_id"
-        WHERE
-          TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
-        UNION ALL
-        SELECT
-          REQ."POINT_IN_TIME",
-          REQ."CUSTOMER_ID",
-          TILE.INDEX,
-          TILE.value_latest_2a1145d57c972a1eace23efb905e5f1e25ba5e73
-        FROM "REQUEST_TABLE_W7776000_F3600_BS900_M1800_CUSTOMER_ID" AS REQ
-        INNER JOIN TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS TILE
-          ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 2160) - 1 = FLOOR(TILE.INDEX / 2160)
-          AND REQ."CUSTOMER_ID" = TILE."cust_id"
-        WHERE
-          TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
-      )
+        "cust_id" AS "cust_id",
+        "cust_value_1" AS "cust_value_1",
+        "cust_value_2" AS "cust_value_2"
+      FROM "db"."public"."dimension_table"
     )
-    WHERE
-      "__FB_ROW_NUMBER" = 1
   ) AS T0
-    ON REQ."POINT_IN_TIME" = T0."POINT_IN_TIME" AND REQ."CUSTOMER_ID" = T0."CUSTOMER_ID"
+    ON REQ."CUSTOMER_ID" = T0."CUSTOMER_ID"
+  LEFT JOIN (
+    SELECT
+      "POINT_IN_TIME",
+      "CUSTOMER_ID",
+      SUM(sum_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb) / SUM(count_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb) AS "_fb_internal_window_w7200_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb"
+    FROM (
+      SELECT
+        REQ."POINT_IN_TIME",
+        REQ."CUSTOMER_ID",
+        TILE.INDEX,
+        TILE.count_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb,
+        TILE.sum_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb
+      FROM "REQUEST_TABLE_W7200_F3600_BS900_M1800_CUSTOMER_ID" AS REQ
+      INNER JOIN TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS TILE
+        ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 2) = FLOOR(TILE.INDEX / 2)
+        AND REQ."CUSTOMER_ID" = TILE."cust_id"
+      WHERE
+        TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+      UNION ALL
+      SELECT
+        REQ."POINT_IN_TIME",
+        REQ."CUSTOMER_ID",
+        TILE.INDEX,
+        TILE.count_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb,
+        TILE.sum_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb
+      FROM "REQUEST_TABLE_W7200_F3600_BS900_M1800_CUSTOMER_ID" AS REQ
+      INNER JOIN TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS TILE
+        ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 2) - 1 = FLOOR(TILE.INDEX / 2)
+        AND REQ."CUSTOMER_ID" = TILE."cust_id"
+      WHERE
+        TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+    )
+    GROUP BY
+      "POINT_IN_TIME",
+      "CUSTOMER_ID"
+  ) AS T1
+    ON REQ."POINT_IN_TIME" = T1."POINT_IN_TIME" AND REQ."CUSTOMER_ID" = T1."CUSTOMER_ID"
+  LEFT JOIN (
+    SELECT
+      "POINT_IN_TIME",
+      "CUSTOMER_ID",
+      SUM(sum_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb) / SUM(count_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb) AS "_fb_internal_window_w172800_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb"
+    FROM (
+      SELECT
+        REQ."POINT_IN_TIME",
+        REQ."CUSTOMER_ID",
+        TILE.INDEX,
+        TILE.count_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb,
+        TILE.sum_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb
+      FROM "REQUEST_TABLE_W172800_F3600_BS900_M1800_CUSTOMER_ID" AS REQ
+      INNER JOIN TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS TILE
+        ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 48) = FLOOR(TILE.INDEX / 48)
+        AND REQ."CUSTOMER_ID" = TILE."cust_id"
+      WHERE
+        TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+      UNION ALL
+      SELECT
+        REQ."POINT_IN_TIME",
+        REQ."CUSTOMER_ID",
+        TILE.INDEX,
+        TILE.count_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb,
+        TILE.sum_value_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb
+      FROM "REQUEST_TABLE_W172800_F3600_BS900_M1800_CUSTOMER_ID" AS REQ
+      INNER JOIN TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS TILE
+        ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 48) - 1 = FLOOR(TILE.INDEX / 48)
+        AND REQ."CUSTOMER_ID" = TILE."cust_id"
+      WHERE
+        TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+    )
+    GROUP BY
+      "POINT_IN_TIME",
+      "CUSTOMER_ID"
+  ) AS T2
+    ON REQ."POINT_IN_TIME" = T2."POINT_IN_TIME" AND REQ."CUSTOMER_ID" = T2."CUSTOMER_ID"
 )
 SELECT
   AGG."__FB_ROW_INDEX_FOR_JOIN",
   AGG."POINT_IN_TIME",
   AGG."CUSTOMER_ID",
-  "_fb_internal_window_w7776000_latest_2a1145d57c972a1eace23efb905e5f1e25ba5e73" AS "a_latest_value_past_90d",
-  "_fb_internal_latest_3b3c2a8389d7720826731fefb7060b6578050e04" AS "a_latest_value"
+  (
+    "_fb_internal_lookup_cust_value_1_input_4" + "_fb_internal_lookup_cust_value_2_input_4"
+  ) AS "MY FEATURE",
+  "_fb_internal_window_w7200_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb" AS "a_2h_average",
+  "_fb_internal_window_w172800_avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb" AS "a_48h_average"
 FROM _FB_AGGREGATED AS AGG

--- a/tests/fixtures/expected_historical_requests_multiple_batches_output_query.sql
+++ b/tests/fixtures/expected_historical_requests_multiple_batches_output_query.sql
@@ -2,14 +2,14 @@ CREATE TABLE "SOME_HISTORICAL_FEATURE_TABLE" AS
 SELECT
   REQ."POINT_IN_TIME",
   REQ."CUSTOMER_ID",
-  T0."a_2h_average",
-  T0."a_48h_average",
+  T2."a_2h_average",
+  T2."a_48h_average",
   T0."order_size",
-  T1."MY FEATURE",
+  T2."MY FEATURE",
   T1."Current Membership Status",
-  T2."a_latest_value_past_90d",
-  T2."a_latest_value",
-  T3."asat_feature"
+  T3."a_latest_value_past_90d",
+  T1."a_latest_value",
+  T0."asat_feature"
 FROM REQUEST_TABLE AS REQ
 LEFT JOIN "__TEMP_646f1b781d1e7970788b32ec_0" AS T0
   ON REQ."__FB_ROW_INDEX_FOR_JOIN" = T0."__FB_ROW_INDEX_FOR_JOIN"

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -566,8 +566,8 @@ def patched_num_features_per_query():
 @pytest.mark.parametrize(
     "in_out_formats",
     [
-        # ("dataframe", "dataframe"),
-        # ("dataframe", "table"),
+        ("dataframe", "dataframe"),
+        ("dataframe", "table"),
         ("table", "table"),
     ],
 )

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -566,8 +566,8 @@ def patched_num_features_per_query():
 @pytest.mark.parametrize(
     "in_out_formats",
     [
-        ("dataframe", "dataframe"),
-        ("dataframe", "table"),
+        # ("dataframe", "dataframe"),
+        # ("dataframe", "table"),
         ("table", "table"),
     ],
 )

--- a/tests/unit/query_graph/conftest.py
+++ b/tests/unit/query_graph/conftest.py
@@ -323,6 +323,30 @@ def groupby_node_params_sum_agg_fixture():
     return node_params
 
 
+@pytest.fixture(name="groupby_node_params_different_feature_job_settings")
+def groupby_node_params_different_feature_job_settings_fixture():
+    """Fixture groupby node parameters
+
+    Same feature job settings as groupby_node_params_fixture, but with different aggregation and
+    different feature windows
+    """
+    node_params = {
+        "keys": ["cust_id"],
+        "serving_names": ["CUSTOMER_ID"],
+        "value_by": None,
+        "parent": "a",
+        "agg_func": "sum",
+        "time_modulo_frequency": 900,  # 15m
+        "frequency": 3600,  # 1h
+        "blind_spot": 900,  # 15m
+        "timestamp": "ts",
+        "names": ["a_2h_sum_v2", "a_36h_sum_v2"],
+        "windows": ["2h", "36h"],
+        "entity_ids": [ObjectId("637516ebc9c18f5a277a78db")],
+    }
+    return node_params
+
+
 @pytest.fixture(name="query_graph_with_groupby")
 def query_graph_with_groupby_fixture(query_graph_and_assign_node, groupby_node_params):
     """Fixture of a query graph with a groupby operation"""
@@ -410,6 +434,33 @@ def query_graph_with_similar_groupby_nodes(
     node2 = add_groupby_operation(graph, groupby_node_params_max_agg, assign_node)
     node3 = add_groupby_operation(graph, groupby_node_params_sum_agg, assign_node)
     return [node1, node2, node3], graph
+
+
+@pytest.fixture(name="query_graph_with_different_groupby_nodes")
+def query_graph_with_different_groupby_nodes_fixture(
+    query_graph_and_assign_node,
+    groupby_node_params,
+    groupby_node_params_different_feature_job_settings,
+):
+    """
+    Fixture of a query graph with two different groupby nodes (different job settings)
+    """
+    graph, assign_node = query_graph_and_assign_node
+    node1 = add_groupby_operation(
+        graph,
+        groupby_node_params,
+        assign_node,
+        override_tile_id="tile_id_1",
+        override_aggregation_id="agg_id_2",
+    )
+    node2 = add_groupby_operation(
+        graph,
+        groupby_node_params_different_feature_job_settings,
+        assign_node,
+        override_tile_id="tile_id_2",
+        override_aggregation_id="agg_id_1",
+    )
+    return [node1, node2], graph
 
 
 @pytest.fixture(name="complex_feature_query_graph")

--- a/tests/unit/query_graph/test_feature_historical.py
+++ b/tests/unit/query_graph/test_feature_historical.py
@@ -17,6 +17,7 @@ from featurebyte.query_graph.sql.feature_historical import (
     FeatureQuery,
     HistoricalFeatureQuerySet,
     convert_point_in_time_dtype_if_needed,
+    get_feature_names,
     get_historical_features,
     get_historical_features_expr,
     get_historical_features_query_set,
@@ -286,6 +287,7 @@ def test_get_historical_feature_query_set__single_batch(
         request_table_columns=request_table_columns,
         source_type=SourceType.SNOWFLAKE,
         output_table_details=output_table_details,
+        output_feature_names=[float_feature.node.name],
     )
     assert query_set.feature_queries == []
     assert_equal_with_expected_fixture(
@@ -309,10 +311,11 @@ def test_get_historical_feature_query_set__multiple_batches(
     query_set = get_historical_features_query_set(
         request_table_name=REQUEST_TABLE_NAME,
         graph=global_graph,
-        node_groups=split_nodes(feature_nodes_all_types, 2),
+        node_groups=split_nodes(global_graph, feature_nodes_all_types, 2),
         request_table_columns=request_table_columns,
         source_type=SourceType.SNOWFLAKE,
         output_table_details=output_table_details,
+        output_feature_names=get_feature_names(global_graph, feature_nodes_all_types),
     )
     for i, feature_query in enumerate(query_set.feature_queries):
         assert_equal_with_expected_fixture(

--- a/tests/util/helper.py
+++ b/tests/util/helper.py
@@ -95,7 +95,9 @@ def get_node(graph_dict, node_name):
     return next(node for node in graph_dict["nodes"] if node["name"] == node_name)
 
 
-def add_groupby_operation(graph, groupby_node_params, input_node):
+def add_groupby_operation(
+    graph, groupby_node_params, input_node, override_tile_id=None, override_aggregation_id=None
+):
     """
     Helper function to add a groupby node
     """
@@ -103,10 +105,14 @@ def add_groupby_operation(graph, groupby_node_params, input_node):
         node_type=NodeType.GROUPBY,
         node_params={
             **groupby_node_params,
-            "tile_id": get_tile_table_identifier("deadbeef1234", groupby_node_params),
+            "tile_id": get_tile_table_identifier("deadbeef1234", groupby_node_params)
+            if override_tile_id is None
+            else override_tile_id,
             "aggregation_id": get_aggregation_identifier(
                 graph.node_name_to_ref[input_node.name], groupby_node_params
-            ),
+            )
+            if override_aggregation_id is None
+            else override_aggregation_id,
         },
         node_output_type=NodeOutputType.FRAME,
         input_nodes=[input_node],


### PR DESCRIPTION
## Description

This improves the columns batching logic in historical features to account for aggregation parameters so that it is not sensitive to the original ordering of features. The change is to introduce a reordering step in the `split_nodes` function.

The previously measured historical features runtime for [`Features V1`](https://github.com/featurebyte/featurebyte-notebooks/blob/f6e8cd4b352c3550540874e9cdd9001ba47a84f0/notebooks/features/grocery/setup.py#L67) was optimistic because the features were ordered meaningfully in the feature list. The runtime increases from 27m to 42m if the feature list is shuffled randomly. With the changes in this PR, the runtime of the shuffled feature list is 25m.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
