### PR TITLE
[DEV-1769] Reduce unnecessary tile computation when previewing features

### DIFF
--- a/featurebyte/query_graph/sql/feature_compute.py
+++ b/featurebyte/query_graph/sql/feature_compute.py
@@ -295,7 +295,7 @@ class FeatureExecutionPlan:
         self,
         request_table_name: str,
         point_in_time_column: str,
-        request_table_columns: list[str],
+        request_table_columns: Optional[list[str]],
         prior_cte_statements: Optional[CteStatements] = None,
         exclude_post_aggregation: bool = False,
         exclude_columns: Optional[set[str]] = None,
@@ -308,7 +308,7 @@ class FeatureExecutionPlan:
             Name of request table to use
         point_in_time_column : str
             Point in time column
-        request_table_columns : list[str]
+        request_table_columns : Optional[list[str]]
             Request table columns
         prior_cte_statements : Optional[list[tuple[str, str]]]
             Other CTE statements to incorporate to the final SQL (namely the request data SQL and
@@ -332,6 +332,7 @@ class FeatureExecutionPlan:
             exclude_columns = set()
 
         if self.parent_serving_preparation is not None:
+            assert request_table_columns is not None
             (
                 updated_request_table_expr,
                 new_columns,

--- a/featurebyte/query_graph/sql/feature_preview.py
+++ b/featurebyte/query_graph/sql/feature_preview.py
@@ -93,11 +93,7 @@ def get_feature_preview_sql(
 
         # build required tiles
         tic = time.time()
-        point_in_time_list = [
-            entry[SpecialColumnName.POINT_IN_TIME] for entry in point_in_time_and_serving_name_list
-        ]
         tile_compute_plan = OnDemandTileComputePlan(
-            point_in_time_list,
             request_table_name=request_table_name,
             source_type=source_type,
         )

--- a/featurebyte/query_graph/sql/tile_compute.py
+++ b/featurebyte/query_graph/sql/tile_compute.py
@@ -55,6 +55,13 @@ class OnDemandTileComputePlan:
 
     @property
     def adapter(self) -> BaseAdapter:
+        """
+        Returns an instance of BaseAdapter based on the source type
+
+        Returns
+        -------
+        BaseAdapter
+        """
         return get_sql_adapter(self.source_type)
 
     def process_node(self, graph: QueryGraphModel, node: Node) -> None:
@@ -256,6 +263,27 @@ def get_tile_sql(
     request_table_name: str,
     window: Optional[int],
 ) -> Select:
+    """
+    Construct the SQL query that would compute the tiles for a given TileGenSql.
+
+    TileGenSql already contains the template for the tile SQL. This function fills in the entity
+    table placeholder so that the SQL is complete.
+
+    Parameters
+    ----------
+    adapter : BaseAdapter
+        Instance of BaseAdapter for generating engine specific SQL
+    tile_info : TileGenSql
+        Tile table information
+    request_table_name : str
+        Name of the request table
+    window : Optional[int]
+        Window size in seconds. None for features with an unbounded window.
+
+    Returns
+    -------
+    Select
+    """
     point_in_time_epoch_expr = adapter.to_epoch_seconds(
         expressions.Max(this=expressions.Identifier(this=SpecialColumnName.POINT_IN_TIME.value))
     )

--- a/featurebyte/query_graph/sql/tile_util.py
+++ b/featurebyte/query_graph/sql/tile_util.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import Any, Optional, Tuple, cast
 
 from sqlglot import expressions, parse_one
-from sqlglot.expressions import Expression, Select
+from sqlglot.expressions import Expression
 
 from featurebyte.enum import InternalName
 from featurebyte.query_graph.sql.adapter import BaseAdapter
@@ -14,7 +14,6 @@ from featurebyte.query_graph.sql.ast.datetime import TimedeltaExtractNode
 from featurebyte.query_graph.sql.ast.literal import make_literal_value
 from featurebyte.query_graph.sql.common import quoted_identifier
 from featurebyte.query_graph.sql.interpreter import TileGenSql
-from featurebyte.query_graph.sql.template import SqlExpressionTemplate
 
 
 def calculate_first_and_last_tile_indices(

--- a/featurebyte/query_graph/sql/tile_util.py
+++ b/featurebyte/query_graph/sql/tile_util.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 
 from typing import Any, Optional, Tuple, cast
 
-from sqlglot import parse_one
+from sqlglot import expressions, parse_one
 from sqlglot.expressions import Expression
 
 from featurebyte.query_graph.sql.adapter import BaseAdapter
+from featurebyte.query_graph.sql.ast.literal import make_literal_value
+from featurebyte.query_graph.sql.interpreter import TileGenSql
 
 
 def calculate_first_and_last_tile_indices(
@@ -128,3 +130,43 @@ def update_maximum_window_size_dict(
             max_window_size_dict[key] = None
         else:
             max_window_size_dict[key] = max(existing_window_size, window_size)
+
+
+def get_previous_job_epoch_expr(
+    point_in_time_epoch_expr: Expression, tile_info: TileGenSql
+) -> Expression:
+    """Get the SQL expression for the epoch second of previous feature job
+
+    Parameters
+    ----------
+    point_in_time_epoch_expr : Expression
+        Expression for point-in-time in epoch second
+    tile_info : TileGenSql
+        Tile table information
+
+    Returns
+    -------
+    str
+    """
+    frequency = make_literal_value(tile_info.frequency)
+    time_modulo_frequency = make_literal_value(tile_info.time_modulo_frequency)
+
+    # FLOOR((POINT_IN_TIME - TIME_MODULO_FREQUENCY) / FREQUENCY)
+    previous_job_index_expr = expressions.Floor(
+        this=expressions.Div(
+            this=expressions.Paren(
+                this=expressions.Sub(
+                    this=point_in_time_epoch_expr, expression=time_modulo_frequency
+                )
+            ),
+            expression=frequency,
+        )
+    )
+
+    # PREVIOUS_JOB_INDEX * FREQUENCY + TIME_MODULO_FREQUENCY
+    previous_job_epoch_expr = expressions.Add(
+        this=expressions.Mul(this=previous_job_index_expr, expression=frequency),
+        expression=time_modulo_frequency,
+    )
+
+    return previous_job_epoch_expr

--- a/tests/fixtures/expected_preview_sql.sql
+++ b/tests/fixtures/expected_preview_sql.sql
@@ -1,4 +1,8 @@
-WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
+WITH REQUEST_TABLE AS (
+  SELECT
+    CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
+    'C1' AS "CUSTOMER_ID"
+), TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
   SELECT
     avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb.INDEX,
     avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb."cust_id",
@@ -15,9 +19,35 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
         *,
         F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "ts"), 1800, 900, 60) AS index
       FROM (
+        WITH __FB_ENTITY_TABLE_NAME AS (
+          (
+            SELECT
+              "CUSTOMER_ID" AS "cust_id",
+              TO_TIMESTAMP(
+                FLOOR((
+                  DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                ) / 3600) * 3600 + 1800 - 900
+              ) AS "__FB_ENTITY_TABLE_END_DATE",
+              DATEADD(
+                microsecond,
+                (
+                  48 * 3600 * CAST(1000000 AS BIGINT) / CAST(1 AS BIGINT)
+                ) * -1,
+                TO_TIMESTAMP(
+                  FLOOR((
+                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                  ) / 3600) * 3600 + 1800 - 900
+                )
+              ) AS "__FB_ENTITY_TABLE_START_DATE"
+            FROM "REQUEST_TABLE"
+            GROUP BY
+              "CUSTOMER_ID"
+          )
+        )
         SELECT
-          *
-        FROM (
+          R.*
+        FROM __FB_ENTITY_TABLE_NAME
+        INNER JOIN (
           SELECT
             "ts" AS "ts",
             "cust_id" AS "cust_id",
@@ -27,20 +57,16 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
               "a" + "b"
             ) AS "c"
           FROM "db"."public"."event_table"
-        )
-        WHERE
-          "ts" >= CAST('2022-04-18 09:15:00' AS TIMESTAMPNTZ)
-          AND "ts" < CAST('2022-04-20 09:15:00' AS TIMESTAMPNTZ)
+        ) AS R
+          ON R."cust_id" = __FB_ENTITY_TABLE_NAME."cust_id"
+          AND R."ts" >= __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_START_DATE
+          AND R."ts" < __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_END_DATE
       )
     )
     GROUP BY
       index,
       "cust_id"
   ) AS avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb
-), REQUEST_TABLE AS (
-  SELECT
-    CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
-    'C1' AS "CUSTOMER_ID"
 ), "REQUEST_TABLE_W7200_F3600_BS900_M1800_CUSTOMER_ID" AS (
   SELECT
     "POINT_IN_TIME",

--- a/tests/fixtures/expected_preview_sql.sql
+++ b/tests/fixtures/expected_preview_sql.sql
@@ -35,7 +35,7 @@ WITH REQUEST_TABLE AS (
                 ) * -1,
                 TO_TIMESTAMP(
                   FLOOR((
-                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                    DATE_PART(EPOCH_SECOND, MIN(POINT_IN_TIME)) - 1800
                   ) / 3600) * 3600 + 1800 - 900
                 )
               ) AS "__FB_ENTITY_TABLE_START_DATE"

