### PR TITLE
[DEV-1810] Remove implicit profile selection

### DIFF
--- a/.changelog/DEV-1810.yaml
+++ b/.changelog/DEV-1810.yaml
@@ -1,0 +1,16 @@
+# Type of change
+change_type: enhancement
+
+# The name of the component
+component: config
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.
+note: "Add default_profile in config to allow for a default profile to be set, and require a profile to be set if default_profile is not set"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/featurebyte/__init__.py
+++ b/featurebyte/__init__.py
@@ -157,7 +157,8 @@ def use_profile(profile: str) -> None:
     finally:
         # report active profile
         try:
-            get_active_profile()
+            # get_active_profile()
+            log_env_summary()
         except InvalidSettingsError:
             pass
 

--- a/featurebyte/config.py
+++ b/featurebyte/config.py
@@ -311,6 +311,11 @@ class Configurations:
         -------
         Profile
             Active profile
+
+        Raises
+        ------
+        InvalidSettingsError
+            No valid profile specified
         """
         if not self._profile:
             raise InvalidSettingsError(
@@ -366,7 +371,12 @@ class Configurations:
             profile_map = {profile.name: profile for profile in self.profiles}
             default_profile = self.settings.pop("default_profile", None)
             selected_profile_name = os.environ.get("FEATUREBYTE_PROFILE")
-            self._profile = profile_map.get(selected_profile_name, profile_map.get(default_profile))
+            if selected_profile_name:
+                self._profile = profile_map.get(
+                    selected_profile_name, profile_map.get(default_profile)
+                )
+            else:
+                self._profile = profile_map.get(default_profile)
 
     @classmethod
     def check_sdk_versions(cls) -> Dict[str, str]:
@@ -448,11 +458,6 @@ class Configurations:
         -------
         APIClient
             API client
-
-        Raises
-        ------
-        InvalidSettingsError
-            Invalid settings
         """
         # pylint: disable=import-outside-toplevel,cyclic-import
         from featurebyte.logging import reconfigure_loggers
@@ -475,11 +480,6 @@ class Configurations:
         -------
         WebsocketClient
             Websocket client
-
-        Raises
-        ------
-        InvalidSettingsError
-            Invalid settings
         """
         url = self.profile.api_url.replace("http://", "ws://").replace("https://", "wss://")
         url = f"{url}/ws/{task_id}"

--- a/featurebyte/config.py
+++ b/featurebyte/config.py
@@ -293,6 +293,7 @@ class Configurations:
                 "profile:\n"
                 "  - name: local\n"
                 "    api_url: http://127.0.0.1:8088\n\n"
+                "default_profile: local\n\n"
             )
 
         self.storage: LocalStorageSettings = LocalStorageSettings()
@@ -425,11 +426,13 @@ class Configurations:
         Content of configuration file at `~/.featurebyte/config.yaml`
         ```
         profile:
-          - name: featurebyte
+          - name: local
             api_url: https://app.featurebyte.com/api/v1
             api_token: API_TOKEN_VALUE
+
+        default_profile: local
         ```
-        Use service profile `featurebyte`
+        Use service profile `local`
 
         >>> fb.Configurations().use_profile("local")
         """

--- a/featurebyte/config.py
+++ b/featurebyte/config.py
@@ -373,9 +373,7 @@ class Configurations:
             default_profile = self.settings.pop("default_profile", None)
             selected_profile_name = os.environ.get("FEATUREBYTE_PROFILE")
             if selected_profile_name:
-                self._profile = profile_map.get(
-                    selected_profile_name, profile_map.get(default_profile)
-                )
+                self._profile = profile_map.get(selected_profile_name)
             else:
                 self._profile = profile_map.get(default_profile)
 

--- a/featurebyte/worker/task_executor.py
+++ b/featurebyte/worker/task_executor.py
@@ -126,7 +126,8 @@ class TaskExecutor:
             "# featurebyte-worker config file\n"
             "profile:\n"
             "  - name: worker\n"
-            f"    api_url: {featurebyte_server}\n\n",
+            f"    api_url: {featurebyte_server}\n\n"
+            "default_profile: worker\n\n",
             encoding="utf-8",
         )
 

--- a/tests/fixtures/config/config.yaml
+++ b/tests/fixtures/config/config.yaml
@@ -14,3 +14,5 @@ logging:
 
 storage:
   local_path: ~/.featurebyte_custom/data
+
+default_profile: featurebyte1

--- a/tests/integration/backward_compatibility/test_get_route.py
+++ b/tests/integration/backward_compatibility/test_get_route.py
@@ -114,6 +114,7 @@ def config_fixture(test_api_client):
                 "api_token": "token",
             }
         ],
