### PR TITLE
[chore] catalog_name_injector: refactor to reuse logic to add catalog name to documents

### DIFF
--- a/featurebyte/routes/catalog/catalog_name_injector.py
+++ b/featurebyte/routes/catalog/catalog_name_injector.py
@@ -36,10 +36,12 @@ class CatalogNameInjector:
             catalog name, and update document groups
         """
         catalog = await self.catalog_service.get_document(catalog_id)
+        catalog_name = catalog.name
+        assert catalog_name is not None
         updated_group = []
         for document_group in documents:
             for document in document_group["data"]:
                 assert document["catalog_id"] == catalog.id
-                document["catalog_name"] = catalog.name
+                document["catalog_name"] = catalog_name
             updated_group.append(document_group)
-        return catalog.name, updated_group
+        return catalog_name, updated_group

--- a/featurebyte/routes/catalog/catalog_name_injector.py
+++ b/featurebyte/routes/catalog/catalog_name_injector.py
@@ -1,0 +1,45 @@
+"""
+Catalog name injector
+"""
+from __future__ import annotations
+
+from typing import Any, List, Tuple
+
+from featurebyte.models.base import PydanticObjectId
+from featurebyte.service.catalog import CatalogService
+
+
+class CatalogNameInjector:
+    """
+    Catalog name injector
+    """
+
+    def __init__(self, catalog_service: CatalogService):
+        self.catalog_service = catalog_service
+
+    async def add_name(
+        self, catalog_id: PydanticObjectId, documents: List[dict[str, Any]]
+    ) -> Tuple[str, List[dict[str, Any]]]:
+        """
+        Add catalog name to the documents.
+
+        Parameters
+        ----------
+        catalog_id: PydanticObjectId
+            Catalog id
+        documents: List[dict[str, Any]]
+            Documents to be updated
+
+        Returns
+        -------
+        Tuple[str, List[dict[str, Any]]]
+            catalog name, and update document groups
+        """
+        catalog = await self.catalog_service.get_document(catalog_id)
+        updated_group = []
+        for document_group in documents:
+            for document in document_group["data"]:
+                assert document["catalog_id"] == catalog.id
+                document["catalog_name"] = catalog.name
+            updated_group.append(document_group)
+        return catalog.name, updated_group

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -6,6 +6,7 @@ This contains all the dependencies that we want to register in order to get our 
 from featurebyte.routes.app_container_config import AppContainerConfig
 from featurebyte.routes.batch_feature_table.controller import BatchFeatureTableController
 from featurebyte.routes.batch_request_table.controller import BatchRequestTableController
+from featurebyte.routes.catalog.catalog_name_injector import CatalogNameInjector
 from featurebyte.routes.catalog.controller import CatalogController
 from featurebyte.routes.common.base import DerivePrimaryEntityHelper
 from featurebyte.routes.context.controller import ContextController
@@ -143,6 +144,7 @@ app_container_config.register_class(BatchRequestTableController)
 app_container_config.register_class(
     CatalogController, dependency_override={"service": "catalog_service"}
 )
+app_container_config.register_class(CatalogNameInjector)
 app_container_config.register_class(
     ContextController, dependency_override={"service": "context_service"}
 )

--- a/featurebyte/service/feature_list_namespace.py
+++ b/featurebyte/service/feature_list_namespace.py
@@ -9,6 +9,7 @@ from bson import ObjectId
 
 from featurebyte.models.feature_list import FeatureListNamespaceModel
 from featurebyte.persistent import Persistent
+from featurebyte.routes.catalog.catalog_name_injector import CatalogNameInjector
 from featurebyte.schema.feature_list_namespace import FeatureListNamespaceServiceUpdate
 from featurebyte.schema.info import (
     EntityBriefInfoList,
@@ -40,14 +41,14 @@ class FeatureListNamespaceService(
         catalog_id: ObjectId,
         entity_service: EntityService,
         table_service: TableService,
-        catalog_service: CatalogService,
         feature_namespace_service: FeatureNamespaceService,
+        catalog_name_injector: CatalogNameInjector,
     ):
         super().__init__(user, persistent, catalog_id)
         self.entity_service = entity_service
         self.table_service = table_service
-        self.catalog_service = catalog_service
         self.feature_namespace_service = feature_namespace_service
+        self.catalog_name_injector = catalog_name_injector
 
     async def get_feature_list_namespace_info(
         self, document_id: ObjectId, verbose: bool
@@ -78,13 +79,10 @@ class FeatureListNamespaceService(
         )
 
         # get catalog info
-        catalog = await self.catalog_service.get_document(namespace.catalog_id)
-        for entity in entities["data"]:
-            assert entity["catalog_id"] == catalog.id
-            entity["catalog_name"] = catalog.name
-        for table in tables["data"]:
-            assert table["catalog_id"] == catalog.id
-            table["catalog_name"] = catalog.name
+        catalog_name, updated_docs = await self.catalog_name_injector.add_name(
+            namespace.catalog_id, [entities, tables]
+        )
+        entities, tables = updated_docs
 
         # get default feature ids
         feat_namespace_to_default_id = {}
@@ -108,7 +106,7 @@ class FeatureListNamespaceService(
             version_count=len(namespace.feature_list_ids),
             feature_count=len(namespace.feature_namespace_ids),
             status=namespace.status,
-            catalog_name=catalog.name,
+            catalog_name=catalog_name,
             feature_namespace_ids=namespace.feature_namespace_ids,
             default_feature_ids=[
                 feat_namespace_to_default_id[feat_namespace_id]

--- a/featurebyte/service/feature_list_namespace.py
+++ b/featurebyte/service/feature_list_namespace.py
@@ -17,7 +17,6 @@ from featurebyte.schema.info import (
     TableBriefInfoList,
 )
 from featurebyte.service.base_document import BaseDocumentService
-from featurebyte.service.catalog import CatalogService
 from featurebyte.service.entity import EntityService, get_primary_entity_from_entities
 from featurebyte.service.feature_namespace import FeatureNamespaceService
 from featurebyte.service.table import TableService

--- a/featurebyte/service/relationship.py
+++ b/featurebyte/service/relationship.py
@@ -18,7 +18,6 @@ from featurebyte.schema.entity import EntityServiceUpdate
 from featurebyte.schema.semantic import SemanticServiceUpdate
 from featurebyte.service.base_document import BaseDocumentService
 from featurebyte.service.base_service import BaseService
-from featurebyte.service.catalog import CatalogService
 from featurebyte.service.entity import EntityService
 from featurebyte.service.semantic import SemanticService
 
@@ -202,17 +201,11 @@ class EntityRelationshipService(RelationshipService):
     EntityRelationshipService is responsible to update relationship between different entities.
     """
 