--- a/tests/fixtures/expected_preview_sql_all_types.sql
+++ b/tests/fixtures/expected_preview_sql_all_types.sql
@@ -1,4 +1,8 @@
-WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
+WITH REQUEST_TABLE AS (
+  SELECT
+    CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
+    'C1' AS "CUSTOMER_ID"
+), TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
   SELECT
     avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb.INDEX,
     avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb."cust_id",
@@ -16,9 +20,35 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
         *,
         F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "ts"), 1800, 900, 60) AS index
       FROM (
+        WITH __FB_ENTITY_TABLE_NAME AS (
+          (
+            SELECT
+              "CUSTOMER_ID" AS "cust_id",
+              TO_TIMESTAMP(
+                FLOOR((
+                  DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                ) / 3600) * 3600 + 1800 - 900
+              ) AS "__FB_ENTITY_TABLE_END_DATE",
+              DATEADD(
+                microsecond,
+                (
+                  2160 * 3600 * CAST(1000000 AS BIGINT) / CAST(1 AS BIGINT)
+                ) * -1,
+                TO_TIMESTAMP(
+                  FLOOR((
+                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                  ) / 3600) * 3600 + 1800 - 900
+                )
+              ) AS "__FB_ENTITY_TABLE_START_DATE"
+            FROM "REQUEST_TABLE"
+            GROUP BY
+              "CUSTOMER_ID"
+          )
+        )
         SELECT
-          *
-        FROM (
+          R.*
+        FROM __FB_ENTITY_TABLE_NAME
+        INNER JOIN (
           SELECT
             "ts" AS "ts",
             "cust_id" AS "cust_id",
@@ -28,10 +58,10 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
               "a" + "b"
             ) AS "c"
           FROM "db"."public"."event_table"
-        )
-        WHERE
-          "ts" >= CAST('2022-01-20 09:15:00' AS TIMESTAMPNTZ)
-          AND "ts" < CAST('2022-04-20 09:15:00' AS TIMESTAMPNTZ)
+        ) AS R
+          ON R."cust_id" = __FB_ENTITY_TABLE_NAME."cust_id"
+          AND R."ts" >= __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_START_DATE
+          AND R."ts" < __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_END_DATE
       )
     )
     GROUP BY
@@ -54,19 +84,45 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
           *,
           F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "ts"), 1800, 900, 60) AS index
         FROM (
+          WITH __FB_ENTITY_TABLE_NAME AS (
+            (
+              SELECT
+                "CUSTOMER_ID" AS "cust_id",
+                TO_TIMESTAMP(
+                  FLOOR((
+                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                  ) / 3600) * 3600 + 1800 - 900
+                ) AS "__FB_ENTITY_TABLE_END_DATE",
+                DATEADD(
+                  microsecond,
+                  (
+                    2160 * 3600 * CAST(1000000 AS BIGINT) / CAST(1 AS BIGINT)
+                  ) * -1,
+                  TO_TIMESTAMP(
+                    FLOOR((
+                      DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                    ) / 3600) * 3600 + 1800 - 900
+                  )
+                ) AS "__FB_ENTITY_TABLE_START_DATE"
+              FROM "REQUEST_TABLE"
+              GROUP BY
+                "CUSTOMER_ID"
+            )
+          )
           SELECT
-            *
-          FROM (
+            R.*
+          FROM __FB_ENTITY_TABLE_NAME
+          INNER JOIN (
             SELECT
               "ts" AS "ts",
               "cust_id" AS "cust_id",
               "a" AS "a",
               "b" AS "b"
             FROM "db"."public"."event_table"
-          )
-          WHERE
-            "ts" >= CAST('2022-01-20 09:15:00' AS TIMESTAMPNTZ)
-            AND "ts" < CAST('2022-04-20 09:15:00' AS TIMESTAMPNTZ)
+          ) AS R
+            ON R."cust_id" = __FB_ENTITY_TABLE_NAME."cust_id"
+            AND R."ts" >= __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_START_DATE
+            AND R."ts" < __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_END_DATE
         )
       )
     )
@@ -99,29 +155,52 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
           *,
           F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "ts"), 1800, 900, 60) AS index
         FROM (
+          WITH __FB_ENTITY_TABLE_NAME AS (
+            (
+              SELECT
+                "CUSTOMER_ID" AS "cust_id",
+                "BUSINESS_ID" AS "biz_id",
+                TO_TIMESTAMP(
+                  FLOOR((
+                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                  ) / 3600) * 3600 + 1800 - 900
+                ) AS "__FB_ENTITY_TABLE_END_DATE",
+                DATEADD(
+                  microsecond,
+                  (
+                    (
+                      1800 - 900
+                    ) * CAST(1000000 AS BIGINT) / CAST(1 AS BIGINT)
+                  ),
+                  CAST('1970-01-01' AS TIMESTAMPNTZ)
+                ) AS "__FB_ENTITY_TABLE_START_DATE"
+              FROM "REQUEST_TABLE"
+              GROUP BY
+                "CUSTOMER_ID",
+                "BUSINESS_ID"
+            )
+          )
           SELECT
-            *
-          FROM (
+            R.*
+          FROM __FB_ENTITY_TABLE_NAME
+          INNER JOIN (
             SELECT
               "ts" AS "ts",
               "cust_id" AS "cust_id",
               "a" AS "a",
               "b" AS "b"
             FROM "db"."public"."event_table"
-          )
-          WHERE
-            "ts" >= CAST('1970-01-01 00:15:00' AS TIMESTAMPNTZ)
-            AND "ts" < CAST('2022-04-20 09:15:00' AS TIMESTAMPNTZ)
+          ) AS R
+            ON R."cust_id" = __FB_ENTITY_TABLE_NAME."cust_id"
+            AND R."biz_id" = __FB_ENTITY_TABLE_NAME."biz_id"
+            AND R."ts" >= __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_START_DATE
+            AND R."ts" < __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_END_DATE
         )
       )
     )
     WHERE
       "__FB_ROW_NUMBER" = 1
   ) AS latest_3b3c2a8389d7720826731fefb7060b6578050e04
-), REQUEST_TABLE AS (
-  SELECT
-    CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
-    'C1' AS "CUSTOMER_ID"
 ), "REQUEST_TABLE_W7200_F3600_BS900_M1800_CUSTOMER_ID" AS (
   SELECT
     "POINT_IN_TIME",

--- a/tests/fixtures/expected_preview_sql_all_types.sql
+++ b/tests/fixtures/expected_preview_sql_all_types.sql
@@ -36,7 +36,7 @@ WITH REQUEST_TABLE AS (
                 ) * -1,
                 TO_TIMESTAMP(
                   FLOOR((
-                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                    DATE_PART(EPOCH_SECOND, MIN(POINT_IN_TIME)) - 1800
                   ) / 3600) * 3600 + 1800 - 900
                 )
               ) AS "__FB_ENTITY_TABLE_START_DATE"
