### PR TITLE
[DEV-1766] Fix multiple deployment sharing the same feature list bug

### DIFF
--- a/.changelog/DEV-1766.yaml
+++ b/.changelog/DEV-1766.yaml
@@ -13,4 +13,9 @@ note: "fix multiple deployments sharing the same feature list bug"
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: |
+  This bug was caused by the deployment enablement and disablement does not consider that the same
+  feature list could be shared by multiple deployments. This meant that when any of the deployment
+  was disabled, it will update the corresponding feature list `deployed` status to false and update
+  data warehouse. A proper fix is to only update the feature list `deployed` status when all deployments
+  using the feature list are disabled.

--- a/.changelog/DEV-1766.yaml
+++ b/.changelog/DEV-1766.yaml
@@ -1,0 +1,16 @@
+# Type of change
+change_type: bug_fix
+
+# The name of the component
+component: deployment
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.
+note: "fix multiple deployments sharing the same feature list bug"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/featurebyte/exception.py
+++ b/featurebyte/exception.py
@@ -216,6 +216,12 @@ class DocumentConflictError(DocumentError):
     """
 
 
+class DocumentCreationError(DocumentError):
+    """
+    Raise when the document invalid creation happens
+    """
+
+
 class DocumentUpdateError(DocumentError):
     """
     Raise when the document invalid update happens

--- a/featurebyte/service/deploy.py
+++ b/featurebyte/service/deploy.py
@@ -368,7 +368,7 @@ class DeployService(BaseService):
 
         Raises
         ------
-        DocumentCreationError
+        DocumentCreationError, Exception
             When there is an unexpected error during deployment creation
         """
         feature_list = await self.feature_list_service.get_document(document_id=feature_list_id)
@@ -421,7 +421,7 @@ class DeployService(BaseService):
 
         Raises
         ------
-        DocumentUpdateError
+        DocumentUpdateError, Exception
             When there is an unexpected error during deployment update
         """
         deployment = await self.deployment_service.get_document(document_id=deployment_id)

--- a/tests/unit/routes/base.py
+++ b/tests/unit/routes/base.py
@@ -150,15 +150,18 @@ class BaseApiTestSuite:
         )
         assert response.status_code == HTTPStatus.OK, response.json()
 
-    @staticmethod
-    def enable_deployment(api_client, deployment_id, catalog_id):
+    def update_deployment_enabled(self, api_client, deployment_id, catalog_id, enabled=True):
         """Enable deployment"""
         response = api_client.patch(
             f"/deployment/{deployment_id}",
             headers={"active-catalog-id": str(catalog_id)},
-            json={"enabled": True},
+            json={"enabled": enabled},
         )
