### PR TITLE
[DEV-1774] Fix websocket client failing with secure connections

### DIFF
--- a/.changelog/DEV-1774.yaml
+++ b/.changelog/DEV-1774.yaml
@@ -1,0 +1,16 @@
+# Type of change
+change_type: bug_fix
+
+# The name of the component
+component: websocket
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.
+note: "fix client failure when starting secure websocket connection"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/featurebyte/config.py
+++ b/featurebyte/config.py
@@ -453,7 +453,7 @@ class Configurations:
             Invalid settings
         """
         if self.profile:
-            url = self.profile.api_url.replace("http://", "ws://")
+            url = self.profile.api_url.replace("http://", "ws://").replace("https://", "wss://")
             url = f"{url}/ws/{task_id}"
             websocket_client = WebsocketClient(url=url, access_token=self.profile.api_token)
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,12 @@ def pytest_addoption(parser):
     parser.addoption("--source-types", type=str, default=None)
 
 
+def pytest_configure(config):
+    """Configure pytest"""
+    # register an additional marker
+    config.addinivalue_line("markers", "no_mock_websocket_client: skip mocking websocket client")
+
+
 @pytest.fixture(scope="session")
 def update_fixtures(pytestconfig):
     """Fixture corresponding to pytest --update-fixtures option"""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -88,17 +88,20 @@ def mock_api_client_fixture():
 
 
 @pytest.fixture(autouse=True)
-def mock_websocket_client_fixture():
+def mock_websocket_client_fixture(request):
     """
     Mock Configurations.get_websocket_client to use test client
     """
-    with mock.patch(
-        "featurebyte.config.Configurations.get_websocket_client"
-    ) as mock_get_websocket_client:
-        mock_get_websocket_client.return_value.__enter__.return_value.receive_json.return_value = (
-            None
-        )
-        yield mock_get_websocket_client
+    if "no_mock_websocket_client" in request.keywords:
+        yield
+    else:
+        with mock.patch(
+            "featurebyte.config.Configurations.get_websocket_client"
+        ) as mock_get_websocket_client:
+            mock_get_websocket_client.return_value.__enter__.return_value.receive_json.return_value = (
+                None
+            )
+            yield mock_get_websocket_client
 
 
 @pytest.fixture(name="storage")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5,9 +5,11 @@ import os
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
 import requests.exceptions
+from websocket import WebSocketAddressException
 
 from featurebyte.config import (
     DEFAULT_HOME_PATH,
@@ -16,6 +18,7 @@ from featurebyte.config import (
     LocalStorageSettings,
     LoggingSettings,
     Profile,
+    WebsocketClient,
 )
 from featurebyte.exception import InvalidSettingsError
 from featurebyte.logging import get_logger
@@ -201,3 +204,17 @@ def test_client_redirection(mock_check_sdk_versions, mock_get_home_path):
             "Connection": "keep-alive",
             "Authorization": "Bearer API_TOKEN_VALUE1",
         }
+
+
+@pytest.mark.no_mock_websocket_client
+def test_websocket_ssl():
+    """
+    Test websocket with ssl
+    """
+    config = Configurations("tests/fixtures/config/config.yaml")
+
+    # getting a websocket client with ssl url should not fail
+    config.profile.api_url = "https://some_endpoint"
+    with pytest.raises(WebSocketAddressException):
+        with config.get_websocket_client(str(uuid4())) as ws_client:
+            assert isinstance(ws_client, WebsocketClient)


### PR DESCRIPTION
## Description

Getting websocket client from the configuration does not work properly with secured connections.

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-1774

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