@@ -100,7 +100,7 @@ WITH REQUEST_TABLE AS (
                   ) * -1,
                   TO_TIMESTAMP(
                     FLOOR((
-                      DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                      DATE_PART(EPOCH_SECOND, MIN(POINT_IN_TIME)) - 1800
                     ) / 3600) * 3600 + 1800 - 900
                   )
                 ) AS "__FB_ENTITY_TABLE_START_DATE"

--- a/tests/fixtures/expected_preview_sql_category.sql
+++ b/tests/fixtures/expected_preview_sql_category.sql
@@ -1,4 +1,8 @@
-WITH TILE_F3600_M1800_B900_FEB86FDFF3B041DC98880F9B22EE9078FBCF5226 AS (
+WITH REQUEST_TABLE AS (
+  SELECT
+    CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
+    'C1' AS "CUSTOMER_ID"
+), TILE_F3600_M1800_B900_FEB86FDFF3B041DC98880F9B22EE9078FBCF5226 AS (
   SELECT
     avg_828be81883198b473c3a5ac214dd4112d7559427.INDEX,
     avg_828be81883198b473c3a5ac214dd4112d7559427."cust_id",
@@ -17,9 +21,35 @@ WITH TILE_F3600_M1800_B900_FEB86FDFF3B041DC98880F9B22EE9078FBCF5226 AS (
         *,
         F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "ts"), 1800, 900, 60) AS index
       FROM (
+        WITH __FB_ENTITY_TABLE_NAME AS (
+          (
+            SELECT
+              "CUSTOMER_ID" AS "cust_id",
+              TO_TIMESTAMP(
+                FLOOR((
+                  DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                ) / 3600) * 3600 + 1800 - 900
+              ) AS "__FB_ENTITY_TABLE_END_DATE",
+              DATEADD(
+                microsecond,
+                (
+                  48 * 3600 * CAST(1000000 AS BIGINT) / CAST(1 AS BIGINT)
+                ) * -1,
+                TO_TIMESTAMP(
+                  FLOOR((
+                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                  ) / 3600) * 3600 + 1800 - 900
+                )
+              ) AS "__FB_ENTITY_TABLE_START_DATE"
+            FROM "REQUEST_TABLE"
+            GROUP BY
+              "CUSTOMER_ID"
+          )
+        )
         SELECT
-          *
-        FROM (
+          R.*
+        FROM __FB_ENTITY_TABLE_NAME
+        INNER JOIN (
           SELECT
             "ts" AS "ts",
             "cust_id" AS "cust_id",
@@ -29,10 +59,10 @@ WITH TILE_F3600_M1800_B900_FEB86FDFF3B041DC98880F9B22EE9078FBCF5226 AS (
               "a" + "b"
             ) AS "c"
           FROM "db"."public"."event_table"
-        )
-        WHERE
-          "ts" >= CAST('2022-04-18 09:15:00' AS TIMESTAMPNTZ)
-          AND "ts" < CAST('2022-04-20 09:15:00' AS TIMESTAMPNTZ)
+        ) AS R
+          ON R."cust_id" = __FB_ENTITY_TABLE_NAME."cust_id"
+          AND R."ts" >= __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_START_DATE
+          AND R."ts" < __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_END_DATE
       )
     )
     GROUP BY
@@ -40,10 +70,6 @@ WITH TILE_F3600_M1800_B900_FEB86FDFF3B041DC98880F9B22EE9078FBCF5226 AS (
       "cust_id",
       "product_type"
   ) AS avg_828be81883198b473c3a5ac214dd4112d7559427
-), REQUEST_TABLE AS (
-  SELECT
-    CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
-    'C1' AS "CUSTOMER_ID"
 ), "REQUEST_TABLE_W7200_F3600_BS900_M1800_CUSTOMER_ID" AS (
   SELECT
     "POINT_IN_TIME",

--- a/tests/fixtures/expected_preview_sql_category.sql
+++ b/tests/fixtures/expected_preview_sql_category.sql
@@ -37,7 +37,7 @@ WITH REQUEST_TABLE AS (
                 ) * -1,
                 TO_TIMESTAMP(
                   FLOOR((
-                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                    DATE_PART(EPOCH_SECOND, MIN(POINT_IN_TIME)) - 1800
                   ) / 3600) * 3600 + 1800 - 900
                 )
               ) AS "__FB_ENTITY_TABLE_START_DATE"

--- a/tests/fixtures/expected_preview_sql_complex_feature.sql
+++ b/tests/fixtures/expected_preview_sql_complex_feature.sql
@@ -33,7 +33,7 @@ WITH REQUEST_TABLE AS (
                 ) * -1,
                 TO_TIMESTAMP(
                   FLOOR((
-                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                    DATE_PART(EPOCH_SECOND, MIN(POINT_IN_TIME)) - 1800
                   ) / 3600) * 3600 + 1800 - 900
                 )
               ) AS "__FB_ENTITY_TABLE_START_DATE"
@@ -98,7 +98,7 @@ WITH REQUEST_TABLE AS (
                 ) * -1,
                 TO_TIMESTAMP(
                   FLOOR((
-                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                    DATE_PART(EPOCH_SECOND, MIN(POINT_IN_TIME)) - 1800
                   ) / 3600) * 3600 + 1800 - 900
                 )
               ) AS "__FB_ENTITY_TABLE_START_DATE"

--- a/tests/fixtures/expected_preview_sql_complex_feature.sql
+++ b/tests/fixtures/expected_preview_sql_complex_feature.sql
@@ -1,4 +1,8 @@
-WITH TILE_F3600_M1800_B900_7BD30FF1B8E84ADD2B289714C473F1A21E9BC624 AS (
+WITH REQUEST_TABLE AS (
+  SELECT
+    CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
+    'C1' AS "CUSTOMER_ID"
+), TILE_F3600_M1800_B900_7BD30FF1B8E84ADD2B289714C473F1A21E9BC624 AS (
   SELECT
     sum_ea3e51f28222785a9bc856e4f09a8ce4642bc6c8.INDEX,
     sum_ea3e51f28222785a9bc856e4f09a8ce4642bc6c8."biz_id",
@@ -13,9 +17,35 @@ WITH TILE_F3600_M1800_B900_7BD30FF1B8E84ADD2B289714C473F1A21E9BC624 AS (
         *,
         F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "ts"), 1800, 900, 60) AS index
       FROM (
+        WITH __FB_ENTITY_TABLE_NAME AS (
+          (
+            SELECT
+              "BUSINESS_ID" AS "biz_id",
+              TO_TIMESTAMP(
+                FLOOR((
+                  DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                ) / 3600) * 3600 + 1800 - 900
+              ) AS "__FB_ENTITY_TABLE_END_DATE",
+              DATEADD(
+                microsecond,
+                (
+                  168 * 3600 * CAST(1000000 AS BIGINT) / CAST(1 AS BIGINT)
+                ) * -1,
+                TO_TIMESTAMP(
+                  FLOOR((
+                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                  ) / 3600) * 3600 + 1800 - 900
+                )
+              ) AS "__FB_ENTITY_TABLE_START_DATE"
+            FROM "REQUEST_TABLE"
+            GROUP BY
+              "BUSINESS_ID"
+          )
+        )
         SELECT
-          *
-        FROM (
+          R.*
+        FROM __FB_ENTITY_TABLE_NAME
+        INNER JOIN (
           SELECT
             "ts" AS "ts",
             "cust_id" AS "cust_id",
@@ -25,10 +55,10 @@ WITH TILE_F3600_M1800_B900_7BD30FF1B8E84ADD2B289714C473F1A21E9BC624 AS (
               "a" + "b"
             ) AS "c"
           FROM "db"."public"."event_table"
-        )
-        WHERE
-          "ts" >= CAST('2022-04-13 09:15:00' AS TIMESTAMPNTZ)
-          AND "ts" < CAST('2022-04-20 09:15:00' AS TIMESTAMPNTZ)
+        ) AS R
+          ON R."biz_id" = __FB_ENTITY_TABLE_NAME."biz_id"
+          AND R."ts" >= __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_START_DATE
+          AND R."ts" < __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_END_DATE
       )
     )
     GROUP BY
