### PR TITLE
enhancement: Block feature readiness & feature list status transition from DRAFT to DEPRECATED

### DIFF
--- a/.changelog/DEV-1761.yaml
+++ b/.changelog/DEV-1761.yaml
@@ -1,0 +1,16 @@
+# Type of change
+change_type: enhancement
+
+# The name of the component
+component: feature
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.
+note: "block feature readiness & feature list status transition from DRAFT to DEPRECATED"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/featurebyte/service/feature_list_status.py
+++ b/featurebyte/service/feature_list_status.py
@@ -63,18 +63,28 @@ class FeatureListStatusService(BaseService):
             # if no change in status, do nothing
             return
 
+        if (
+            feature_list_namespace.status == FeatureListStatus.DRAFT
+            and target_feature_list_status == FeatureListStatus.DEPRECATED
+        ):
+            raise DocumentUpdateError(
+                "Not allowed to update status of feature list from DRAFT to DEPRECATED. "
+                "Valid status transition: DRAFT -> PUBLIC_DRAFT or DRAFT -> TEMPLATE. "
+                "Please use delete feature list instead if it is no longer needed."
+            )
+
         if target_feature_list_status == FeatureListStatus.DRAFT:
             # feature list is not allowed to be updated to draft status
             raise DocumentUpdateError(
                 f'Not allowed to update status of FeatureList (name: "{feature_list_namespace.name}") '
-                f"to draft status."
+                "to draft status."
             )
 
         if target_feature_list_status == FeatureListStatus.DEPLOYED:
             if not deployed_feature_list_ids:
                 raise DocumentUpdateError(
                     f'Not allowed to update status of FeatureList (name: "{feature_list_namespace.name}") '
-                    f"to deployed status without deployed feature list."
+                    "to deployed status without deployed feature list."
                 )
 
         if feature_list_namespace.status == FeatureListStatus.DEPLOYED:

--- a/featurebyte/service/feature_list_status.py
+++ b/featurebyte/service/feature_list_status.py
@@ -70,7 +70,7 @@ class FeatureListStatusService(BaseService):
             raise DocumentUpdateError(
                 "Not allowed to update status of feature list from DRAFT to DEPRECATED. "
                 "Valid status transition: DRAFT -> PUBLIC_DRAFT or DRAFT -> TEMPLATE. "
-                "Please use delete feature list instead if it is no longer needed."
+                "Please delete feature list instead if it is no longer needed."
             )
 
         if target_feature_list_status == FeatureListStatus.DRAFT:

--- a/featurebyte/service/feature_readiness.py
+++ b/featurebyte/service/feature_readiness.py
@@ -307,6 +307,16 @@ class FeatureReadinessService(BaseService):
         ):
             raise DocumentUpdateError("Cannot update feature readiness to DRAFT.")
 
+        if (
+            document.readiness == FeatureReadiness.DRAFT
+            and target_readiness == FeatureReadiness.DEPRECATED
+        ):
+            raise DocumentUpdateError(
+                "Cannot update feature readiness from DRAFT to DEPRECATED. "
+                "Valid transitions are DRAFT -> PUBLIC_DRAFT or DRAFT -> PRODUCTION_READY. "
+                "Please delete the feature instead if it is no longer needed."
+            )
+
     async def update_feature(
         self,
         feature_id: ObjectId,

--- a/featurebyte/service/feature_readiness.py
+++ b/featurebyte/service/feature_readiness.py
@@ -312,7 +312,7 @@ class FeatureReadinessService(BaseService):
             and target_readiness == FeatureReadiness.DEPRECATED
         ):
             raise DocumentUpdateError(
-                "Cannot update feature readiness from DRAFT to DEPRECATED. "
+                "Not allowed to update feature readiness from DRAFT to DEPRECATED. "
                 "Valid transitions are DRAFT -> PUBLIC_DRAFT or DRAFT -> PRODUCTION_READY. "
                 "Please delete the feature instead if it is no longer needed."
             )

--- a/tests/unit/api/test_feature.py
+++ b/tests/unit/api/test_feature.py
@@ -1101,7 +1101,7 @@ def test_feature_synchronization(saved_feature):
     assert cloned_feat.default_version_mode == target_mode
 
     # update original feature's readiness (stored at feature record)
-    target_readiness = FeatureReadiness.DEPRECATED
+    target_readiness = FeatureReadiness.PUBLIC_DRAFT
     assert saved_feature.readiness != target_readiness
     saved_feature.update_readiness(target_readiness)
     assert saved_feature.readiness == target_readiness

