### PR TITLE
[chore] app_container: refactor app_container to simplify

### DIFF
--- a/featurebyte/routes/app_container_config.py
+++ b/featurebyte/routes/app_container_config.py
@@ -23,7 +23,6 @@ class DepType(OrderedStrEnum):
     - non-service classes with deps
     """
 
-    NO_DEPS = "10_no_deps"
     BASIC_SERVICE = "20_basic_service"
     SERVICE_WITH_EXTRA_DEPS = "30_service_with_extra_deps"
     CLASS_WITH_DEPS = "40_class_with_deps"
@@ -50,8 +49,6 @@ class AppContainerConfig:
     """
 
     def __init__(self) -> None:
-        # These are objects which don't take in any dependencies, and can be instantiated as is.
-        self.no_dependency_objects: List[ClassDefinition] = []
         # These services have dependencies in addition to the normal user, and persistent dependencies.
         self.service_with_extra_deps: List[ClassDefinition] = []
         # These services only require the user, and persistent dependencies.
@@ -74,22 +71,9 @@ class AppContainerConfig:
             self.dependency_mapping[dep.name] = dep
         return self.dependency_mapping
 
-    def add_no_dep_objects(self, name: str, class_: type) -> None:
-        """
-        Register a class with no dependencies.
-
-        Parameters
-        ----------
-        name: str
-            name of the object
-        class_: type
-            type we are registering
-        """
-        self.no_dependency_objects.append(
-            ClassDefinition(name=name, class_=class_, dependencies=[], dep_type=DepType.NO_DEPS)
-        )
-
-    def add_service_with_extra_deps(self, name: str, class_: type, dependencies: List[str]) -> None:
+    def add_service_with_extra_deps(
+        self, name: str, class_: type, dependencies: List[str] = ()
+    ) -> None:
         """
         Register a service with extra dependencies
 
@@ -111,27 +95,7 @@ class AppContainerConfig:
             )
         )
 
-    def add_basic_service(self, name: str, class_: type) -> None:
-        """
-        Register a basic service
-
-        Parameters
-        ----------
-        name: str
-            name of the object
-        class_: type
-            type we are registering
-        """
-        self.basic_services.append(
-            ClassDefinition(
-                name=name,
-                class_=class_,
-                dependencies=[],
-                dep_type=DepType.BASIC_SERVICE,
-            )
-        )
-
-    def add_class_with_deps(self, name: str, class_: type, dependencies: List[str]) -> None:
+    def add_class_with_deps(self, name: str, class_: type, dependencies: List[str] = ()) -> None:
         """
         Register a helper service
 
@@ -155,8 +119,6 @@ class AppContainerConfig:
 
     def _all_dependencies(self) -> List[ClassDefinition]:
         output = []
-        output.extend(self.no_dependency_objects)
-        output.extend(self.basic_services)
         output.extend(self.service_with_extra_deps)
         output.extend(self.classes_with_deps)
         return output

--- a/featurebyte/routes/app_container_config.py
+++ b/featurebyte/routes/app_container_config.py
@@ -3,6 +3,8 @@ App container config module.
 
 This contains all our registrations for dependency injection.
 """
+from __future__ import annotations
+
 from typing import Dict, List, Tuple
 
 from dataclasses import dataclass

--- a/featurebyte/routes/app_container_config.py
+++ b/featurebyte/routes/app_container_config.py
@@ -3,7 +3,7 @@ App container config module.
 
 This contains all our registrations for dependency injection.
 """
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from dataclasses import dataclass
 
@@ -115,17 +115,15 @@ class AppContainerConfig:
         output.extend(self.classes_with_deps)
         return output
 
-    def validate(self) -> None:
+    def _validate_duplicate_names(self):
         """
-        Validate the correctness of the config. We check that there's no duplicate names registered.
-        Can consider pushing this into each of the add functions so we can fail faster.
+        Validate that there's no duplicate names registered.
 
         Raises
         ------
         ValueError
             raised when a name has been defined already.
         """
-        # validate that there are no clashing names
         seen_names = set()
         for definition in self._all_dependencies():
             definition_name = definition.name
@@ -135,3 +133,89 @@ class AppContainerConfig:
                     "Consider changing the name of the dependency."
                 )
             seen_names.add(definition_name)
