### PR TITLE
[chore] make graph related attribute lazy

### DIFF
--- a/featurebyte/api/feature.py
+++ b/featurebyte/api/feature.py
@@ -810,8 +810,8 @@ class Feature(
         FeatureModel
         """
         pruned_graph, mapped_node = self.extract_pruned_graph_and_node()
-        feature_dict = self.dict()
-        feature_dict["graph"] = pruned_graph
+        feature_dict = self.dict(by_alias=True)
+        feature_dict["graph"] = pruned_graph.dict()
         feature_dict["node_name"] = mapped_node.name
         return FeatureModel(**feature_dict)
 

--- a/featurebyte/models/context.py
+++ b/featurebyte/models/context.py
@@ -24,6 +24,8 @@ class ContextModel(FeatureByteCatalogBaseDocumentModel):
         Graph to store the context view
     """
 
+    # TODO: make graph attribute lazy
+
     entity_ids: List[PydanticObjectId]
     graph: Optional[QueryGraph]
     node_name: Optional[str]

--- a/featurebyte/models/feature.py
+++ b/featurebyte/models/feature.py
@@ -201,7 +201,7 @@ class FeatureModel(FeatureByteCatalogBaseDocumentModel):
     definition: Optional[str] = Field(allow_mutation=False, default=None)
 
     # special handling for those attributes that are expensive to deserialize
-    # internal_* is used to store the raw data from persistence, _* is used to store the deserialized data
+    # internal_* is used to store the raw data from persistence, _* is used as a cache
     internal_graph: Any = Field(allow_mutation=False, alias="graph")
     _graph: Optional[QueryGraph] = PrivateAttr(default=None)
 
@@ -261,7 +261,7 @@ class FeatureModel(FeatureByteCatalogBaseDocumentModel):
     @property
     def graph(self) -> QueryGraph:
         """
-        Retrieve graph
+        Get the graph. If the graph is not loaded, load it first.
 
         Returns
         -------

--- a/featurebyte/models/feature.py
+++ b/featurebyte/models/feature.py
@@ -272,13 +272,13 @@ class FeatureModel(FeatureByteCatalogBaseDocumentModel):
         if self._graph is None:
             if isinstance(self.internal_graph, QueryGraph):
                 self._graph = self.internal_graph
-
-            if isinstance(self.internal_graph, dict):
-                graph_dict = self.internal_graph
             else:
-                # for example, QueryGraphModel
-                graph_dict = self.internal_graph.dict(by_alias=True)
-            self._graph = QueryGraph(**graph_dict)
+                if isinstance(self.internal_graph, dict):
+                    graph_dict = self.internal_graph
+                else:
+                    # for example, QueryGraphModel
+                    graph_dict = self.internal_graph.dict(by_alias=True)
+                self._graph = QueryGraph(**graph_dict)
         return self._graph
 
     def extract_pruned_graph_and_node(self, **kwargs: Any) -> tuple[QueryGraphModel, Node]:

--- a/featurebyte/models/feature_list.py
+++ b/featurebyte/models/feature_list.py
@@ -478,7 +478,7 @@ class FeatureListModel(FeatureByteCatalogBaseDocumentModel):
     deployed: bool = Field(allow_mutation=False, default=False)
 
     # special handling for those attributes that are expensive to deserialize
-    # internal_* is used to store the raw data from persistence, _* is used to store the deserialized data
+    # internal_* is used to store the raw data from persistence, _* is used as a cache
     internal_feature_clusters: Optional[List[Any]] = Field(
         allow_mutation=False, alias="feature_clusters"
     )

--- a/featurebyte/routes/feature/controller.py
+++ b/featurebyte/routes/feature/controller.py
@@ -442,7 +442,7 @@ class FeatureController(
         feature = await self.service.get_document(feature_id)
         return await self.feature_store_warehouse_service.get_feature_job_logs(
             feature_store_id=feature.tabular_source.feature_store_id,
-            features=[ExtendedFeatureModel(**feature.dict())],
+            features=[ExtendedFeatureModel(**feature.dict(by_alias=True))],
             hour_limit=hour_limit,
             get_credential=get_credential,
         )

--- a/featurebyte/service/batch_request_table.py
+++ b/featurebyte/service/batch_request_table.py
@@ -73,7 +73,7 @@ class BatchRequestTableService(
             await self.context_service.get_document(document_id=data.context_id)
 
         return BatchRequestTableTaskPayload(
-            **data.dict(),
+            **data.dict(by_alias=True),
             user_id=self.user.id,
             catalog_id=self.catalog_id,
             output_document_id=output_document_id,

--- a/featurebyte/service/feature.py
+++ b/featurebyte/service/feature.py
@@ -196,10 +196,6 @@ class FeatureService(BaseDocumentService[FeatureModel, FeatureServiceCreate, Fea
 
         # create feature definition
         graph, node_name = document.graph, document.node_name
-        if graph is None:
-            import pdb
-
-            pdb.set_trace()
         sdk_code_gen_state = SDKCodeExtractor(graph=graph).extract(
             node=graph.get_node_by_name(node_name),
             to_use_saved_data=True,

--- a/featurebyte/service/feature.py
+++ b/featurebyte/service/feature.py
@@ -196,6 +196,10 @@ class FeatureService(BaseDocumentService[FeatureModel, FeatureServiceCreate, Fea
 
         # create feature definition
         graph, node_name = document.graph, document.node_name
+        if graph is None:
+            import pdb
+
+            pdb.set_trace()
         sdk_code_gen_state = SDKCodeExtractor(graph=graph).extract(
             node=graph.get_node_by_name(node_name),
             to_use_saved_data=True,

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -81,7 +81,7 @@ class ObservationTableService(
             await self.context_service.get_document(document_id=data.context_id)
 
         return ObservationTableTaskPayload(
-            **data.dict(),
+            **data.dict(by_alias=True),
             user_id=self.user.id,
             catalog_id=self.catalog_id,
             output_document_id=output_document_id,

--- a/featurebyte/service/online_enable.py
+++ b/featurebyte/service/online_enable.py
@@ -105,7 +105,6 @@ class OnlineEnableService(BaseService):
         self,
         feature_namespace_id: ObjectId,
         feature: FeatureModel,
-        document: Optional[FeatureNamespaceModel] = None,
         return_document: bool = True,
     ) -> Optional[FeatureNamespaceModel]:
         """
@@ -117,8 +116,6 @@ class OnlineEnableService(BaseService):
             FeatureNamespace ID
         feature: FeatureModel
             Updated Feature object
-        document: Optional[FeatureNamespaceModel]
-            Document to be updated (when provided, this method won't query persistent for retrieval)
         return_document: bool
             Whether to return updated document
 
@@ -159,7 +156,7 @@ class OnlineEnableService(BaseService):
         task_manager: Optional[TaskManager]
             TaskManager object
         """
-        extended_feature_model = ExtendedFeatureModel(**feature.dict())
+        extended_feature_model = ExtendedFeatureModel(**feature.dict(by_alias=True))
         online_feature_spec = OnlineFeatureSpec(feature=extended_feature_model)
 
         if not online_feature_spec.is_online_store_eligible:

--- a/featurebyte/service/static_source_table.py
+++ b/featurebyte/service/static_source_table.py
@@ -68,7 +68,7 @@ class StaticSourceTableService(
         await self.feature_store_service.get_document(document_id=data.feature_store_id)
 
         return StaticSourceTableTaskPayload(
-            **data.dict(),
+            **data.dict(by_alias=True),
             user_id=self.user.id,
             catalog_id=self.catalog_id,
             output_document_id=output_document_id,

--- a/tests/unit/models/test_feature.py
+++ b/tests/unit/models/test_feature.py
@@ -50,9 +50,9 @@ def test_feature_model(feature_model_dict, api_object_to_id):
     feature = FeatureModel(**feature_model_dict)
     feature_json = feature.json(by_alias=True)
     loaded_feature = FeatureModel.parse_raw(feature_json)
-    feature_dict = feature.dict()
+    feature_dict = feature.dict(by_alias=True)
     assert loaded_feature.id == feature.id
-    assert loaded_feature.dict() == feature_dict
+    assert loaded_feature.dict(by_alias=True) == feature_dict
     assert feature_dict == {
         "created_at": None,
         "deployed_feature_list_ids": [],
@@ -65,7 +65,7 @@ def test_feature_model(feature_model_dict, api_object_to_id):
             "edges": feature_dict["graph"]["edges"],
             "nodes": feature_dict["graph"]["nodes"],
         },
-        "id": ObjectId(feature_model_dict["_id"]),
+        "_id": ObjectId(feature_model_dict["_id"]),
         "name": "sum_30m",
         "node_name": "project_1",
         "online_enabled": False,

--- a/tests/unit/models/test_feature_list.py
+++ b/tests/unit/models/test_feature_list.py
@@ -67,7 +67,7 @@ def feature_list_namespace_model_dict_fixture():
 def test_feature_list_model(feature_list_model_dict):
     """Test feature list model"""
     feature_list = FeatureListModel.parse_obj(feature_list_model_dict)
-    serialized_feature_list = feature_list.dict(exclude={"id": True})
+    serialized_feature_list = feature_list.dict(exclude={"id": True}, by_alias=True)
     feature_list_dict_sorted_ids = {
         key: sorted(value) if key.endswith("_ids") and key != "feature_ids" else value
         for key, value in feature_list_model_dict.items()
@@ -96,7 +96,9 @@ def test_feature_list_model(feature_list_model_dict):
 def test_feature_list_namespace_model(feature_list_namespace_model_dict):
     """Test feature list namespace model"""
     feature_list_namespace = FeatureListNamespaceModel.parse_obj(feature_list_namespace_model_dict)
-    serialized_feature_list_namespace = feature_list_namespace.dict(exclude={"id": True})
+    serialized_feature_list_namespace = feature_list_namespace.dict(
+        exclude={"id": True}, by_alias=True
+    )
     feature_list_namespace_model_dict_sorted_ids = {
         key: sorted(value) if key.endswith("_ids") else value
         for key, value in feature_list_namespace_model_dict.items()


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

Recent runtime performance investigation found that it takes long time to serialize & deserialize the model when it contains complicated graphs (loading from persistent, convert to response model). To improve the runtime performance, this PR aims to make these attribute lazy (keeps the original dictionary format when it is not loaded, when accessing the attribute, convert them into expected format & then stored it in the model cache).

## Performance Results

With current changes:
* loading save feature list object: reduce from 13 seconds to 1.5 seconds
* create a feature list with 204 saved features & delete the feature list: reduce from 35 seconds to 9-15 seconds

Time to list assets through catalog object:
Before:
```
                     list_method_name                elapsed
5                  list_feature_lists 0 days 00:00:01.198686
7                       list_features 0 days 00:00:00.549711
11                 list_relationships 0 days 00:00:00.060092
13                        list_tables 0 days 00:00:00.027998
3                       list_entities 0 days 00:00:00.014406
6                 list_feature_stores 0 days 00:00:00.012503
1           list_batch_request_tables 0 days 00:00:00.012432
4   list_feature_job_setting_analyses 0 days 00:00:00.012278
0           list_batch_feature_tables 0 days 00:00:00.012140
2                    list_deployments 0 days 00:00:00.011310
8      list_historical_feature_tables 0 days 00:00:00.011035
9             list_observation_tables 0 days 00:00:00.010707
12          list_static_source_tables 0 days 00:00:00.010282
10                list_periodic_tasks 0 days 00:00:00.010119
```

After:
```
                     list_method_name                elapsed
7                       list_features 0 days 00:00:00.207054
5                  list_feature_lists 0 days 00:00:00.146189
11                 list_relationships 0 days 00:00:00.062013
13                        list_tables 0 days 00:00:00.027012
3                       list_entities 0 days 00:00:00.013862
0           list_batch_feature_tables 0 days 00:00:00.012779
6                 list_feature_stores 0 days 00:00:00.012019
8      list_historical_feature_tables 0 days 00:00:00.011921
4   list_feature_job_setting_analyses 0 days 00:00:00.011829
2                    list_deployments 0 days 00:00:00.011525
1           list_batch_request_tables 0 days 00:00:00.011103
10                list_periodic_tasks 0 days 00:00:00.011039
12          list_static_source_tables 0 days 00:00:00.009585
9             list_observation_tables 0 days 00:00:00.009201
```

Time to call list routes:
Before:
```
                            route                elapsed
11                       /feature 0 days 00:00:01.001080
13                  /feature_list 0 days 00:00:00.917046
27                          /task 0 days 00:00:00.059043
15             /feature_namespace 0 days 00:00:00.029259
6                /deployment/all/ 0 days 00:00:00.013126
4                     /credential 0 days 00:00:00.012444
26                         /table 0 days 00:00:00.012057
14        /feature_list_namespace 0 days 00:00:00.011753
22                     /scd_table 0 days 00:00:00.011164
10                   /event_table 0 days 00:00:00.010914
2                        /catalog 0 days 00:00:00.010897
18                    /item_table 0 days 00:00:00.010780
23                      /semantic 0 days 00:00:00.010390
12  /feature_job_setting_analysis 0 days 00:00:00.010327
9                         /entity 0 days 00:00:00.010153
7            /deployment/summary/ 0 days 00:00:00.010127
8                /dimension_table 0 days 00:00:00.010004
0            /batch_feature_table 0 days 00:00:00.009988
17      /historical_feature_table 0 days 00:00:00.009600
21             /relationship_info 0 days 00:00:00.009547
5                     /deployment 0 days 00:00:00.009546
3                        /context 0 days 00:00:00.009056
1            /batch_request_table 0 days 00:00:00.009013
19             /observation_table 0 days 00:00:00.008918
16                 /feature_store 0 days 00:00:00.008862
20                 /periodic_task 0 days 00:00:00.008853
24           /static_source_table 0 days 00:00:00.008725
25                        /status 0 days 00:00:00.004642
```
After:
```
                            route                elapsed
27                          /task 0 days 00:00:00.060037
13                  /feature_list 0 days 00:00:00.057604
11                       /feature 0 days 00:00:00.032201
15             /feature_namespace 0 days 00:00:00.014279
6                /deployment/all/ 0 days 00:00:00.013371
22                     /scd_table 0 days 00:00:00.012458
26                         /table 0 days 00:00:00.011473
18                    /item_table 0 days 00:00:00.011370
4                     /credential 0 days 00:00:00.011175
24           /static_source_table 0 days 00:00:00.011057
5                     /deployment 0 days 00:00:00.010763
14        /feature_list_namespace 0 days 00:00:00.010698
7            /deployment/summary/ 0 days 00:00:00.010665
2                        /catalog 0 days 00:00:00.010518
19             /observation_table 0 days 00:00:00.009953
23                      /semantic 0 days 00:00:00.009901
10                   /event_table 0 days 00:00:00.009800
8                /dimension_table 0 days 00:00:00.009775
1            /batch_request_table 0 days 00:00:00.009714
9                         /entity 0 days 00:00:00.009639
21             /relationship_info 0 days 00:00:00.009638
0            /batch_feature_table 0 days 00:00:00.009490
17      /historical_feature_table 0 days 00:00:00.009405
20                 /periodic_task 0 days 00:00:00.009185
3                        /context 0 days 00:00:00.008861
16                 /feature_store 0 days 00:00:00.008576
12  /feature_job_setting_analysis 0 days 00:00:00.007662
25                        /status 0 days 00:00:00.003958
```



<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