@@ -52,9 +82,35 @@ WITH TILE_F3600_M1800_B900_7BD30FF1B8E84ADD2B289714C473F1A21E9BC624 AS (
         *,
         F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "ts"), 1800, 900, 60) AS index
       FROM (
+        WITH __FB_ENTITY_TABLE_NAME AS (
+          (
+            SELECT
+              "CUSTOMER_ID" AS "cust_id",
+              TO_TIMESTAMP(
+                FLOOR((
+                  DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                ) / 3600) * 3600 + 1800 - 900
+              ) AS "__FB_ENTITY_TABLE_END_DATE",
+              DATEADD(
+                microsecond,
+                (
+                  48 * 3600 * CAST(1000000 AS BIGINT) / CAST(1 AS BIGINT)
+                ) * -1,
+                TO_TIMESTAMP(
+                  FLOOR((
+                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                  ) / 3600) * 3600 + 1800 - 900
+                )
+              ) AS "__FB_ENTITY_TABLE_START_DATE"
+            FROM "REQUEST_TABLE"
+            GROUP BY
+              "CUSTOMER_ID"
+          )
+        )
         SELECT
-          *
-        FROM (
+          R.*
+        FROM __FB_ENTITY_TABLE_NAME
+        INNER JOIN (
           SELECT
             "ts" AS "ts",
             "cust_id" AS "cust_id",
@@ -64,20 +120,16 @@ WITH TILE_F3600_M1800_B900_7BD30FF1B8E84ADD2B289714C473F1A21E9BC624 AS (
               "a" + "b"
             ) AS "c"
           FROM "db"."public"."event_table"
-        )
-        WHERE
-          "ts" >= CAST('2022-04-18 09:15:00' AS TIMESTAMPNTZ)
-          AND "ts" < CAST('2022-04-20 09:15:00' AS TIMESTAMPNTZ)
+        ) AS R
+          ON R."cust_id" = __FB_ENTITY_TABLE_NAME."cust_id"
+          AND R."ts" >= __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_START_DATE
+          AND R."ts" < __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_END_DATE
       )
     )
     GROUP BY
       index,
       "cust_id"
   ) AS avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb
-), REQUEST_TABLE AS (
-  SELECT
-    CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
-    'C1' AS "CUSTOMER_ID"
 ), "REQUEST_TABLE_W7200_F3600_BS900_M1800_CUSTOMER_ID" AS (
   SELECT
     "POINT_IN_TIME",

--- a/tests/fixtures/expected_preview_sql_databricks.sql
+++ b/tests/fixtures/expected_preview_sql_databricks.sql
@@ -40,7 +40,7 @@ WITH REQUEST_TABLE AS (
                   ) * -1 / 60000000.0,
                   TO_TIMESTAMP(
                     FLOOR((
-                      UNIX_TIMESTAMP(MAX(POINT_IN_TIME)) - 1800
+                      UNIX_TIMESTAMP(MIN(POINT_IN_TIME)) - 1800
                     ) / 3600) * 3600 + 1800 - 900
                   )
                 )

--- a/tests/fixtures/expected_preview_sql_double_aggregation.sql
+++ b/tests/fixtures/expected_preview_sql_double_aggregation.sql
@@ -1,4 +1,8 @@
-WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
+WITH REQUEST_TABLE AS (
+  SELECT
+    CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
+    'C1' AS "CUSTOMER_ID"
+), TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
   SELECT
     avg_9f23dee9ad91063f4d7ac913cdb563037b0099ff.INDEX,
     avg_9f23dee9ad91063f4d7ac913cdb563037b0099ff."cust_id",
@@ -15,9 +19,35 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
         *,
         F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "ts"), 1800, 900, 60) AS index
       FROM (
+        WITH __FB_ENTITY_TABLE_NAME AS (
+          (
+            SELECT
+              "CUSTOMER_ID" AS "cust_id",
+              TO_TIMESTAMP(
+                FLOOR((
+                  DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                ) / 3600) * 3600 + 1800 - 900
+              ) AS "__FB_ENTITY_TABLE_END_DATE",
+              DATEADD(
+                microsecond,
+                (
+                  720 * 3600 * CAST(1000000 AS BIGINT) / CAST(1 AS BIGINT)
+                ) * -1,
+                TO_TIMESTAMP(
+                  FLOOR((
+                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                  ) / 3600) * 3600 + 1800 - 900
+                )
+              ) AS "__FB_ENTITY_TABLE_START_DATE"
+            FROM "REQUEST_TABLE"
+            GROUP BY
+              "CUSTOMER_ID"
+          )
+        )
         SELECT
-          *
-        FROM (
+          R.*
+        FROM __FB_ENTITY_TABLE_NAME
+        INNER JOIN (
           SELECT
             "ts" AS "ts",
             "cust_id" AS "cust_id",
@@ -58,20 +88,16 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
             ) AS T0
               ON REQ."order_id" = T0."order_id"
           )
-        )
-        WHERE
-          "ts" >= CAST('2022-03-21 09:15:00' AS TIMESTAMPNTZ)
-          AND "ts" < CAST('2022-04-20 09:15:00' AS TIMESTAMPNTZ)
+        ) AS R
+          ON R."cust_id" = __FB_ENTITY_TABLE_NAME."cust_id"
+          AND R."ts" >= __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_START_DATE
+          AND R."ts" < __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_END_DATE
       )
     )
     GROUP BY
       index,
       "cust_id"
   ) AS avg_9f23dee9ad91063f4d7ac913cdb563037b0099ff
-), REQUEST_TABLE AS (
-  SELECT
-    CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
-    'C1' AS "CUSTOMER_ID"
 ), "REQUEST_TABLE_W2592000_F3600_BS900_M1800_CUSTOMER_ID" AS (
   SELECT
     "POINT_IN_TIME",

--- a/tests/fixtures/expected_preview_sql_double_aggregation.sql
+++ b/tests/fixtures/expected_preview_sql_double_aggregation.sql
@@ -35,7 +35,7 @@ WITH REQUEST_TABLE AS (
                 ) * -1,
                 TO_TIMESTAMP(
                   FLOOR((
-                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                    DATE_PART(EPOCH_SECOND, MIN(POINT_IN_TIME)) - 1800
                   ) / 3600) * 3600 + 1800 - 900
                 )
               ) AS "__FB_ENTITY_TABLE_START_DATE"

--- a/tests/fixtures/expected_preview_sql_item_groupby.sql
+++ b/tests/fixtures/expected_preview_sql_item_groupby.sql
@@ -1,4 +1,8 @@
-WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
+WITH REQUEST_TABLE AS (
+  SELECT
+    CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
+    'C1' AS "CUSTOMER_ID"
+), TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
   SELECT
     avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb.INDEX,
     avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb."cust_id",