+        "default_profile": "local",
         "logging": {
             "level": "DEBUG",
         },

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -191,6 +191,7 @@ def config_fixture():
                 "api_token": "token",
             }
         ],
+        "default_profile": "local",
         "logging": {
             "level": "DEBUG",
         },

--- a/tests/integration/worker/conftest.py
+++ b/tests/integration/worker/conftest.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import os
 import subprocess
+import tempfile
 import threading
 
 import pymongo
@@ -37,39 +38,41 @@ async def celery_service_fixture():
     """
     Start celery service for testing
     """
-    # create new database for testing
-    database_name = f"test_{ObjectId()}"
-    client = pymongo.MongoClient(MONGO_CONNECTION)
-    persistent = MongoDB(uri=MONGO_CONNECTION, database=database_name)
-    env = os.environ.copy()
-    env.update(
-        {
-            "MONGODB_URI": MONGO_CONNECTION,
-            "MONGODB_DB": database_name,
-            "FEATUREBYTE_SERVER": "http://127.0.0.1:8080",
-        }
-    )
-    celery = get_celery()
-    celery.conf.mongodb_backend_settings["database"] = database_name
-    proc = subprocess.Popen(
-        [
-            "celery",
-            "--app",
-            "featurebyte.worker.start.celery",
-            "worker",
-            "-Q",
-            "cpu_task,cpu_task:1,cpu_task:2,cpu_task:3",
-            "--loglevel=INFO",
-            "--beat",
-            "--scheduler",
-            "celerybeatmongo.schedulers.MongoScheduler",
-        ],
-        env=env,
-        stdout=subprocess.PIPE,
-    )
-    thread = RunThread(proc.stdout)
-    thread.daemon = True
-    thread.start()
-    yield persistent, celery
-    proc.terminate()
-    client.drop_database(database_name)
+    with tempfile.TemporaryDirectory() as tempdir:
+        # create new database for testing
+        database_name = f"test_{ObjectId()}"
+        client = pymongo.MongoClient(MONGO_CONNECTION)
+        persistent = MongoDB(uri=MONGO_CONNECTION, database=database_name)
+        env = os.environ.copy()
+        env.update(
+            {
+                "MONGODB_URI": MONGO_CONNECTION,
+                "MONGODB_DB": database_name,
+                "FEATUREBYTE_SERVER": "http://127.0.0.1:8080",
+                "FEATUREBYTE_HOME": tempdir,
+            }
+        )
+        celery = get_celery()
+        celery.conf.mongodb_backend_settings["database"] = database_name
+        proc = subprocess.Popen(
+            [
+                "celery",
+                "--app",
+                "featurebyte.worker.start.celery",
+                "worker",
+                "-Q",
+                "cpu_task,cpu_task:1,cpu_task:2,cpu_task:3",
+                "--loglevel=INFO",
+                "--beat",
+                "--scheduler",
+                "celerybeatmongo.schedulers.MongoScheduler",
+            ],
+            env=env,
+            stdout=subprocess.PIPE,
+        )
+        thread = RunThread(proc.stdout)
+        thread.daemon = True
+        thread.start()
+        yield persistent, celery
+        proc.terminate()
+        client.drop_database(database_name)

--- a/tests/unit/conftest_config.py
+++ b/tests/unit/conftest_config.py
@@ -26,6 +26,7 @@ def config_file_fixture():
                 "api_token": "token",
             },
         ],
+        "default_profile": "local",
         "logging": {
             "level": "DEBUG",
         },

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -71,7 +71,10 @@ def test_get_client_no_persistence_settings():
     """
     with pytest.raises(InvalidSettingsError) as exc_info:
         Configurations("tests/fixtures/config/invalid_config.yaml").get_client()
-    assert str(exc_info.value) == "No profile setting specified"
+    assert (
+        str(exc_info.value)
+        == 'No valid profile specified. Update config file or specify valid profile name with "use_profile".'
+    )
 
 
 def test_get_client__success():

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -212,6 +212,9 @@ def test_client_redirection(mock_check_sdk_versions, mock_get_home_path):
             "Authorization": "Bearer API_TOKEN_VALUE1",
         }
 
+    # clean up environment variable
+    os.environ.pop("FEATUREBYTE_PROFILE")
+
 
 @pytest.mark.no_mock_websocket_client
 def test_websocket_ssl():


### PR DESCRIPTION
## Description

Changes introduced:
1. Remove use of implicit default profile. Profile needs to be specified to connect to the right service.
2. Add `default_profile` section in config file to explicitly specify default profile to use.


## Related Issue

https://featurebyte.atlassian.net/browse/DEV-1810

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