+
+    def _is_cyclic_dfs(
+        self,
+        class_def: ClassDefinition,
+        visited_nodes: dict[str, bool],
+        recursive_stack: dict[str, bool],
+        class_def_mapping: dict[str, ClassDefinition],
+    ) -> Tuple[bool, list[str]]:
+        """
+        DFS helper function to detect circular dependencies.
+
+        Parameters
+        ----------
+        class_def: ClassDefinition
+            class definition we are currently visiting
+        visited_nodes: dict[str, bool]
+            dictionary of visited nodes
+        recursive_stack: dict[str, bool]
+            dictionary of nodes currently in the recursive stack
+        class_def_mapping: dict[str, ClassDefinition]
+            dictionary of class definitions
+
+        Returns
+        -------
+        bool
+            True if there's a circular dependency, False otherwise.
+        """
+        # Mark current node as visited and adds to recursion stack.
+        visited_nodes[class_def.name] = True
+        recursive_stack[class_def.name] = True
+
+        # Iterate through the dependencies
+        # If any dependency has been visited before, and is in the current recursive stack, the
+        # dependency graph is cyclic.
+        for neighbour_name in class_def_mapping[class_def.name].dependencies:
+            neighbour = class_def_mapping[neighbour_name]
+            if not visited_nodes.get(neighbour.name, False):
+                is_cyclic, path = self._is_cyclic_dfs(
+                    neighbour, visited_nodes, recursive_stack, class_def_mapping
+                )
+                if is_cyclic:
+                    return True, path
+            elif recursive_stack[neighbour.name]:
+                cyclic_path = list(recursive_stack.keys())
+                cyclic_path.append(neighbour.name)
+                return True, cyclic_path
+
+        # The node needs to be popped from stack before function ends
+        recursive_stack[class_def.name] = False
+        return False, []
+
+    def _validate_circular_dependencies(self) -> None:
+        """
+        Validate that there are no circular dependencies.
+
+        We do this by iterating through the graph dependencies in a DFS manner, and look for a back edge.
+
+        Raises
+        ------
+        ValueError
+            raised when a circular dependency is detected.
+        """
+        class_def_mapping = self.get_class_def_mapping()
+        # Visited nodes keeps track of whether we have been to this node before.
+        visited_nodes = {}
+        # Recursive stack keeps track of nodes that are currently being visited in the recursive call.
+        # This is to allow us to see if there's a back edge.
+        recursive_stack = {}
+        for node in self._all_dependencies():
+            # Only need to recurse on nodes we have not been to before.
+            if not visited_nodes.get(node.name, False):
+                is_cyclic, path = self._is_cyclic_dfs(
+                    node, visited_nodes, recursive_stack, class_def_mapping
+                )
+                if is_cyclic:
+                    path_str = " -> ".join(path)
+                    raise ValueError(
+                        f"There's a circular dependency in the dependency graph.\n{path_str}"
+                    )
+
+    def validate(self) -> None:
+        """
+        Validate the correctness of the config.
+        """
+        self._validate_duplicate_names()
+        self._validate_circular_dependencies()

--- a/featurebyte/routes/app_container_config.py
+++ b/featurebyte/routes/app_container_config.py
@@ -7,25 +7,18 @@ from typing import Dict, List
 
 from dataclasses import dataclass
 
-from featurebyte.enum import OrderedStrEnum
+from featurebyte.enum import StrEnum
 
 
-class DepType(OrderedStrEnum):
+class DepType(StrEnum):
     """
-    DepType enums
+    DepType enums.
 
-    They are prefixed with numbers to ensure that they are initialized in the correct order. For example, if a class
-    has dependencies on all 4 types, the dependencies will be initialized in the following order:
-
-    - no deps
-    - basic services
-    - services with extra deps
-    - non-service classes with deps
+    Used to determine what type of dependency we have, so that we can build them correctly.
     """
 
-    BASIC_SERVICE = "20_basic_service"
-    SERVICE_WITH_EXTRA_DEPS = "30_service_with_extra_deps"
-    CLASS_WITH_DEPS = "40_class_with_deps"
+    SERVICE_WITH_EXTRA_DEPS = "service_with_extra_deps"
+    CLASS_WITH_DEPS = "class_with_deps"
 
 
 @dataclass
@@ -51,8 +44,6 @@ class AppContainerConfig:
     def __init__(self) -> None:
         # These services have dependencies in addition to the normal user, and persistent dependencies.
         self.service_with_extra_deps: List[ClassDefinition] = []
-        # These services only require the user, and persistent dependencies.
-        self.basic_services: List[ClassDefinition] = []
         # Classes with deps can depend on any object defined above.
         self.classes_with_deps: List[ClassDefinition] = []
 
@@ -71,11 +62,12 @@ class AppContainerConfig:
             self.dependency_mapping[dep.name] = dep
         return self.dependency_mapping
 
-    def add_service_with_extra_deps(
-        self, name: str, class_: type, dependencies: List[str] = ()
-    ) -> None:
+    def register_service(self, name: str, class_: type, dependencies: List[str] = ()) -> None:
         """
-        Register a service with extra dependencies
+        Register a service with extra dependencies if needed.
+
+        This endpoint is only for featurebyte services, as they'll automatically have a user, persistent, and catalog
+        ID, injected into the service initialization.
 
         Parameters
         ----------
@@ -95,9 +87,9 @@ class AppContainerConfig:
             )
         )
 
-    def add_class_with_deps(self, name: str, class_: type, dependencies: List[str] = ()) -> None:
+    def register_class(self, name: str, class_: type, dependencies: List[str] = ()) -> None:
         """
-        Register a helper service
+        Register a class, with dependencies if needed.
 
         Parameters
         ----------

--- a/featurebyte/routes/app_container_config.py
+++ b/featurebyte/routes/app_container_config.py
@@ -5,7 +5,7 @@ This contains all our registrations for dependency injection.
 """
 from __future__ import annotations
 
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from dataclasses import dataclass
 
@@ -64,7 +64,9 @@ class AppContainerConfig:
             self.dependency_mapping[dep.name] = dep
         return self.dependency_mapping
 
-    def register_service(self, name: str, class_: type, dependencies: List[str] = ()) -> None:
+    def register_service(
+        self, name: str, class_: type, dependencies: Optional[List[str]] = None
+    ) -> None:
         """
         Register a service with extra dependencies if needed.
 
@@ -80,6 +82,8 @@ class AppContainerConfig:
         dependencies: list[str]
             dependencies
         """
+        if dependencies is None:
+            dependencies = []
         self.service_with_extra_deps.append(
             ClassDefinition(
                 name=name,
@@ -89,7 +93,9 @@ class AppContainerConfig:
             )
         )
 
-    def register_class(self, name: str, class_: type, dependencies: List[str] = ()) -> None:
+    def register_class(
+        self, name: str, class_: type, dependencies: Optional[List[str]] = None
+    ) -> None:
         """
         Register a class, with dependencies if needed.
 