-        assert response.status_code == HTTPStatus.OK, response.json()
+        assert response.status_code == HTTPStatus.OK
+        self.wait_for_results(api_client, response)
+        deployment_response = api_client.get(f"/deployment/{deployment_id}")
+        assert deployment_response.status_code == HTTPStatus.OK
+        assert deployment_response.json()["enabled"] == enabled
 
     def wait_for_results(self, api_client, create_response):
         """

--- a/tests/unit/routes/test_batch_feature_table.py
+++ b/tests/unit/routes/test_batch_feature_table.py
@@ -90,7 +90,7 @@ class TestBatchFeatureTableApi(BaseMaterializedTableTestSuite):
             if api_object == "deployment":
                 assert response.json()["status"] == "SUCCESS"
                 deployment_id = response.json()["payload"]["output_document_id"]
-                self.enable_deployment(api_client, deployment_id, catalog_id)
+                self.update_deployment_enabled(api_client, deployment_id, catalog_id)
 
     def multiple_success_payload_generator(self, api_client):
         """Create multiple payload for setting up create_multiple_success_responses fixture"""

--- a/tests/unit/routes/test_deployment.py
+++ b/tests/unit/routes/test_deployment.py
@@ -196,6 +196,7 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
 
     @staticmethod
     def check_feature_list_deployed(api_client, feature_list_id, expected_deployed):
+        """Check feature list deployed status"""
         feature_list_response = api_client.get(f"/feature_list/{feature_list_id}")
         feature_list_dict = feature_list_response.json()
         assert feature_list_response.status_code == HTTPStatus.OK

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -492,15 +492,22 @@ async def production_ready_feature_list_fixture(production_ready_feature, featur
 
 @pytest_asyncio.fixture(name="deployed_feature_list")
 async def deployed_feature_list_fixture(
-    online_enable_service_data_warehouse_mocks, deploy_service, production_ready_feature_list
+    online_enable_service_data_warehouse_mocks,
+    deploy_service,
+    feature_list_service,
+    production_ready_feature_list,
 ):
     """Fixture for a deployed feature list"""
     _ = online_enable_service_data_warehouse_mocks
-    updated_feature_list = await deploy_service.update_feature_list(
+    await deploy_service.create_deployment(
         feature_list_id=production_ready_feature_list.id,
-        deployed=True,
+        deployment_id=ObjectId(),
+        deployment_name="test-deployment",
+        to_enable_deployment=True,
         get_credential=Mock(),
-        return_document=True,
+    )
+    updated_feature_list = await feature_list_service.get_document(
+        document_id=production_ready_feature_list.id
     )
     return updated_feature_list
 

--- a/tests/unit/service/test_deploy.py
+++ b/tests/unit/service/test_deploy.py
@@ -5,60 +5,93 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 import pytest_asyncio
+from bson import ObjectId
 
-from featurebyte.exception import DocumentUpdateError
+from featurebyte.exception import DocumentNotFoundError, DocumentUpdateError
+from featurebyte.models.deployment import DeploymentModel
 from featurebyte.models.feature_list import FeatureListModel
 
 
+@pytest_asyncio.fixture(name="disabled_deployment")
+async def disabled_deployment_fixture(app_container, feature_list):
+    """Disabled deployment fixture"""
+    deployment_id = ObjectId()
+    await app_container.deploy_service.create_deployment(
+        feature_list_id=feature_list.id,
+        deployment_id=deployment_id,
+        deployment_name=None,
+        to_enable_deployment=False,
+        get_credential=Mock(),
+    )
+    deployment = await app_container.deployment_service.get_document(document_id=deployment_id)
+    assert deployment.enabled is False
+    yield deployment
+
+
 @pytest.mark.asyncio
-async def test_update_feature_list__feature_not_online_enabled_error(deploy_service, feature_list):
-    """Test update feature list (not all features are online enabled validation error)"""
+async def test_create_disabled_deployment(app_container, disabled_deployment):
+    """Test create deployment (disabled)"""
+    updated_feature_list = await app_container.feature_list_service.get_document(
+        document_id=disabled_deployment.feature_list_id
+    )
+    assert updated_feature_list.deployed is False
+
+
+@pytest.mark.asyncio
+async def test_create_enabled_deployment__not_all_features_are_online_enabled(
+    app_container, feature_list
+):
+    """Test create deployment (not all features are online enabled validation error)"""
+    deployment_id = ObjectId()
     with pytest.raises(DocumentUpdateError) as exc:
-        await deploy_service.update_feature_list(
-            feature_list_id=feature_list.id, deployed=True, get_credential=Mock()
+        await app_container.deploy_service.create_deployment(
+            feature_list_id=feature_list.id,
+            deployment_id=deployment_id,
+            deployment_name=None,
+            to_enable_deployment=True,
+            get_credential=Mock(),
         )
+
     expected_msg = "Only FeatureList object of all production ready features can be deployed."
     assert expected_msg in str(exc.value)
 
+    # check that deployment is not created
+    with pytest.raises(DocumentNotFoundError):
+        await app_container.deployment_service.get_document(document_id=deployment_id)
+
 
 @pytest.mark.asyncio
-async def test_update_feature_list__no_update(deploy_service, feature_list):
+async def test_update_deployment__not_all_features_are_online_enabled(
+    app_container, disabled_deployment
+):
+    """Test update deployment (not all features are online enabled validation error)"""
+    with pytest.raises(DocumentUpdateError) as exc:
+        await app_container.deploy_service.update_deployment(
+            deployment_id=disabled_deployment.id, enabled=True, get_credential=Mock()
+        )
+
+    expected_msg = "Only FeatureList object of all production ready features can be deployed."
+    assert expected_msg in str(exc.value)
+
+    # check that deployment is not updated
+    updated_deployment = await app_container.deployment_service.get_document(
+        document_id=disabled_deployment.id
+    )
+    assert updated_deployment.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_update_deployment__no_update(app_container, disabled_deployment):
     """Test update feature list when deployed status is the same"""
-    updated_feature_list = await deploy_service.update_feature_list(
-        feature_list_id=feature_list.id,
-        deployed=feature_list.deployed,
-        get_credential=Mock(),
-    )
-    assert updated_feature_list == feature_list
-
-
-@pytest.mark.asyncio
-async def test_update_feature_list_namespace__no_update_except_updated_at(
-    deploy_service, feature_list, feature_list_namespace
-):
-    """Test update feature list namespace when deployed status is the same"""
-    updated_namespace = await deploy_service._update_feature_list_namespace(
-        feature_list_namespace_id=feature_list.feature_list_namespace_id,
-        feature_list=feature_list,
-    )
-    assert updated_namespace.dict(exclude={"updated_at": True}) == feature_list_namespace.dict(
-        exclude={"updated_at": True}
+    await app_container.deploy_service.update_deployment(
+        deployment_id=disabled_deployment.id, enabled=False, get_credential=Mock()
     )
 
-
-@pytest.mark.asyncio
-async def test_update_feature__no_update_except_updated_at(
-    deploy_service, feature_service, feature, feature_list
-):
-    """Test update feature when deployed status is the same"""
-    feature = await feature_service.get_document(document_id=feature.id)
-    updated_feature = await deploy_service._update_feature(
-        feature_id=feature.id,
-        feature_list=feature_list,
+    # check that deployment is not updated
+    updated_deployment = await app_container.deployment_service.get_document(
+        document_id=disabled_deployment.id
     )
-    assert updated_feature.dict(exclude={"updated_at": True}) == feature.dict(
-        exclude={"updated_at": True}
-    )
+    assert updated_deployment == disabled_deployment
 
 
 async def check_states_after_deployed_change(
@@ -93,24 +126,44 @@ async def production_ready_feature_list_fixture(feature_list, feature_readiness_
     yield feature_list
 
 
+@pytest_asyncio.fixture(name="disabled_deployment_with_production_ready_features")
+async def disabled_deployment_with_prod_ready_features(
+    app_container, production_ready_feature_list
+):
+    """Disabled deployment fixture"""
+    deployment_id = ObjectId()
+    await app_container.deploy_service.create_deployment(
+        feature_list_id=production_ready_feature_list.id,
+        deployment_id=deployment_id,
+        deployment_name=None,
+        to_enable_deployment=False,
+        get_credential=Mock(),
+    )
+    deployment = await app_container.deployment_service.get_document(document_id=deployment_id)
+    assert deployment.enabled is False
+    yield deployment
+
+
 @pytest.mark.asyncio
-async def test_update_feature_list(
-    feature_service,
-    feature_list_namespace_service,
-    feature_list_service,
-    feature_list_status_service,
+async def test_update_deployment(
+    app_container,
     production_ready_feature_list,
-    deploy_service,
     mock_update_data_warehouse,
 ):
     """Test update feature list"""
     feature_list = production_ready_feature_list
-    assert feature_list.online_enabled_feature_ids == []
-    deployed_feature_list = await deploy_service.update_feature_list(
-        feature_list_id=feature_list.id,
-        deployed=True,
-        return_document=True,
+
+    deployment_id = ObjectId()
+    await app_container.deploy_service.create_deployment(
+        feature_list_id=production_ready_feature_list.id,
+        deployment_id=deployment_id,
+        deployment_name=None,
+        to_enable_deployment=True,
         get_credential=Mock(),
+    )
+    deployment = await app_container.deployment_service.get_document(document_id=deployment_id)
+    deployed_feature_list = await app_container.feature_list_service.get_document(
+        document_id=deployment.feature_list_id
     )
     mock_update_data_warehouse.assert_called_once()
     assert mock_update_data_warehouse.call_args[1]["updated_feature"].online_enabled is True
@@ -118,19 +171,21 @@ async def test_update_feature_list(
     assert deployed_feature_list.online_enabled_feature_ids == deployed_feature_list.feature_ids
     assert isinstance(deployed_feature_list, FeatureListModel)
     await check_states_after_deployed_change(
-        feature_service=feature_service,
-        feature_list_namespace_service=feature_list_namespace_service,
-        feature_list_service=feature_list_service,
+        feature_service=app_container.feature_service,
+        feature_list_namespace_service=app_container.feature_list_namespace_service,
+        feature_list_service=app_container.feature_list_service,
         feature_list=deployed_feature_list,
         expected_deployed=True,
         expected_deployed_feature_list_ids=[feature_list.id],
     )
 
-    deployed_disabled_feature_list = await deploy_service.update_feature_list(
-        feature_list_id=feature_list.id,
-        deployed=False,
-        return_document=True,
+    await app_container.deploy_service.update_deployment(
+        deployment_id=deployment_id,
+        enabled=False,
         get_credential=Mock(),
+    )
+    deployed_disabled_feature_list = await app_container.feature_list_service.get_document(
+        document_id=deployment.feature_list_id
     )
     assert mock_update_data_warehouse.call_count == 2
     assert mock_update_data_warehouse.call_args[1]["updated_feature"].online_enabled is False
@@ -138,9 +193,9 @@ async def test_update_feature_list(
     assert deployed_disabled_feature_list.online_enabled_feature_ids == []
     assert isinstance(deployed_disabled_feature_list, FeatureListModel)
     await check_states_after_deployed_change(
-        feature_service=feature_service,
-        feature_list_namespace_service=feature_list_namespace_service,
-        feature_list_service=feature_list_service,
+        feature_service=app_container.feature_service,
+        feature_list_namespace_service=app_container.feature_list_namespace_service,
+        feature_list_service=app_container.feature_list_service,
         feature_list=deployed_disabled_feature_list,
         expected_deployed=False,
         expected_deployed_feature_list_ids=[],
@@ -148,46 +203,43 @@ async def test_update_feature_list(
 
     # update feature list namespace status to deprecated and then deploy the feature list
     # should raise exception
-    await feature_list_status_service.update_feature_list_namespace_status(
+    await app_container.feature_list_status_service.update_feature_list_namespace_status(
         feature_list_namespace_id=feature_list.feature_list_namespace_id,
         target_feature_list_status="DEPRECATED",
     )
-    namespace = await feature_list_namespace_service.get_document(
+    namespace = await app_container.feature_list_namespace_service.get_document(
         document_id=feature_list.feature_list_namespace_id
     )
     assert namespace.status == "DEPRECATED"
     with pytest.raises(DocumentUpdateError) as exc:
-        await deploy_service.update_feature_list(
-            feature_list_id=feature_list.id,
-            deployed=True,
-            return_document=True,
+        await app_container.deploy_service.update_deployment(
+            deployment_id=deployment.id,
+            enabled=True,
             get_credential=Mock(),
         )
+
     expected_msg = "Deprecated feature list cannot be deployed."
     assert expected_msg in str(exc.value)
 
 
 @pytest.mark.asyncio
-async def test_update_feature_list_error__state_is_reverted_when_update_feature_list_namespace_is_failed(
-    feature_list_namespace_service,
-    feature_list_service,
-    production_ready_feature_list,
-    deploy_service,
+async def test_update_deployment_error__state_is_reverted_when_update_feature_list_namespace_is_failed(
+    app_container,
+    disabled_deployment_with_production_ready_features,
     mock_update_data_warehouse,
 ):
     """Test update feature list exception happens when updating feature list namespace"""
     _ = mock_update_data_warehouse
-    feature_list = production_ready_feature_list
-    assert feature_list.online_enabled_feature_ids == []
 
-    with patch.object(deploy_service, "_update_feature_list_namespace") as mock_update_fl_namespace:
+    with patch.object(
+        app_container.deploy_service, "_update_feature_list_namespace"
+    ) as mock_update_fl_namespace:
         error_msg = "random error when calling _update_feature_list_namespace!!"
         mock_update_fl_namespace.side_effect = Exception(error_msg)
         with pytest.raises(Exception) as exc:
-            _ = await deploy_service.update_feature_list(
-                feature_list_id=feature_list.id,
-                deployed=True,
-                return_document=True,
+            _ = await app_container.deploy_service.update_deployment(
+                deployment_id=disabled_deployment_with_production_ready_features.id,
+                enabled=True,
                 get_credential=Mock(),
             )
 
@@ -198,8 +250,10 @@ async def test_update_feature_list_error__state_is_reverted_when_update_feature_
     assert mock_update_fl_namespace.call_count == 2
 
     # check feature's online_enabled status & feature list deployed status
-    feature_list = await feature_list_service.get_document(document_id=feature_list.id)
-    feature_list_namespace = await feature_list_namespace_service.get_document(
+    feature_list = await app_container.feature_list_service.get_document(
+        document_id=disabled_deployment_with_production_ready_features.feature_list_id
+    )
+    feature_list_namespace = await app_container.feature_list_namespace_service.get_document(
         document_id=feature_list.feature_list_namespace_id
     )
     assert feature_list.deployed is False
@@ -208,30 +262,24 @@ async def test_update_feature_list_error__state_is_reverted_when_update_feature_
 
 
 @pytest.mark.asyncio
-async def test_update_feature_list_error__state_is_reverted_when_update_feature_is_failed(
-    feature_list_namespace_service,
-    feature_list_service,
-    production_ready_feature_list,
-    deploy_service,
+async def test_update_deployment_error__state_is_reverted_when_update_feature_is_failed(
+    app_container,
+    disabled_deployment_with_production_ready_features,
     mock_update_data_warehouse,
 ):
     """Test update feature list exception happens when updating feature"""
     _ = mock_update_data_warehouse
-    feature_list = production_ready_feature_list
-    assert feature_list.deployed is False
-    assert feature_list.online_enabled_feature_ids == []
 
     with patch.object(
-        deploy_service, "_update_feature", new_callable=AsyncMock
+        app_container.deploy_service, "_update_feature", new_callable=AsyncMock
     ) as mock_update_feature:
         error_msg = "random error when calling _update_feature!!"
         mock_update_feature.side_effect = Exception(error_msg)
         with pytest.raises(Exception) as exc:
-            _ = await deploy_service.update_feature_list(
-                feature_list_id=feature_list.id,
-                deployed=True,
-                return_document=True,
-                get_credential=AsyncMock(),
+            _ = await app_container.deploy_service.update_deployment(
+                deployment_id=disabled_deployment_with_production_ready_features.id,
+                enabled=True,
+                get_credential=Mock(),
             )
 
         # check exception message
@@ -241,8 +289,10 @@ async def test_update_feature_list_error__state_is_reverted_when_update_feature_
     mock_update_feature.assert_called_once()
 
     # check feature's online_enabled status & feature list deployed status
-    feature_list = await feature_list_service.get_document(document_id=feature_list.id)
-    feature_list_namespace = await feature_list_namespace_service.get_document(
+    feature_list = await app_container.feature_list_service.get_document(
+        document_id=disabled_deployment_with_production_ready_features.feature_list_id
+    )
+    feature_list_namespace = await app_container.feature_list_namespace_service.get_document(
         document_id=feature_list.feature_list_namespace_id
     )
     assert feature_list.deployed is False
@@ -252,6 +302,7 @@ async def test_update_feature_list_error__state_is_reverted_when_update_feature_
 
 @pytest.mark.asyncio
 async def test_update_feature_list_error__state_is_reverted_after_feature_list_namespace_updated(
+    app_container,
     feature_list_namespace_service,
     feature_list_service,
     production_ready_feature_list,
@@ -274,9 +325,8 @@ async def test_update_feature_list_error__state_is_reverted_after_feature_list_n
             raise ValueError("return_document throws error!!")
 
     with pytest.raises(ValueError) as exc:
-        _ = await deploy_service.update_feature_list(
+        _ = await deploy_service._update_feature_list(
             feature_list_id=feature_list.id,
-            deployed=True,
             return_document=ReturnDocument(),
             get_credential=AsyncMock(),
         )
@@ -293,14 +343,21 @@ async def test_update_feature_list_error__state_is_reverted_after_feature_list_n
     assert feature_list_namespace.deployed_feature_list_ids == []
 
     # test another exception raised during revert changes
+    # create a enabled deployment first so that feature_list.deployed != target_deployed
+    await app_container.deployment_service.create_document(
+        data=DeploymentModel(
+            name="test deployment",
+            feature_list_id=feature_list.id,
+            enabled=True,
+        )
+    )
     with pytest.raises(Exception) as exc:
         with patch.object(
             deploy_service, "_revert_changes", new_callable=AsyncMock
         ) as mock_update_feature:
             mock_update_feature.side_effect = Exception("Error during revert changes")
-            _ = await deploy_service.update_feature_list(
+            _ = await deploy_service._update_feature_list(
                 feature_list_id=feature_list.id,
-                deployed=True,
                 return_document=ReturnDocument(),
                 get_credential=AsyncMock(),
             )

--- a/tests/unit/service/test_deploy.py
+++ b/tests/unit/service/test_deploy.py
@@ -7,12 +7,7 @@ import pytest
 import pytest_asyncio
 from bson import ObjectId
 
-from featurebyte.exception import (
-    DocumentCreationError,
-    DocumentError,
-    DocumentNotFoundError,
-    DocumentUpdateError,
-)
+from featurebyte.exception import DocumentError, DocumentNotFoundError, DocumentUpdateError
 from featurebyte.models.deployment import DeploymentModel
 from featurebyte.models.feature_list import FeatureListModel
 


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

Current deployment enabling & disabling does not consider the case when multiple deployments sharing the same feature list. One issue is that feature list's `deployed` status is updated to `False` when any of the enabled deployments is disabled without considering there may be other enabled deployment(s).

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
