### PR TITLE
[bug] fix primary entity identification bug

### DIFF
--- a/.changelog/DEV-1812.yaml
+++ b/.changelog/DEV-1812.yaml
@@ -1,0 +1,16 @@
+# Type of change
+change_type: enhancement
+
+# The name of the component
+component: feature
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.
+note: "fix primary entity identification bug for time aggregation over item aggregation features"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/featurebyte/api/api_object.py
+++ b/featurebyte/api/api_object.py
@@ -621,7 +621,7 @@ class ApiObject(FeatureByteBaseDocumentModel):
             raise NotImplementedError
 
         data = self._update_schema_class(  # pylint: disable=not-callable
-            **{**self.json_dict(), **update_payload}
+            **{**self.dict(by_alias=True), **update_payload}
         )
         client = Configurations().get_client()
         response = client.patch(url=f"{self._route}/{self.id}", json=data.json_dict())

--- a/featurebyte/api/base_table.py
+++ b/featurebyte/api/base_table.py
@@ -549,9 +549,9 @@ class TableApiObject(AbstractTableData, TableListMixin, SavableApiObject, GetAtt
             Table data object used for SQL query construction.
         """
         try:
-            return self._table_data_class(**self.cached_model.json_dict())
+            return self._table_data_class(**self.cached_model.dict(by_alias=True))
         except RecordRetrievalException:
-            return self._table_data_class(**self.json_dict())
+            return self._table_data_class(**self.dict(by_alias=True))
 
     @property
     def columns_info(self) -> List[ColumnInfo]:
@@ -697,7 +697,7 @@ class TableApiObject(AbstractTableData, TableListMixin, SavableApiObject, GetAtt
 
     def _get_create_payload(self) -> dict[str, Any]:
         assert self._create_schema_class is not None
-        data = self._create_schema_class(**self.json_dict())  # pylint: disable=not-callable
+        data = self._create_schema_class(**self.dict(by_alias=True))  # pylint: disable=not-callable
         return data.json_dict()
 
     @classmethod
@@ -755,7 +755,7 @@ class TableApiObject(AbstractTableData, TableListMixin, SavableApiObject, GetAtt
             response_dict = response.json()
             if not response_dict["data"]:
                 table = cls(
-                    **data.json_dict(),
+                    **data.dict(by_alias=True),
                     feature_store=source_table.feature_store,
                     _validate_schema=True,
                 )

--- a/featurebyte/api/catalog.py
+++ b/featurebyte/api/catalog.py
@@ -91,7 +91,7 @@ class Catalog(NameAttributeUpdatableMixin, SavableApiObject, CatalogGetByIdMixin
             return self.internal_default_feature_store_ids
 
     def _get_create_payload(self) -> Dict[str, Any]:
-        data = CatalogCreate(**self.json_dict())
+        data = CatalogCreate(**self.dict(by_alias=True))
         return data.json_dict()
 
     def info(self, verbose: bool = False) -> Dict[str, Any]:

--- a/featurebyte/api/credential.py
+++ b/featurebyte/api/credential.py
@@ -70,7 +70,7 @@ class Credential(DeletableApiObject, SavableApiObject):
     )
 
     def _get_create_payload(self) -> Dict[str, Any]:
-        data = CredentialCreate(**self.json_dict())
+        data = CredentialCreate(**self.dict(by_alias=True))
         return data.json_dict()
 
     @property

--- a/featurebyte/api/entity.py
+++ b/featurebyte/api/entity.py
@@ -41,7 +41,7 @@ class Entity(NameAttributeUpdatableMixin, SavableApiObject):
     internal_serving_names: List[str] = Field(alias="serving_names")
 
     def _get_create_payload(self) -> dict[str, Any]:
-        data = EntityCreate(serving_name=self.serving_name, **self.json_dict())
+        data = EntityCreate(serving_name=self.serving_name, **self.dict(by_alias=True))
         return data.json_dict()
 
     @property

--- a/featurebyte/api/feature.py
+++ b/featurebyte/api/feature.py
@@ -111,7 +111,7 @@ class Feature(
         return {"feature_store": self.feature_store}
 
     def _get_create_payload(self) -> dict[str, Any]:
-        data = FeatureCreate(**self.json_dict())
+        data = FeatureCreate(**self.dict(by_alias=True))
         return data.json_dict(exclude_none=True)
 
     def _get_feature_tiles_specs(self) -> List[Tuple[str, List[TileSpec]]]:

--- a/featurebyte/api/feature_list.py
+++ b/featurebyte/api/feature_list.py
@@ -661,7 +661,7 @@ class FeatureList(BaseFeatureGroup, DeletableApiObject, SavableApiObject, Featur
     def _get_create_payload(self) -> dict[str, Any]:
         feature_ids = [feature.id for feature in self.feature_objects.values()]
         data = FeatureListCreate(
-            **{**self.json_dict(exclude_none=True), "feature_ids": feature_ids}
+            **{**self.dict(by_alias=True, exclude_none=True), "feature_ids": feature_ids}
         )
         return data.json_dict()
 
@@ -677,9 +677,9 @@ class FeatureList(BaseFeatureGroup, DeletableApiObject, SavableApiObject, Featur
                     feat = Feature.get(name=feat_name)
                     self.feature_objects[feat_name] = feat
                 except RecordRetrievalException:
-                    feature_payloads.append(FeatureCreate(**feat.json_dict()))
+                    feature_payloads.append(FeatureCreate(**feat.dict(by_alias=True)))
             if conflict_resolution == "raise" and not feat.saved:
-                feature_payloads.append(FeatureCreate(**feat.json_dict()))
+                feature_payloads.append(FeatureCreate(**feat.dict(by_alias=True)))
 
         self.post_async_task(
             route="/feature/batch",

--- a/featurebyte/api/feature_store.py
+++ b/featurebyte/api/feature_store.py
@@ -42,7 +42,7 @@ class FeatureStore(FeatureStoreModel, SavableApiObject):
     storage_credential: Optional[StorageCredential] = None
 
     def _get_create_payload(self) -> dict[str, Any]:
-        data = FeatureStoreCreate(**self.json_dict())
+        data = FeatureStoreCreate(**self.dict(by_alias=True))
         return data.json_dict()
 
     def info(self, verbose: bool = False) -> Dict[str, Any]:

--- a/featurebyte/api/source_table.py
+++ b/featurebyte/api/source_table.py
@@ -164,7 +164,7 @@ class AbstractTableData(ConstructGraphMixin, FeatureByteBaseModel, ABC):
         BaseTableData
             Table data object used for SQL query construction.
         """
-        return self._table_data_class(**self.json_dict())
+        return self._table_data_class(**self.dict(by_alias=True))
 
     @property
     def frame(self) -> TableDataFrame:

--- a/featurebyte/api/view.py
+++ b/featurebyte/api/view.py
@@ -1008,7 +1008,7 @@ class View(ProtectedColumnsQueryObject, Frame, ABC):
         return type(self)(
             feature_store=self.feature_store,
             **{
-                **self.json_dict(exclude={"feature_store": True}),
+                **self.dict(by_alias=True, exclude={"feature_store": True}),
                 "graph": self.graph,
                 "node_name": new_node_name,
                 "columns_info": joined_columns_info,

--- a/featurebyte/models/feature_store.py
+++ b/featurebyte/models/feature_store.py
@@ -41,7 +41,7 @@ class FeatureStoreModel(FeatureByteBaseDocumentModel, FeatureStoreDetails):
         -------
         FeatureStoreDetails
         """
-        return FeatureStoreDetails(**self.json_dict())
+        return FeatureStoreDetails(**self.dict(by_alias=True))
 
     class Settings(FeatureByteBaseDocumentModel.Settings):
         """
@@ -175,7 +175,7 @@ class TableModel(BaseTableData, ConstructGraphMixin, FeatureByteCatalogBaseDocum
         -------
         BaseTableData
         """
-        return self._table_data_class(**self.json_dict())
+        return self._table_data_class(**self.dict(by_alias=True))
 
     @property
     @abstractmethod

--- a/featurebyte/query_graph/graph.py
+++ b/featurebyte/query_graph/graph.py
@@ -34,6 +34,7 @@ from featurebyte.query_graph.node.metadata.operation import (
     SourceDataColumn,
 )
 from featurebyte.query_graph.node.mixin import BaseGroupbyParameters
+from featurebyte.query_graph.transform.entity_extractor import EntityExtractor
 from featurebyte.query_graph.transform.flattening import GraphFlatteningTransformer
 from featurebyte.query_graph.transform.operation_structure import OperationStructureExtractor
 from featurebyte.query_graph.transform.pruning import prune_query_graph
@@ -130,15 +131,10 @@ class QueryGraph(QueryGraphModel):
         List[ObjectId]
             List of entity IDs in the query graph
         """
-        output = []
-        target_node = self.get_node_by_name(node_name)
-        for node in self.iterate_nodes(target_node=target_node, node_type=None):
-            if isinstance(node.parameters, BaseGroupbyParameters):
-                if node.parameters.entity_ids:
-                    output.extend(node.parameters.entity_ids)
-            elif isinstance(node, LookupNode):
-                output.append(node.parameters.entity_id)
-        return sorted(set(output))
+        entity_state = EntityExtractor(graph=self).extract(
+            node=self.get_node_by_name(node_name=node_name)
+        )
+        return sorted(entity_state.entity_ids)
 
     def get_entity_columns(self, node_name: str) -> List[str]:
         """

--- a/featurebyte/query_graph/transform/entity_extractor.py
+++ b/featurebyte/query_graph/transform/entity_extractor.py
@@ -43,7 +43,7 @@ class EntityExtractor(
             # if groupby node has entity_ids, skip further exploration on input nodes
             if node.parameters.entity_ids:
                 global_state.entity_ids.update(node.parameters.entity_ids)
-                skip_input_nodes = True
+            skip_input_nodes = True
         elif isinstance(node, LookupNode):
             global_state.entity_ids.add(node.parameters.entity_id)
         return [] if skip_input_nodes else input_node_names, False

--- a/featurebyte/query_graph/transform/entity_extractor.py
+++ b/featurebyte/query_graph/transform/entity_extractor.py
@@ -1,0 +1,78 @@
+"""
+This module contains graph entity extraction related classes.
+"""
+from typing import Any, List, Set, Tuple
+
+from dataclasses import dataclass, field
+
+from bson import ObjectId
+
+from featurebyte.query_graph.node import Node
+from featurebyte.query_graph.node.generic import LookupNode
+from featurebyte.query_graph.node.mixin import BaseGroupbyParameters
+from featurebyte.query_graph.transform.base import BaseGraphExtractor
+
+
+class EntityExtractorBranchState:
+    """EntityExtractorBranchState class"""
+
+
+@dataclass
+class EntityExtractorGlobalState:
+    """EntityExtractorGlobalState class"""
+
+    entity_ids: Set[ObjectId] = field(default_factory=set)
+
+
+class EntityExtractor(
+    BaseGraphExtractor[
+        EntityExtractorGlobalState, EntityExtractorBranchState, EntityExtractorGlobalState
+    ]
+):
+    """EntityExtractor class"""
+
+    def _pre_compute(
+        self,
+        branch_state: EntityExtractorBranchState,
+        global_state: EntityExtractorGlobalState,
+        node: Node,
+        input_node_names: List[str],
+    ) -> Tuple[List[str], bool]:
+        skip_input_nodes = False
+        if isinstance(node.parameters, BaseGroupbyParameters):
+            # if groupby node has entity_ids, skip further exploration on input nodes
+            if node.parameters.entity_ids:
+                global_state.entity_ids.update(node.parameters.entity_ids)
+                skip_input_nodes = True
+        elif isinstance(node, LookupNode):
+            global_state.entity_ids.add(node.parameters.entity_id)
+        return [] if skip_input_nodes else input_node_names, False
+
+    def _in_compute(
+        self,
+        branch_state: EntityExtractorBranchState,
+        global_state: EntityExtractorGlobalState,
+        node: Node,
+        input_node: Node,
+    ) -> EntityExtractorBranchState:
+        return branch_state
+
+    def _post_compute(
+        self,
+        branch_state: EntityExtractorBranchState,
+        global_state: EntityExtractorGlobalState,
+        node: Node,
+        inputs: List[Any],
+        skip_post: bool,
+    ) -> EntityExtractorGlobalState:
+        return global_state
+
+    def extract(self, node: Node, **kwargs: Any) -> EntityExtractorGlobalState:
+        global_state = EntityExtractorGlobalState()
+        self._extract(
+            node=node,
+            branch_state=EntityExtractorBranchState(),
+            global_state=global_state,
+            topological_order_map=self.graph.node_topological_order_map,
+        )
+        return global_state

--- a/featurebyte/routes/credential/controller.py
+++ b/featurebyte/routes/credential/controller.py
@@ -55,7 +55,7 @@ class CredentialController(
             CredentialRead object
         """
         document = await self.service.create_document(data=data)
-        return CredentialRead(**document.json_dict())
+        return CredentialRead(**document.dict(by_alias=True))
 
     async def update_credential(
         self,
@@ -79,10 +79,10 @@ class CredentialController(
         """
         document = await self.service.update_document(
             document_id=credential_id,
-            data=CredentialServiceUpdate(**data.dict()),
+            data=CredentialServiceUpdate(**data.dict(by_alias=True)),
         )
         assert document is not None
-        return CredentialRead(**document.json_dict())
+        return CredentialRead(**document.dict(by_alias=True))
 
     async def delete_credential(
         self,

--- a/featurebyte/routes/feature/controller.py
+++ b/featurebyte/routes/feature/controller.py
@@ -103,7 +103,7 @@ class FeatureController(
         """
         payload = BatchFeatureCreateTaskPayload(
             **{
-                **data.json_dict(),
+                **data.dict(by_alias=True),
                 "catalog_id": self.service.catalog_id,
             }
         )
@@ -128,7 +128,7 @@ class FeatureController(
         """
         if isinstance(data, FeatureCreate):
             document = await self.service.create_document(
-                data=FeatureServiceCreate(**data.json_dict())
+                data=FeatureServiceCreate(**data.dict(by_alias=True))
             )
         else:
             document = await self.version_service.create_new_feature_version(data=data)

--- a/featurebyte/routes/feature_list/controller.py
+++ b/featurebyte/routes/feature_list/controller.py
@@ -97,7 +97,7 @@ class FeatureListController(
         """
         if isinstance(data, FeatureListCreate):
             document = await self.service.create_document(
-                data=FeatureListServiceCreate(**data.json_dict())
+                data=FeatureListServiceCreate(**data.dict(by_alias=True))
             )
         else:
             document = await self.version_service.create_new_feature_list_version(data=data)

--- a/featurebyte/routes/feature_list_namespace/controller.py
+++ b/featurebyte/routes/feature_list_namespace/controller.py
@@ -71,7 +71,7 @@ class FeatureListNamespaceController(
             document_id=document_id, exception_detail=exception_detail
         )
         output = FeatureListNamespaceModelResponse(
-            **document.json_dict(),
+            **document.dict(by_alias=True),
             primary_entity_ids=await self.derive_primary_entity_ids(entity_ids=document.entity_ids),
         )
         return cast(Document, output)

--- a/featurebyte/routes/feature_namespace/controller.py
+++ b/featurebyte/routes/feature_namespace/controller.py
@@ -72,7 +72,7 @@ class FeatureNamespaceController(
             document_id=document.default_feature_id
         )
         output = FeatureNamespaceModelResponse(
-            **document.json_dict(),
+            **document.dict(by_alias=True),
             primary_table_ids=default_feature.primary_table_ids,
             primary_entity_ids=await self.derive_primary_entity_ids(entity_ids=document.entity_ids),
         )

--- a/featurebyte/routes/feature_store/controller.py
+++ b/featurebyte/routes/feature_store/controller.py
@@ -151,7 +151,7 @@ class FeatureStoreController(
             )
             # Try to persist credential
             await self.credential_service.create_document(
-                data=CredentialCreate(**credential.json_dict())
+                data=CredentialCreate(**credential.dict(by_alias=True))
             )
             # If no error thrown from creating, try to create the metadata table with the feature store ID.
             metadata_schema_initializer = MetadataSchemaInitializer(session)

--- a/featurebyte/service/base_document.py
+++ b/featurebyte/service/base_document.py
@@ -146,7 +146,7 @@ class BaseDocumentService(
 
         document = self.document_class(
             **{
-                **data.json_dict(),
+                **data.dict(by_alias=True),
                 **kwargs,
                 "user_id": self.user.id,
             },
@@ -775,7 +775,7 @@ class BaseDocumentService(
 
         # perform validation first before actual update
         update_dict = data.dict(exclude_none=exclude_none)
-        updated_document = self.document_class(**{**document.json_dict(), **update_dict})
+        updated_document = self.document_class(**{**document.dict(by_alias=True), **update_dict})
 
         # check any conflict with existing documents
         await self._check_document_unique_constraints(

--- a/featurebyte/service/base_table_document.py
+++ b/featurebyte/service/base_table_document.py
@@ -122,7 +122,7 @@ class BaseTableDocumentService(BaseDocumentService[Document, DocumentCreate, Doc
 
         # create document ID if it is None
         data_doc_id = data.id or ObjectId()
-        payload_dict = {**data.json_dict(), "_id": data_doc_id}
+        payload_dict = {**data.dict(by_alias=True), "_id": data_doc_id}
         if self.is_catalog_specific:
             payload_dict = {**payload_dict, "catalog_id": self.catalog_id}
 

--- a/featurebyte/service/credential.py
+++ b/featurebyte/service/credential.py
@@ -116,10 +116,12 @@ class CredentialService(
         -------
         CredentialModel
         """
-        credential = self.document_class(**data.json_dict())
+        credential = self.document_class(**data.dict(by_alias=True))
         await self._validate_credential(credential=credential)
         credential.encrypt()
-        return await super().create_document(data=CredentialCreate(**credential.json_dict()))
+        return await super().create_document(
+            data=CredentialCreate(**credential.dict(by_alias=True))
+        )
 
     async def update_document(
         self,
@@ -160,7 +162,7 @@ class CredentialService(
 
         # verify credential is valid
         update_dict = data.dict(exclude_none=exclude_none)
-        updated_document = self.document_class(**{**document.json_dict(), **update_dict})
+        updated_document = self.document_class(**{**document.dict(by_alias=True), **update_dict})
         await self._validate_credential(credential=updated_document)
         data.encrypt()
 

--- a/featurebyte/service/feature.py
+++ b/featurebyte/service/feature.py
@@ -156,7 +156,7 @@ class FeatureService(BaseDocumentService[FeatureModel, FeatureServiceCreate, Fea
         """
         document = FeatureModel(
             **{
-                **data.json_dict(),
+                **data.dict(by_alias=True),
                 "readiness": FeatureReadiness.DRAFT,
                 "version": await self._get_feature_version(data.name),
                 "user_id": self.user.id,
@@ -170,7 +170,9 @@ class FeatureService(BaseDocumentService[FeatureModel, FeatureServiceCreate, Fea
         )
 
         # create a new feature document (so that the derived attributes like table_ids is generated properly)
-        return FeatureModel(**{**document.json_dict(), "graph": graph, "node_name": node_name})
+        return FeatureModel(
+            **{**document.dict(by_alias=True), "graph": graph, "node_name": node_name}
+        )
 
     async def prepare_feature_definition(self, document: FeatureModel) -> str:
         """

--- a/featurebyte/service/feature_list.py
+++ b/featurebyte/service/feature_list.py
@@ -200,7 +200,7 @@ class FeatureListService(
         # sort feature_ids before saving to persistent storage to ease feature_ids comparison in uniqueness check
         document = FeatureListModel(
             **{
-                **data.json_dict(),
+                **data.dict(by_alias=True),
                 "version": await self._get_feature_list_version(data.name),
                 "user_id": self.user.id,
                 "catalog_id": self.catalog_id,

--- a/featurebyte/worker/task/batch_feature_create.py
+++ b/featurebyte/worker/task/batch_feature_create.py
@@ -131,7 +131,7 @@ class BatchFeatureCreateTask(BaseTask):
         for i, feature_create_data in enumerate(payload.iterate_features()):
             # prepare the feature document & definition
             document = await feature_service.prepare_feature_model(
-                data=FeatureServiceCreate(**feature_create_data.json_dict()),
+                data=FeatureServiceCreate(**feature_create_data.dict(by_alias=True)),
                 sanitize_for_definition=True,
             )
             definition = await feature_service.prepare_feature_definition(document=document)

--- a/tests/unit/api/test_sdk_code.py
+++ b/tests/unit/api/test_sdk_code.py
@@ -187,6 +187,14 @@ def test_sdk_code_generation__complex_feature(
         saved_event_table.id,
     ]
 
+    # check entity ids extracted from the graph,
+    assert feat_item_sum.entity_ids == [transaction_entity.id]
+    assert feat_event_sum.entity_ids == [saved_event_table.cust_id.info.entity_id]
+    comp = feat_event_sum + feat_item_sum
+    assert comp.entity_ids == sorted(
+        [saved_event_table.cust_id.info.entity_id, transaction_entity.id]
+    )
+
 
 def test_sdk_code_generation__multi_table_feature(
     saved_event_table, saved_item_table, transaction_entity, cust_id_entity, update_fixtures

--- a/tests/unit/api/test_sdk_code.py
+++ b/tests/unit/api/test_sdk_code.py
@@ -194,6 +194,13 @@ def test_sdk_code_generation__complex_feature(
     assert comp.entity_ids == sorted(
         [saved_event_table.cust_id.info.entity_id, transaction_entity.id]
     )
+    feat_empty_keys = event_view.groupby([]).aggregate_over(
+        value_column=feat_item_sum.name,
+        method="sum",
+        windows=["24h"],
+        feature_names=["sum_a_24h"],
+    )["sum_a_24h"]
+    assert feat_empty_keys.entity_ids == []
 
 
 def test_sdk_code_generation__multi_table_feature(

--- a/tests/unit/api/test_view.py
+++ b/tests/unit/api/test_view.py
@@ -49,8 +49,10 @@ class SimpleTestView(View):
     def get_join_column(self) -> str:
         return self.join_col
 
-    def json_dict(self, **kwargs: Any) -> Dict[str, Any]:
-        return {}
+    def dict(self, **kwargs: Any) -> Dict[str, Any]:
+        if "exclude" in kwargs:
+            return {}
+        return super().dict(**kwargs)
 
     def set_join_col_override(self, join_col_override: str):
         """


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR aims to fix primary entity identification bug for the time-aggregated-item-aggregated feature. Below is the example of such feature:
```
# Generated by SDK version: 0.3.0.dev10
from bson import ObjectId
from featurebyte import EventTable
from featurebyte import FeatureJobSetting
from featurebyte import ItemTable


# item_table name: "LABOBSERVATION", event_table name: "LABRESULT"
item_table = ItemTable.get_by_id(ObjectId("64874aa0f48964db9d3e9847"))
item_view = item_table.get_view(
    event_suffix=None,
    view_mode="manual",
    drop_column_names=[],
    column_cleaning_operations=[],
    event_drop_column_names=["record_available_at"],
    event_column_cleaning_operations=[],
    event_join_column_names=["ReportDate", "LabResultGuid", "PatientGuid"],
)
col = item_view["IsAbnormalValue"]
view = item_view.copy()
view["IsAbnormalValueInt"] = (col == "true").astype(int)
col_1 = view.groupby(by_keys=["LabResultGuid"], category=None).aggregate(
    value_column="IsAbnormalValueInt",
    method="sum",
    feature_name="Abnormal Values count by labresult",
    skip_fill_na=True,
)
col_2 = col_1.copy()
col_2[col_1.isnull()] = 0
col_2.name = "Abnormal Values count by labresult"

# event_table name: "LABRESULT"
event_table = EventTable.get_by_id(ObjectId("64874a9af48964db9d3e9846"))
event_view = event_table.get_view(
    view_mode="manual",
    drop_column_names=["record_available_at"],
    column_cleaning_operations=[],
)
joined_view = event_view.add_feature(
    new_column_name="number_of_abnormal_values",
    feature=col_2,
    entity_column="LabResultGuid",
)
grouped = joined_view.groupby(
    by_keys=["PatientGuid"], category=None
).aggregate_over(
    value_column="number_of_abnormal_values",
    method="sum",
    windows=["90d"],
    feature_names=["Number of abnormal results in the Last 90d"],
    feature_job_setting=FeatureJobSetting(
        blind_spot="64800s", frequency="86400s", time_modulo_frequency="5s"
    ),
    skip_fill_na=True,
)
feat = grouped["Number of abnormal results in the Last 90d"]
feat_1 = feat.copy()
feat_1[feat.isnull()] = 0
feat_1.name = "Number of abnormal results in the Last 90d"
output = feat_1
output.save(_id=ObjectId("64874c6f1e2c4b4eeb6e6fe0"))
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