@@ -102,6 +108,8 @@ class AppContainerConfig:
         dependencies: list[str]
             dependencies
         """
+        if dependencies is None:
+            dependencies = []
         self.classes_with_deps.append(
             ClassDefinition(
                 name=name,
@@ -117,7 +125,7 @@ class AppContainerConfig:
         output.extend(self.classes_with_deps)
         return output
 
-    def _validate_duplicate_names(self):
+    def _validate_duplicate_names(self) -> None:
         """
         Validate that there's no duplicate names registered.
 
@@ -199,10 +207,10 @@ class AppContainerConfig:
         """
         class_def_mapping = self.get_class_def_mapping()
         # Visited nodes keeps track of whether we have been to this node before.
-        visited_nodes = {}
+        visited_nodes: dict[str, bool] = {}
         # Recursive stack keeps track of nodes that are currently being visited in the recursive call.
         # This is to allow us to see if there's a back edge.
-        recursive_stack = {}
+        recursive_stack: dict[str, bool] = {}
         for node in self._all_dependencies():
             # Only need to recurse on nodes we have not been to before.
             if not visited_nodes.get(node.name, False):

--- a/featurebyte/routes/lazy_app_container.py
+++ b/featurebyte/routes/lazy_app_container.py
@@ -193,11 +193,7 @@ def build_deps(
         if dep.name in new_deps:
             continue
         # Build dependencies for this dep
-        if dep.dep_type == DepType.NO_DEPS:
-            new_deps[dep.name] = build_no_dep(dep)
-        elif dep.dep_type == DepType.BASIC_SERVICE:
-            new_deps[dep.name] = build_service(dep, user, persistent, catalog_id)
-        elif dep.dep_type == DepType.SERVICE_WITH_EXTRA_DEPS:
+        if dep.dep_type == DepType.SERVICE_WITH_EXTRA_DEPS:
             new_deps[dep.name] = build_service_with_deps(
                 dep, user, persistent, catalog_id, new_deps
             )

--- a/featurebyte/routes/lazy_app_container.py
+++ b/featurebyte/routes/lazy_app_container.py
@@ -61,46 +61,6 @@ def get_all_deps_for_key(
     return all_deps
 
 
-def build_no_dep(class_def: ClassDefinition) -> Any:
-    """
-    Build a class with no dependencies.
-
-    Parameters
-    ----------
-    class_def: ClassDefinition
-        class definition
-
-    Returns
-    -------
-    Any
-    """
-    return class_def.class_()
-
-
-def build_service(
-    class_def: ClassDefinition, user: Any, persistent: Persistent, catalog_id: ObjectId
-) -> Any:
-    """
-    Build a service with the given dependencies.
-
-    Parameters
-    ----------
-    class_def: ClassDefinition
-        class definition
-    user: Any
-        user object
-    persistent: Persistent
-        persistent object
-    catalog_id: ObjectId
-        catalog id
-
-    Returns
-    -------
-    Any
-    """
-    return class_def.class_(user=user, persistent=persistent, catalog_id=catalog_id)
-
-
 def build_service_with_deps(
     class_def: ClassDefinition,
     user: Any,

--- a/featurebyte/routes/lazy_app_container.py
+++ b/featurebyte/routes/lazy_app_container.py
@@ -210,9 +210,6 @@ class LazyAppContainer:
         self.catalog_id = catalog_id
         self.app_container_config = app_container_config
 
-        # Validate the container config
-        app_container_config.validate()
-
         # Used to cache instances if they've already been built
         # Pre-load with some default deps
         self.instance_map: Dict[str, Any] = {

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -31,6 +31,8 @@ from featurebyte.routes.semantic.controller import SemanticController
 from featurebyte.routes.static_source_table.controller import StaticSourceTableController
 from featurebyte.routes.table.controller import TableController
 from featurebyte.routes.target.controller import TargetController
+from featurebyte.routes.task.controller import TaskController
+from featurebyte.routes.temp_data.controller import TempDataController
 from featurebyte.service.batch_feature_table import BatchFeatureTableService
 from featurebyte.service.batch_request_table import BatchRequestTableService
 from featurebyte.service.catalog import CatalogService
@@ -73,10 +75,12 @@ from featurebyte.service.table_columns_info import TableColumnsInfoService
 from featurebyte.service.table_info import TableInfoService
 from featurebyte.service.table_status import TableStatusService
 from featurebyte.service.target import TargetService
+from featurebyte.service.task_manager import TaskManager
 from featurebyte.service.user_service import UserService
 from featurebyte.service.validator.production_ready_validator import ProductionReadyValidator
 from featurebyte.service.version import VersionService
 from featurebyte.service.view_construction import ViewConstructionService
+from featurebyte.utils.credential import MongoBackedCredentialProvider
 
 app_container_config = AppContainerConfig()
 
@@ -533,3 +537,12 @@ app_container_config.register_class(
         "feature_store_service",
     ],
 )
+
+app_container_config.register_class("task_controller", TaskController)
+app_container_config.register_class("tempdata_controller", TempDataController)
+app_container_config.register_class("credential_provider", MongoBackedCredentialProvider)
+app_container_config.register_class("task_manager", TaskManager)
+
+# Validate the config after all classes have been registered.
+# This should be the last line in this module.
+app_container_config.validate()

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -180,10 +180,10 @@ app_container_config.add_service_with_extra_deps(
 app_container_config.add_service_with_extra_deps(
     "entity_service", EntityService, ["catalog_service"]
 )
-app_container_config.add_basic_service("dimension_table_service", DimensionTableService)
-app_container_config.add_basic_service("event_table_service", EventTableService)
-app_container_config.add_basic_service("item_table_service", ItemTableService)
-app_container_config.add_basic_service("scd_table_service", SCDTableService)
+app_container_config.add_service_with_extra_deps("dimension_table_service", DimensionTableService)
+app_container_config.add_service_with_extra_deps("event_table_service", EventTableService)
+app_container_config.add_service_with_extra_deps("item_table_service", ItemTableService)
+app_container_config.add_service_with_extra_deps("scd_table_service", SCDTableService)
 app_container_config.add_service_with_extra_deps(
     "feature_service", FeatureService, ["table_service", "view_construction_service"]
 )
@@ -197,8 +197,8 @@ app_container_config.add_service_with_extra_deps(
         "feature_list_namespace_service",
     ],
 )
-app_container_config.add_basic_service("deployment_service", DeploymentService)
-app_container_config.add_basic_service(
+app_container_config.add_service_with_extra_deps("deployment_service", DeploymentService)
+app_container_config.add_service_with_extra_deps(
     "online_store_table_version_service", OnlineStoreTableVersionService
 )
 app_container_config.add_service_with_extra_deps(
@@ -263,7 +263,9 @@ app_container_config.add_service_with_extra_deps(
     FeatureListNamespaceService,
     ["entity_service", "table_service", "catalog_service", "feature_namespace_service"],
 )
-app_container_config.add_basic_service("feature_namespace_service", FeatureNamespaceService)
+app_container_config.add_service_with_extra_deps(
+    "feature_namespace_service", FeatureNamespaceService
+)
 app_container_config.add_service_with_extra_deps(
     "table_columns_info_service",
     TableColumnsInfoService,
@@ -279,9 +281,9 @@ app_container_config.add_service_with_extra_deps(
     DefaultVersionModeService,
     ["feature_namespace_service", "feature_readiness_service", "feature_list_namespace_service"],
 )
-app_container_config.add_basic_service("feature_store_service", FeatureStoreService)
-app_container_config.add_basic_service("semantic_service", SemanticService)
-app_container_config.add_basic_service("table_service", TableService)
+app_container_config.add_service_with_extra_deps("feature_store_service", FeatureStoreService)
+app_container_config.add_service_with_extra_deps("semantic_service", SemanticService)
+app_container_config.add_service_with_extra_deps("table_service", TableService)
 app_container_config.add_service_with_extra_deps(
     "version_service",
     VersionService,
@@ -294,16 +296,22 @@ app_container_config.add_service_with_extra_deps(
         "view_construction_service",
     ],
 )
-app_container_config.add_basic_service("entity_relationship_service", EntityRelationshipService)
-app_container_config.add_basic_service("semantic_relationship_service", SemanticRelationshipService)
-app_container_config.add_basic_service("catalog_service", CatalogService)
-app_container_config.add_basic_service("target_service", TargetService)
-app_container_config.add_basic_service("relationship_info_service", RelationshipInfoService)
-app_container_config.add_basic_service("user_service", UserService)
+app_container_config.add_service_with_extra_deps(
+    "entity_relationship_service", EntityRelationshipService
+)
+app_container_config.add_service_with_extra_deps(
+    "semantic_relationship_service", SemanticRelationshipService
+)
+app_container_config.add_service_with_extra_deps("catalog_service", CatalogService)
+app_container_config.add_service_with_extra_deps("target_service", TargetService)
+app_container_config.add_service_with_extra_deps(
+    "relationship_info_service", RelationshipInfoService
+)
+app_container_config.add_service_with_extra_deps("user_service", UserService)
 app_container_config.add_service_with_extra_deps(
     "view_construction_service", ViewConstructionService, ["table_service"]
 )
-app_container_config.add_basic_service("periodic_task_service", PeriodicTaskService)
+app_container_config.add_service_with_extra_deps("periodic_task_service", PeriodicTaskService)
 app_container_config.add_service_with_extra_deps(
     "credential_service",
     CredentialService,

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -80,22 +80,22 @@ from featurebyte.service.view_construction import ViewConstructionService
 
 app_container_config = AppContainerConfig()
 
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "session_validator_service",
     SessionValidatorService,
     ["credential_provider", "feature_store_service"],
 )
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "production_ready_validator",
     ProductionReadyValidator,
     ["table_service", "feature_service", "version_service"],
 )
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "table_info_service",
     TableInfoService,
     ["entity_service", "semantic_service", "catalog_service"],
 )
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "session_manager_service",
     SessionManagerService,
     [
@@ -103,7 +103,7 @@ app_container_config.add_service_with_extra_deps(
         "session_validator_service",
     ],
 )
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "parent_entity_lookup_service",
     ParentEntityLookupService,
     [
@@ -111,7 +111,7 @@ app_container_config.add_service_with_extra_deps(
         "table_service",
     ],
 )
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "online_enable_service",
     OnlineEnableService,
     [
@@ -124,12 +124,12 @@ app_container_config.add_service_with_extra_deps(
         "online_store_table_version_service",
     ],
 )
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "entity_validation_service",
     EntityValidationService,
     ["entity_service", "parent_entity_lookup_service"],
 )
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "online_serving_service",
     OnlineServingService,
     [
@@ -139,12 +139,12 @@ app_container_config.add_service_with_extra_deps(
         "feature_store_service",
     ],
 )
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "feature_list_status_service",
     FeatureListStatusService,
     ["feature_list_namespace_service", "feature_list_service"],
 )
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "deploy_service",
     DeployService,
     [
@@ -156,7 +156,7 @@ app_container_config.add_service_with_extra_deps(
         "feature_list_service",
     ],
 )
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "preview_service",
     PreviewService,
     [
@@ -166,7 +166,7 @@ app_container_config.add_service_with_extra_deps(
         "feature_store_service",
     ],
 )
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "feature_store_warehouse_service",
     FeatureStoreWarehouseService,
     [
@@ -174,20 +174,16 @@ app_container_config.add_service_with_extra_deps(
         "feature_store_service",
     ],
 )
-app_container_config.add_service_with_extra_deps(
-    "context_service", ContextService, ["entity_service"]
-)
-app_container_config.add_service_with_extra_deps(
-    "entity_service", EntityService, ["catalog_service"]
-)
-app_container_config.add_service_with_extra_deps("dimension_table_service", DimensionTableService)
-app_container_config.add_service_with_extra_deps("event_table_service", EventTableService)
-app_container_config.add_service_with_extra_deps("item_table_service", ItemTableService)
-app_container_config.add_service_with_extra_deps("scd_table_service", SCDTableService)
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service("context_service", ContextService, ["entity_service"])
+app_container_config.register_service("entity_service", EntityService, ["catalog_service"])
+app_container_config.register_service("dimension_table_service", DimensionTableService)
+app_container_config.register_service("event_table_service", EventTableService)
+app_container_config.register_service("item_table_service", ItemTableService)
+app_container_config.register_service("scd_table_service", SCDTableService)
+app_container_config.register_service(
     "feature_service", FeatureService, ["table_service", "view_construction_service"]
 )
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "feature_list_service",
     FeatureListService,
     [
@@ -197,11 +193,11 @@ app_container_config.add_service_with_extra_deps(
         "feature_list_namespace_service",
     ],
 )
-app_container_config.add_service_with_extra_deps("deployment_service", DeploymentService)
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service("deployment_service", DeploymentService)
+app_container_config.register_service(
     "online_store_table_version_service", OnlineStoreTableVersionService
 )
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "observation_table_service",
     ObservationTableService,
     [
@@ -209,12 +205,12 @@ app_container_config.add_service_with_extra_deps(
         "context_service",
     ],
 )
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "historical_feature_table_service",
     HistoricalFeatureTableService,
     ["feature_store_service"],
 )
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "batch_request_table_service",
     BatchRequestTableService,
     [
@@ -222,19 +218,19 @@ app_container_config.add_service_with_extra_deps(
         "context_service",
     ],
 )
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "batch_feature_table_service",
     BatchFeatureTableService,
     ["feature_store_service"],
 )
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "static_source_table_service",
     StaticSourceTableService,
     [
         "feature_store_service",
     ],
 )
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "feature_readiness_service",
     FeatureReadinessService,
     [
@@ -245,7 +241,7 @@ app_container_config.add_service_with_extra_deps(
         "production_ready_validator",
     ],
 )
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "table_status_service",
     TableStatusService,
     [
@@ -253,20 +249,18 @@ app_container_config.add_service_with_extra_deps(
         "feature_readiness_service",
     ],
 )
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "feature_job_setting_analysis_service",
     FeatureJobSettingAnalysisService,
     ["event_table_service"],
 )
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "feature_list_namespace_service",
     FeatureListNamespaceService,
     ["entity_service", "table_service", "catalog_service", "feature_namespace_service"],
 )
-app_container_config.add_service_with_extra_deps(
-    "feature_namespace_service", FeatureNamespaceService
-)
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service("feature_namespace_service", FeatureNamespaceService)
+app_container_config.register_service(
     "table_columns_info_service",
     TableColumnsInfoService,
     [
@@ -276,15 +270,15 @@ app_container_config.add_service_with_extra_deps(
         "entity_relationship_service",
     ],
 )
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service(
     "default_version_mode_service",
     DefaultVersionModeService,
     ["feature_namespace_service", "feature_readiness_service", "feature_list_namespace_service"],
 )
-app_container_config.add_service_with_extra_deps("feature_store_service", FeatureStoreService)
-app_container_config.add_service_with_extra_deps("semantic_service", SemanticService)
-app_container_config.add_service_with_extra_deps("table_service", TableService)
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service("feature_store_service", FeatureStoreService)
+app_container_config.register_service("semantic_service", SemanticService)
+app_container_config.register_service("table_service", TableService)
+app_container_config.register_service(
     "version_service",
     VersionService,
     [
@@ -296,47 +290,39 @@ app_container_config.add_service_with_extra_deps(
         "view_construction_service",
     ],
 )
-app_container_config.add_service_with_extra_deps(
-    "entity_relationship_service", EntityRelationshipService
-)
-app_container_config.add_service_with_extra_deps(
-    "semantic_relationship_service", SemanticRelationshipService
-)
-app_container_config.add_service_with_extra_deps("catalog_service", CatalogService)
-app_container_config.add_service_with_extra_deps("target_service", TargetService)
-app_container_config.add_service_with_extra_deps(
-    "relationship_info_service", RelationshipInfoService
-)
-app_container_config.add_service_with_extra_deps("user_service", UserService)
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service("entity_relationship_service", EntityRelationshipService)
+app_container_config.register_service("semantic_relationship_service", SemanticRelationshipService)
+app_container_config.register_service("catalog_service", CatalogService)
+app_container_config.register_service("target_service", TargetService)
+app_container_config.register_service("relationship_info_service", RelationshipInfoService)
+app_container_config.register_service("user_service", UserService)
+app_container_config.register_service(
     "view_construction_service", ViewConstructionService, ["table_service"]
 )
-app_container_config.add_service_with_extra_deps("periodic_task_service", PeriodicTaskService)
-app_container_config.add_service_with_extra_deps(
+app_container_config.register_service("periodic_task_service", PeriodicTaskService)
+app_container_config.register_service(
     "credential_service",
     CredentialService,
     ["feature_store_warehouse_service", "feature_store_service"],
 )
 
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "target_controller",
     TargetController,
     ["target_service", "entity_service"],
 )
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "relationship_info_controller",
     RelationshipInfoController,
     ["relationship_info_service", "entity_service", "table_service", "user_service"],
 )
-app_container_config.add_class_with_deps(
-    "context_controller", ContextController, ["context_service"]
-)
-app_container_config.add_class_with_deps(
+app_container_config.register_class("context_controller", ContextController, ["context_service"])
+app_container_config.register_class(
     "entity_controller",
     EntityController,
     ["entity_service", "entity_relationship_service", "catalog_service"],
 )
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "event_table_controller",
     EventTableController,
     [
@@ -348,7 +334,7 @@ app_container_config.add_class_with_deps(
     ],
 )
 
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "dimension_table_controller",
     DimensionTableController,
     [
@@ -359,7 +345,7 @@ app_container_config.add_class_with_deps(
         "table_info_service",
     ],
 )
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "item_table_controller",
     ItemTableController,
     [
@@ -371,7 +357,7 @@ app_container_config.add_class_with_deps(
         "event_table_service",
     ],
 )
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "scd_table_controller",
     SCDTableController,
     [
@@ -382,7 +368,7 @@ app_container_config.add_class_with_deps(
         "table_info_service",
     ],
 )
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "feature_controller",
     FeatureController,
     [
@@ -401,7 +387,7 @@ app_container_config.add_class_with_deps(
         "semantic_service",
     ],
 )
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "feature_list_controller",
     FeatureListController,
     [
@@ -416,7 +402,7 @@ app_container_config.add_class_with_deps(
         "task_controller",
     ],
 )
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "feature_job_setting_analysis_controller",
     FeatureJobSettingAnalysisController,
     [
@@ -426,7 +412,7 @@ app_container_config.add_class_with_deps(
         "catalog_service",
     ],
 )
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "feature_list_namespace_controller",
     FeatureListNamespaceController,
     [
@@ -438,7 +424,7 @@ app_container_config.add_class_with_deps(
         "feature_list_status_service",
     ],
 )
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "feature_namespace_controller",
     FeatureNamespaceController,
     [
@@ -451,7 +437,7 @@ app_container_config.add_class_with_deps(
         "catalog_service",
     ],
 )
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "feature_store_controller",
     FeatureStoreController,
     [
@@ -464,20 +450,18 @@ app_container_config.add_class_with_deps(
     ],
 )
 
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "semantic_controller", SemanticController, ["semantic_service", "semantic_relationship_service"]
 )
-app_container_config.add_class_with_deps("table_controller", TableController, ["table_service"])
-app_container_config.add_class_with_deps(
-    "catalog_controller", CatalogController, ["catalog_service"]
-)
-app_container_config.add_class_with_deps(
+app_container_config.register_class("table_controller", TableController, ["table_service"])
+app_container_config.register_class("catalog_controller", CatalogController, ["catalog_service"])
+app_container_config.register_class(
     "periodic_task_controller", PeriodicTaskController, ["periodic_task_service"]
 )
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "credential_controller", CredentialController, ["credential_service", "feature_store_service"]
 )
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "observation_table_controller",
     ObservationTableController,
     [
@@ -488,7 +472,7 @@ app_container_config.add_class_with_deps(
         "feature_store_service",
     ],
 )
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "historical_feature_table_controller",
     HistoricalFeatureTableController,
     [
@@ -501,7 +485,7 @@ app_container_config.add_class_with_deps(
         "feature_list_service",
     ],
 )
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "batch_request_table_controller",
     BatchRequestTableController,
     [
@@ -512,7 +496,7 @@ app_container_config.add_class_with_deps(
         "feature_store_service",
     ],
 )
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "batch_feature_table_controller",
     BatchFeatureTableController,
     [
@@ -526,7 +510,7 @@ app_container_config.add_class_with_deps(
         "task_controller",
     ],
 )
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "deployment_controller",
     DeploymentController,
     [
@@ -538,7 +522,7 @@ app_container_config.add_class_with_deps(
         "task_controller",
     ],
 )
-app_container_config.add_class_with_deps(
+app_container_config.register_class(
     "static_source_table_controller",
     StaticSourceTableController,
     [

--- a/tests/unit/routes/test_app_container_config.py
+++ b/tests/unit/routes/test_app_container_config.py
@@ -1,6 +1,8 @@
 """
 Test app container config
 """
+from __future__ import annotations
+
 import pytest
 
 from featurebyte.routes.app_container_config import AppContainerConfig
@@ -22,6 +24,33 @@ class TestClassB:
 
     def __init__(self, test_class_a: TestClassA):
         self.test_class_a = test_class_a
+
+
+class TestClassC:
+    """
+    Test class C
+    """
+
+    def __init__(self, test_class_d: TestClassD):
+        self.test_class_d = test_class_d
+
+
+class TestClassD:
+    """
+    Test class D
+    """
+
+    def __init__(self, test_class_e: TestClassE):
+        self.test_class_e = test_class_e
+
+
+class TestClassE:
+    """
+    Test class E
+    """
+
+    def __init__(self, test_class_c: TestClassC):
+        self.test_class_c = test_class_c
 
 
 def test_all_dependencies():
@@ -49,3 +78,17 @@ def test_validate():
     with pytest.raises(ValueError) as exc:
         config.validate()
     assert "error creating dependency map" in str(exc)
+
+
+def test_circular_dependencies():
+    """
+    Test circular dependencies are validated against.
+    """
+    config = AppContainerConfig()
+    config.register_class("test_class_c", TestClassC, ["test_class_d"])
+    config.register_class("test_class_d", TestClassD, ["test_class_e"])
+    config.register_class("test_class_e", TestClassD, ["test_class_c"])
+    with pytest.raises(ValueError) as exc:
+        config.validate()
+    assert "circular dependency in the dependency graph" in str(exc)
+    assert "test_class_c -> test_class_d -> test_class_e -> test_class_c" in str(exc)

--- a/tests/unit/routes/test_app_container_config.py
+++ b/tests/unit/routes/test_app_container_config.py
@@ -29,10 +29,10 @@ def test_all_dependencies():
     Test all dependencies
     """
     config = AppContainerConfig()
