### PR TITLE
[DEV-1793] Make websocket client more resilient against connection drop

### DIFF
--- a/.changelog/DEV-1793.yaml
+++ b/.changelog/DEV-1793.yaml
@@ -1,0 +1,16 @@
+# Type of change
+change_type: bug_fix
+
+# The name of the component
+component: websocket
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.
+note: "make websocket client more resilient connection lost"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/featurebyte/service/deploy.py
+++ b/featurebyte/service/deploy.py
@@ -306,7 +306,7 @@ class DeployService(BaseService):
                         )
 
                     if update_progress:
-                        percent = 20 + 60 // len(document.feature_ids) * (ind + 1)
+                        percent = 20 + int(60 / len(document.feature_ids) * (ind + 1))
                         update_progress(percent, f"Updated {feature.name}")
 
                 if update_progress:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -4,12 +4,16 @@ Test config parser
 import os
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from uuid import uuid4
 
 import pytest
 import requests.exceptions
-from websocket import WebSocketAddressException
+from websocket import (
+    WebSocketAddressException,
+    WebSocketBadStatusException,
+    WebSocketConnectionClosedException,
+)
 
 from featurebyte.config import (
     DEFAULT_HOME_PATH,
@@ -218,3 +222,43 @@ def test_websocket_ssl():
     with pytest.raises(WebSocketAddressException):
         with config.get_websocket_client(str(uuid4())) as ws_client:
             assert isinstance(ws_client, WebsocketClient)
+
+
+@pytest.mark.no_mock_websocket_client
+def test_websocket_reconnect():
+    """
+    Test websocket reconnection logic
+    """
+    config = Configurations("tests/fixtures/config/config.yaml")
+
+    with patch("featurebyte.config.websocket.create_connection") as mock_create_connection:
+        mock_ws = Mock()
+        mock_create_connection.side_effect = lambda *args, **kwargs: mock_ws
+
+        with config.get_websocket_client(str(uuid4())) as ws_client:
+            # get some data from websocket
+            mock_ws.recv.side_effect = [b"test"]
+            data = ws_client.receive_bytes()
+            assert data == b"test"
+
+            # get empty data from websocket
+            mock_ws.recv.side_effect = [b""]
+            data = ws_client.receive_bytes()
+            assert data == b""
+
+            # unexpected disconnect of valid connection
+            mock_ws.recv.side_effect = [
+                WebSocketConnectionClosedException(),
+                WebSocketConnectionClosedException(),
+                b"test",
+            ]
+            data = ws_client.receive_bytes()
+            assert data == b"test"
+
+            # unexpected disconnect of closed connection
+            mock_ws.recv.side_effect = [
+                WebSocketConnectionClosedException(),
+                WebSocketBadStatusException("Not found", 404),
+            ]
+            with pytest.raises(WebSocketBadStatusException):
+                ws_client.receive_bytes()


### PR DESCRIPTION
## Description

Some load balancers do not take into account websocket ping pong packets when enforcing connection timeouts.
To make the websocket connection resilient to this, automatic reconnection is added to re-establish connection while receiving a new message.


## Related Issue

https://featurebyte.atlassian.net/browse/DEV-1793

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
