### PR TITLE
[chore] refactor to use perf_logging decorator

### DIFF
--- a/featurebyte/api/feature.py
+++ b/featurebyte/api/feature.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 from typing import Any, ClassVar, Dict, List, Literal, Optional, Sequence, Tuple, Type, Union, cast
 
-import time
 from http import HTTPStatus
 
 import pandas as pd
@@ -33,6 +32,7 @@ from featurebyte.config import Configurations
 from featurebyte.core.accessor.count_dict import CdAccessorMixin
 from featurebyte.core.accessor.feature_datetime import FeatureDtAccessorMixin
 from featurebyte.core.accessor.feature_string import FeatureStrAccessorMixin
+from featurebyte.core.mixin import perf_logging
 from featurebyte.core.series import FrozenSeries, FrozenSeriesT, Series
 from featurebyte.enum import ConflictResolution
 from featurebyte.exception import RecordCreationException, RecordRetrievalException
@@ -831,6 +831,7 @@ class Feature(
         feature_dict["node_name"] = mapped_node.name
         return FeatureModel(**feature_dict)
 
+    @perf_logging
     @enforce_observation_set_row_order
     @typechecked
     def preview(
@@ -891,8 +892,6 @@ class Feature(
         - [FeatureList.compute_historical_features](/reference/featurebyte.api.feature_list.FeatureList.compute_historical_features/):
           Get historical features from a feature list.
         """
-        tic = time.time()
-
         feature = self._get_pruned_feature_model()
         payload = FeaturePreview(
             feature_store_name=self.feature_store.name,
@@ -906,9 +905,6 @@ class Feature(
         if response.status_code != HTTPStatus.OK:
             raise RecordRetrievalException(response)
         result = response.json()
-
-        elapsed = time.time() - tic
-        logger.debug(f"Preview took {elapsed:.2f}s")
         return dataframe_from_json(result)  # pylint: disable=no-member
 
     @typechecked

--- a/featurebyte/query_graph/sql/common.py
+++ b/featurebyte/query_graph/sql/common.py
@@ -10,6 +10,7 @@ from enum import Enum
 from sqlglot import expressions
 from sqlglot.expressions import Expression, select
 
+from featurebyte.core.mixin import perf_logging
 from featurebyte.enum import SourceType
 
 REQUEST_TABLE_NAME = "REQUEST_TABLE"
@@ -136,6 +137,7 @@ def get_dialect_from_source_type(source_type: SourceType) -> str:
     return dialect
 
 
+@perf_logging
 def sql_to_string(sql_expr: Expression, source_type: SourceType) -> str:
     """Convert a SQL expression to text given the source type
 

--- a/featurebyte/query_graph/sql/feature_preview.py
+++ b/featurebyte/query_graph/sql/feature_preview.py
@@ -103,7 +103,6 @@ def get_feature_preview_sql(
         elapsed = time.time() - tic
         logger.debug(f"Constructing required tiles SQL took {elapsed:.2}s")
 
-    tic = time.time()
     preview_sql = sql_to_string(
         execution_plan.construct_combined_sql(
             request_table_name=request_table_name,
@@ -114,7 +113,5 @@ def get_feature_preview_sql(
         ),
         source_type=source_type,
     )
-    elapsed = time.time() - tic
-    logger.debug(f"Generating full SQL took {elapsed:.2}s")
 
     return preview_sql


### PR DESCRIPTION
## Description
Small refactor to reuse the `perf_logging` decorator where is easy to replace right now. 

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