-    config.add_class_with_deps("test_class_a", TestClassA)
-    config.add_class_with_deps("test_class_b", TestClassB, ["test_class_a"])
-    config.add_service_with_extra_deps("basic_service", TestClassA)
-    config.add_service_with_extra_deps("service_with_deps", TestClassB, ["test_class_a"])
+    config.register_class("test_class_a", TestClassA)
+    config.register_class("test_class_b", TestClassB, ["test_class_a"])
+    config.register_service("basic_service", TestClassA)
+    config.register_service("service_with_deps", TestClassB, ["test_class_a"])
 
     all_deps = config._all_dependencies()
     assert len(all_deps) == 4
@@ -43,8 +43,8 @@ def test_validate():
     Test validate
     """
     config = AppContainerConfig()
-    config.add_class_with_deps("test_class_a", TestClassA)
-    config.add_class_with_deps("test_class_a", TestClassB)
+    config.register_class("test_class_a", TestClassA)
+    config.register_class("test_class_a", TestClassB)
 
     with pytest.raises(ValueError) as exc:
         config.validate()

--- a/tests/unit/routes/test_app_container_config.py
+++ b/tests/unit/routes/test_app_container_config.py
@@ -29,9 +29,9 @@ def test_all_dependencies():
     Test all dependencies
     """
     config = AppContainerConfig()
