### PR TITLE
[chore] app_registry: simplify DI service registration interface further

### DIFF
--- a/featurebyte/migration/service/mixin.py
+++ b/featurebyte/migration/service/mixin.py
@@ -192,7 +192,7 @@ class DataWarehouseMigrationMixin(FeatureStoreService, BaseMigrationServiceMixin
             user=user,
             persistent=self.persistent,
             catalog_id=self.catalog_id,
-            credential_provider=credential_provider,
+            mongo_backed_credential_provider=credential_provider,
             session_validator_service=session_validator_service,
         )
         session = await session_manager_service.get_feature_store_session(

--- a/featurebyte/routes/app_container_config.py
+++ b/featurebyte/routes/app_container_config.py
@@ -7,9 +7,33 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional, Tuple
 
+import re
 from dataclasses import dataclass
 
 from featurebyte.enum import StrEnum
+
+CAMEL_CASE_TO_SNAKE_CASE_PATTERN = re.compile(r"(?<!^)(?=[A-Z])")
+
+
+def _get_class_name(class_: type, name_override: Optional[str] = None) -> str:
+    """
+    Helper method to get a class name
+
+    Parameters
+    ----------
+    class_: type
+        class
+    name_override: str
+        name override
+
+    Returns
+    -------
+    str
+        name
+    """
+    if name_override is not None:
+        return name_override
+    return CAMEL_CASE_TO_SNAKE_CASE_PATTERN.sub("_", class_.__name__).lower()
 
 
 class DepType(StrEnum):
@@ -65,7 +89,10 @@ class AppContainerConfig:
         return self.dependency_mapping
 
     def register_service(
-        self, name: str, class_: type, dependencies: Optional[List[str]] = None
+        self,
+        class_: type,
+        dependencies: Optional[List[str]] = None,
+        name_override: Optional[str] = None,
     ) -> None:
         """
         Register a service with extra dependencies if needed.
@@ -75,13 +102,14 @@ class AppContainerConfig:
 
         Parameters
         ----------
-        name: str
-            name of the object
         class_: type
             type we are registering
         dependencies: list[str]
             dependencies
+        name_override: str
+            name override
         """
+        name = _get_class_name(class_, name_override)
         if dependencies is None:
             dependencies = []
         self.service_with_extra_deps.append(
@@ -94,20 +122,24 @@ class AppContainerConfig:
         )
 
     def register_class(
-        self, name: str, class_: type, dependencies: Optional[List[str]] = None
+        self,
+        class_: type,
+        dependencies: Optional[List[str]] = None,
+        name_override: Optional[str] = None,
     ) -> None:
         """
         Register a class, with dependencies if needed.
 
         Parameters
         ----------
-        name: str
-            name of the object
         class_: type
             type we are registering
         dependencies: list[str]
             dependencies
+        name_override: str
+            name override
         """
+        name = _get_class_name(class_, name_override)
         if dependencies is None:
             dependencies = []
         self.classes_with_deps.append(

--- a/featurebyte/routes/app_container_config.py
+++ b/featurebyte/routes/app_container_config.py
@@ -54,7 +54,7 @@ def _get_constructor_params_from_class(
     list[str]
         constructor params
     """
-    sig = inspect.signature(class_.__init__)
+    sig = inspect.signature(class_.__init__)  # type: ignore[misc]
     keys = list(sig.parameters.keys())
     keys_to_skip = 1 + skip_params
     params = []

--- a/featurebyte/routes/app_container_config.py
+++ b/featurebyte/routes/app_container_config.py
@@ -34,7 +34,6 @@ def _get_class_name(class_name: str, name_override: Optional[str] = None) -> str
     """
     if name_override is not None:
         return name_override
-    print(str(class_name))
     return CAMEL_CASE_TO_SNAKE_CASE_PATTERN.sub("_", class_name).lower()
 
 
@@ -245,8 +244,6 @@ class AppContainerConfig:
         # If any dependency has been visited before, and is in the current recursive stack, the
         # dependency graph is cyclic.
         for neighbour_name in class_def_mapping[class_def.name].dependencies:
-            if neighbour_name not in class_def_mapping:
-                print(class_def)
             neighbour = class_def_mapping[neighbour_name]
             if not visited_nodes.get(neighbour.name, False):
                 is_cyclic, path = self._is_cyclic_dfs(

--- a/featurebyte/routes/app_container_config.py
+++ b/featurebyte/routes/app_container_config.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional, Tuple
 
+import inspect
 import re
 from dataclasses import dataclass
 
@@ -15,13 +16,13 @@ from featurebyte.enum import StrEnum
 CAMEL_CASE_TO_SNAKE_CASE_PATTERN = re.compile(r"(?<!^)(?=[A-Z])")
 
 
-def _get_class_name(class_: type, name_override: Optional[str] = None) -> str:
+def _get_class_name(class_name: str, name_override: Optional[str] = None) -> str:
     """
     Helper method to get a class name
 
     Parameters
     ----------
-    class_: type
+    class_name: type
         class
     name_override: str
         name override
@@ -33,7 +34,41 @@ def _get_class_name(class_: type, name_override: Optional[str] = None) -> str:
     """
     if name_override is not None:
         return name_override
-    return CAMEL_CASE_TO_SNAKE_CASE_PATTERN.sub("_", class_.__name__).lower()
+    print(str(class_name))
+    return CAMEL_CASE_TO_SNAKE_CASE_PATTERN.sub("_", class_name).lower()
+
+
+def _get_constructor_params_from_class(
+    class_: type, dependency_override: Optional[dict[str, str]] = None, skip_params: int = 0
+) -> List[str]:
+    """
+    Helper method to get constructor params from class.
+
+    Parameters
+    ----------
+    class_: type
+        class
+
+    Returns
+    -------
+    list[str]
+        constructor params
+    """
+    sig = inspect.signature(class_.__init__)
+    keys = list(sig.parameters.keys())
+    keys_to_skip = 1 + skip_params
+    params = []
+    dep_override = dependency_override or {}
+    for key in keys[keys_to_skip:]:
+        param_type = sig.parameters[key]
+        type_annotation = param_type.name
+        if isinstance(type_annotation, type):
+            type_annotation = type_annotation.__name__
+        class_name = _get_class_name(type_annotation)
+        if key in dep_override:
+            class_name = dep_override[key]
+        params.append(class_name)
+    return params
 
 
 class DepType(StrEnum):
@@ -91,7 +126,7 @@ class AppContainerConfig:
     def register_service(
         self,
         class_: type,
-        dependencies: Optional[List[str]] = None,
+        dependency_override: Optional[Dict[str, str]] = None,
         name_override: Optional[str] = None,
     ) -> None:
         """
@@ -104,19 +139,16 @@ class AppContainerConfig:
         ----------
         class_: type
             type we are registering
-        dependencies: list[str]
+        dependency_override: list[str]
             dependencies
         name_override: str
             name override
         """
-        name = _get_class_name(class_, name_override)
-        if dependencies is None:
-            dependencies = []
         self.service_with_extra_deps.append(
             ClassDefinition(
-                name=name,
+                name=_get_class_name(class_.__name__, name_override),
                 class_=class_,
-                dependencies=dependencies,
+                dependencies=_get_constructor_params_from_class(class_, dependency_override, 3),
                 dep_type=DepType.SERVICE_WITH_EXTRA_DEPS,
             )
         )
@@ -124,8 +156,9 @@ class AppContainerConfig:
     def register_class(
         self,
         class_: type,
-        dependencies: Optional[List[str]] = None,
+        dependency_override: Optional[Dict[str, str]] = None,
         name_override: Optional[str] = None,
+        force_no_deps: bool = False,
     ) -> None:
         """
         Register a class, with dependencies if needed.
@@ -134,19 +167,21 @@ class AppContainerConfig:
         ----------
         class_: type
             type we are registering
-        dependencies: list[str]
+        dependency_override: list[str]
             dependencies
         name_override: str
             name override
+        force_no_deps: bool
+            force no dependencies
         """
-        name = _get_class_name(class_, name_override)
-        if dependencies is None:
-            dependencies = []
+        deps = _get_constructor_params_from_class(class_, dependency_override)
+        if force_no_deps:
+            deps = []
         self.classes_with_deps.append(
             ClassDefinition(
-                name=name,
+                name=_get_class_name(class_.__name__, name_override),
                 class_=class_,
-                dependencies=dependencies,
+                dependencies=deps,
                 dep_type=DepType.CLASS_WITH_DEPS,
             )
         )
@@ -210,6 +245,8 @@ class AppContainerConfig:
         # If any dependency has been visited before, and is in the current recursive stack, the
         # dependency graph is cyclic.
         for neighbour_name in class_def_mapping[class_def.name].dependencies:
+            if neighbour_name not in class_def_mapping:
+                print(class_def)
             neighbour = class_def_mapping[neighbour_name]
             if not visited_nodes.get(neighbour.name, False):
                 is_cyclic, path = self._is_cyclic_dfs(

--- a/featurebyte/routes/batch_feature_table/controller.py
+++ b/featurebyte/routes/batch_feature_table/controller.py
@@ -33,7 +33,7 @@ class BatchFeatureTableController(
 
     def __init__(
         self,
-        service: BatchFeatureTableService,
+        batch_feature_table_service: BatchFeatureTableService,
         preview_service: PreviewService,
         feature_store_service: FeatureStoreService,
         feature_list_service: FeatureListService,
@@ -42,7 +42,7 @@ class BatchFeatureTableController(
         entity_validation_service: EntityValidationService,
         task_controller: TaskController,
     ):
-        super().__init__(service=service, preview_service=preview_service)
+        super().__init__(service=batch_feature_table_service, preview_service=preview_service)
         self.feature_store_service = feature_store_service
         self.feature_list_service = feature_list_service
         self.batch_request_table_service = batch_request_table_service

--- a/featurebyte/routes/batch_request_table/controller.py
+++ b/featurebyte/routes/batch_request_table/controller.py
@@ -31,13 +31,13 @@ class BatchRequestTableController(
 
     def __init__(
         self,
-        service: BatchRequestTableService,
+        batch_request_table_service: BatchRequestTableService,
         preview_service: PreviewService,
         batch_feature_table_service: BatchFeatureTableService,
         task_controller: TaskController,
         feature_store_service: FeatureStoreService,
     ):
-        super().__init__(service=service, preview_service=preview_service)
+        super().__init__(service=batch_request_table_service, preview_service=preview_service)
         self.batch_feature_table_service = batch_feature_table_service
         self.task_controller = task_controller
         self.feature_store_service = feature_store_service

--- a/featurebyte/routes/credential/controller.py
+++ b/featurebyte/routes/credential/controller.py
@@ -29,8 +29,10 @@ class CredentialController(
 
     paginated_document_class = CredentialList
 
-    def __init__(self, service: CredentialService, feature_store_service: FeatureStoreService):
-        super().__init__(service)
+    def __init__(
+        self, credential_service: CredentialService, feature_store_service: FeatureStoreService
+    ):
+        super().__init__(credential_service)
         self.feature_store_service = feature_store_service
 
     async def create_credential(

--- a/featurebyte/routes/deployment/controller.py
+++ b/featurebyte/routes/deployment/controller.py
@@ -50,14 +50,14 @@ class DeploymentController(
 
     def __init__(
         self,
-        service: DeploymentService,
+        deployment_service: DeploymentService,
         catalog_service: CatalogService,
         context_service: ContextService,
         feature_list_service: FeatureListService,
         online_serving_service: OnlineServingService,
         task_controller: TaskController,
     ):
-        super().__init__(service)
+        super().__init__(deployment_service)
         self.catalog_service = catalog_service
         self.context_service = context_service
         self.feature_list_service = feature_list_service

--- a/featurebyte/routes/dimension_table/controller.py
+++ b/featurebyte/routes/dimension_table/controller.py
@@ -31,14 +31,17 @@ class DimensionTableController(
 
     def __init__(
         self,
-        service: TableDocumentService,
+        dimension_table_service: TableDocumentService,
         table_columns_info_service: TableColumnsInfoService,
         table_status_service: TableStatusService,
         semantic_service: SemanticService,
         table_info_service: TableInfoService,
     ):
         super().__init__(
-            service, table_columns_info_service, table_status_service, semantic_service
+            dimension_table_service,
+            table_columns_info_service,
+            table_status_service,
+            semantic_service,
         )
         self.table_info_service = table_info_service
 

--- a/featurebyte/routes/entity/controller.py
+++ b/featurebyte/routes/entity/controller.py
@@ -23,11 +23,11 @@ class EntityController(BaseDocumentController[EntityModel, EntityService, Entity
 
     def __init__(
         self,
-        service: EntityService,
+        entity_service: EntityService,
         entity_relationship_service: EntityRelationshipService,
         catalog_service: CatalogService,
     ):
-        super().__init__(service)
+        super().__init__(entity_service)
         self.relationship_service = entity_relationship_service
         self.catalog_service = catalog_service
 

--- a/featurebyte/routes/event_table/controller.py
+++ b/featurebyte/routes/event_table/controller.py
@@ -31,14 +31,14 @@ class EventTableController(
 
     def __init__(
         self,
-        service: TableDocumentService,
+        event_table_service: TableDocumentService,
         table_columns_info_service: TableColumnsInfoService,
         table_status_service: TableStatusService,
         semantic_service: SemanticService,
         table_info_service: TableInfoService,
     ):
         super().__init__(
-            service, table_columns_info_service, table_status_service, semantic_service
+            event_table_service, table_columns_info_service, table_status_service, semantic_service
         )
         self.table_info_service = table_info_service
 

--- a/featurebyte/routes/feature/controller.py
+++ b/featurebyte/routes/feature/controller.py
@@ -168,7 +168,7 @@ class FeatureController(
 
     def __init__(
         self,
-        service: FeatureService,
+        feature_service: FeatureService,
         feature_namespace_service: FeatureNamespaceService,
         entity_service: EntityService,
         feature_list_service: FeatureListService,
@@ -183,7 +183,7 @@ class FeatureController(
         semantic_service: SemanticService,
     ):
         # pylint: disable=too-many-arguments
-        super().__init__(service)
+        super().__init__(feature_service)
         self.feature_namespace_service = feature_namespace_service
         self.entity_service = entity_service
         self.feature_list_service = feature_list_service

--- a/featurebyte/routes/feature_job_setting_analysis/controller.py
+++ b/featurebyte/routes/feature_job_setting_analysis/controller.py
@@ -41,12 +41,12 @@ class FeatureJobSettingAnalysisController(
 
     def __init__(
         self,
-        service: FeatureJobSettingAnalysisService,
+        feature_job_setting_analysis_service: FeatureJobSettingAnalysisService,
         task_controller: TaskController,
         event_table_service: EventTableService,
         catalog_service: CatalogService,
     ):
-        super().__init__(service)
+        super().__init__(feature_job_setting_analysis_service)
         self.task_controller = task_controller
         self.event_table_service = event_table_service
         self.catalog_service = catalog_service

--- a/featurebyte/routes/feature_list/controller.py
+++ b/featurebyte/routes/feature_list/controller.py
@@ -65,7 +65,7 @@ class FeatureListController(
     # pylint: disable=too-many-arguments
     def __init__(
         self,
-        service: FeatureListService,
+        feature_list_service: FeatureListService,
         feature_list_namespace_service: FeatureListNamespaceService,
         feature_service: FeatureService,
         feature_readiness_service: FeatureReadinessService,
@@ -75,7 +75,7 @@ class FeatureListController(
         feature_store_warehouse_service: FeatureStoreWarehouseService,
         task_controller: TaskController,
     ):
-        super().__init__(service)
+        super().__init__(feature_list_service)
         self.feature_list_namespace_service = feature_list_namespace_service
         self.feature_service = feature_service
         self.feature_readiness_service = feature_readiness_service

--- a/featurebyte/routes/feature_list_namespace/controller.py
+++ b/featurebyte/routes/feature_list_namespace/controller.py
@@ -45,14 +45,14 @@ class FeatureListNamespaceController(
 
     def __init__(
         self,
-        service: FeatureListNamespaceService,
+        feature_list_namespace_service: FeatureListNamespaceService,
         entity_service: EntityService,
         feature_list_service: FeatureListService,
         default_version_mode_service: DefaultVersionModeService,
         feature_readiness_service: FeatureReadinessService,
         feature_list_status_service: FeatureListStatusService,
     ):
-        super().__init__(service)
+        super().__init__(feature_list_namespace_service)
         self.entity_service = entity_service
         self.feature_list_service = feature_list_service
         self.default_version_mode_service = default_version_mode_service

--- a/featurebyte/routes/feature_namespace/controller.py
+++ b/featurebyte/routes/feature_namespace/controller.py
@@ -46,7 +46,7 @@ class FeatureNamespaceController(
 
     def __init__(
         self,
-        service: FeatureNamespaceService,
+        feature_namespace_service: FeatureNamespaceService,
         entity_service: EntityService,
         feature_service: FeatureService,
         default_version_mode_service: DefaultVersionModeService,
@@ -54,7 +54,7 @@ class FeatureNamespaceController(
         table_service: TableService,
         catalog_service: CatalogService,
     ):
-        super().__init__(service)
+        super().__init__(feature_namespace_service)
         self.entity_service = entity_service
         self.feature_service = feature_service
         self.default_version_mode_service = default_version_mode_service

--- a/featurebyte/routes/feature_store/controller.py
+++ b/featurebyte/routes/feature_store/controller.py
@@ -43,14 +43,14 @@ class FeatureStoreController(
 
     def __init__(
         self,
-        service: FeatureStoreService,
+        feature_store_service: FeatureStoreService,
         preview_service: PreviewService,
         session_manager_service: SessionManagerService,
         session_validator_service: SessionValidatorService,
         feature_store_warehouse_service: FeatureStoreWarehouseService,
         credential_service: CredentialService,
     ):
-        super().__init__(service)
+        super().__init__(feature_store_service)
         self.preview_service = preview_service
         self.session_manager_service = session_manager_service
         self.session_validator_service = session_validator_service

--- a/featurebyte/routes/historical_feature_table/controller.py
+++ b/featurebyte/routes/historical_feature_table/controller.py
@@ -42,7 +42,7 @@ class HistoricalFeatureTableController(
 
     def __init__(
         self,
-        service: HistoricalFeatureTableService,
+        historical_feature_table_service: HistoricalFeatureTableService,
         preview_service: PreviewService,
         feature_store_service: FeatureStoreService,
         observation_table_service: ObservationTableService,
@@ -50,7 +50,7 @@ class HistoricalFeatureTableController(
         task_controller: TaskController,
         feature_list_service: FeatureListService,
     ):
-        super().__init__(service=service, preview_service=preview_service)
+        super().__init__(service=historical_feature_table_service, preview_service=preview_service)
         self.feature_store_service = feature_store_service
         self.observation_table_service = observation_table_service
         self.entity_validation_service = entity_validation_service

--- a/featurebyte/routes/item_table/controller.py
+++ b/featurebyte/routes/item_table/controller.py
@@ -32,7 +32,7 @@ class ItemTableController(
 
     def __init__(
         self,
-        service: TableDocumentService,
+        item_table_service: TableDocumentService,
         table_columns_info_service: TableColumnsInfoService,
         table_status_service: TableStatusService,
         semantic_service: SemanticService,
@@ -40,7 +40,7 @@ class ItemTableController(
         event_table_service: EventTableService,
     ):
         super().__init__(
-            service, table_columns_info_service, table_status_service, semantic_service
+            item_table_service, table_columns_info_service, table_status_service, semantic_service
         )
         self.table_info_service = table_info_service
         self.event_table_service = event_table_service

--- a/featurebyte/routes/lazy_app_container.py
+++ b/featurebyte/routes/lazy_app_container.py
@@ -214,8 +214,10 @@ class LazyAppContainer:
         # Pre-load with some default deps
         self.instance_map: Dict[str, Any] = {
             "task_controller": TaskController(task_manager=task_manager),
-            "tempdata_controller": TempDataController(temp_storage=temp_storage),
-            "credential_provider": MongoBackedCredentialProvider(persistent=persistent),
+            "temp_data_controller": TempDataController(temp_storage=temp_storage),
+            "mongo_backed_credential_provider": MongoBackedCredentialProvider(
+                persistent=persistent
+            ),
             "task_manager": task_manager,
         }
 

--- a/featurebyte/routes/observation_table/controller.py
+++ b/featurebyte/routes/observation_table/controller.py
@@ -31,13 +31,13 @@ class ObservationTableController(
 
     def __init__(
         self,
-        service: ObservationTableService,
+        observation_table_service: ObservationTableService,
         preview_service: PreviewService,
         historical_feature_table_service: HistoricalFeatureTableService,
         task_controller: TaskController,
         feature_store_service: FeatureStoreService,
     ):
-        super().__init__(service=service, preview_service=preview_service)
+        super().__init__(service=observation_table_service, preview_service=preview_service)
         self.historical_feature_table_service = historical_feature_table_service
         self.task_controller = task_controller
         self.feature_store_service = feature_store_service

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -84,102 +84,104 @@ from featurebyte.utils.credential import MongoBackedCredentialProvider
 
 app_container_config = AppContainerConfig()
 
-app_container_config.register_service(SessionValidatorService)
-app_container_config.register_class(ProductionReadyValidator)
-app_container_config.register_class(TableInfoService)
-app_container_config.register_service(SessionManagerService)
-app_container_config.register_service(ParentEntityLookupService)
-app_container_config.register_service(OnlineEnableService)
-app_container_config.register_service(EntityValidationService)
-app_container_config.register_service(OnlineServingService)
-app_container_config.register_service(FeatureListStatusService)
-app_container_config.register_service(DeployService)
-app_container_config.register_service(PreviewService)
-app_container_config.register_service(FeatureStoreWarehouseService)
-app_container_config.register_service(ContextService)
-app_container_config.register_service(EntityService)
-app_container_config.register_service(DimensionTableService)
-app_container_config.register_service(EventTableService)
-app_container_config.register_service(ItemTableService)
-app_container_config.register_service(SCDTableService, name_override="scd_table_service")
-app_container_config.register_service(FeatureService)
-app_container_config.register_service(FeatureListService)
-app_container_config.register_service(DeploymentService)
-app_container_config.register_service(OnlineStoreTableVersionService)
-app_container_config.register_service(ObservationTableService)
-app_container_config.register_service(HistoricalFeatureTableService)
-app_container_config.register_service(BatchRequestTableService)
+# Register services - please keep sorted by alphabetical order.
 app_container_config.register_service(BatchFeatureTableService)
-app_container_config.register_service(StaticSourceTableService)
-app_container_config.register_service(FeatureReadinessService)
-app_container_config.register_service(TableStatusService)
-app_container_config.register_service(FeatureJobSettingAnalysisService)
-app_container_config.register_service(FeatureListNamespaceService)
-app_container_config.register_service(FeatureNamespaceService)
-app_container_config.register_service(TableColumnsInfoService)
-app_container_config.register_service(DefaultVersionModeService)
-app_container_config.register_service(FeatureStoreService)
-app_container_config.register_service(SemanticService)
-app_container_config.register_service(TableService)
-app_container_config.register_service(VersionService)
-app_container_config.register_service(EntityRelationshipService)
-app_container_config.register_service(SemanticRelationshipService)
+app_container_config.register_service(BatchRequestTableService)
 app_container_config.register_service(CatalogService)
-app_container_config.register_service(TargetService)
-app_container_config.register_service(RelationshipInfoService)
-app_container_config.register_service(UserService)
-app_container_config.register_service(ViewConstructionService)
-app_container_config.register_service(PeriodicTaskService)
 app_container_config.register_service(CredentialService)
+app_container_config.register_service(ContextService)
+app_container_config.register_service(DefaultVersionModeService)
+app_container_config.register_service(DeployService)
+app_container_config.register_service(DeploymentService)
+app_container_config.register_service(DimensionTableService)
+app_container_config.register_service(EntityRelationshipService)
+app_container_config.register_service(EntityService)
+app_container_config.register_service(EntityValidationService)
+app_container_config.register_service(EventTableService)
+app_container_config.register_service(FeatureService)
+app_container_config.register_service(FeatureJobSettingAnalysisService)
+app_container_config.register_service(FeatureListService)
+app_container_config.register_service(FeatureListNamespaceService)
+app_container_config.register_service(FeatureListStatusService)
+app_container_config.register_service(FeatureNamespaceService)
+app_container_config.register_service(FeatureReadinessService)
+app_container_config.register_service(FeatureStoreService)
+app_container_config.register_service(FeatureStoreWarehouseService)
+app_container_config.register_service(HistoricalFeatureTableService)
+app_container_config.register_service(ItemTableService)
+app_container_config.register_service(ObservationTableService)
+app_container_config.register_service(OnlineEnableService)
+app_container_config.register_service(OnlineServingService)
+app_container_config.register_service(OnlineStoreTableVersionService)
+app_container_config.register_service(ParentEntityLookupService)
+app_container_config.register_service(PeriodicTaskService)
+app_container_config.register_service(PreviewService)
+app_container_config.register_service(RelationshipInfoService)
+app_container_config.register_service(SCDTableService, name_override="scd_table_service")
+app_container_config.register_service(SemanticService)
+app_container_config.register_service(SemanticRelationshipService)
+app_container_config.register_service(SessionManagerService)
+app_container_config.register_service(SessionValidatorService)
+app_container_config.register_service(StaticSourceTableService)
+app_container_config.register_service(TableService)
+app_container_config.register_service(TableColumnsInfoService)
+app_container_config.register_service(TableStatusService)
+app_container_config.register_service(TargetService)
+app_container_config.register_service(UserService)
+app_container_config.register_service(VersionService)
+app_container_config.register_service(ViewConstructionService)
+
+
+# Register classes - please keep sorted by alphabetical order.
+app_container_config.register_class(BatchFeatureTableController)
+app_container_config.register_class(BatchRequestTableController)
 app_container_config.register_class(
-    TargetController, dependency_override={"service": "target_service"}
+    CatalogController, dependency_override={"service": "catalog_service"}
 )
-app_container_config.register_class(RelationshipInfoController)
 app_container_config.register_class(
     ContextController, dependency_override={"service": "context_service"}
 )
+app_container_config.register_class(CredentialController)
+app_container_config.register_class(DeploymentController)
+app_container_config.register_class(DimensionTableController)
 app_container_config.register_class(EntityController)
 app_container_config.register_class(EventTableController)
-app_container_config.register_class(DimensionTableController)
+app_container_config.register_class(FeatureController)
+app_container_config.register_class(FeatureJobSettingAnalysisController)
+app_container_config.register_class(FeatureListController)
+app_container_config.register_class(FeatureListNamespaceController)
+app_container_config.register_class(FeatureNamespaceController)
+app_container_config.register_class(FeatureStoreController)
+app_container_config.register_class(HistoricalFeatureTableController)
 app_container_config.register_class(ItemTableController)
+app_container_config.register_class(
+    PeriodicTaskController, dependency_override={"service": "periodic_task_service"}
+)
+app_container_config.register_class(ObservationTableController)
+app_container_config.register_class(ProductionReadyValidator)
+app_container_config.register_class(RelationshipInfoController)
 app_container_config.register_class(
     SCDTableController,
     dependency_override={"service": "scd_table_service"},
     name_override="scd_table_controller",
 )
-app_container_config.register_class(FeatureController)
-app_container_config.register_class(FeatureListController)
-app_container_config.register_class(FeatureJobSettingAnalysisController)
-app_container_config.register_class(FeatureListNamespaceController)
-app_container_config.register_class(FeatureNamespaceController)
-app_container_config.register_class(FeatureStoreController)
 app_container_config.register_class(SemanticController)
+app_container_config.register_class(StaticSourceTableController)
 app_container_config.register_class(
     TableController, dependency_override={"service": "table_service"}
 )
+app_container_config.register_class(TableInfoService)
 app_container_config.register_class(
-    CatalogController, dependency_override={"service": "catalog_service"}
+    TargetController, dependency_override={"service": "target_service"}
 )
-app_container_config.register_class(
-    PeriodicTaskController, dependency_override={"service": "periodic_task_service"}
-)
-app_container_config.register_class(CredentialController)
-app_container_config.register_class(ObservationTableController)
-app_container_config.register_class(HistoricalFeatureTableController)
-app_container_config.register_class(BatchRequestTableController)
-app_container_config.register_class(BatchFeatureTableController)
-app_container_config.register_class(DeploymentController)
-app_container_config.register_class(StaticSourceTableController)
 
-# These have dependency overrides set as [] as they are manually initialized.
+
+# These have force_no_deps set as True, as they are manually initialized.
+app_container_config.register_class(MongoBackedCredentialProvider, force_no_deps=True)
 app_container_config.register_class(TaskController, force_no_deps=True)
-app_container_config.register_class(
-    TempDataController, force_no_deps=True, name_override="tempdata_controller"
-)
-app_container_config.register_class(
-    MongoBackedCredentialProvider, force_no_deps=True, name_override="credential_provider"
-)
 app_container_config.register_class(TaskManager, force_no_deps=True)
+app_container_config.register_class(TempDataController, force_no_deps=True)
+
 
 # Validate the config after all classes have been registered.
 # This should be the last line in this module.

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -84,416 +84,102 @@ from featurebyte.utils.credential import MongoBackedCredentialProvider
 
 app_container_config = AppContainerConfig()
 
-app_container_config.register_service(
-    SessionValidatorService,
-    ["credential_provider", "feature_store_service"],
-)
-app_container_config.register_class(
-    ProductionReadyValidator,
-    ["table_service", "feature_service", "version_service"],
-)
-app_container_config.register_class(
-    TableInfoService,
-    ["entity_service", "semantic_service", "catalog_service"],
-)
-app_container_config.register_service(
-    SessionManagerService,
-    [
-        "credential_provider",
-        "session_validator_service",
-    ],
-)
-app_container_config.register_service(
-    ParentEntityLookupService,
-    [
-        "entity_service",
-        "table_service",
-    ],
-)
-app_container_config.register_service(
-    OnlineEnableService,
-    [
-        "session_manager_service",
-        "task_manager",
-        "feature_service",
-        "feature_store_service",
-        "feature_namespace_service",
-        "feature_list_service",
-        "online_store_table_version_service",
-    ],
-)
-app_container_config.register_service(
-    EntityValidationService,
-    ["entity_service", "parent_entity_lookup_service"],
-)
-app_container_config.register_service(
-    OnlineServingService,
-    [
-        "session_manager_service",
-        "entity_validation_service",
-        "online_store_table_version_service",
-        "feature_store_service",
-    ],
-)
-app_container_config.register_service(
-    FeatureListStatusService,
-    ["feature_list_namespace_service", "feature_list_service"],
-)
-app_container_config.register_service(
-    DeployService,
-    [
-        "feature_service",
-        "online_enable_service",
-        "feature_list_status_service",
-        "deployment_service",
-        "feature_list_namespace_service",
-        "feature_list_service",
-    ],
-)
-app_container_config.register_service(
-    PreviewService,
-    [
-        "session_manager_service",
-        "feature_list_service",
-        "entity_validation_service",
-        "feature_store_service",
-    ],
-)
-app_container_config.register_service(
-    FeatureStoreWarehouseService,
-    [
-        "session_manager_service",
-        "feature_store_service",
-    ],
-)
-app_container_config.register_service(ContextService, ["entity_service"])
-app_container_config.register_service(EntityService, ["catalog_service"])
+app_container_config.register_service(SessionValidatorService)
+app_container_config.register_class(ProductionReadyValidator)
+app_container_config.register_class(TableInfoService)
+app_container_config.register_service(SessionManagerService)
+app_container_config.register_service(ParentEntityLookupService)
+app_container_config.register_service(OnlineEnableService)
+app_container_config.register_service(EntityValidationService)
+app_container_config.register_service(OnlineServingService)
+app_container_config.register_service(FeatureListStatusService)
+app_container_config.register_service(DeployService)
+app_container_config.register_service(PreviewService)
+app_container_config.register_service(FeatureStoreWarehouseService)
+app_container_config.register_service(ContextService)
+app_container_config.register_service(EntityService)
 app_container_config.register_service(DimensionTableService)
 app_container_config.register_service(EventTableService)
 app_container_config.register_service(ItemTableService)
 app_container_config.register_service(SCDTableService, name_override="scd_table_service")
-app_container_config.register_service(
-    FeatureService, ["table_service", "view_construction_service"]
-)
-app_container_config.register_service(
-    FeatureListService,
-    [
-        "entity_service",
-        "relationship_info_service",
-        "feature_service",
-        "feature_list_namespace_service",
-    ],
-)
+app_container_config.register_service(FeatureService)
+app_container_config.register_service(FeatureListService)
 app_container_config.register_service(DeploymentService)
 app_container_config.register_service(OnlineStoreTableVersionService)
-app_container_config.register_service(
-    ObservationTableService,
-    [
-        "feature_store_service",
-        "context_service",
-    ],
-)
-app_container_config.register_service(
-    HistoricalFeatureTableService,
-    ["feature_store_service"],
-)
-app_container_config.register_service(
-    BatchRequestTableService,
-    [
-        "feature_store_service",
-        "context_service",
-    ],
-)
-app_container_config.register_service(
-    BatchFeatureTableService,
-    ["feature_store_service"],
-)
-app_container_config.register_service(
-    StaticSourceTableService,
-    [
-        "feature_store_service",
-    ],
-)
-app_container_config.register_service(
-    FeatureReadinessService,
-    [
-        "feature_service",
-        "feature_namespace_service",
-        "feature_list_service",
-        "feature_list_namespace_service",
-        "production_ready_validator",
-    ],
-)
-app_container_config.register_service(
-    TableStatusService,
-    [
-        "feature_service",
-        "feature_readiness_service",
-    ],
-)
-app_container_config.register_service(
-    FeatureJobSettingAnalysisService,
-    ["event_table_service"],
-)
-app_container_config.register_service(
-    FeatureListNamespaceService,
-    ["entity_service", "table_service", "catalog_service", "feature_namespace_service"],
-)
+app_container_config.register_service(ObservationTableService)
+app_container_config.register_service(HistoricalFeatureTableService)
+app_container_config.register_service(BatchRequestTableService)
+app_container_config.register_service(BatchFeatureTableService)
+app_container_config.register_service(StaticSourceTableService)
+app_container_config.register_service(FeatureReadinessService)
+app_container_config.register_service(TableStatusService)
+app_container_config.register_service(FeatureJobSettingAnalysisService)
+app_container_config.register_service(FeatureListNamespaceService)
 app_container_config.register_service(FeatureNamespaceService)
-app_container_config.register_service(
-    TableColumnsInfoService,
-    [
-        "semantic_service",
-        "entity_service",
-        "relationship_info_service",
-        "entity_relationship_service",
-    ],
-)
-app_container_config.register_service(
-    DefaultVersionModeService,
-    ["feature_namespace_service", "feature_readiness_service", "feature_list_namespace_service"],
-)
+app_container_config.register_service(TableColumnsInfoService)
+app_container_config.register_service(DefaultVersionModeService)
 app_container_config.register_service(FeatureStoreService)
 app_container_config.register_service(SemanticService)
 app_container_config.register_service(TableService)
-app_container_config.register_service(
-    VersionService,
-    [
-        "table_service",
-        "feature_service",
-        "feature_namespace_service",
-        "feature_list_service",
-        "feature_list_namespace_service",
-        "view_construction_service",
-    ],
-)
+app_container_config.register_service(VersionService)
 app_container_config.register_service(EntityRelationshipService)
 app_container_config.register_service(SemanticRelationshipService)
 app_container_config.register_service(CatalogService)
 app_container_config.register_service(TargetService)
 app_container_config.register_service(RelationshipInfoService)
 app_container_config.register_service(UserService)
-app_container_config.register_service(ViewConstructionService, ["table_service"])
+app_container_config.register_service(ViewConstructionService)
 app_container_config.register_service(PeriodicTaskService)
-app_container_config.register_service(
-    CredentialService,
-    ["feature_store_warehouse_service", "feature_store_service"],
-)
-
+app_container_config.register_service(CredentialService)
 app_container_config.register_class(
-    TargetController,
-    ["target_service", "entity_service"],
+    TargetController, dependency_override={"service": "target_service"}
 )
+app_container_config.register_class(RelationshipInfoController)
 app_container_config.register_class(
-    RelationshipInfoController,
-    ["relationship_info_service", "entity_service", "table_service", "user_service"],
+    ContextController, dependency_override={"service": "context_service"}
 )
-app_container_config.register_class(ContextController, ["context_service"])
-app_container_config.register_class(
-    EntityController,
-    ["entity_service", "entity_relationship_service", "catalog_service"],
-)
-app_container_config.register_class(
-    EventTableController,
-    [
-        "event_table_service",
-        "table_columns_info_service",
-        "table_status_service",
-        "semantic_service",
-        "table_info_service",
-    ],
-)
-
-app_container_config.register_class(
-    DimensionTableController,
-    [
-        "dimension_table_service",
-        "table_columns_info_service",
-        "table_status_service",
-        "semantic_service",
-        "table_info_service",
-    ],
-)
-app_container_config.register_class(
-    ItemTableController,
-    [
-        "item_table_service",
-        "table_columns_info_service",
-        "table_status_service",
-        "semantic_service",
-        "table_info_service",
-        "event_table_service",
-    ],
-)
+app_container_config.register_class(EntityController)
+app_container_config.register_class(EventTableController)
+app_container_config.register_class(DimensionTableController)
+app_container_config.register_class(ItemTableController)
 app_container_config.register_class(
     SCDTableController,
-    [
-        "scd_table_service",
-        "table_columns_info_service",
-        "table_status_service",
-        "semantic_service",
-        "table_info_service",
-    ],
+    dependency_override={"service": "scd_table_service"},
     name_override="scd_table_controller",
 )
+app_container_config.register_class(FeatureController)
+app_container_config.register_class(FeatureListController)
+app_container_config.register_class(FeatureJobSettingAnalysisController)
+app_container_config.register_class(FeatureListNamespaceController)
+app_container_config.register_class(FeatureNamespaceController)
+app_container_config.register_class(FeatureStoreController)
+app_container_config.register_class(SemanticController)
 app_container_config.register_class(
-    FeatureController,
-    [
-        "feature_service",
-        "feature_namespace_service",
-        "entity_service",
-        "feature_list_service",
-        "feature_readiness_service",
-        "preview_service",
-        "version_service",
-        "feature_store_warehouse_service",
-        "task_controller",
-        "catalog_service",
-        "table_service",
-        "feature_namespace_controller",
-        "semantic_service",
-    ],
+    TableController, dependency_override={"service": "table_service"}
 )
 app_container_config.register_class(
-    FeatureListController,
-    [
-        "feature_list_service",
-        "feature_list_namespace_service",
-        "feature_service",
-        "feature_readiness_service",
-        "deploy_service",
-        "preview_service",
-        "version_service",
-        "feature_store_warehouse_service",
-        "task_controller",
-    ],
+    CatalogController, dependency_override={"service": "catalog_service"}
 )
 app_container_config.register_class(
-    FeatureJobSettingAnalysisController,
-    [
-        "feature_job_setting_analysis_service",
-        "task_controller",
-        "event_table_service",
-        "catalog_service",
-    ],
+    PeriodicTaskController, dependency_override={"service": "periodic_task_service"}
 )
-app_container_config.register_class(
-    FeatureListNamespaceController,
-    [
-        "feature_list_namespace_service",
-        "entity_service",
-        "feature_list_service",
-        "default_version_mode_service",
-        "feature_readiness_service",
-        "feature_list_status_service",
-    ],
-)
-app_container_config.register_class(
-    FeatureNamespaceController,
-    [
-        "feature_namespace_service",
-        "entity_service",
-        "feature_service",
-        "default_version_mode_service",
-        "feature_readiness_service",
-        "table_service",
-        "catalog_service",
-    ],
-)
-app_container_config.register_class(
-    FeatureStoreController,
-    [
-        "feature_store_service",
-        "preview_service",
-        "session_manager_service",
-        "session_validator_service",
-        "feature_store_warehouse_service",
-        "credential_service",
-    ],
-)
+app_container_config.register_class(CredentialController)
+app_container_config.register_class(ObservationTableController)
+app_container_config.register_class(HistoricalFeatureTableController)
+app_container_config.register_class(BatchRequestTableController)
+app_container_config.register_class(BatchFeatureTableController)
+app_container_config.register_class(DeploymentController)
+app_container_config.register_class(StaticSourceTableController)
 
+# These have dependency overrides set as [] as they are manually initialized.
+app_container_config.register_class(TaskController, force_no_deps=True)
 app_container_config.register_class(
-    SemanticController, ["semantic_service", "semantic_relationship_service"]
-)
-app_container_config.register_class(TableController, ["table_service"])
-app_container_config.register_class(CatalogController, ["catalog_service"])
-app_container_config.register_class(PeriodicTaskController, ["periodic_task_service"])
-app_container_config.register_class(
-    CredentialController, ["credential_service", "feature_store_service"]
+    TempDataController, force_no_deps=True, name_override="tempdata_controller"
 )
 app_container_config.register_class(
-    ObservationTableController,
-    [
-        "observation_table_service",
-        "preview_service",
-        "historical_feature_table_service",
-        "task_controller",
-        "feature_store_service",
-    ],
+    MongoBackedCredentialProvider, force_no_deps=True, name_override="credential_provider"
 )
-app_container_config.register_class(
-    HistoricalFeatureTableController,
-    [
-        "historical_feature_table_service",
-        "preview_service",
-        "feature_store_service",
-        "observation_table_service",
-        "entity_validation_service",
-        "task_controller",
-        "feature_list_service",
-    ],
-)
-app_container_config.register_class(
-    BatchRequestTableController,
-    [
-        "batch_request_table_service",
-        "preview_service",
-        "batch_feature_table_service",
-        "task_controller",
-        "feature_store_service",
-    ],
-)
-app_container_config.register_class(
-    BatchFeatureTableController,
-    [
-        "batch_feature_table_service",
-        "preview_service",
-        "feature_store_service",
-        "feature_list_service",
-        "batch_request_table_service",
-        "deployment_service",
-        "entity_validation_service",
-        "task_controller",
-    ],
-)
-app_container_config.register_class(
-    DeploymentController,
-    [
-        "deployment_service",
-        "catalog_service",
-        "context_service",
-        "feature_list_service",
-        "online_serving_service",
-        "task_controller",
-    ],
-)
-app_container_config.register_class(
-    StaticSourceTableController,
-    [
-        "static_source_table_service",
-        "preview_service",
-        "table_service",
-        "task_controller",
-        "feature_store_service",
-    ],
-)
-
-app_container_config.register_class(TaskController)
-app_container_config.register_class(TempDataController, name_override="tempdata_controller")
-app_container_config.register_class(
-    MongoBackedCredentialProvider, name_override="credential_provider"
-)
-app_container_config.register_class(TaskManager)
+app_container_config.register_class(TaskManager, force_no_deps=True)
 
 # Validate the config after all classes have been registered.
 # This should be the last line in this module.

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -85,22 +85,18 @@ from featurebyte.utils.credential import MongoBackedCredentialProvider
 app_container_config = AppContainerConfig()
 
 app_container_config.register_service(
-    "session_validator_service",
     SessionValidatorService,
     ["credential_provider", "feature_store_service"],
 )
 app_container_config.register_class(
-    "production_ready_validator",
     ProductionReadyValidator,
     ["table_service", "feature_service", "version_service"],
 )
 app_container_config.register_class(
-    "table_info_service",
     TableInfoService,
     ["entity_service", "semantic_service", "catalog_service"],
 )
 app_container_config.register_service(
-    "session_manager_service",
     SessionManagerService,
     [
         "credential_provider",
@@ -108,7 +104,6 @@ app_container_config.register_service(
     ],
 )
 app_container_config.register_service(
-    "parent_entity_lookup_service",
     ParentEntityLookupService,
     [
         "entity_service",
@@ -116,7 +111,6 @@ app_container_config.register_service(
     ],
 )
 app_container_config.register_service(
-    "online_enable_service",
     OnlineEnableService,
     [
         "session_manager_service",
@@ -129,12 +123,10 @@ app_container_config.register_service(
     ],
 )
 app_container_config.register_service(
-    "entity_validation_service",
     EntityValidationService,
     ["entity_service", "parent_entity_lookup_service"],
 )
 app_container_config.register_service(
-    "online_serving_service",
     OnlineServingService,
     [
         "session_manager_service",
@@ -144,12 +136,10 @@ app_container_config.register_service(
     ],
 )
 app_container_config.register_service(
-    "feature_list_status_service",
     FeatureListStatusService,
     ["feature_list_namespace_service", "feature_list_service"],
 )
 app_container_config.register_service(
-    "deploy_service",
     DeployService,
     [
         "feature_service",
@@ -161,7 +151,6 @@ app_container_config.register_service(
     ],
 )
 app_container_config.register_service(
-    "preview_service",
     PreviewService,
     [
         "session_manager_service",
@@ -171,24 +160,22 @@ app_container_config.register_service(
     ],
 )
 app_container_config.register_service(
-    "feature_store_warehouse_service",
     FeatureStoreWarehouseService,
     [
         "session_manager_service",
         "feature_store_service",
     ],
 )
-app_container_config.register_service("context_service", ContextService, ["entity_service"])
-app_container_config.register_service("entity_service", EntityService, ["catalog_service"])
-app_container_config.register_service("dimension_table_service", DimensionTableService)
-app_container_config.register_service("event_table_service", EventTableService)
-app_container_config.register_service("item_table_service", ItemTableService)
-app_container_config.register_service("scd_table_service", SCDTableService)
+app_container_config.register_service(ContextService, ["entity_service"])
+app_container_config.register_service(EntityService, ["catalog_service"])
+app_container_config.register_service(DimensionTableService)
+app_container_config.register_service(EventTableService)
+app_container_config.register_service(ItemTableService)
+app_container_config.register_service(SCDTableService, name_override="scd_table_service")
 app_container_config.register_service(
-    "feature_service", FeatureService, ["table_service", "view_construction_service"]
+    FeatureService, ["table_service", "view_construction_service"]
 )
 app_container_config.register_service(
-    "feature_list_service",
     FeatureListService,
     [
         "entity_service",
@@ -197,12 +184,9 @@ app_container_config.register_service(
         "feature_list_namespace_service",
     ],
 )
-app_container_config.register_service("deployment_service", DeploymentService)
+app_container_config.register_service(DeploymentService)
+app_container_config.register_service(OnlineStoreTableVersionService)
 app_container_config.register_service(
-    "online_store_table_version_service", OnlineStoreTableVersionService
-)
-app_container_config.register_service(
-    "observation_table_service",
     ObservationTableService,
     [
         "feature_store_service",
@@ -210,12 +194,10 @@ app_container_config.register_service(
     ],
 )
 app_container_config.register_service(
-    "historical_feature_table_service",
     HistoricalFeatureTableService,
     ["feature_store_service"],
 )
 app_container_config.register_service(
-    "batch_request_table_service",
     BatchRequestTableService,
     [
         "feature_store_service",
@@ -223,19 +205,16 @@ app_container_config.register_service(
     ],
 )
 app_container_config.register_service(
-    "batch_feature_table_service",
     BatchFeatureTableService,
     ["feature_store_service"],
 )
 app_container_config.register_service(
-    "static_source_table_service",
     StaticSourceTableService,
     [
         "feature_store_service",
     ],
 )
 app_container_config.register_service(
-    "feature_readiness_service",
     FeatureReadinessService,
     [
         "feature_service",
@@ -246,7 +225,6 @@ app_container_config.register_service(
     ],
 )
 app_container_config.register_service(
-    "table_status_service",
     TableStatusService,
     [
         "feature_service",
@@ -254,18 +232,15 @@ app_container_config.register_service(
     ],
 )
 app_container_config.register_service(
-    "feature_job_setting_analysis_service",
     FeatureJobSettingAnalysisService,
     ["event_table_service"],
 )
 app_container_config.register_service(
-    "feature_list_namespace_service",
     FeatureListNamespaceService,
     ["entity_service", "table_service", "catalog_service", "feature_namespace_service"],
 )
-app_container_config.register_service("feature_namespace_service", FeatureNamespaceService)
+app_container_config.register_service(FeatureNamespaceService)
 app_container_config.register_service(
-    "table_columns_info_service",
     TableColumnsInfoService,
     [
         "semantic_service",
@@ -275,15 +250,13 @@ app_container_config.register_service(
     ],
 )
 app_container_config.register_service(
-    "default_version_mode_service",
     DefaultVersionModeService,
     ["feature_namespace_service", "feature_readiness_service", "feature_list_namespace_service"],
 )
-app_container_config.register_service("feature_store_service", FeatureStoreService)
-app_container_config.register_service("semantic_service", SemanticService)
-app_container_config.register_service("table_service", TableService)
+app_container_config.register_service(FeatureStoreService)
+app_container_config.register_service(SemanticService)
+app_container_config.register_service(TableService)
 app_container_config.register_service(
-    "version_service",
     VersionService,
     [
         "table_service",
@@ -294,40 +267,33 @@ app_container_config.register_service(
         "view_construction_service",
     ],
 )
-app_container_config.register_service("entity_relationship_service", EntityRelationshipService)
-app_container_config.register_service("semantic_relationship_service", SemanticRelationshipService)
-app_container_config.register_service("catalog_service", CatalogService)
-app_container_config.register_service("target_service", TargetService)
-app_container_config.register_service("relationship_info_service", RelationshipInfoService)
-app_container_config.register_service("user_service", UserService)
+app_container_config.register_service(EntityRelationshipService)
+app_container_config.register_service(SemanticRelationshipService)
+app_container_config.register_service(CatalogService)
+app_container_config.register_service(TargetService)
+app_container_config.register_service(RelationshipInfoService)
+app_container_config.register_service(UserService)
+app_container_config.register_service(ViewConstructionService, ["table_service"])
+app_container_config.register_service(PeriodicTaskService)
 app_container_config.register_service(
-    "view_construction_service", ViewConstructionService, ["table_service"]
-)
-app_container_config.register_service("periodic_task_service", PeriodicTaskService)
-app_container_config.register_service(
-    "credential_service",
     CredentialService,
     ["feature_store_warehouse_service", "feature_store_service"],
 )
 
 app_container_config.register_class(
-    "target_controller",
     TargetController,
     ["target_service", "entity_service"],
 )
 app_container_config.register_class(
-    "relationship_info_controller",
     RelationshipInfoController,
     ["relationship_info_service", "entity_service", "table_service", "user_service"],
 )
-app_container_config.register_class("context_controller", ContextController, ["context_service"])
+app_container_config.register_class(ContextController, ["context_service"])
 app_container_config.register_class(
-    "entity_controller",
     EntityController,
     ["entity_service", "entity_relationship_service", "catalog_service"],
 )
 app_container_config.register_class(
-    "event_table_controller",
     EventTableController,
     [
         "event_table_service",
@@ -339,7 +305,6 @@ app_container_config.register_class(
 )
 
 app_container_config.register_class(
-    "dimension_table_controller",
     DimensionTableController,
     [
         "dimension_table_service",
@@ -350,7 +315,6 @@ app_container_config.register_class(
     ],
 )
 app_container_config.register_class(
-    "item_table_controller",
     ItemTableController,
     [
         "item_table_service",
@@ -362,7 +326,6 @@ app_container_config.register_class(
     ],
 )
 app_container_config.register_class(
-    "scd_table_controller",
     SCDTableController,
     [
         "scd_table_service",
@@ -371,9 +334,9 @@ app_container_config.register_class(
         "semantic_service",
         "table_info_service",
     ],
+    name_override="scd_table_controller",
 )
 app_container_config.register_class(
-    "feature_controller",
     FeatureController,
     [
         "feature_service",
@@ -392,7 +355,6 @@ app_container_config.register_class(
     ],
 )
 app_container_config.register_class(
-    "feature_list_controller",
     FeatureListController,
     [
         "feature_list_service",
@@ -407,7 +369,6 @@ app_container_config.register_class(
     ],
 )
 app_container_config.register_class(
-    "feature_job_setting_analysis_controller",
     FeatureJobSettingAnalysisController,
     [
         "feature_job_setting_analysis_service",
@@ -417,7 +378,6 @@ app_container_config.register_class(
     ],
 )
 app_container_config.register_class(
-    "feature_list_namespace_controller",
     FeatureListNamespaceController,
     [
         "feature_list_namespace_service",
@@ -429,7 +389,6 @@ app_container_config.register_class(
     ],
 )
 app_container_config.register_class(
-    "feature_namespace_controller",
     FeatureNamespaceController,
     [
         "feature_namespace_service",
@@ -442,7 +401,6 @@ app_container_config.register_class(
     ],
 )
 app_container_config.register_class(
-    "feature_store_controller",
     FeatureStoreController,
     [
         "feature_store_service",
@@ -455,18 +413,15 @@ app_container_config.register_class(
 )
 
 app_container_config.register_class(
-    "semantic_controller", SemanticController, ["semantic_service", "semantic_relationship_service"]
+    SemanticController, ["semantic_service", "semantic_relationship_service"]
 )
-app_container_config.register_class("table_controller", TableController, ["table_service"])
-app_container_config.register_class("catalog_controller", CatalogController, ["catalog_service"])
+app_container_config.register_class(TableController, ["table_service"])
+app_container_config.register_class(CatalogController, ["catalog_service"])
+app_container_config.register_class(PeriodicTaskController, ["periodic_task_service"])
 app_container_config.register_class(
-    "periodic_task_controller", PeriodicTaskController, ["periodic_task_service"]
-)
-app_container_config.register_class(
-    "credential_controller", CredentialController, ["credential_service", "feature_store_service"]
+    CredentialController, ["credential_service", "feature_store_service"]
 )
 app_container_config.register_class(
-    "observation_table_controller",
     ObservationTableController,
     [
         "observation_table_service",
@@ -477,7 +432,6 @@ app_container_config.register_class(
     ],
 )
 app_container_config.register_class(
-    "historical_feature_table_controller",
     HistoricalFeatureTableController,
     [
         "historical_feature_table_service",
@@ -490,7 +444,6 @@ app_container_config.register_class(
     ],
 )
 app_container_config.register_class(
-    "batch_request_table_controller",
     BatchRequestTableController,
     [
         "batch_request_table_service",
@@ -501,7 +454,6 @@ app_container_config.register_class(
     ],
 )
 app_container_config.register_class(
-    "batch_feature_table_controller",
     BatchFeatureTableController,
     [
         "batch_feature_table_service",
@@ -515,7 +467,6 @@ app_container_config.register_class(
     ],
 )
 app_container_config.register_class(
-    "deployment_controller",
     DeploymentController,
     [
         "deployment_service",
@@ -527,7 +478,6 @@ app_container_config.register_class(
     ],
 )
 app_container_config.register_class(
-    "static_source_table_controller",
     StaticSourceTableController,
     [
         "static_source_table_service",
@@ -538,10 +488,12 @@ app_container_config.register_class(
     ],
 )
 
-app_container_config.register_class("task_controller", TaskController)
-app_container_config.register_class("tempdata_controller", TempDataController)
-app_container_config.register_class("credential_provider", MongoBackedCredentialProvider)
-app_container_config.register_class("task_manager", TaskManager)
+app_container_config.register_class(TaskController)
+app_container_config.register_class(TempDataController, name_override="tempdata_controller")
+app_container_config.register_class(
+    MongoBackedCredentialProvider, name_override="credential_provider"
+)
+app_container_config.register_class(TaskManager)
 
 # Validate the config after all classes have been registered.
 # This should be the last line in this module.

--- a/featurebyte/routes/relationship_info/controller.py
+++ b/featurebyte/routes/relationship_info/controller.py
@@ -31,13 +31,13 @@ class RelationshipInfoController(
         self,
         relationship_info_service: RelationshipInfoService,
         entity_service: EntityService,
-        data_service: TableService,
+        table_service: TableService,
         user_service: UserService,
     ):
         super().__init__(relationship_info_service)
         self.relationship_info_service = relationship_info_service
         self.entity_service = entity_service
-        self.data_service = data_service
+        self.data_service = table_service
         self.user_service = user_service
 
     async def create_relationship_info(

--- a/featurebyte/routes/semantic/controller.py
+++ b/featurebyte/routes/semantic/controller.py
@@ -23,10 +23,10 @@ class SemanticController(
 
     def __init__(
         self,
-        service: SemanticService,
+        semantic_service: SemanticService,
         semantic_relationship_service: SemanticRelationshipService,
     ):
-        super().__init__(service)
+        super().__init__(semantic_service)
         self.relationship_service = semantic_relationship_service
 
     async def create_semantic(

--- a/featurebyte/routes/static_source_table/controller.py
+++ b/featurebyte/routes/static_source_table/controller.py
@@ -31,13 +31,13 @@ class StaticSourceTableController(
 
     def __init__(
         self,
-        service: StaticSourceTableService,
+        static_source_table_service: StaticSourceTableService,
         preview_service: PreviewService,
         table_service: TableService,
         task_controller: TaskController,
         feature_store_service: FeatureStoreService,
     ):
-        super().__init__(service=service, preview_service=preview_service)
+        super().__init__(service=static_source_table_service, preview_service=preview_service)
         self.table_service = table_service
         self.task_controller = task_controller
         self.feature_store_service = feature_store_service

--- a/featurebyte/routes/target/controller.py
+++ b/featurebyte/routes/target/controller.py
@@ -21,10 +21,10 @@ class TargetController(BaseDocumentController[TargetModel, TargetService, Target
 
     def __init__(
         self,
-        service: TargetService,
+        target_service: TargetService,
         entity_service: EntityService,
     ):
-        super().__init__(service)
+        super().__init__(target_service)
         self.entity_service = entity_service
 
     async def create_target(

--- a/featurebyte/routes/temp_data/api.py
+++ b/featurebyte/routes/temp_data/api.py
@@ -17,7 +17,7 @@ async def get_data(request: Request, path: Path = Query()) -> StreamingResponse:
     """
     Retrieve temp data
     """
-    controller = request.state.app_container.tempdata_controller
+    controller = request.state.app_container.temp_data_controller
     result: StreamingResponse = await controller.get_data(
         path=path,
     )

--- a/featurebyte/service/online_serving.py
+++ b/featurebyte/service/online_serving.py
@@ -34,14 +34,14 @@ class OnlineServingService(BaseService):
         catalog_id: ObjectId,
         session_manager_service: SessionManagerService,
         entity_validation_service: EntityValidationService,
-        online_table_version_service: OnlineStoreTableVersionService,
+        online_store_table_version_service: OnlineStoreTableVersionService,
         feature_store_service: FeatureStoreService,
     ):
         super().__init__(user, persistent, catalog_id)
         self.feature_store_service = feature_store_service
         self.session_manager_service = session_manager_service
         self.entity_validation_service = entity_validation_service
-        self.online_store_table_version_service = online_table_version_service
+        self.online_store_table_version_service = online_store_table_version_service
 
     async def get_online_features_from_feature_list(
         self,

--- a/featurebyte/service/session_manager.py
+++ b/featurebyte/service/session_manager.py
@@ -25,13 +25,13 @@ class SessionManagerService:
         user: Any,
         persistent: Persistent,
         catalog_id: ObjectId,
-        credential_provider: MongoBackedCredentialProvider,
+        mongo_backed_credential_provider: MongoBackedCredentialProvider,
         session_validator_service: SessionValidatorService,
     ):
         self.user = user
         self.persistent = persistent
         self.catalog_id = catalog_id
-        self.credential_provider = credential_provider
+        self.credential_provider = mongo_backed_credential_provider
         self.session_validator_service = session_validator_service
 
     async def get_feature_store_session(

--- a/featurebyte/service/session_validator.py
+++ b/featurebyte/service/session_validator.py
@@ -39,13 +39,13 @@ class SessionValidatorService:
         user: Any,
         persistent: Persistent,
         catalog_id: ObjectId,
-        credential_provider: MongoBackedCredentialProvider,
+        mongo_backed_credential_provider: MongoBackedCredentialProvider,
         feature_store_service: FeatureStoreService,
     ):
         self.user = user
         self.persistent = persistent
         self.catalog_id = catalog_id
-        self.credential_provider = credential_provider
+        self.credential_provider = mongo_backed_credential_provider
         self.feature_store_service = feature_store_service
 
     @classmethod

--- a/tests/unit/routes/test_app_container_config.py
+++ b/tests/unit/routes/test_app_container_config.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 
 import pytest
 
-from featurebyte.routes.app_container_config import AppContainerConfig, _get_class_name
+from featurebyte.routes.app_container_config import (
+    AppContainerConfig,
+    _get_class_name,
+    _get_constructor_params_from_class,
+)
 
 
 class TestClassA:
@@ -59,12 +63,12 @@ def test_all_dependencies():
     """
     config = AppContainerConfig()
     config.register_class(TestClassA)
-    config.register_class(TestClassB, ["test_class_a"])
+    config.register_class(TestClassB)
     config.register_service(
         TestClassA,
         name_override="basic_service",
     )
-    config.register_service(TestClassB, ["test_class_a"], name_override="service_with_deps")
+    config.register_service(TestClassB, name_override="service_with_deps")
 
     all_deps = config._all_dependencies()
     assert len(all_deps) == 4
@@ -88,9 +92,9 @@ def test_circular_dependencies():
     Test circular dependencies are validated against.
     """
     config = AppContainerConfig()
-    config.register_class(TestClassC, ["test_class_d"])
-    config.register_class(TestClassD, ["test_class_e"])
-    config.register_class(TestClassE, ["test_class_c"])
+    config.register_class(TestClassC)
+    config.register_class(TestClassD)
+    config.register_class(TestClassE)
     with pytest.raises(ValueError) as exc:
         config.validate()
     assert "circular dependency in the dependency graph" in str(exc)
@@ -101,8 +105,13 @@ def test_get_class_name():
     """
     Test _get_class_name
     """
-    name = _get_class_name(TestClassC)
+    name = _get_class_name(TestClassC.__name__)
     assert name == "test_class_c"
 
-    name = _get_class_name(TestClassC, name_override="hello")
+    name = _get_class_name(TestClassC.__name__, name_override="hello")
     assert name == "hello"
+
+
+def test_get_constructor_params_from_class():
+    params = _get_constructor_params_from_class(TestClassC)
+    assert params == ["test_class_d"]

--- a/tests/unit/routes/test_app_container_config.py
+++ b/tests/unit/routes/test_app_container_config.py
@@ -113,5 +113,8 @@ def test_get_class_name():
 
 
 def test_get_constructor_params_from_class():
+    """
+    Test _get_constructor_params_from_class
+    """
     params = _get_constructor_params_from_class(TestClassC)
     assert params == ["test_class_d"]

--- a/tests/unit/routes/test_app_container_config.py
+++ b/tests/unit/routes/test_app_container_config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import pytest
 
-from featurebyte.routes.app_container_config import AppContainerConfig
+from featurebyte.routes.app_container_config import AppContainerConfig, _get_class_name
 
 
 class TestClassA:
@@ -58,22 +58,25 @@ def test_all_dependencies():
     Test all dependencies
     """
     config = AppContainerConfig()
-    config.register_class("test_class_a", TestClassA)
-    config.register_class("test_class_b", TestClassB, ["test_class_a"])
-    config.register_service("basic_service", TestClassA)
-    config.register_service("service_with_deps", TestClassB, ["test_class_a"])
+    config.register_class(TestClassA)
+    config.register_class(TestClassB, ["test_class_a"])
+    config.register_service(
+        TestClassA,
+        name_override="basic_service",
+    )
+    config.register_service(TestClassB, ["test_class_a"], name_override="service_with_deps")
 
     all_deps = config._all_dependencies()
     assert len(all_deps) == 4
 
 
-def test_validate():
+def test_validate__duplicate_name():
     """
-    Test validate
+    Test validate - duplicate name throws error
     """
     config = AppContainerConfig()
-    config.register_class("test_class_a", TestClassA)
-    config.register_class("test_class_a", TestClassB)
+    config.register_class(TestClassA)
+    config.register_class(TestClassB, name_override="test_class_a")
 
     with pytest.raises(ValueError) as exc:
         config.validate()
@@ -85,10 +88,21 @@ def test_circular_dependencies():
     Test circular dependencies are validated against.
     """
     config = AppContainerConfig()
-    config.register_class("test_class_c", TestClassC, ["test_class_d"])
-    config.register_class("test_class_d", TestClassD, ["test_class_e"])
-    config.register_class("test_class_e", TestClassD, ["test_class_c"])
+    config.register_class(TestClassC, ["test_class_d"])
+    config.register_class(TestClassD, ["test_class_e"])
+    config.register_class(TestClassE, ["test_class_c"])
     with pytest.raises(ValueError) as exc:
         config.validate()
     assert "circular dependency in the dependency graph" in str(exc)
     assert "test_class_c -> test_class_d -> test_class_e -> test_class_c" in str(exc)
+
+
+def test_get_class_name():
+    """
+    Test _get_class_name
+    """
+    name = _get_class_name(TestClassC)
+    assert name == "test_class_c"
+
+    name = _get_class_name(TestClassC, name_override="hello")
+    assert name == "hello"

--- a/tests/unit/routes/test_lazy_app_container.py
+++ b/tests/unit/routes/test_lazy_app_container.py
@@ -79,10 +79,10 @@ def test_app_config_fixture():
     Test app config fixture
     """
     app_container_config = AppContainerConfig()
-    app_container_config.register_class("no_dep", NoDeps)
-    app_container_config.register_service("test_service", TestService)
-    app_container_config.register_service("extra_deps", TestServiceWithOtherDeps, ["test_service"])
-    app_container_config.register_class("test_controller", TestController, ["test_service"])
+    app_container_config.register_class(NoDeps)
+    app_container_config.register_service(TestService)
+    app_container_config.register_service(TestServiceWithOtherDeps, ["test_service"])
+    app_container_config.register_class(TestController, ["test_service"])
     return app_container_config
 
 
@@ -146,7 +146,7 @@ def test_construction__build_with_missing_deps(app_container_constructor_params)
     Test that an error is raised in an invalid dependency is passed in.
     """
     app_container_config = AppContainerConfig()
-    app_container_config.register_service("extra_deps", TestServiceWithOtherDeps, ["test_service"])
+    app_container_config.register_service(TestServiceWithOtherDeps, ["test_service"])
 
     # KeyError raised as no `test_service` dep found
     app_container = LazyAppContainer(
@@ -166,7 +166,7 @@ def test_construction__service_with_invalid_constructor(app_container_constructo
     is tighter for users.
     """
     app_container_config = AppContainerConfig()
-    app_container_config.register_class("random", TestController, ["test_service"])
+    app_container_config.register_class(TestController, ["test_service"], name_override="random")
 
     app_container = LazyAppContainer(
         **app_container_constructor_params,

--- a/tests/unit/routes/test_lazy_app_container.py
+++ b/tests/unit/routes/test_lazy_app_container.py
@@ -81,8 +81,8 @@ def test_app_config_fixture():
     app_container_config = AppContainerConfig()
     app_container_config.register_class(NoDeps)
     app_container_config.register_service(TestService)
-    app_container_config.register_service(TestServiceWithOtherDeps, ["test_service"])
-    app_container_config.register_class(TestController, ["test_service"])
+    app_container_config.register_service(TestServiceWithOtherDeps, {"other_dep": "test_service"})
+    app_container_config.register_class(TestController)
     return app_container_config
 
 
@@ -146,7 +146,7 @@ def test_construction__build_with_missing_deps(app_container_constructor_params)
     Test that an error is raised in an invalid dependency is passed in.
     """
     app_container_config = AppContainerConfig()
-    app_container_config.register_service(TestServiceWithOtherDeps, ["test_service"])
+    app_container_config.register_service(TestServiceWithOtherDeps, {"other_dep": "test_service"})
 
     # KeyError raised as no `test_service` dep found
     app_container = LazyAppContainer(
@@ -166,7 +166,7 @@ def test_construction__service_with_invalid_constructor(app_container_constructo
     is tighter for users.
     """
     app_container_config = AppContainerConfig()
-    app_container_config.register_class(TestController, ["test_service"], name_override="random")
+    app_container_config.register_class(TestController, name_override="random")
 
     app_container = LazyAppContainer(
         **app_container_constructor_params,


### PR DESCRIPTION
## Description
Simplify interface further by inferring the name, and dependencies as much as possible.

With these changes, registering a service/class should be as simple as 
`app_container_config.register_class(<class>)` 
for >90% of the cases, compared to 
`app_container_config.register_class(<class_name>, <class>, [<dependencies>])`
which is the current format.

There are some edge cases where we _might_ need to specify overrides:
- classes that don't override a constructor (eg. controller implementations)
- camel case class names that are acronyms (eg. SCDTable -> manually override to `scd_table`. otherwise, we'll infer as `s_c_d_table`)

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
