### PR TITLE
[DEV-1896] Avoid using SHOW COLUMNS to support Spark 3.2

### DIFF
--- a/.changelog/DEV-1896.yaml
+++ b/.changelog/DEV-1896.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Avoid using SHOW COLUMNS to support Spark 3.2"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/sql/base.py
+++ b/featurebyte/sql/base.py
@@ -1,7 +1,7 @@
 """
 Base Class for SQL related operations
 """
-from typing import Any, List
+from typing import Any
 
 from pydantic.fields import PrivateAttr
 from pydantic.main import BaseModel

--- a/featurebyte/sql/base.py
+++ b/featurebyte/sql/base.py
@@ -69,40 +69,6 @@ class BaseSqlModel(BaseModel):
 
         return f"{left_expr} <=> {right_expr}"
 
-    @property
-    def schema_column_name(self) -> str:
-        """
-        Column name for schema based on session type
-
-        Returns
-        -------
-            column name for schema
-        """
-        if isinstance(self._session, SnowflakeSession):
-            return "column_name"
-
-        return "col_name"
-
-    async def get_table_columns(self, table_name: str) -> List[str]:
-        """
-        Get column names for a table. The column names are returned in upper case.
-
-        Parameters
-        ----------
-        table_name: str
-            input table name
-
-        Returns
-        -------
-            list of column names in upper case
-        """
-        cols_df = await self._session.execute_query(f"SHOW COLUMNS IN {table_name}")
-        cols = []
-        if cols_df is not None:
-            for _, row in cols_df.iterrows():
-                cols.append(row[self.schema_column_name].upper())
-        return cols
-
     async def table_exists(self, table_name: str) -> bool:
         """
         Check if table exists

--- a/featurebyte/sql/tile_registry.py
+++ b/featurebyte/sql/tile_registry.py
@@ -51,7 +51,14 @@ class TileRegistry(TileCommon):
             await self.tile_registry_service.create_document(tile_model)
 
         if self.table_exist:
-            cols = await self.get_table_columns(self.table_name)
+            cols = [
+                c.upper()
+                for c in (
+                    await self._session.list_table_schema(
+                        self.table_name, self._session.database_name, self._session.schema_name
+                    )
+                ).keys()
+            ]
             tile_add_sql = f"ALTER TABLE {self.table_name} ADD COLUMN\n"
             add_statements = []
             for i, input_column in enumerate(input_value_columns):


### PR DESCRIPTION
## Description

This fixes the `SHOW COLUMNS` command error in Spark 3.2 by using an alternative way to retrieve column names.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