-    config.add_no_dep_objects("test_class_a", TestClassA)
+    config.add_class_with_deps("test_class_a", TestClassA)
     config.add_class_with_deps("test_class_b", TestClassB, ["test_class_a"])
-    config.add_basic_service("basic_service", TestClassA)
+    config.add_service_with_extra_deps("basic_service", TestClassA)
     config.add_service_with_extra_deps("service_with_deps", TestClassB, ["test_class_a"])
 
     all_deps = config._all_dependencies()
@@ -43,8 +43,8 @@ def test_validate():
     Test validate
     """
     config = AppContainerConfig()
-    config.add_no_dep_objects("test_class_a", TestClassA)
-    config.add_no_dep_objects("test_class_a", TestClassB)
+    config.add_class_with_deps("test_class_a", TestClassA)
+    config.add_class_with_deps("test_class_a", TestClassB)
 
     with pytest.raises(ValueError) as exc:
         config.validate()

--- a/tests/unit/routes/test_lazy_app_container.py
+++ b/tests/unit/routes/test_lazy_app_container.py
@@ -149,12 +149,11 @@ def test_construction__build_with_missing_deps(app_container_constructor_params)
     app_container_config.register_service("extra_deps", TestServiceWithOtherDeps, ["test_service"])
 
     # KeyError raised as no `test_service` dep found
-    app_container = LazyAppContainer(
-        **app_container_constructor_params,
-        app_container_config=app_container_config,
-    )
     with pytest.raises(KeyError):
-        _ = app_container.extra_deps
+        LazyAppContainer(
+            **app_container_constructor_params,
+            app_container_config=app_container_config,
+        )
 
 
 def test_construction__service_with_invalid_constructor(app_container_constructor_params):
@@ -168,14 +167,12 @@ def test_construction__service_with_invalid_constructor(app_container_constructo
     app_container_config = AppContainerConfig()
     app_container_config.register_class("random", TestController, ["test_service"])
 
-    app_container = LazyAppContainer(
-        **app_container_constructor_params,
-        app_container_config=app_container_config,
-    )
     with pytest.raises(KeyError) as exc:
-        _ = app_container.random
-
-    assert "KeyError('test_service')" in str(exc)
+        LazyAppContainer(
+            **app_container_constructor_params,
+            app_container_config=app_container_config,
+        )
+    assert "test_service" in str(exc)
 
 
 def get_class_def(key: str, deps: List[str]) -> ClassDefinition:

--- a/tests/unit/routes/test_lazy_app_container.py
+++ b/tests/unit/routes/test_lazy_app_container.py
@@ -79,12 +79,10 @@ def test_app_config_fixture():
     Test app config fixture
     """
     app_container_config = AppContainerConfig()
