### PR TITLE
[DEV-1773] Playground startup + docker startup to allow user to specify KRB5 params

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -27,8 +27,7 @@ setup_permissions() {
     fi
     if [ "$HOST_UID" = '1000' ]; then
       echo "Using default user id 1000, skipping user modification."
-    else
-      usermod -u "${HOST_UID}" -o "${NON_PRIVUSER}"
+    else usermod -u "${HOST_UID}" -o "${NON_PRIVUSER}"
     fi
     chown -R "${HOST_UID}:${HOST_GID}" /app
   fi
@@ -65,7 +64,7 @@ EOF
 
 _main() {
   setup_permissions
-#  setup_kdc
+  setup_kdc
   if [ "$(id -u)" = '0' ]; then
     # Running as root, downgrading to normal user
     exec gosu "${NON_PRIVUSER}:${NON_PRIVGROUP}" "$BASH_SOURCE" "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -35,30 +35,30 @@ setup_permissions() {
 
 setup_kdc() {
   echo "Setting up KDC"
+  export KRB5_CONFIG=/app/krb5.conf
+
   if [ -f "${KRB5_CONFIG}" ]; then
     echo "KRB5_CONFIG already exists, skipping KDC setup"
     return
   fi
 
-  export KRB5_CONFIG=/app/krb5.conf
+  # skip if KRB5_REALM or KRB5_KDC is not set
   if [ -z "${KRB5_REALM}" ]; then
-    echo "KRB5_REALM is set, setting up KDC"
+    echo "KRB5_REALM not set, skipping KDC setup"
 
-    if [ -z "${KRB5_KDC}" ]; then
-      KRB5_KDC="kdc = ${KRB5_KDC}"
-    fi
-
+  elif [ -z "${KRB5_KDC}" ]; then
+    echo "KRB5_KDC not set, skipping KDC setup"
+  else
+    echo "Setting up KDC"
     cat <<EOF > ${KRB5_CONFIG}
 [libdefaults]
     default_realm = ${KRB5_REALM}
 
 [realms]
     ${KRB5_REALM} = {
-        ${KRB5_KDC}
+        kdc = ${KRB5_KDC}
     }
 EOF
-  else
-    echo "KRB5_REALM not set, skipping KDC setup"
   fi
 }
 

--- a/featurebyte/__init__.py
+++ b/featurebyte/__init__.py
@@ -303,6 +303,8 @@ def stop(clean: bool = False) -> None:
 
 def playground(
     datasets: Optional[List[str]] = None,
+    krb5_realm: Optional[str] = None,
+    krb5_kdc: Optional[str] = None,
     force_import: bool = False,
 ) -> None:
     """
@@ -312,11 +314,17 @@ def playground(
     ----------
     datasets : Optional[List[str]]
         List of datasets to import, by default None (import all datasets)
+    krb5_realm : Optional[str]
+        Kerberos realm, by default None
+    krb5_kdc : Optional[str]
+        Kerberos kdc of the krb5_realm, by default None
     force_import: bool
         Import datasets even if they are already imported, by default False
     """
     _start_playground(
         datasets=datasets,
+        krb5_realm=krb5_realm,
+        krb5_kdc=krb5_kdc,
         force_import=force_import,
         verbose=False,
     )

--- a/featurebyte/__main__.py
+++ b/featurebyte/__main__.py
@@ -29,17 +29,29 @@ def start(
     app_name: ApplicationName = typer.Argument(
         default="featurebyte", help="Name of application to start"
     ),
+    krb5_realm: str = typer.Option(default=None, help="Kerberos realm, eg: ATHENA.MIT.EDU"),
+    krb5_kdc: str = typer.Option(
+        default=None, help="Kerberos KDC hostname, eg: kerberos.mit.edu:88"
+    ),
 ) -> None:
     """Start application"""
-    start_app(app_name)
+    start_app(app_name, krb5_realm=krb5_realm, krb5_kdc=krb5_kdc)
 
 
 @app.command(name="playground")
 def playground(
     force_import: bool = typer.Option(default=False, help="Import datasets even if they exist"),
+    krb5_realm: str = typer.Option(default=None, help="Kerberos realm, eg: ATHENA.MIT.EDU"),
+    krb5_kdc: str = typer.Option(
+        default=None, help="Kerberos KDC hostname, eg: kerberos.mit.edu:88"
+    ),
 ) -> None:
     """Start playground environment"""
-    start_playground(force_import=force_import)
+    start_playground(
+        force_import=force_import,
+        krb5_realm=krb5_realm,
+        krb5_kdc=krb5_kdc,
+    )
 
 
 @app.callback(invoke_without_command=True)

--- a/featurebyte/docker/featurebyte.yml
+++ b/featurebyte/docker/featurebyte.yml
@@ -56,6 +56,8 @@ services:
       - "LOG_LEVEL=${LOG_LEVEL}"
       - "LOCAL_UID=${LOCAL_UID}"
       - "LOCAL_GID=${LOCAL_GID}"
+      - "KRB5_REALM=${KRB5_REALM}"
+      - "KRB5_KDC=${KRB5_KDC}"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8088/status"]
       interval: 5s
@@ -87,6 +89,8 @@ services:
       - "LOG_LEVEL=${LOG_LEVEL}"
       - "LOCAL_UID=${LOCAL_UID}"
       - "LOCAL_GID=${LOCAL_GID}"
+      - "KRB5_REALM=${KRB5_REALM}"
+      - "KRB5_KDC=${KRB5_KDC}"
     command: ["bash", "/docker-entrypoint.sh", "worker"]
     volumes:
       - files-data:/app/.featurebyte/data/files


### PR DESCRIPTION
## Description

**Starting the server with playground**
![image](https://github.com/featurebyte/featurebyte/assets/28699647/f67661d3-7fdd-42fd-9975-540b8306c100)

**KRB config written out to /app/krb5.conf**
![image](https://github.com/featurebyte/featurebyte/assets/28699647/d2f6227a-de79-498d-9b1e-f204db2352be)

**Environment Variable Set in running process**
![image](https://github.com/featurebyte/featurebyte/assets/28699647/5d2bebdd-6979-467a-832c-8510f30a5faf)


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