@@ -15,9 +19,35 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
         *,
         F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "ts"), 1800, 900, 60) AS index
       FROM (
+        WITH __FB_ENTITY_TABLE_NAME AS (
+          (
+            SELECT
+              "CUSTOMER_ID" AS "cust_id",
+              TO_TIMESTAMP(
+                FLOOR((
+                  DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                ) / 3600) * 3600 + 1800 - 900
+              ) AS "__FB_ENTITY_TABLE_END_DATE",
+              DATEADD(
+                microsecond,
+                (
+                  48 * 3600 * CAST(1000000 AS BIGINT) / CAST(1 AS BIGINT)
+                ) * -1,
+                TO_TIMESTAMP(
+                  FLOOR((
+                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                  ) / 3600) * 3600 + 1800 - 900
+                )
+              ) AS "__FB_ENTITY_TABLE_START_DATE"
+            FROM "REQUEST_TABLE"
+            GROUP BY
+              "CUSTOMER_ID"
+          )
+        )
         SELECT
-          *
-        FROM (
+          R.*
+        FROM __FB_ENTITY_TABLE_NAME
+        INNER JOIN (
           SELECT
             "ts" AS "ts",
             "cust_id" AS "cust_id",
@@ -27,20 +57,16 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
               "a" + "b"
             ) AS "c"
           FROM "db"."public"."event_table"
-        )
-        WHERE
-          "ts" >= CAST('2022-04-18 09:15:00' AS TIMESTAMPNTZ)
-          AND "ts" < CAST('2022-04-20 09:15:00' AS TIMESTAMPNTZ)
+        ) AS R
+          ON R."cust_id" = __FB_ENTITY_TABLE_NAME."cust_id"
+          AND R."ts" >= __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_START_DATE
+          AND R."ts" < __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_END_DATE
       )
     )
     GROUP BY
       index,
       "cust_id"
   ) AS avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb
-), REQUEST_TABLE AS (
-  SELECT
-    CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
-    'C1' AS "CUSTOMER_ID"
 ), "REQUEST_TABLE_W7200_F3600_BS900_M1800_CUSTOMER_ID" AS (
   SELECT
     "POINT_IN_TIME",

--- a/tests/fixtures/expected_preview_sql_item_groupby.sql
+++ b/tests/fixtures/expected_preview_sql_item_groupby.sql
@@ -35,7 +35,7 @@ WITH REQUEST_TABLE AS (
                 ) * -1,
                 TO_TIMESTAMP(
                   FLOOR((
-                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                    DATE_PART(EPOCH_SECOND, MIN(POINT_IN_TIME)) - 1800
                   ) / 3600) * 3600 + 1800 - 900
                 )
               ) AS "__FB_ENTITY_TABLE_START_DATE"

--- a/tests/fixtures/expected_preview_sql_latest_aggregation.sql
+++ b/tests/fixtures/expected_preview_sql_latest_aggregation.sql
@@ -39,7 +39,7 @@ WITH REQUEST_TABLE AS (
                   ) * -1,
                   TO_TIMESTAMP(
                     FLOOR((
-                      DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                      DATE_PART(EPOCH_SECOND, MIN(POINT_IN_TIME)) - 1800
                     ) / 3600) * 3600 + 1800 - 900
                   )
                 ) AS "__FB_ENTITY_TABLE_START_DATE"

--- a/tests/fixtures/expected_preview_sql_latest_aggregation.sql
+++ b/tests/fixtures/expected_preview_sql_latest_aggregation.sql
@@ -1,4 +1,8 @@
-WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
+WITH REQUEST_TABLE AS (
+  SELECT
+    CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
+    'C1' AS "CUSTOMER_ID"
+), TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
   SELECT
     latest_2a1145d57c972a1eace23efb905e5f1e25ba5e73.INDEX,
     latest_2a1145d57c972a1eace23efb905e5f1e25ba5e73."cust_id",
@@ -19,29 +23,51 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
           *,
           F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "ts"), 1800, 900, 60) AS index
         FROM (
+          WITH __FB_ENTITY_TABLE_NAME AS (
+            (
+              SELECT
+                "CUSTOMER_ID" AS "cust_id",
+                TO_TIMESTAMP(
+                  FLOOR((
+                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                  ) / 3600) * 3600 + 1800 - 900
+                ) AS "__FB_ENTITY_TABLE_END_DATE",
+                DATEADD(
+                  microsecond,
+                  (
+                    2160 * 3600 * CAST(1000000 AS BIGINT) / CAST(1 AS BIGINT)
+                  ) * -1,
+                  TO_TIMESTAMP(
+                    FLOOR((
+                      DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                    ) / 3600) * 3600 + 1800 - 900
+                  )
+                ) AS "__FB_ENTITY_TABLE_START_DATE"
+              FROM "REQUEST_TABLE"
+              GROUP BY
+                "CUSTOMER_ID"
+            )
+          )
           SELECT
-            *
-          FROM (
+            R.*
+          FROM __FB_ENTITY_TABLE_NAME
+          INNER JOIN (
             SELECT
               "ts" AS "ts",
               "cust_id" AS "cust_id",
               "a" AS "a",
               "b" AS "b"
             FROM "db"."public"."event_table"
-          )
-          WHERE
-            "ts" >= CAST('2022-01-20 09:15:00' AS TIMESTAMPNTZ)
-            AND "ts" < CAST('2022-04-20 09:15:00' AS TIMESTAMPNTZ)
+          ) AS R
+            ON R."cust_id" = __FB_ENTITY_TABLE_NAME."cust_id"
+            AND R."ts" >= __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_START_DATE
+            AND R."ts" < __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_END_DATE
         )
       )
     )
     WHERE
       "__FB_ROW_NUMBER" = 1
   ) AS latest_2a1145d57c972a1eace23efb905e5f1e25ba5e73
-), REQUEST_TABLE AS (
-  SELECT
-    CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
-    'C1' AS "CUSTOMER_ID"
 ), "REQUEST_TABLE_W7776000_F3600_BS900_M1800_CUSTOMER_ID" AS (
   SELECT
     "POINT_IN_TIME",

--- a/tests/fixtures/expected_preview_sql_multiple_nodes.sql
+++ b/tests/fixtures/expected_preview_sql_multiple_nodes.sql
@@ -37,7 +37,7 @@ WITH REQUEST_TABLE AS (
                 ) * -1,
                 TO_TIMESTAMP(
                   FLOOR((
-                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                    DATE_PART(EPOCH_SECOND, MIN(POINT_IN_TIME)) - 1800
                   ) / 3600) * 3600 + 1800 - 900
                 )
               ) AS "__FB_ENTITY_TABLE_START_DATE"
@@ -95,7 +95,7 @@ WITH REQUEST_TABLE AS (
                 ) * -1,
                 TO_TIMESTAMP(
                   FLOOR((
-                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                    DATE_PART(EPOCH_SECOND, MIN(POINT_IN_TIME)) - 1800
                   ) / 3600) * 3600 + 1800 - 900
                 )
               ) AS "__FB_ENTITY_TABLE_START_DATE"
@@ -155,7 +155,7 @@ WITH REQUEST_TABLE AS (
                 ) * -1,
                 TO_TIMESTAMP(
                   FLOOR((
-                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                    DATE_PART(EPOCH_SECOND, MIN(POINT_IN_TIME)) - 1800
                   ) / 3600) * 3600 + 1800 - 900
                 )
               ) AS "__FB_ENTITY_TABLE_START_DATE"

--- a/tests/fixtures/expected_preview_sql_multiple_nodes.sql
+++ b/tests/fixtures/expected_preview_sql_multiple_nodes.sql
@@ -1,4 +1,8 @@
-WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
+WITH REQUEST_TABLE AS (
+  SELECT
+    CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
+    'C1' AS "CUSTOMER_ID"
+), TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
   SELECT
     avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb.INDEX,
     avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb."cust_id",
