### PR TITLE
[chore] Fix mongo error in integration tests due to non-threadsafe persistent

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1414,7 +1414,7 @@ def online_store_table_version_service(user, mongo_persistent):
 
 
 @pytest.fixture()
-def online_store_table_version_service_factory():
+def online_store_table_version_service_factory(mongo_database_name):
     """
     Fixture for a callback that returns a new OnlineStoreTableVersionService with a new persistent
 
@@ -1425,7 +1425,7 @@ def online_store_table_version_service_factory():
     def factory():
         return OnlineStoreTableVersionService(
             user=user(),
-            persistent=get_new_persistent(mongo_database_name())[0],
+            persistent=get_new_persistent(mongo_database_name)[0],
             catalog_id=DEFAULT_CATALOG_ID,
         )
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -249,17 +249,32 @@ def persistent_fixture():
     client.drop_database(database_name)
 
 
+@pytest.fixture(name="mongo_database_name")
+def mongo_database_name():
+    """
+    Mongo database name used by integration tests
+    """
+    return f"test_{ObjectId()}"
+
+
+def get_new_persistent(database_name):
+    """
+    Get a new persistent instance
+    """
+    client = pymongo.MongoClient(MONGO_CONNECTION)
+    persistent = MongoDB(uri=MONGO_CONNECTION, database=database_name)
+    return persistent, client
+
+
 @pytest.fixture(name="mongo_persistent")
-def mongo_persistent_fixture():
+def mongo_persistent_fixture(mongo_database_name):
     """
     Mongo persistent fixture that uses a non-async client. Used by some integration tests that
     interact with the persistent directly.
     """
-    database_name = f"test_{ObjectId()}"
-    client = pymongo.MongoClient(MONGO_CONNECTION)
-    persistent = MongoDB(uri=MONGO_CONNECTION, database=database_name)
-    yield persistent, client[database_name]
-    client.drop_database(database_name)
+    persistent, client = get_new_persistent(mongo_database_name)
+    yield persistent, client[mongo_database_name]
+    client.drop_database(mongo_database_name)
 
 
 @pytest.fixture(name="mock_get_persistent", scope="session")
@@ -1388,11 +1403,30 @@ def user():
 
 
 @pytest.fixture()
-def online_store_table_version_service(user, persistent):
+def online_store_table_version_service(user, mongo_persistent):
     """
     Fixture for online store table version service
     """
     service = OnlineStoreTableVersionService(
-        user=user, persistent=persistent, catalog_id=DEFAULT_CATALOG_ID
+        user=user, persistent=mongo_persistent[0], catalog_id=DEFAULT_CATALOG_ID
     )
     yield service
+
+
+@pytest.fixture()
+def online_store_table_version_service_factory():
+    """
+    Fixture for a callback that returns a new OnlineStoreTableVersionService with a new persistent
+
+    This is needed in tests where we need a threadsafe instance of the persistent (which cannot be
+    the global one).
+    """
+
+    def factory():
+        return OnlineStoreTableVersionService(
+            user=user(),
+            persistent=get_new_persistent(mongo_database_name())[0],
+            catalog_id=DEFAULT_CATALOG_ID,
+        )
+
+    return factory

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1418,8 +1418,8 @@ def online_store_table_version_service_factory(mongo_database_name):
     """
     Fixture for a callback that returns a new OnlineStoreTableVersionService with a new persistent
 
-    This is needed in tests where we need a threadsafe instance of the persistent (which cannot be
-    the global one).
+    This is needed in tests where we need new instances of the persistent for different threads
+    (the persistent object is not threadsafe)
     """
 
     def factory():

--- a/tests/integration/query_graph/test_online_serving.py
+++ b/tests/integration/query_graph/test_online_serving.py
@@ -95,7 +95,6 @@ async def test_online_serving_sql(
     data_source,
     get_session_callback,
     online_store_table_version_service_factory,
-    mongo_database_name,
 ):
     """
     Test executing feature compute sql and feature retrieval SQL for online store

--- a/tests/integration/query_graph/test_online_serving.py
+++ b/tests/integration/query_graph/test_online_serving.py
@@ -220,7 +220,10 @@ def check_get_batch_features(deployment, batch_request_table, df_historical, col
 
 
 async def check_concurrent_online_store_table_updates(
-    get_session_callback, feature_list, job_schedule_ts_str, online_store_table_version_service
+    get_session_callback,
+    feature_list,
+    job_schedule_ts_str,
+    online_store_table_version_service_factory,
 ):
     """
     Test concurrent online store table updates
@@ -257,7 +260,7 @@ async def check_concurrent_online_store_table_updates(
             aggregation_id=aggregation_id,
             job_schedule_ts_str=job_schedule_ts_str,
             retry_num=1,  # no issue even without retry
-            online_store_table_version_service=online_store_table_version_service,
+            online_store_table_version_service=online_store_table_version_service_factory(),
         )
         try:
             await online_store_job.execute()

--- a/tests/integration/query_graph/test_online_serving.py
+++ b/tests/integration/query_graph/test_online_serving.py
@@ -94,7 +94,8 @@ async def test_online_serving_sql(
     config,
     data_source,
     get_session_callback,
-    online_store_table_version_service,
+    online_store_table_version_service_factory,
+    mongo_database_name,
 ):
     """
     Test executing feature compute sql and feature retrieval SQL for online store
@@ -159,7 +160,7 @@ async def test_online_serving_sql(
             get_session_callback,
             feature_list,
             next_job_datetime.strftime("%Y-%m-%d %H:%M:%S"),
-            online_store_table_version_service,
+            online_store_table_version_service_factory,
         )
     finally:
         deployment.disable()


### PR DESCRIPTION
## Description

This fixes a mongo failure that occurs in `tests/integration/query_graph/test_online_serving.py::test_online_serving_sql` because the test is sharing the same instance of persistent between threads.

The error looks like this:

> E       pymongo.errors.OperationFailure: Transaction with { txnNumber: 1 } has been committed., full error: {'ok': 0.0, 'errmsg': 'Transaction with { txnNumber: 1 } has been committed.', 'code': 256, 'codeName': 'TransactionCommitted', '$clusterTime': {'clusterTime': Timestamp(1686796484, 4), 'signature': {'hash': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 'keyId': 0}}, 'operationTime': Timestamp(1686796484, 1)}

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