-    def __init__(self, user: Any, persistent: Persistent, catalog_id: ObjectId):
+    def __init__(
+        self, user: Any, persistent: Persistent, catalog_id: ObjectId, entity_service: EntityService
+    ):
         super().__init__(user, persistent, catalog_id)
-        self.catalog_service = CatalogService(
-            user=user, persistent=persistent, catalog_id=catalog_id
-        )
-        self.entity_service = EntityService(
-            user=user,
-            persistent=persistent,
-            catalog_id=catalog_id,
-            catalog_service=self.catalog_service,
-        )
+        self.entity_service = entity_service
 
     @property
     def document_service(self) -> BaseDocumentServiceT:

--- a/featurebyte/service/table_info.py
+++ b/featurebyte/service/table_info.py
@@ -8,7 +8,6 @@ from bson import ObjectId
 from featurebyte.models.feature_store import TableModel
 from featurebyte.routes.catalog.catalog_name_injector import CatalogNameInjector
 from featurebyte.schema.info import EntityBriefInfoList
-from featurebyte.service.catalog import CatalogService
 from featurebyte.service.entity import EntityService
 from featurebyte.service.semantic import SemanticService
 

--- a/featurebyte/service/table_info.py
+++ b/featurebyte/service/table_info.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 from bson import ObjectId
 
 from featurebyte.models.feature_store import TableModel
+from featurebyte.routes.catalog.catalog_name_injector import CatalogNameInjector
 from featurebyte.schema.info import EntityBriefInfoList
 from featurebyte.service.catalog import CatalogService
 from featurebyte.service.entity import EntityService
@@ -21,11 +22,11 @@ class TableInfoService:
         self,
         entity_service: EntityService,
         semantic_service: SemanticService,
-        catalog_service: CatalogService,
+        catalog_name_injector: CatalogNameInjector,
     ):
         self.entity_service = entity_service
         self.semantic_service = semantic_service
-        self.catalog_service = catalog_service
+        self.catalog_name_injector = catalog_name_injector
 
     async def get_table_info(self, data_document: TableModel, verbose: bool) -> Dict[str, Any]:
         """
@@ -66,10 +67,10 @@ class TableInfoService:
                 )
 
         # get catalog info
-        catalog = await self.catalog_service.get_document(data_document.catalog_id)
-        for entity in entities["data"]:
-            assert entity["catalog_id"] == catalog.id
-            entity["catalog_name"] = catalog.name
+        catalog_name, updated_docs = await self.catalog_name_injector.add_name(
+            data_document.catalog_id, [entities]
+        )
+        entities = updated_docs[0]
 
         return {
             "name": data_document.name,
@@ -82,5 +83,5 @@ class TableInfoService:
             "semantics": [semantic["name"] for semantic in semantics["data"]],
             "column_count": len(data_document.columns_info),
             "columns_info": columns_info,
-            "catalog_name": catalog.name,
+            "catalog_name": catalog_name,
         }


### PR DESCRIPTION
## Description
This PR does a small refactoring to reuse some logic that adds the `catalog_name` field onto documents when reading them. 

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