@@ -17,9 +21,35 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
         *,
         F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "ts"), 1800, 900, 60) AS index
       FROM (
+        WITH __FB_ENTITY_TABLE_NAME AS (
+          (
+            SELECT
+              "CUSTOMER_ID" AS "cust_id",
+              TO_TIMESTAMP(
+                FLOOR((
+                  DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                ) / 3600) * 3600 + 1800 - 900
+              ) AS "__FB_ENTITY_TABLE_END_DATE",
+              DATEADD(
+                microsecond,
+                (
+                  48 * 3600 * CAST(1000000 AS BIGINT) / CAST(1 AS BIGINT)
+                ) * -1,
+                TO_TIMESTAMP(
+                  FLOOR((
+                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                  ) / 3600) * 3600 + 1800 - 900
+                )
+              ) AS "__FB_ENTITY_TABLE_START_DATE"
+            FROM "REQUEST_TABLE"
+            GROUP BY
+              "CUSTOMER_ID"
+          )
+        )
         SELECT
-          *
-        FROM (
+          R.*
+        FROM __FB_ENTITY_TABLE_NAME
+        INNER JOIN (
           SELECT
             "ts" AS "ts",
             "cust_id" AS "cust_id",
@@ -29,10 +59,10 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
               "a" + "b"
             ) AS "c"
           FROM "db"."public"."event_table"
-        )
-        WHERE
-          "ts" >= CAST('2022-04-18 09:15:00' AS TIMESTAMPNTZ)
-          AND "ts" < CAST('2022-04-20 09:15:00' AS TIMESTAMPNTZ)
+        ) AS R
+          ON R."cust_id" = __FB_ENTITY_TABLE_NAME."cust_id"
+          AND R."ts" >= __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_START_DATE
+          AND R."ts" < __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_END_DATE
       )
     )
     GROUP BY
@@ -49,9 +79,35 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
         *,
         F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "ts"), 1800, 900, 60) AS index
       FROM (
+        WITH __FB_ENTITY_TABLE_NAME AS (
+          (
+            SELECT
+              "CUSTOMER_ID" AS "cust_id",
+              TO_TIMESTAMP(
+                FLOOR((
+                  DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                ) / 3600) * 3600 + 1800 - 900
+              ) AS "__FB_ENTITY_TABLE_END_DATE",
+              DATEADD(
+                microsecond,
+                (
+                  48 * 3600 * CAST(1000000 AS BIGINT) / CAST(1 AS BIGINT)
+                ) * -1,
+                TO_TIMESTAMP(
+                  FLOOR((
+                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                  ) / 3600) * 3600 + 1800 - 900
+                )
+              ) AS "__FB_ENTITY_TABLE_START_DATE"
+            FROM "REQUEST_TABLE"
+            GROUP BY
+              "CUSTOMER_ID"
+          )
+        )
         SELECT
-          *
-        FROM (
+          R.*
+        FROM __FB_ENTITY_TABLE_NAME
+        INNER JOIN (
           SELECT
             "ts" AS "ts",
             "cust_id" AS "cust_id",
@@ -61,10 +117,10 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
               "a" + "b"
             ) AS "c"
           FROM "db"."public"."event_table"
-        )
-        WHERE
-          "ts" >= CAST('2022-04-18 09:15:00' AS TIMESTAMPNTZ)
-          AND "ts" < CAST('2022-04-20 09:15:00' AS TIMESTAMPNTZ)
+        ) AS R
+          ON R."cust_id" = __FB_ENTITY_TABLE_NAME."cust_id"
+          AND R."ts" >= __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_START_DATE
+          AND R."ts" < __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_END_DATE
       )
     )
     GROUP BY
@@ -83,9 +139,35 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
         *,
         F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "ts"), 1800, 900, 60) AS index
       FROM (
+        WITH __FB_ENTITY_TABLE_NAME AS (
+          (
+            SELECT
+              "CUSTOMER_ID" AS "cust_id",
+              TO_TIMESTAMP(
+                FLOOR((
+                  DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                ) / 3600) * 3600 + 1800 - 900
+              ) AS "__FB_ENTITY_TABLE_END_DATE",
+              DATEADD(
+                microsecond,
+                (
+                  48 * 3600 * CAST(1000000 AS BIGINT) / CAST(1 AS BIGINT)
+                ) * -1,
+                TO_TIMESTAMP(
+                  FLOOR((
+                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                  ) / 3600) * 3600 + 1800 - 900
+                )
+              ) AS "__FB_ENTITY_TABLE_START_DATE"
+            FROM "REQUEST_TABLE"
+            GROUP BY
+              "CUSTOMER_ID"
+          )
+        )
         SELECT
-          *
-        FROM (
+          R.*
+        FROM __FB_ENTITY_TABLE_NAME
+        INNER JOIN (
           SELECT
             "ts" AS "ts",
             "cust_id" AS "cust_id",
@@ -95,10 +177,10 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
               "a" + "b"
             ) AS "c"
           FROM "db"."public"."event_table"
-        )
-        WHERE
-          "ts" >= CAST('2022-04-18 09:15:00' AS TIMESTAMPNTZ)
-          AND "ts" < CAST('2022-04-20 09:15:00' AS TIMESTAMPNTZ)
+        ) AS R
+          ON R."cust_id" = __FB_ENTITY_TABLE_NAME."cust_id"
+          AND R."ts" >= __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_START_DATE
+          AND R."ts" < __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_END_DATE
       )
     )
     GROUP BY
@@ -107,10 +189,6 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
   ) AS sum_999015eb44ce788935f8962d3d34957b95bcf04f
     ON avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb.INDEX = sum_999015eb44ce788935f8962d3d34957b95bcf04f.INDEX
     AND avg_30d0e03bfdc9aa70e3001f8c32a5f82e6f793cbb."cust_id" = sum_999015eb44ce788935f8962d3d34957b95bcf04f."cust_id"
-), REQUEST_TABLE AS (
-  SELECT
-    CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
-    'C1' AS "CUSTOMER_ID"
 ), "REQUEST_TABLE_W7200_F3600_BS900_M1800_CUSTOMER_ID" AS (
   SELECT
     "POINT_IN_TIME",

--- a/tests/fixtures/expected_preview_sql_on_demand_features.sql
+++ b/tests/fixtures/expected_preview_sql_on_demand_features.sql
@@ -39,7 +39,7 @@ WITH REQUEST_TABLE AS (
                   ) * -1,
                   TO_TIMESTAMP(
                     FLOOR((
-                      DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                      DATE_PART(EPOCH_SECOND, MIN(POINT_IN_TIME)) - 1800
                     ) / 3600) * 3600 + 1800 - 900
                   )
                 ) AS "__FB_ENTITY_TABLE_START_DATE"

--- a/tests/fixtures/expected_preview_sql_on_demand_features.sql
+++ b/tests/fixtures/expected_preview_sql_on_demand_features.sql
@@ -1,4 +1,8 @@
-WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
+WITH REQUEST_TABLE AS (
+  SELECT
+    CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
+    'C1' AS "CUSTOMER_ID"
+), TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
   SELECT
     latest_f243fc3de55421dea9679ba6aec5bc0ac03ffe30.INDEX,
     latest_f243fc3de55421dea9679ba6aec5bc0ac03ffe30."cust_id",
@@ -19,29 +23,51 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
           *,
           F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "ts"), 1800, 900, 60) AS index
         FROM (
+          WITH __FB_ENTITY_TABLE_NAME AS (
+            (
+              SELECT
+                "CUSTOMER_ID" AS "cust_id",
+                TO_TIMESTAMP(
+                  FLOOR((
+                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                  ) / 3600) * 3600 + 1800 - 900
+                ) AS "__FB_ENTITY_TABLE_END_DATE",
+                DATEADD(
+                  microsecond,
+                  (
+                    2160 * 3600 * CAST(1000000 AS BIGINT) / CAST(1 AS BIGINT)
+                  ) * -1,
+                  TO_TIMESTAMP(
+                    FLOOR((
+                      DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                    ) / 3600) * 3600 + 1800 - 900
+                  )
+                ) AS "__FB_ENTITY_TABLE_START_DATE"
+              FROM "REQUEST_TABLE"
+              GROUP BY
+                "CUSTOMER_ID"
+            )
+          )
           SELECT
-            *
-          FROM (
+            R.*
+          FROM __FB_ENTITY_TABLE_NAME
+          INNER JOIN (
             SELECT
               "ts" AS "ts",
               "cust_id" AS "cust_id",
               "a" AS "a",
               "b" AS "b"
             FROM "db"."public"."event_table"
-          )
-          WHERE
-            "ts" >= CAST('2022-01-20 09:15:00' AS TIMESTAMPNTZ)
-            AND "ts" < CAST('2022-04-20 09:15:00' AS TIMESTAMPNTZ)
+          ) AS R
+            ON R."cust_id" = __FB_ENTITY_TABLE_NAME."cust_id"
+            AND R."ts" >= __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_START_DATE
+            AND R."ts" < __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_END_DATE
         )
       )
     )
     WHERE
       "__FB_ROW_NUMBER" = 1
   ) AS latest_f243fc3de55421dea9679ba6aec5bc0ac03ffe30
