### PR TITLE
[chore] Skip query warehouse when executing SDK code in server mode

### DIFF
--- a/featurebyte/api/api_object_util.py
+++ b/featurebyte/api/api_object_util.py
@@ -4,6 +4,7 @@ API Object Util
 from typing import Any, Optional
 
 import ctypes
+import os
 import threading
 
 from featurebyte.config import Configurations
@@ -113,3 +114,17 @@ class NameAttributeUpdatableMixin:
             except RecordRetrievalException:
                 pass
         return super().__getattribute__(item)
+
+
+def is_server_mode() -> bool:
+    """
+    Check if the code is running in server mode. Server mode is used when running the SDK code inside
+    featurebyte worker.
+
+    Returns
+    -------
+    bool
+        True if the code is running in server mode
+    """
+    sdk_execution_mode = os.environ.get("FEATUREBYTE_SDK_EXECUTION_MODE")
+    return sdk_execution_mode == "SERVER"

--- a/featurebyte/api/feature.py
+++ b/featurebyte/api/feature.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from typing import Any, ClassVar, Dict, List, Literal, Optional, Sequence, Tuple, Type, Union, cast
 
-import os
 import time
 from http import HTTPStatus
 
@@ -16,6 +15,7 @@ from pydantic import Field, root_validator
 from typeguard import typechecked
 
 from featurebyte.api.api_object import ConflictResolution
+from featurebyte.api.api_object_util import is_server_mode
 from featurebyte.api.entity import Entity
 from featurebyte.api.feature_job import FeatureJobMixin
 from featurebyte.api.feature_namespace import FeatureNamespace
@@ -718,8 +718,7 @@ class Feature(
         ... )["InvoiceAmountAvg_60days"]
         >>> invoice_amount_avg_60days.save()  # doctest: +SKIP
         """
-        sdk_execution_mode = os.environ.get("FEATUREBYTE_SDK_EXECUTION_MODE")
-        if sdk_execution_mode == "SERVER":
+        if is_server_mode():
             # server mode save a feature by POST /feature/ endpoint directly without running the feature definition.
             super().save(conflict_resolution=conflict_resolution, _id=_id)
         else:

--- a/featurebyte/api/source_table.py
+++ b/featurebyte/api/source_table.py
@@ -15,6 +15,7 @@ from bson import ObjectId
 from pydantic import Field
 from typeguard import typechecked
 
+from featurebyte.api.api_object_util import is_server_mode
 from featurebyte.common.doc_util import FBAutoDoc
 from featurebyte.config import Configurations
 from featurebyte.core.frame import BaseFrame
@@ -117,6 +118,7 @@ class AbstractTableData(ConstructGraphMixin, FeatureByteBaseModel, ABC):
             table_details = TableDetails(**table_details)
 
         to_validate_schema = values.get("_validate_schema") or "columns_info" not in values
+        to_validate_schema &= not is_server_mode()
         if to_validate_schema:
             client = Configurations().get_client()
             response = client.post(


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

As parts of the effort to reduce time to save features & feature lists, this PR updates table object constructor logic to skip querying warehouse when running the SDK code in server mode.

With current changes, the time to save 204 features drop from 11.5min to 2min.

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
