### PR TITLE
enhancement: limit manual default version selection to the versions with the highest readiness level only

### DIFF
--- a/.changelog/DEV-1795.yaml
+++ b/.changelog/DEV-1795.yaml
@@ -1,0 +1,16 @@
+# Type of change
+change_type: enhancement
+
+# The name of the component
+component: feature
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.
+note: "limit manual default feature version selection to only the versions with highest readiness level"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/featurebyte/api/feature_list.py
+++ b/featurebyte/api/feature_list.py
@@ -1377,6 +1377,7 @@ class FeatureList(BaseFeatureGroup, DeletableApiObject, SavableApiObject, Featur
         ...     )
         ...   ]
         ... )
+        >>> current_feature.update_readiness("DEPRECATED")
         >>> new_feature.update_default_version_mode("MANUAL")
         >>> new_feature.as_default_version()
         >>> new_feature.is_default is True and current_feature.is_default is False
@@ -1398,6 +1399,7 @@ class FeatureList(BaseFeatureGroup, DeletableApiObject, SavableApiObject, Featur
         Reset the default version mode of the feature to make original feature as default. Create a new version
         of feature list using original feature list should throw an error due to no change in feature list is detected.
 
+        >>> current_feature.update_readiness("PRODUCTION_READY")
         >>> current_feature.update_default_version_mode("AUTO")
         >>> current_feature.is_default
         True

--- a/featurebyte/routes/feature_namespace/controller.py
+++ b/featurebyte/routes/feature_namespace/controller.py
@@ -3,11 +3,12 @@ FeatureNamespace API route controller
 """
 from __future__ import annotations
 
-from typing import Any, Literal, cast
+from typing import Any, Literal, Optional, cast
 
 from bson.objectid import ObjectId
 
 from featurebyte.exception import DocumentUpdateError
+from featurebyte.models.base import VersionIdentifier
 from featurebyte.models.feature import DefaultVersionMode, FeatureModel, FeatureReadiness
 from featurebyte.routes.common.base import (
     BaseDocumentController,
@@ -168,16 +169,20 @@ class FeatureNamespaceController(
             new_default_feature = await self.feature_service.get_document(
                 document_id=data.default_feature_id
             )
-            max_readiness = new_default_feature.readiness
+            max_readiness = FeatureReadiness(new_default_feature.readiness)
+            version: Optional[str] = None
             async for feature_dict in self.feature_service.list_documents_iterator(
                 query_filter={"_id": {"$in": feature_namespace.feature_ids}}
             ):
                 max_readiness = max(max_readiness, FeatureReadiness(feature_dict["readiness"]))
+                if feature_dict["readiness"] == max_readiness:
+                    version = VersionIdentifier(**feature_dict["version"]).to_str()
 
             if new_default_feature.readiness != max_readiness:
                 raise DocumentUpdateError(
                     f"Cannot set default feature ID to {new_default_feature.id} "
-                    f"because it has lower readiness level than {max_readiness}."
+                    f"because its readiness level ({new_default_feature.readiness}) "
+                    f"is lower than the readiness level of version {version} ({max_readiness.value})."
                 )
 
             # update feature namespace default feature ID and update feature readiness

--- a/featurebyte/worker/task/batch_feature_create.py
+++ b/featurebyte/worker/task/batch_feature_create.py
@@ -150,4 +150,4 @@ class BatchFeatureCreateTask(BaseTask):
 
             # update the progress
             percent = 100 * (i + 1) / total
-            self.update_progress(percent=int(percent), message="Completed {i+1}/{total} features")
+            self.update_progress(percent=int(percent), message=f"Completed {i+1}/{total} features")

--- a/tests/unit/api/test_feature.py
+++ b/tests/unit/api/test_feature.py
@@ -727,7 +727,8 @@ def test_feature__as_default_version(saved_feature):
 
     error_msg = (
         f"Cannot set default feature ID to {new_version.id} "
-        f"because it has lower readiness level than PUBLIC_DRAFT."
+        f"because its readiness level (DRAFT) is lower than the readiness level of "
+        f"version {saved_feature.version} (PUBLIC_DRAFT)."
     )
     assert error_msg in str(exc.value)
     assert new_version.is_default is False

--- a/tests/unit/routes/base.py
+++ b/tests/unit/routes/base.py
@@ -516,6 +516,29 @@ class BaseCatalogApiTestSuite(BaseApiTestSuite):
         assert response.status_code == HTTPStatus.CREATED
         return ObjectId(response.json()["_id"])
 
+    @staticmethod
+    def create_new_feature_version(test_api_client, feature_id):
+        """Create new feature version"""
+        post_feature_response = test_api_client.post(
+            "/feature",
+            json={
+                "source_feature_id": feature_id,
+                "table_feature_job_settings": [
+                    {
+                        "table_name": "sf_event_table",
+                        "feature_job_setting": {
+                            "blind_spot": "23h",
+                            "frequency": "24h",
+                            "time_modulo_frequency": "1h",
+                        },
+                    }
+                ],
+            },
+        )
+        assert post_feature_response.status_code == HTTPStatus.CREATED
+        new_feature_id = post_feature_response.json()["_id"]
+        return new_feature_id
+
     @pytest_asyncio.fixture()
     async def create_success_response_non_default_catalog(
         self, test_api_client_persistent, catalog_id


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

Manual default version selection is designed to resolve issue when there are more than 1 feature version which are at the highest readiness version. This PR aims to impose more constraints on the default feature version selection.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
