### PR TITLE
[chore] Bind spark-thrift-test to different ports to not interfere with docker-dev

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,8 +23,8 @@ services:
     container_name: spark-thrift-test
     image: featurebyte/cluster-apache-spark:3.3.1
     ports:
-      - "10000:10000"
-      - "4040:4040"
+      - "10009:10000"
+      - "4049:4040"
     environment:
       - SPARK_MASTER=local
       - SPARK_LOCAL_IP=spark-thrift

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -352,7 +352,7 @@ def feature_store_details_fixture(source_type, sqlite_filename):
         temp_schema_name = f"{schema_name}_{datetime.now().strftime('%Y%m%d%H%M%S_%f')}"
         return SparkDetails(
             host="localhost",
-            port=10000,
+            port=10009,
             http_path="cliservice",
             use_http_transport=False,
             storage_type=StorageType.FILE,


### PR DESCRIPTION
## Description

The `spark-thrift-test` container is used by integration tests. When the container is running, it is not possible start the featurebyte spark container since they bind to the same ports. This binds the ports used by `spark-thrift-test` to different ones so these containers can co-exist. This should make development a bit more convenient (no need to stop the featurebyte services before running `task test-setup` and vice versa).

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
