### PR TITLE
[DEV-1467] Update schema recreation process to be aware of materialized tables

### DIFF
--- a/featurebyte/enum.py
+++ b/featurebyte/enum.py
@@ -339,3 +339,25 @@ class SemanticType(StrEnum):
     DIMENSION_ID = "dimension_id"
     SCD_NATURAL_KEY_ID = "scd_natural_key_id"
     SCD_SURROGATE_KEY_ID = "scd_surrogate_key_id"
+
+
+class MaterializedTableNamePrefix(StrEnum):
+    """
+    Prefixes for the physical table names of materialized tables
+    """
+
+    OBSERVATION_TABLE = "OBSERVATION_TABLE"
+    HISTORICAL_FEATURE_TABLE = "HISTORICAL_FEATURE_TABLE"
+    BATCH_REQUEST_TABLE = "BATCH_REQUEST_TABLE"
+    BATCH_FEATURE_TABLE = "BATCH_FEATURE_TABLE"
+
+    @classmethod
+    def all(cls) -> list[str]:
+        """
+        List all prefixes
+
+        Returns
+        -------
+        list[str]
+        """
+        return [c.value for c in cls]

--- a/featurebyte/migration/service/mixin.py
+++ b/featurebyte/migration/service/mixin.py
@@ -233,7 +233,7 @@ class DataWarehouseMigrationMixin(FeatureStoreService, BaseMigrationServiceMixin
             # Verify that session is fully functional by attempting to execute a query
             _ = await session.execute_query("SELECT 1 AS A")
         except CredentialsError:
-            logger.debug(f"Got CredentialsError, skipping migration for {feature_store.name}")
+            logger.warning(f"Got CredentialsError, skipping migration for {feature_store.name}")
             return
         except Exception:  # pylint: disable=broad-except
             logger.exception(

--- a/featurebyte/service/batch_feature_table.py
+++ b/featurebyte/service/batch_feature_table.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from bson import ObjectId
 
+from featurebyte.enum import MaterializedTableNamePrefix
 from featurebyte.models.base import FeatureByteBaseDocumentModel
 from featurebyte.models.batch_feature_table import BatchFeatureTableModel
 from featurebyte.schema.batch_feature_table import BatchFeatureTableCreate
@@ -20,7 +21,7 @@ class BatchFeatureTableService(
     """
 
     document_class = BatchFeatureTableModel
-    materialized_table_name_prefix = "BATCH_FEATURE_TABLE"
+    materialized_table_name_prefix = MaterializedTableNamePrefix.BATCH_FEATURE_TABLE
 
     @property
     def class_name(self) -> str:

--- a/featurebyte/service/batch_request_table.py
+++ b/featurebyte/service/batch_request_table.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from bson import ObjectId
 
+from featurebyte.enum import MaterializedTableNamePrefix
 from featurebyte.models.base import FeatureByteBaseDocumentModel
 from featurebyte.models.batch_request_table import BatchRequestTableModel
 from featurebyte.persistent import Persistent
@@ -25,7 +26,7 @@ class BatchRequestTableService(
     """
 
     document_class = BatchRequestTableModel
-    materialized_table_name_prefix = "BATCH_REQUEST_TABLE"
+    materialized_table_name_prefix = MaterializedTableNamePrefix.BATCH_REQUEST_TABLE
 
     def __init__(
         self,

--- a/featurebyte/service/historical_feature_table.py
+++ b/featurebyte/service/historical_feature_table.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pandas as pd
 from bson import ObjectId
 
+from featurebyte.enum import MaterializedTableNamePrefix
 from featurebyte.models.base import FeatureByteBaseDocumentModel
 from featurebyte.models.historical_feature_table import HistoricalFeatureTableModel
 from featurebyte.schema.historical_feature_table import HistoricalFeatureTableCreate
@@ -28,7 +29,7 @@ class HistoricalFeatureTableService(
     """
 
     document_class = HistoricalFeatureTableModel
-    materialized_table_name_prefix = "HISTORICAL_FEATURE_TABLE"
+    materialized_table_name_prefix = MaterializedTableNamePrefix.HISTORICAL_FEATURE_TABLE
 
     @property
     def class_name(self) -> str:

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, cast
 import pandas as pd
 from bson import ObjectId
 
-from featurebyte.enum import DBVarType, SpecialColumnName
+from featurebyte.enum import DBVarType, MaterializedTableNamePrefix, SpecialColumnName
 from featurebyte.exception import (
     MissingPointInTimeColumnError,
     UnsupportedPointInTimeColumnTypeError,
@@ -34,7 +34,7 @@ class ObservationTableService(
     """
 
     document_class = ObservationTableModel
-    materialized_table_name_prefix = "OBSERVATION_TABLE"
+    materialized_table_name_prefix = MaterializedTableNamePrefix.OBSERVATION_TABLE
 
     def __init__(
         self,

--- a/featurebyte/session/snowflake.py
+++ b/featurebyte/session/snowflake.py
@@ -358,15 +358,6 @@ class SnowflakeSchemaInitializer(BaseSchemaInitializer):
         query = f"DROP {object_type} {self._fully_qualified(name)}"
         await self.session.execute_query(query)
 
-    async def _drop_tasks(self) -> None:
-        tasks = await self._list_objects("TASKS")
-        while tasks.shape[0]:
-            # Drop tasks in a loop since new tasks might get added while the initial list of tasks
-            # are getting dropped (each shell task schedule new task as they are running)
-            for name in tasks["name"]:
-                await self._drop_object("TASK", name)
-            tasks = await self._list_objects("TASKS")
-
     async def drop_all_objects_in_working_schema(self) -> None:
         if not await self.schema_exists():
             return
@@ -384,8 +375,6 @@ class SnowflakeSchemaInitializer(BaseSchemaInitializer):
                 objects["arguments"].tolist()
             ):
                 await self._drop_object("PROCEDURE", func_name_with_args)
-
-        await self._drop_tasks()
 
         table_names = await self.session.list_tables(
             self.session.database_name, self.session.schema_name

--- a/featurebyte/session/snowflake.py
+++ b/featurebyte/session/snowflake.py
@@ -376,8 +376,5 @@ class SnowflakeSchemaInitializer(BaseSchemaInitializer):
             ):
                 await self._drop_object("PROCEDURE", func_name_with_args)
 
-        table_names = await self.session.list_tables(
-            self.session.database_name, self.session.schema_name
-        )
-        for name in table_names:
+        for name in await self.list_droppable_tables_in_working_schema():
             await self._drop_object("TABLE", name)


### PR DESCRIPTION
## Description

When recreating a schema from scratch, all tables in the the working schema are dropped before being reinstated. However, this is not applicable to materialized tables which also reside in the working schema. This updates the process to be aware of materialized tables and not drop them.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
