### PR TITLE
Fix failing unit test test_get_historical_features__feature_list_not_saved

### DIFF
--- a/featurebyte/api/feature.py
+++ b/featurebyte/api/feature.py
@@ -112,7 +112,7 @@ class Feature(
         return {"feature_store": self.feature_store}
 
     def _get_feature_tiles_specs(self) -> List[Tuple[str, List[TileSpec]]]:
-        tile_specs = ExtendedFeatureModel(**self.dict()).tile_specs
+        tile_specs = ExtendedFeatureModel(**self.dict(by_alias=True)).tile_specs
         return [(str(self.name), tile_specs)] if tile_specs else []
 
     @root_validator(pre=True)

--- a/featurebyte/api/feature_list.py
+++ b/featurebyte/api/feature_list.py
@@ -433,7 +433,7 @@ class FeatureList(BaseFeatureGroup, DeletableApiObject, SavableApiObject, Featur
     def _get_feature_tiles_specs(self) -> List[Tuple[str, List[TileSpec]]]:
         feature_tile_specs = []
         for feature in self.feature_objects.values():
-            tile_specs = ExtendedFeatureModel(**feature.dict()).tile_specs
+            tile_specs = ExtendedFeatureModel(**feature.dict(by_alias=True)).tile_specs
             if tile_specs:
                 feature_tile_specs.append((str(feature.name), tile_specs))
         return feature_tile_specs

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -1196,7 +1196,7 @@ def test_non_float_tile_value_added_to_tile_table(event_view, source_type):
     feature_list_2 = FeatureList([feature_group_2], name="feature_list_2")
 
     def _get_tile_table_id(feature_obj):
-        return ExtendedFeatureModel(**feature_obj.dict()).tile_specs[0].tile_id
+        return ExtendedFeatureModel(**feature_obj.dict(by_alias=True)).tile_specs[0].tile_id
 
     assert _get_tile_table_id(feature_group_1["COUNT_2h"]) == _get_tile_table_id(
         feature_group_2["LATEST_EVENT_TIMESTAMP_BY_USER"]

--- a/tests/integration/query_graph/test_online_serving.py
+++ b/tests/integration/query_graph/test_online_serving.py
@@ -166,42 +166,6 @@ async def test_online_serving_sql(
         assert deployment.enabled is False
 
 
-<<<<<<< Updated upstream
-=======
-def get_online_feature_spec(feature):
-    """
-    Helper function to create an online feature spec from a feature
-    """
-    return OnlineFeatureSpec(feature=ExtendedFeatureModel(**feature.dict(by_alias=True)))
-
-
-def get_online_store_table_name_to_aggregation_id(feature_list):
-    """
-    Helper function to get a mapping from online store table name to aggregation ids
-    """
-    online_store_table_name_to_aggregation_id = defaultdict(set)
-    for _, feature_object in feature_list.feature_objects.items():
-        for query in get_online_feature_spec(feature_object).precompute_queries:
-            online_store_table_name_to_aggregation_id[query.table_name].add(query.aggregation_id)
-    return online_store_table_name_to_aggregation_id
-
-
-async def sanity_check_online_store_tables(session, feature_list):
-    """
-    Verify that online enabling related features do not trigger redundant online store updates
-    """
-    table_names = list(get_online_store_table_name_to_aggregation_id(feature_list).keys())
-    for table_name in table_names:
-        df = await session.execute_query(
-            f"SELECT MAX({InternalName.ONLINE_STORE_VERSION_COLUMN}) AS OUT FROM {table_name}"
-        )
-        max_version = df.iloc[0]["OUT"]
-        # Verify that all results are at the very first version. If that is not the case, some
-        # results were calculated more than once.
-        assert max_version == 0
-
-
->>>>>>> Stashed changes
 def check_online_features_route(deployment, config, df_historical, columns):
     """
     Online enable a feature and call the online features endpoint

--- a/tests/integration/query_graph/test_online_serving.py
+++ b/tests/integration/query_graph/test_online_serving.py
@@ -166,6 +166,42 @@ async def test_online_serving_sql(
         assert deployment.enabled is False
 
 
+<<<<<<< Updated upstream
+=======
+def get_online_feature_spec(feature):
+    """
+    Helper function to create an online feature spec from a feature
+    """
+    return OnlineFeatureSpec(feature=ExtendedFeatureModel(**feature.dict(by_alias=True)))
+
+
+def get_online_store_table_name_to_aggregation_id(feature_list):
+    """
+    Helper function to get a mapping from online store table name to aggregation ids
+    """
+    online_store_table_name_to_aggregation_id = defaultdict(set)
+    for _, feature_object in feature_list.feature_objects.items():
+        for query in get_online_feature_spec(feature_object).precompute_queries:
+            online_store_table_name_to_aggregation_id[query.table_name].add(query.aggregation_id)
+    return online_store_table_name_to_aggregation_id
+
+
+async def sanity_check_online_store_tables(session, feature_list):
+    """
+    Verify that online enabling related features do not trigger redundant online store updates
+    """
+    table_names = list(get_online_store_table_name_to_aggregation_id(feature_list).keys())
+    for table_name in table_names:
+        df = await session.execute_query(
+            f"SELECT MAX({InternalName.ONLINE_STORE_VERSION_COLUMN}) AS OUT FROM {table_name}"
+        )
+        max_version = df.iloc[0]["OUT"]
+        # Verify that all results are at the very first version. If that is not the case, some
+        # results were calculated more than once.
+        assert max_version == 0
+
+
+>>>>>>> Stashed changes
 def check_online_features_route(deployment, config, df_historical, columns):
     """
     Online enable a feature and call the online features endpoint

--- a/tests/unit/service/test_preview.py
+++ b/tests/unit/service/test_preview.py
@@ -238,7 +238,9 @@ async def test_get_historical_features__feature_list_not_saved(
     """
     Test compute_historical_features when feature list is not saved
     """
-    feature_list = FeatureList([Feature(**production_ready_feature.dict())], name="mylist")
+    feature_list = FeatureList(
+        [Feature(**production_ready_feature.dict(by_alias=True))], name="mylist"
+    )
     featurelist_get_historical_features = FeatureListGetHistoricalFeatures(
         feature_list_id=feature_list.id,
         feature_clusters=feature_list._get_feature_clusters(),


### PR DESCRIPTION
## Description

This fixes the test `test_get_historical_features__feature_list_not_saved` which fails when run individually. Also fixes a few places where the `by_alias=True` option should have been specified when calling `dict()`.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
