### PR TITLE
enhancement: skip calling data warehouse during table construction

### DIFF
--- a/.changelog/DEV-1818.yaml
+++ b/.changelog/DEV-1818.yaml
@@ -1,0 +1,16 @@
+# Type of change
+change_type: enhancement
+
+# The name of the component
+component: table
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.
+note: "skip calling data warehouse for table metadata during table construction"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/featurebyte/api/source_table.py
+++ b/featurebyte/api/source_table.py
@@ -8,19 +8,15 @@ from typing import TYPE_CHECKING, Any, ClassVar, List, Optional, Tuple, Type, Ty
 
 from abc import ABC, abstractmethod
 from datetime import datetime
-from http import HTTPStatus
 
 import pandas as pd
 from bson import ObjectId
 from pydantic import Field
 from typeguard import typechecked
 
-from featurebyte.api.api_object_util import is_server_mode
 from featurebyte.common.doc_util import FBAutoDoc
-from featurebyte.config import Configurations
 from featurebyte.core.frame import BaseFrame
 from featurebyte.enum import DBVarType
-from featurebyte.exception import RecordRetrievalException
 from featurebyte.logging import get_logger
 from featurebyte.models.base import FeatureByteBaseModel
 from featurebyte.models.batch_request_table import SourceTableBatchRequestInput
@@ -33,7 +29,6 @@ from featurebyte.query_graph.model.graph import QueryGraphModel
 from featurebyte.query_graph.model.table import AllTableDataT, SourceTableData
 from featurebyte.query_graph.node import Node
 from featurebyte.query_graph.node.input import InputNode
-from featurebyte.query_graph.node.schema import TableDetails
 from featurebyte.schema.batch_request_table import BatchRequestTableCreate
 from featurebyte.schema.observation_table import ObservationTableCreate
 from featurebyte.schema.static_source_table import StaticSourceTableCreate
@@ -101,10 +96,9 @@ class AbstractTableData(ConstructGraphMixin, FeatureByteBaseModel, ABC):
     internal_columns_info: List[ColumnInfo] = Field(alias="columns_info")
 
     def __init__(self, **kwargs: Any):
-        # Construct feature_store, input node & set the graph related parameters based on the given input dictionary
+        # construct feature_store based on the given input dictionary
         values = kwargs
         tabular_source = dict(values["tabular_source"])
-        table_details = tabular_source["table_details"]
         if "feature_store" not in values:
             # attempt to set feature_store object if it does not exist in the input
             from featurebyte.api.feature_store import (  # pylint: disable=import-outside-toplevel,cyclic-import
@@ -112,44 +106,6 @@ class AbstractTableData(ConstructGraphMixin, FeatureByteBaseModel, ABC):
             )
 
             values["feature_store"] = FeatureStore.get_by_id(id=tabular_source["feature_store_id"])
-
-        feature_store = values["feature_store"]
-        if isinstance(table_details, dict):
-            table_details = TableDetails(**table_details)
-
-        to_validate_schema = values.get("_validate_schema") or "columns_info" not in values
-        to_validate_schema &= not is_server_mode()
-        if to_validate_schema:
-            client = Configurations().get_client()
-            response = client.post(
-                url=(
-                    f"/feature_store/column?"
-                    f"database_name={table_details.database_name}&"
-                    f"schema_name={table_details.schema_name}&"
-                    f"table_name={table_details.table_name}"
-                ),
-                json=feature_store.json_dict(),
-            )
-            if response.status_code == HTTPStatus.OK:
-                column_specs = response.json()
-                recent_schema = {
-                    column_spec["name"]: DBVarType(column_spec["dtype"])
-                    for column_spec in column_specs
-                }
-            else:
-                raise RecordRetrievalException(response)
-
-            if "columns_info" in values:
-                columns_info = [ColumnInfo(**dict(col)) for col in values["columns_info"]]
-                schema = {col.name: col.dtype for col in columns_info}
-                if not recent_schema.items() >= schema.items():
-                    logger.warning("Table schema has been changed.")
-            else:
-                columns_info = [
-                    ColumnInfo(name=name, dtype=var_type)
-                    for name, var_type in recent_schema.items()
-                ]
-                values["columns_info"] = columns_info
 
         # call pydantic constructor to validate input parameters
         super().__init__(**values)

--- a/tests/unit/api/test_event_table.py
+++ b/tests/unit/api/test_event_table.py
@@ -666,37 +666,6 @@ def test_get_event_table(snowflake_event_table, mock_config_path_env):
     assert expected_msg in str(exc.value)
 
 