-), REQUEST_TABLE AS (
-  SELECT
-    CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
-    'C1' AS "CUSTOMER_ID"
 ), "REQUEST_TABLE_W7776000_F3600_BS900_M1800_CUSTOMER_ID" AS (
   SELECT
     "POINT_IN_TIME",

--- a/tests/fixtures/expected_preview_sql_with_missing_value_imputation.sql
+++ b/tests/fixtures/expected_preview_sql_with_missing_value_imputation.sql
@@ -1,4 +1,8 @@
-WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
+WITH REQUEST_TABLE AS (
+  SELECT
+    CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
+    'C1' AS "CUSTOMER_ID"
+), TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
   SELECT
     avg_d2afc651cc81ba20447f12d1bc06cf1aa00fe8ac.INDEX,
     avg_d2afc651cc81ba20447f12d1bc06cf1aa00fe8ac."cust_id",
@@ -15,9 +19,35 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
         *,
         F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "ts"), 1800, 900, 60) AS index
       FROM (
+        WITH __FB_ENTITY_TABLE_NAME AS (
+          (
+            SELECT
+              "CUSTOMER_ID" AS "cust_id",
+              TO_TIMESTAMP(
+                FLOOR((
+                  DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                ) / 3600) * 3600 + 1800 - 900
+              ) AS "__FB_ENTITY_TABLE_END_DATE",
+              DATEADD(
+                microsecond,
+                (
+                  48 * 3600 * CAST(1000000 AS BIGINT) / CAST(1 AS BIGINT)
+                ) * -1,
+                TO_TIMESTAMP(
+                  FLOOR((
+                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                  ) / 3600) * 3600 + 1800 - 900
+                )
+              ) AS "__FB_ENTITY_TABLE_START_DATE"
+            FROM "REQUEST_TABLE"
+            GROUP BY
+              "CUSTOMER_ID"
+          )
+        )
         SELECT
-          *
-        FROM (
+          R.*
+        FROM __FB_ENTITY_TABLE_NAME
+        INNER JOIN (
           SELECT
             "ts" AS "ts",
             "cust_id" AS "cust_id",
@@ -26,20 +56,16 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
             ) THEN 0 ELSE "a" END AS "a",
             "b" AS "b"
           FROM "db"."public"."event_table"
-        )
-        WHERE
-          "ts" >= CAST('2022-04-18 09:15:00' AS TIMESTAMPNTZ)
-          AND "ts" < CAST('2022-04-20 09:15:00' AS TIMESTAMPNTZ)
+        ) AS R
+          ON R."cust_id" = __FB_ENTITY_TABLE_NAME."cust_id"
+          AND R."ts" >= __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_START_DATE
+          AND R."ts" < __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_END_DATE
       )
     )
     GROUP BY
       index,
       "cust_id"
   ) AS avg_d2afc651cc81ba20447f12d1bc06cf1aa00fe8ac
-), REQUEST_TABLE AS (
-  SELECT
-    CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
-    'C1' AS "CUSTOMER_ID"
 ), "REQUEST_TABLE_W7200_F3600_BS900_M1800_CUSTOMER_ID" AS (
   SELECT
     "POINT_IN_TIME",

--- a/tests/fixtures/expected_preview_sql_with_missing_value_imputation.sql
+++ b/tests/fixtures/expected_preview_sql_with_missing_value_imputation.sql
@@ -35,7 +35,7 @@ WITH REQUEST_TABLE AS (
                 ) * -1,
                 TO_TIMESTAMP(
                   FLOOR((
-                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                    DATE_PART(EPOCH_SECOND, MIN(POINT_IN_TIME)) - 1800
                   ) / 3600) * 3600 + 1800 - 900
                 )
               ) AS "__FB_ENTITY_TABLE_START_DATE"

--- a/tests/fixtures/expected_preview_sql_with_parent_serving_preparation.sql
+++ b/tests/fixtures/expected_preview_sql_with_parent_serving_preparation.sql
@@ -66,7 +66,7 @@ WITH REQUEST_TABLE AS (
                 ) * -1,
                 TO_TIMESTAMP(
                   FLOOR((
-                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                    DATE_PART(EPOCH_SECOND, MIN(POINT_IN_TIME)) - 1800
                   ) / 3600) * 3600 + 1800 - 900
                 )
               ) AS "__FB_ENTITY_TABLE_START_DATE"