-    app_container_config.add_class_with_deps("no_dep", NoDeps)
-    app_container_config.add_service_with_extra_deps("test_service", TestService)
-    app_container_config.add_service_with_extra_deps(
-        "extra_deps", TestServiceWithOtherDeps, ["test_service"]
-    )
-    app_container_config.add_class_with_deps("test_controller", TestController, ["test_service"])
+    app_container_config.register_class("no_dep", NoDeps)
+    app_container_config.register_service("test_service", TestService)
+    app_container_config.register_service("extra_deps", TestServiceWithOtherDeps, ["test_service"])
+    app_container_config.register_class("test_controller", TestController, ["test_service"])
     return app_container_config
 
 
@@ -148,9 +146,7 @@ def test_construction__build_with_missing_deps(app_container_constructor_params)
     Test that an error is raised in an invalid dependency is passed in.
     """
     app_container_config = AppContainerConfig()
-    app_container_config.add_service_with_extra_deps(
-        "extra_deps", TestServiceWithOtherDeps, ["test_service"]
-    )
+    app_container_config.register_service("extra_deps", TestServiceWithOtherDeps, ["test_service"])
 
     # KeyError raised as no `test_service` dep found
     app_container = LazyAppContainer(
@@ -170,7 +166,7 @@ def test_construction__service_with_invalid_constructor(app_container_constructo
     is tighter for users.
     """
     app_container_config = AppContainerConfig()