-@patch("featurebyte.api.source_table.logger")
-@patch("featurebyte.service.session_manager.SessionManager.get_session")
-def test_get_event_table__schema_has_been_changed(mock_get_session, mock_logger, saved_event_table):
-    """
-    Test retrieving event table after table schema has been changed
-    """
-    recent_schema = {"column": "INT"}
-    mock_get_session.return_value.list_databases.return_value = ["sf_database"]
-    mock_get_session.return_value.list_schemas.return_value = ["sf_schema"]
-    mock_get_session.return_value.list_tables.return_value = ["sf_table"]
-    mock_get_session.return_value.list_table_schema.return_value = recent_schema
-    _ = EventTable.get_by_id(saved_event_table.id)
-    assert mock_logger.warning.call_args.args[0] == "Table schema has been changed."
-
-    # this is ok as additional column should not break backward compatibility
-    recent_schema = {
-        "col_binary": "BINARY",
-        "col_boolean": "BOOL",
-        "col_char": "CHAR",
-        "col_float": "FLOAT",
-        "col_int": "INT",
-        "col_text": "VARCHAR",
-        "created_at": "TIMESTAMP",
-        "cust_id": "INT",
-        "event_timestamp": "TIMESTAMP",
-        "additional_column": "INT",
-    }
-    mock_get_session.return_value.list_table_schema.return_value = recent_schema
-    _ = EventTable.get_by_id(saved_event_table.id)
-
-
 def test_default_feature_job_setting_history(saved_event_table):
     """
     Test default_feature_job_setting_history on saved event table

--- a/tests/unit/api/test_table.py
+++ b/tests/unit/api/test_table.py
@@ -3,13 +3,9 @@ Unit test for Table class
 """
 from __future__ import annotations
 
-from unittest.mock import patch
-
 import pytest
-import pytest_asyncio
 
 from featurebyte.api.dimension_table import DimensionTable
-from featurebyte.api.entity import Entity
 from featurebyte.api.event_table import EventTable
 from featurebyte.api.item_table import ItemTable
 from featurebyte.api.scd_table import SCDTable
@@ -91,54 +87,3 @@ def test_get_dimension_table(saved_dimension_table, snowflake_dimension_table):
         'Table (name: "unknown_dimension_table") not found. ' "Please save the Table object first."
     )
     assert expected_msg in str(exc.value)
-
-
-@pytest_asyncio.fixture(name="mock_list_columns")
-async def mock_list_columns_fixture():
-    with patch(
-        "featurebyte.routes.feature_store.controller.FeatureStoreController.list_columns"
-    ) as mock_list_columns:
-        yield mock_list_columns
-
-
-def test_update__schema_validation(saved_event_table, mock_api_client_fixture):
-    """
-    Test update table won't make addition API calls for schema validation
-    """
-    mock_request = mock_api_client_fixture
-    cust_entity = Entity(name="customer", serving_names=["cust_id"])
-    cust_entity.save()
-
-    # check that call update won't make additional snowflake query (post feature store list columns) due to
-    # (1) columns_info is available
-    # (2) _validate_schema not set
-    api_count = mock_request.call_count
-    saved_event_table.cust_id.as_entity(cust_entity.name)
-    assert mock_request.call_count == api_count + 2
-    # get entity call
-    assert mock_request.call_args_list[api_count][0][0] == "GET"
-    assert mock_request.call_args_list[api_count][0][1].endswith("/entity")
-    # patch event table columns_info call
-    assert mock_request.call_args_list[api_count + 1][0][0] == "PATCH"
-    assert mock_request.call_args_list[api_count + 1][0][1].endswith(
-        f"/event_table/{saved_event_table.id}"
-    )
-
-    # check the case when there is an additional post call
-    api_count = mock_request.call_count
-    # use .columns to make sure actual call happens (due to proxy object)
-    _ = EventTable.get(name=saved_event_table.name).columns
-    assert mock_request.call_count == api_count + 3
-    # get event_table
-    assert mock_request.call_args_list[api_count][0][0] == "GET"
-    assert mock_request.call_args_list[api_count][0][1].endswith("/event_table")
-    # get feature store
-    assert mock_request.call_args_list[api_count + 1][0][0] == "GET"
-    assert mock_request.call_args_list[api_count + 1][0][1].endswith(
-        f"/feature_store/{saved_event_table.feature_store.id}"
-    )
-    # post feature store table schema
-    assert mock_request.call_args_list[api_count + 2][0][0] == "POST"
-    assert mock_request.call_args_list[api_count + 2][0][1].endswith(
-        "feature_store/column?database_name=sf_database&schema_name=sf_schema&table_name=sf_table"
-    )


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

API related to querying data warehouse is expensive. To improve the user experience on using the SDK, this PR removes data warehouse related API calls during table construction. Move the data warehouse table schema API call to `get_source_table` method.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