--- a/tests/unit/service/test_feature_list_status.py
+++ b/tests/unit/service/test_feature_list_status.py
@@ -62,6 +62,27 @@ async def test_feature_list_status__not_allow_update_to_deployed_without_deploye
     assert expected_msg in str(exc.value)
 
 
+@pytest.mark.asyncio
+async def test_feature_list_status__prohibit_deprecate_draft_feature_list(
+    feature_list_status_service, feature_list_namespace
+):
+    """Test deployed status validation check."""
+    assert feature_list_namespace.status == FeatureListStatus.DRAFT
+
+    with pytest.raises(DocumentUpdateError) as exc:
+        await feature_list_status_service.update_feature_list_namespace_status(
+            feature_list_namespace_id=feature_list_namespace.id,
+            target_feature_list_status=FeatureListStatus.DEPRECATED,
+        )
+
+    expected_msg = (
+        "Not allowed to update status of feature list from DRAFT to DEPRECATED. "
+        "Valid status transition: DRAFT -> PUBLIC_DRAFT or DRAFT -> TEMPLATE. "
+        "Please use delete feature list instead if it is no longer needed."
+    )
+    assert expected_msg in str(exc.value)
+
+
 async def check_transit_to_draft_is_not_allow(feature_list_status_service, feature_list_namespace):
     """Test that a feature list namespace cannot be updated to draft status."""
     with pytest.raises(DocumentUpdateError) as exc:

--- a/tests/unit/service/test_feature_list_status.py
+++ b/tests/unit/service/test_feature_list_status.py
@@ -78,7 +78,7 @@ async def test_feature_list_status__prohibit_deprecate_draft_feature_list(
     expected_msg = (
         "Not allowed to update status of feature list from DRAFT to DEPRECATED. "
         "Valid status transition: DRAFT -> PUBLIC_DRAFT or DRAFT -> TEMPLATE. "
-        "Please use delete feature list instead if it is no longer needed."
+        "Please delete feature list instead if it is no longer needed."
     )
     assert expected_msg in str(exc.value)
 

--- a/tests/unit/service/test_feature_readiness.py
+++ b/tests/unit/service/test_feature_readiness.py
@@ -315,7 +315,7 @@ async def test_feature_readiness__prohibit_deprecate_draft_feature(
         )
 
     expected_msg = (
-        "Cannot update feature readiness from DRAFT to DEPRECATED. "
+        "Not allowed to update feature readiness from DRAFT to DEPRECATED. "
         "Valid transitions are DRAFT -> PUBLIC_DRAFT or DRAFT -> PRODUCTION_READY. "
         "Please delete the feature instead if it is no longer needed."
     )

--- a/tests/unit/service/test_feature_readiness.py
+++ b/tests/unit/service/test_feature_readiness.py
@@ -303,6 +303,26 @@ async def test_feature_readiness__prohibit_transition_to_draft(feature, feature_
 
 
 @pytest.mark.asyncio
+async def test_feature_readiness__prohibit_deprecate_draft_feature(
+    feature, feature_readiness_service
+):
+    """Test that it is not possible to deprecate a feature with DRAFT readiness level"""
+    assert feature.readiness == "DRAFT"
+
+    with pytest.raises(DocumentUpdateError) as exc:
+        await feature_readiness_service.update_feature(
+            feature_id=feature.id, readiness="DEPRECATED"
+        )
+
+    expected_msg = (
+        "Cannot update feature readiness from DRAFT to DEPRECATED. "
+        "Valid transitions are DRAFT -> PUBLIC_DRAFT or DRAFT -> PRODUCTION_READY. "
+        "Please delete the feature instead if it is no longer needed."
+    )
+    assert expected_msg in str(exc.value)
+
+
+@pytest.mark.asyncio
 async def test_feature_readiness__update_feature_namespace_with_deletion__auto_mode(
     feature_readiness_service, feature_namespace_service, feature, setup_for_feature_readiness
 ):


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR aims to block DRAFT to DEPRECATED transition to prevent misuse of DEPRECATED (delete should be used in this case).

State diagram after this update:
<img width="300" alt="Screenshot 2023-05-31 at 4 52 07 PM" src="https://github.com/featurebyte/featurebyte/assets/37915749/c8f45ce7-6ad7-4876-b4a8-4fe57319b9c6">
<img width="300" alt="Screenshot 2023-05-31 at 4 52 29 PM" src="https://github.com/featurebyte/featurebyte/assets/37915749/65f1fe8e-5f86-48dd-81b9-97e1fb0f5f59">


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