--- a/tests/fixtures/expected_preview_sql_with_parent_serving_preparation.sql
+++ b/tests/fixtures/expected_preview_sql_with_parent_serving_preparation.sql
@@ -1,42 +1,4 @@
-WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
-  SELECT
-    avg_d2afc651cc81ba20447f12d1bc06cf1aa00fe8ac.INDEX,
-    avg_d2afc651cc81ba20447f12d1bc06cf1aa00fe8ac."cust_id",
-    sum_value_avg_d2afc651cc81ba20447f12d1bc06cf1aa00fe8ac,
-    count_value_avg_d2afc651cc81ba20447f12d1bc06cf1aa00fe8ac
-  FROM (
-    SELECT
-      index,
-      "cust_id",
-      SUM("a") AS sum_value_avg_d2afc651cc81ba20447f12d1bc06cf1aa00fe8ac,
-      COUNT("a") AS count_value_avg_d2afc651cc81ba20447f12d1bc06cf1aa00fe8ac
-    FROM (
-      SELECT
-        *,
-        F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "ts"), 1800, 900, 60) AS index
-      FROM (
-        SELECT
-          *
-        FROM (
-          SELECT
-            "ts" AS "ts",
-            "cust_id" AS "cust_id",
-            CASE WHEN (
-              "a" IS NULL
-            ) THEN 0 ELSE "a" END AS "a",
-            "b" AS "b"
-          FROM "db"."public"."event_table"
-        )
-        WHERE
-          "ts" >= CAST('2022-04-18 09:15:00' AS TIMESTAMPNTZ)
-          AND "ts" < CAST('2022-04-20 09:15:00' AS TIMESTAMPNTZ)
-      )
-    )
-    GROUP BY
-      index,
-      "cust_id"
-  ) AS avg_d2afc651cc81ba20447f12d1bc06cf1aa00fe8ac
-), REQUEST_TABLE AS (
+WITH REQUEST_TABLE AS (
   SELECT
     CAST('2022-04-20 10:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
     'C1' AS "CUSTOMER_ID"
@@ -71,6 +33,70 @@ WITH TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
     ) AS T0
       ON REQ."COL_TEXT" = T0."COL_TEXT"
   ) AS REQ
+), TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725 AS (
+  SELECT
+    avg_d2afc651cc81ba20447f12d1bc06cf1aa00fe8ac.INDEX,
+    avg_d2afc651cc81ba20447f12d1bc06cf1aa00fe8ac."cust_id",
+    sum_value_avg_d2afc651cc81ba20447f12d1bc06cf1aa00fe8ac,
+    count_value_avg_d2afc651cc81ba20447f12d1bc06cf1aa00fe8ac
+  FROM (
+    SELECT
+      index,
+      "cust_id",
+      SUM("a") AS sum_value_avg_d2afc651cc81ba20447f12d1bc06cf1aa00fe8ac,
+      COUNT("a") AS count_value_avg_d2afc651cc81ba20447f12d1bc06cf1aa00fe8ac
+    FROM (
+      SELECT
+        *,
+        F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "ts"), 1800, 900, 60) AS index
+      FROM (
+        WITH __FB_ENTITY_TABLE_NAME AS (
+          (
+            SELECT
+              "CUSTOMER_ID" AS "cust_id",
+              TO_TIMESTAMP(
+                FLOOR((
+                  DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                ) / 3600) * 3600 + 1800 - 900
+              ) AS "__FB_ENTITY_TABLE_END_DATE",
+              DATEADD(
+                microsecond,
+                (
+                  48 * 3600 * CAST(1000000 AS BIGINT) / CAST(1 AS BIGINT)
+                ) * -1,
+                TO_TIMESTAMP(
+                  FLOOR((
+                    DATE_PART(EPOCH_SECOND, MAX(POINT_IN_TIME)) - 1800
+                  ) / 3600) * 3600 + 1800 - 900
+                )
+              ) AS "__FB_ENTITY_TABLE_START_DATE"
+            FROM "JOINED_PARENTS_REQUEST_TABLE"
+            GROUP BY
+              "CUSTOMER_ID"
+          )
+        )
+        SELECT
+          R.*
+        FROM __FB_ENTITY_TABLE_NAME
+        INNER JOIN (
+          SELECT
+            "ts" AS "ts",
+            "cust_id" AS "cust_id",
+            CASE WHEN (
+              "a" IS NULL
+            ) THEN 0 ELSE "a" END AS "a",
+            "b" AS "b"
+          FROM "db"."public"."event_table"
+        ) AS R
+          ON R."cust_id" = __FB_ENTITY_TABLE_NAME."cust_id"
+          AND R."ts" >= __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_START_DATE
+          AND R."ts" < __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_END_DATE
+      )
+    )
+    GROUP BY
+      index,
+      "cust_id"
+  ) AS avg_d2afc651cc81ba20447f12d1bc06cf1aa00fe8ac
 ), "REQUEST_TABLE_W7200_F3600_BS900_M1800_CUSTOMER_ID" AS (
   SELECT
     "POINT_IN_TIME",

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -325,6 +325,29 @@ def test_feature_operations__feature_group_preview(feature_group):
 
 
 @pytest.mark.parametrize("source_type", ["snowflake", "spark", "databricks"], indirect=True)
+def test_feature_preview__same_entity_multiple_point_in_times(feature_group):
+    """
+    Test previewing features when the same entity has multiple point in times in the request data
+    """
+    preview_data = pd.DataFrame(
+        {
+            "POINT_IN_TIME": ["2001-01-20 10:00:00", "2001-01-02 10:00:00"],
+            "üser id": [1, 1],
+        }
+    )
+    df_feature_preview = feature_group.preview(preview_data)
+    df_expected = pd.DataFrame(
+        {
+            "POINT_IN_TIME": pd.to_datetime(["2001-01-20 10:00:00", "2001-01-02 10:00:00"]),
+            "üser id": [1, 1],
+            "COUNT_2h": [0, 3],
+            "COUNT_24h": [17, 14],
+        }
+    )
+    fb_assert_frame_equal(df_feature_preview, df_expected)
+
+
+@pytest.mark.parametrize("source_type", ["snowflake", "spark", "databricks"], indirect=True)
 def test_isnull_compare_with_bool(event_view):
     """
     Test a special case of using isnull with bool literal

--- a/tests/integration/tile/test_tile_cache.py
+++ b/tests/integration/tile/test_tile_cache.py
@@ -105,8 +105,8 @@ async def test_tile_cache(session, feature_for_tile_cache_tests, groupby_categor
     assert len(requests) == 1
     df_entity_expected = pd.DataFrame(
         {
-            "ÜSER ID": [1.0, 2.0, 3.0, 4.0, np.nan],
             "LAST_TILE_START_DATE": pd.to_datetime(["2001-01-02 07:45:00"] * 5),
+            "ÜSER ID": [1.0, 2.0, 3.0, 4.0, np.nan],
             "__FB_ENTITY_TABLE_END_DATE": pd.to_datetime(["2001-01-02 08:45:00"] * 5),
             "__FB_ENTITY_TABLE_START_DATE": pd.to_datetime(["1969-12-31 23:45:00"] * 5),
         }
@@ -149,8 +149,8 @@ async def test_tile_cache(session, feature_for_tile_cache_tests, groupby_categor
     assert len(requests) == 1
     df_entity_expected = pd.DataFrame(
         {
-            "ÜSER ID": [3, 4, np.nan],
             "LAST_TILE_START_DATE": pd.to_datetime(["2001-01-03 07:45:00"] * 3),
+            "ÜSER ID": [3, 4, np.nan],
             "__FB_ENTITY_TABLE_END_DATE": pd.to_datetime(["2001-01-03 08:45:00"] * 3),
             "__FB_ENTITY_TABLE_START_DATE": pd.to_datetime(["2001-01-02 08:45:00"] * 3),
         }
@@ -194,10 +194,10 @@ async def test_tile_cache(session, feature_for_tile_cache_tests, groupby_categor
     assert len(requests) == 1
     df_entity_expected = pd.DataFrame(
         {
-            "ÜSER ID": [1, 6, 7],
             "LAST_TILE_START_DATE": pd.to_datetime(
                 ["2001-01-03 07:45:00"] + ["2001-01-02 07:45:00"] * 2
             ),
+            "ÜSER ID": [1, 6, 7],
             "__FB_ENTITY_TABLE_END_DATE": pd.to_datetime(
                 ["2001-01-03 08:45:00"] + ["2001-01-02 08:45:00"] * 2
             ),

--- a/tests/unit/query_graph/test_tile_compute.py
+++ b/tests/unit/query_graph/test_tile_compute.py
@@ -4,7 +4,7 @@ from featurebyte.query_graph.sql.tile_compute import OnDemandTileComputePlan
 
 def test_combine_tile_tables(query_graph_with_similar_groupby_nodes):
     nodes, graph = query_graph_with_similar_groupby_nodes
-    plan = OnDemandTileComputePlan(["2022-04-20 10:00:00"], "REQUEST_TABLE", SourceType.SNOWFLAKE)
+    plan = OnDemandTileComputePlan("REQUEST_TABLE", SourceType.SNOWFLAKE)
 
     # Check that each groupby node has the same tile_id. Their respective tile sqls have to be
     # merged into one

--- a/tests/unit/query_graph/test_tile_compute.py
+++ b/tests/unit/query_graph/test_tile_compute.py
@@ -4,7 +4,7 @@ from featurebyte.query_graph.sql.tile_compute import OnDemandTileComputePlan
 
 def test_combine_tile_tables(query_graph_with_similar_groupby_nodes):
     nodes, graph = query_graph_with_similar_groupby_nodes
-    plan = OnDemandTileComputePlan("2022-04-20 10:00:00", SourceType.SNOWFLAKE)
+    plan = OnDemandTileComputePlan(["2022-04-20 10:00:00"], "REQUEST_TABLE", SourceType.SNOWFLAKE)
 
     # Check that each groupby node has the same tile_id. Their respective tile sqls have to be
     # merged into one


### PR DESCRIPTION
## Description

This updates the feature preview queries to compute tiles for only the required entities and time range. Previously when previewing features, the data is filtered only by date range and can result in a lot of redundant computation for entities that are not of interest.

Before this change, previewing a feature like [`CustomerSpendingStability_7d28d`](https://github.com/featurebyte/featurebyte-notebooks/blob/f6e8cd4b352c3550540874e9cdd9001ba47a84f0/notebooks/features/grocery/features_set_5.py#L143-L148) with a small observation set takes 23 minutes (exceeding the 600 request time out). After this change, it takes about 23 seconds.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