-    app_container_config.add_class_with_deps("random", TestController, ["test_service"])
+    app_container_config.register_class("random", TestController, ["test_service"])
 
     app_container = LazyAppContainer(
         **app_container_constructor_params,
@@ -190,7 +186,7 @@ def get_class_def(key: str, deps: List[str]) -> ClassDefinition:
         name=key,
         class_=TestService,
         dependencies=deps,
-        dep_type=DepType.BASIC_SERVICE,
+        dep_type=DepType.SERVICE_WITH_EXTRA_DEPS,
     )
 
 

--- a/tests/unit/routes/test_lazy_app_container.py
+++ b/tests/unit/routes/test_lazy_app_container.py
@@ -149,11 +149,12 @@ def test_construction__build_with_missing_deps(app_container_constructor_params)
     app_container_config.register_service("extra_deps", TestServiceWithOtherDeps, ["test_service"])
 
     # KeyError raised as no `test_service` dep found
+    app_container = LazyAppContainer(
+        **app_container_constructor_params,
+        app_container_config=app_container_config,
+    )
     with pytest.raises(KeyError):
-        LazyAppContainer(
-            **app_container_constructor_params,
-            app_container_config=app_container_config,
-        )
+        _ = app_container.extra_deps
 
 
 def test_construction__service_with_invalid_constructor(app_container_constructor_params):
