### PR TITLE
[DEV-1895] Fix DATEADD undefined function error in Spark 3.2

### DIFF
--- a/.changelog/DEV-1895.yaml
+++ b/.changelog/DEV-1895.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix DATEADD undefined function error in Spark 3.2"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/tests/fixtures/expected_preview_sql_databricks.sql
+++ b/tests/fixtures/expected_preview_sql_databricks.sql
@@ -28,21 +28,15 @@ WITH REQUEST_TABLE AS (
                   UNIX_TIMESTAMP(MAX(POINT_IN_TIME)) - 1800
                 ) / 3600) * 3600 + 1800 - 900
               ) AS `__FB_ENTITY_TABLE_END_DATE`,
-              DATEADD(
-                microsecond,
-                (
-                  48 * 3600 * CAST(1000000 AS LONG) / CAST(1 AS LONG)
-                ) * -1 % 60000000.0,
-                DATEADD(
-                  minute,
-                  (
-                    48 * 3600 * CAST(1000000 AS LONG) / CAST(1 AS LONG)
-                  ) * -1 / 60000000.0,
-                  TO_TIMESTAMP(
+              TO_TIMESTAMP(
+                FROM_UNIXTIME(
+                  CAST(TO_TIMESTAMP(
                     FLOOR((
                       UNIX_TIMESTAMP(MIN(POINT_IN_TIME)) - 1800
                     ) / 3600) * 3600 + 1800 - 900
-                  )
+                  ) AS DOUBLE) + (
+                    48 * 3600 * CAST(1000000 AS LONG) / CAST(1 AS LONG)
+                  ) * -1 / 1000000.0
                 )
               ) AS `__FB_ENTITY_TABLE_START_DATE`
             FROM `REQUEST_TABLE`


### PR DESCRIPTION
## Description

The Databricks flavoured `DATEADD` function is only available since Spark 3.3. To support older versions of Spark, this updates the adapter to perform timestamp addition by casting timestamps to seconds.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
