### PR TITLE
[DEV-1875] Fix incorrect point-in-time value when updating online store tables

### DIFF
--- a/.changelog/DEV-1875.yaml
+++ b/.changelog/DEV-1875.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: online-serving
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix the job_schedule_ts_str parameter when updating online store tables in scheduled tile tasks"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/models/tile.py
+++ b/featurebyte/models/tile.py
@@ -131,7 +131,7 @@ class TileCommonParameters(FeatureByteBaseModel):
     value_column_names: List[str]
     value_column_types: List[str]
 
-    class Config:
+    class Config(FeatureByteBaseModel.Config):
         """Model configuration"""
 
         extra = "forbid"

--- a/featurebyte/models/tile.py
+++ b/featurebyte/models/tile.py
@@ -122,7 +122,7 @@ class TileCommonParameters(FeatureByteBaseModel):
 
     tile_id: str
     aggregation_id: str
-    tile_modulo_frequency_second: int
+    time_modulo_frequency_second: int
     blind_spot_second: int
     frequency_minute: int
 

--- a/featurebyte/service/tile_manager.py
+++ b/featurebyte/service/tile_manager.py
@@ -185,7 +185,7 @@ class TileManagerService(BaseService):
         tile_generate_ins = TileGenerate(
             session=session,
             tile_id=tile_spec.tile_id,
-            tile_modulo_frequency_second=tile_spec.time_modulo_frequency_second,
+            time_modulo_frequency_second=tile_spec.time_modulo_frequency_second,
             blind_spot_second=tile_spec.blind_spot_second,
             frequency_minute=tile_spec.frequency_minute,
             sql=tile_sql,
@@ -327,7 +327,7 @@ class TileManagerService(BaseService):
             logger.info(f"Creating new job {job_id}")
             parameters = TileScheduledJobParameters(
                 tile_id=tile_spec.tile_id,
-                tile_modulo_frequency_second=tile_spec.time_modulo_frequency_second,
+                time_modulo_frequency_second=tile_spec.time_modulo_frequency_second,
                 blind_spot_second=tile_spec.blind_spot_second,
                 frequency_minute=tile_spec.frequency_minute,
                 sql=tile_spec.tile_sql,

--- a/featurebyte/sql/tile_generate.py
+++ b/featurebyte/sql/tile_generate.py
@@ -39,7 +39,7 @@ class TileGenerate(TileCommon):
             sql=tile_sql,
             table_name=self.tile_id,
             table_exist=tile_table_exist_flag,
-            tile_modulo_frequency_second=self.tile_modulo_frequency_second,
+            time_modulo_frequency_second=self.time_modulo_frequency_second,
             blind_spot_second=self.blind_spot_second,
             frequency_minute=self.frequency_minute,
             entity_column_names=self.entity_column_names,
@@ -104,7 +104,7 @@ class TileGenerate(TileCommon):
         if self.last_tile_start_str:
             ind_value = date_util.timestamp_utc_to_tile_index(
                 dateutil.parser.isoparse(self.last_tile_start_str),
-                self.tile_modulo_frequency_second,
+                self.time_modulo_frequency_second,
                 self.blind_spot_second,
                 self.frequency_minute,
             )

--- a/featurebyte/sql/tile_monitor.py
+++ b/featurebyte/sql/tile_monitor.py
@@ -36,7 +36,7 @@ class TileMonitor(TileCommon):
                 sql=tile_sql,
                 table_name=self.tile_id,
                 table_exist=True,
-                tile_modulo_frequency_second=self.tile_modulo_frequency_second,
+                time_modulo_frequency_second=self.time_modulo_frequency_second,
                 blind_spot_second=self.blind_spot_second,
                 frequency_minute=self.frequency_minute,
                 entity_column_names=self.entity_column_names,
@@ -50,7 +50,7 @@ class TileMonitor(TileCommon):
                 select
                     F_INDEX_TO_TIMESTAMP(
                         INDEX,
-                        {self.tile_modulo_frequency_second},
+                        {self.time_modulo_frequency_second},
                         {self.blind_spot_second},
                         {self.frequency_minute}
                     ) as {InternalName.TILE_START_DATE},
@@ -110,7 +110,7 @@ class TileMonitor(TileCommon):
                     sql=tile_sql,
                     table_name=monitor_table_name,
                     table_exist=True,
-                    tile_modulo_frequency_second=self.tile_modulo_frequency_second,
+                    time_modulo_frequency_second=self.time_modulo_frequency_second,
                     blind_spot_second=self.blind_spot_second,
                     frequency_minute=self.frequency_minute,
                     entity_column_names=self.entity_column_names,

--- a/featurebyte/sql/tile_registry.py
+++ b/featurebyte/sql/tile_registry.py
@@ -61,7 +61,7 @@ class TileRegistry(TileCommon):
                     '{self.value_column_names_str}',
                     '{self.value_column_types_str}',
                     {self.frequency_minute},
-                    {self.tile_modulo_frequency_second},
+                    {self.time_modulo_frequency_second},
                     {self.blind_spot_second},
                     TRUE,
                     current_timestamp(),

--- a/tests/integration/tile/test_generate_tile.py
+++ b/tests/integration/tile/test_generate_tile.py
@@ -38,7 +38,7 @@ async def test_generate_tile(session, base_sql_model):
     tile_generate_ins = TileGenerate(
         session=session,
         tile_id=tile_id,
-        tile_modulo_frequency_second=183,
+        time_modulo_frequency_second=183,
         blind_spot_second=3,
         frequency_minute=5,
         sql=tile_sql,
@@ -82,7 +82,7 @@ async def test_generate_tile_no_data(session, base_sql_model):
     tile_generate_ins = TileGenerate(
         session=session,
         tile_id=tile_id,
-        tile_modulo_frequency_second=183,
+        time_modulo_frequency_second=183,
         blind_spot_second=3,
         frequency_minute=5,
         sql=tile_sql,
@@ -126,7 +126,7 @@ async def test_generate_tile_new_value_column(session, base_sql_model):
     tile_generate_ins = TileGenerate(
         session=session,
         tile_id=tile_id,
-        tile_modulo_frequency_second=183,
+        time_modulo_frequency_second=183,
         blind_spot_second=3,
         frequency_minute=5,
         sql=tile_sql,
@@ -155,7 +155,7 @@ async def test_generate_tile_new_value_column(session, base_sql_model):
     tile_generate_ins = TileGenerate(
         session=session,
         tile_id=tile_id,
-        tile_modulo_frequency_second=183,
+        time_modulo_frequency_second=183,
         blind_spot_second=3,
         frequency_minute=5,
         sql=tile_sql_2,

--- a/tests/integration/tile/test_monitor_tile.py
+++ b/tests/integration/tile/test_monitor_tile.py
@@ -36,7 +36,7 @@ async def test_monitor_tile__missing_tile(session, base_sql_model):
     tile_generate_ins = TileGenerate(
         session=session,
         tile_id=tile_id,
-        tile_modulo_frequency_second=183,
+        time_modulo_frequency_second=183,
         blind_spot_second=3,
         frequency_minute=5,
         sql=tile_sql,
@@ -51,7 +51,7 @@ async def test_monitor_tile__missing_tile(session, base_sql_model):
     tile_monitor_ins = TileMonitor(
         session=session,
         tile_id=tile_id,
-        tile_modulo_frequency_second=183,
+        time_modulo_frequency_second=183,
         blind_spot_second=3,
         frequency_minute=5,
         sql=tile_sql,
@@ -105,7 +105,7 @@ async def test_monitor_tile__updated_tile(session, base_sql_model):
     tile_generate_ins = TileGenerate(
         session=session,
         tile_id=tile_id,
-        tile_modulo_frequency_second=183,
+        time_modulo_frequency_second=183,
         blind_spot_second=3,
         frequency_minute=5,
         sql=tile_sql,
@@ -123,7 +123,7 @@ async def test_monitor_tile__updated_tile(session, base_sql_model):
     tile_monitor_ins = TileMonitor(
         session=session,
         tile_id=tile_id,
-        tile_modulo_frequency_second=183,
+        time_modulo_frequency_second=183,
         blind_spot_second=3,
         frequency_minute=5,
         sql=tile_sql,
@@ -177,7 +177,7 @@ async def test_monitor_tile__updated_tile_new_column(session, base_sql_model):
     tile_generate_ins = TileGenerate(
         session=session,
         tile_id=tile_id,
-        tile_modulo_frequency_second=183,
+        time_modulo_frequency_second=183,
         blind_spot_second=3,
         frequency_minute=5,
         sql=tile_sql,
@@ -202,7 +202,7 @@ async def test_monitor_tile__updated_tile_new_column(session, base_sql_model):
     tile_monitor_ins = TileMonitor(
         session=session,
         tile_id=tile_id,
-        tile_modulo_frequency_second=183,
+        time_modulo_frequency_second=183,
         blind_spot_second=3,
         frequency_minute=5,
         sql=tile_sql,
@@ -253,7 +253,7 @@ async def test_monitor_tile__partial_columns(session, base_sql_model):
     tile_generate_ins = TileGenerate(
         session=session,
         tile_id=tile_id,
-        tile_modulo_frequency_second=183,
+        time_modulo_frequency_second=183,
         blind_spot_second=3,
         frequency_minute=5,
         sql=tile_sql,
@@ -268,7 +268,7 @@ async def test_monitor_tile__partial_columns(session, base_sql_model):
     tile_monitor_ins = TileMonitor(
         session=session,
         tile_id=tile_id,
-        tile_modulo_frequency_second=183,
+        time_modulo_frequency_second=183,
         blind_spot_second=3,
         frequency_minute=5,
         sql=tile_sql,
@@ -289,7 +289,7 @@ async def test_monitor_tile__partial_columns(session, base_sql_model):
     tile_monitor_ins = TileMonitor(
         session=session,
         tile_id=tile_id,
-        tile_modulo_frequency_second=183,
+        time_modulo_frequency_second=183,
         blind_spot_second=3,
         frequency_minute=5,
         sql=tile_sql,

--- a/tests/integration/tile/test_schedule_generate_tile.py
+++ b/tests/integration/tile/test_schedule_generate_tile.py
@@ -12,11 +12,11 @@ from featurebyte.sql.common import construct_create_table_query
 
 
 @pytest.fixture(name="tile_task_executor")
-def tile_task_executor_fixture(online_store_table_version_service):
+def tile_task_executor_fixture(app_container) -> TileTaskExecutor:
     """
     Fixture for tile task executor
     """
-    return TileTaskExecutor(online_store_table_version_service=online_store_table_version_service)
+    return app_container.tile_task_executor
 
 
 @pytest.mark.parametrize("source_type", ["spark", "snowflake"], indirect=True)

--- a/tests/integration/tile/test_schedule_generate_tile.py
+++ b/tests/integration/tile/test_schedule_generate_tile.py
@@ -50,7 +50,7 @@ async def test_schedule_generate_tile_online(
 
     tile_schedule_ins = TileScheduledJobParameters(
         tile_id=tile_id,
-        tile_modulo_frequency_second=183,
+        time_modulo_frequency_second=183,
         blind_spot_second=3,
         frequency_minute=5,
         sql=tile_sql,
@@ -121,7 +121,7 @@ async def test_schedule_monitor_tile_online(session, base_sql_model, tile_task_e
 
     tile_schedule_ins = TileScheduledJobParameters(
         tile_id=tile_id,
-        tile_modulo_frequency_second=183,
+        time_modulo_frequency_second=183,
         blind_spot_second=3,
         frequency_minute=5,
         sql=tile_sql,
@@ -148,7 +148,7 @@ async def test_schedule_monitor_tile_online(session, base_sql_model, tile_task_e
     tile_end_ts_2 = "2022-06-05T23:58:03Z"
     tile_schedule_ins = TileScheduledJobParameters(
         tile_id=tile_id,
-        tile_modulo_frequency_second=183,
+        time_modulo_frequency_second=183,
         blind_spot_second=3,
         frequency_minute=5,
         sql=tile_sql,
@@ -200,7 +200,7 @@ async def test_schedule_generate_tile__with_registry(
 
     tile_schedule_ins = TileScheduledJobParameters(
         tile_id=tile_id,
-        tile_modulo_frequency_second=183,
+        time_modulo_frequency_second=183,
         blind_spot_second=3,
         frequency_minute=5,
         sql=tile_sql,
@@ -271,7 +271,7 @@ async def test_schedule_generate_tile__no_default_job_ts(
     )
 
     date_format = "%Y-%m-%d %H:%M:%S"
-    tile_modulo_frequency_second = 3
+    time_modulo_frequency_second = 3
     blind_spot_second = 3
     frequency_minute = 1
 
@@ -279,7 +279,7 @@ async def test_schedule_generate_tile__no_default_job_ts(
     used_job_schedule_ts = "2023-05-04 14:33:03"
     tile_schedule_ins = TileScheduledJobParameters(
         tile_id=tile_id,
-        tile_modulo_frequency_second=tile_modulo_frequency_second,
+        time_modulo_frequency_second=time_modulo_frequency_second,
         blind_spot_second=blind_spot_second,
         frequency_minute=frequency_minute,
         sql=tile_sql,
@@ -304,7 +304,7 @@ async def test_schedule_generate_tile__no_default_job_ts(
     used_job_schedule_ts = "2023-05-04 14:33:30"
     tile_schedule_ins = TileScheduledJobParameters(
         tile_id=tile_id,
-        tile_modulo_frequency_second=tile_modulo_frequency_second,
+        time_modulo_frequency_second=time_modulo_frequency_second,
         blind_spot_second=blind_spot_second,
         frequency_minute=frequency_minute,
         sql=tile_sql,

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -196,6 +196,14 @@ def tile_cache_service_fixture(app_container):
     return app_container.tile_cache_service
 
 
+@pytest.fixture(name="tile_task_executor")
+def tile_task_executor_fixture(app_container):
+    """
+    TileTaskExecutor fixture
+    """
+    return app_container.tile_task_executor
+
+
 @pytest.fixture(name="relationship_info_service")
 def relationship_info_service_fixture(app_container):
     """

--- a/tests/unit/service/tile/test_tile_task_executor.py
+++ b/tests/unit/service/tile/test_tile_task_executor.py
@@ -67,7 +67,7 @@ async def test_online_store_job_schedule_ts(
     """
     Test that the job_schedule_ts_str parameter passed to TileScheduleOnlineStore is correct
     """
-    # The scheduled task is run 1 minute past the intended schedule
+    # The scheduled task is run 1 second past the intended schedule
     tile_task_parameters.job_schedule_ts = "2023-01-15 10:00:11"
     await tile_task_executor.execute(session, tile_task_parameters)
 

--- a/tests/unit/service/tile/test_tile_task_executor.py
+++ b/tests/unit/service/tile/test_tile_task_executor.py
@@ -1,0 +1,76 @@
+"""
+Unit tests for TileTaskExecutor
+"""
+from unittest.mock import Mock, patch
+
+import pytest
+
+from featurebyte import SourceType
+from featurebyte.models.tile import TileScheduledJobParameters
+from featurebyte.session.snowflake import SnowflakeSession
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    """
+    Fixture for the db session object
+    """
+    return Mock(
+        name="mock_snowflake_session",
+        spec=SnowflakeSession,
+        source_type=SourceType.SNOWFLAKE,
+    )
+
+
+@pytest.fixture(name="tile_task_parameters")
+def tile_task_parameters_fixture() -> TileScheduledJobParameters:
+    """
+    Fixture for TileScheduledJobParameters
+    """
+    return TileScheduledJobParameters(
+        tile_id="some_tile_id",
+        aggregation_id="some_agg_id",
+        time_modulo_frequency_second=10,
+        blind_spot_second=30,
+        frequency_minute=5,
+        sql="SELECT * FROM some_table",
+        entity_column_names=["cust_id"],
+        value_column_names=["sum_value"],
+        value_column_types=["FLOAT"],
+        offline_period_minute=1440,
+        tile_type="online",
+        monitor_periods=10,
+    )
+
+
+@pytest.fixture(name="patched_tile_classes")
+def patched_tile_classes_fixture():
+    """
+    Fixture to patch TileMonitor, TileGenerate and TileScheduleOnlineStore used in TileTaskExecutor
+    """
+    mocks = {}
+    patchers = []
+    classes_to_patch = ["TileMonitor", "TileGenerate", "TileScheduleOnlineStore"]
+    for class_name in classes_to_patch:
+        patcher = patch(f"featurebyte.service.tile.tile_task_executor.{class_name}", autospec=True)
+        mocks[class_name] = patcher.start()
+        patchers.append(patcher)
+    yield mocks
+    for patcher in patchers:
+        patcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_online_store_job_schedule_ts(
+    tile_task_executor, tile_task_parameters, session, patched_tile_classes
+):
+    """
+    Test that the job_schedule_ts_str parameter passed to TileScheduleOnlineStore is correct
+    """
+    # The scheduled task is run 1 minute past the intended schedule
+    tile_task_parameters.job_schedule_ts = "2023-01-15 10:00:11"
+    await tile_task_executor.execute(session, tile_task_parameters)
+
+    # The online store calculation should use the corrected schedule time as point in time
+    _, kwargs = patched_tile_classes["TileScheduleOnlineStore"].call_args
+    assert kwargs["job_schedule_ts_str"] == "2023-01-15 10:00:10"


### PR DESCRIPTION
## Description

This fixes a bug where incorrect point-in-time value was passed to `TileScheduleOnlineStore` in the scheduled tile task. The timestamp should be the scheduled job timestamp, not the tile end timestamp adjusted for blind spot.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