@@ -167,11 +168,12 @@ def test_construction__service_with_invalid_constructor(app_container_constructo
     app_container_config = AppContainerConfig()
     app_container_config.register_class("random", TestController, ["test_service"])
 
+    app_container = LazyAppContainer(
+        **app_container_constructor_params,
+        app_container_config=app_container_config,
+    )
     with pytest.raises(KeyError) as exc:
-        LazyAppContainer(
-            **app_container_constructor_params,
-            app_container_config=app_container_config,
-        )
+        _ = app_container.random
     assert "test_service" in str(exc)
 
 

--- a/tests/unit/routes/test_lazy_app_container.py
+++ b/tests/unit/routes/test_lazy_app_container.py
@@ -79,8 +79,8 @@ def test_app_config_fixture():
     Test app config fixture
     """
     app_container_config = AppContainerConfig()
-    app_container_config.add_no_dep_objects("no_dep", NoDeps)
-    app_container_config.add_basic_service("test_service", TestService)
+    app_container_config.add_class_with_deps("no_dep", NoDeps)
+    app_container_config.add_service_with_extra_deps("test_service", TestService)
     app_container_config.add_service_with_extra_deps(
         "extra_deps", TestServiceWithOtherDeps, ["test_service"]
     )
@@ -170,16 +170,16 @@ def test_construction__service_with_invalid_constructor(app_container_constructo
     is tighter for users.
     """
     app_container_config = AppContainerConfig()
-    app_container_config.add_basic_service("random", TestController)
+    app_container_config.add_class_with_deps("random", TestController, ["test_service"])
 
     app_container = LazyAppContainer(
         **app_container_constructor_params,
         app_container_config=app_container_config,
     )
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(KeyError) as exc:
         _ = app_container.random
 
-    assert "unexpected keyword argument" in str(exc)
+    assert "KeyError('test_service')" in str(exc)
 
 
 def get_class_def(key: str, deps: List[str]) -> ClassDefinition:


### PR DESCRIPTION
## Description
With the introduction of the `LazyAppContainer`, and the smarter way of building our dependencies, we can actually simplify the API for the app_container, as the registration of dependencies is no longer order dependent (i.e. the order in which the registration happens in `registry.py` can be out of order, whereas previously it couldn't be).

As such, we can also simplify the registration API on the config to just 2 methods - `register_service`, and `register_class`. We still keep a special `register_service` since our services consistently take in a few parameters like user, persistent and catalog_id. 

We also add a new validator to check for cycles in the dependencies when the app_container_config is built.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
