### PR TITLE
[chore] workflow/notify: fix new line formatting

### DIFF
--- a/.github/workflows/notify_gen.yaml
+++ b/.github/workflows/notify_gen.yaml
@@ -36,7 +36,14 @@ jobs:
                       "type": "section",
                       "text": {
                           "type": "mrkdwn",
-                          "text": "Actor: ${{ github.actor }}\\nChanges: ${{ github.event.pull_request._links.html.href }}/files"
+                          "text": "Actor: ${{ github.actor }}"
+                      }
+                  },
+                  {
+                      "type": "section",
+                      "text": {
+                          "type": "mrkdwn",
+                          "text": "Changes: ${{ github.event.pull_request._links.html.href }}/files"
                       }
                   }
               ]


### PR DESCRIPTION
## Description
Fix new line formatting.

Currently looks like 
<img width="591" alt="Screenshot 2023-06-26 at 6 53 14 PM" src="https://github.com/featurebyte/featurebyte/assets/2313101/98f1ffdb-9a31-42c8-b159-bb36c9ede5b8">

which is kinda ugly.
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
