### PR TITLE
[DEV-1899][DEV-1902] Remove usage of ILIKE and DATEADD which are incompatible with Spark 3.2

### DIFF
--- a/.changelog/DEV-1899.yaml
+++ b/.changelog/DEV-1899.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix unnecessary usage of SQL functions incompatible with Spark 3.2 (ILIKE and DATEADD)"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/sql/base.py
+++ b/featurebyte/sql/base.py
@@ -36,6 +36,10 @@ class BaseSqlModel(BaseModel):
     def adapter(self) -> BaseAdapter:
         """
         Get SQL adapter based on session type
+
+        Returns
+        -------
+        BaseAdapter
         """
         return get_sql_adapter(self._session.source_type)
 

--- a/featurebyte/sql/base.py
+++ b/featurebyte/sql/base.py
@@ -6,6 +6,7 @@ from typing import Any
 from pydantic.fields import PrivateAttr
 from pydantic.main import BaseModel
 
+from featurebyte.query_graph.sql.adapter import BaseAdapter, get_sql_adapter
 from featurebyte.session.base import BaseSession
 from featurebyte.session.snowflake import SnowflakeSession
 
@@ -30,6 +31,13 @@ class BaseSqlModel(BaseModel):
         """
         super().__init__(**kwargs)
         self._session = session
+
+    @property
+    def adapter(self) -> BaseAdapter:
+        """
+        Get SQL adapter based on session type
+        """
+        return get_sql_adapter(self._session.source_type)
 
     def quote_column(self, col_val: str) -> str:
         """

--- a/featurebyte/sql/tile_monitor.py
+++ b/featurebyte/sql/tile_monitor.py
@@ -1,8 +1,12 @@
 """
 Tile Monitor Job
 """
+from sqlglot import expressions
+
 from featurebyte.enum import InternalName
 from featurebyte.logging import get_logger
+from featurebyte.query_graph.sql.ast.literal import make_literal_value
+from featurebyte.query_graph.sql.common import get_qualified_column_identifier, sql_to_string
 from featurebyte.service.tile_registry_service import TileRegistryService
 from featurebyte.sql.common import construct_create_table_query, retry_sql
 from featurebyte.sql.tile_common import TileCommon
@@ -80,17 +84,24 @@ class TileMonitor(TileCommon):
                 ]
             )
 
+            offset_expr = expressions.Add(
+                this=expressions.Mul(
+                    this=make_literal_value(self.frequency_minute),
+                    expression=make_literal_value(60),
+                ),
+                expression=make_literal_value(self.blind_spot_second),
+            )
+            expected_created_at_expr = self.adapter.dateadd_microsecond(
+                get_qualified_column_identifier(InternalName.TILE_START_DATE, "a"),
+                expressions.Mul(this=offset_expr, expression=make_literal_value(1e6)),
+            )
             compare_sql = f"""
                 select * from
                     (select
                         a.*,
                         {value_select_cols_str},
                         cast('{self.tile_type}' as string) as TILE_TYPE,
-                        DATEADD(
-                            SECOND,
-                            ({self.blind_spot_second}+{self.frequency_minute}*60),
-                            a.{InternalName.TILE_START_DATE}
-                        ) as EXPECTED_CREATED_AT,
+                        {sql_to_string(expected_created_at_expr, source_type=self._session.source_type)} as EXPECTED_CREATED_AT,
                         current_timestamp() as CREATED_AT
                     from
                         ({new_tile_sql}) a left outer join {self.tile_id} b

--- a/featurebyte/sql/tile_monitor.py
+++ b/featurebyte/sql/tile_monitor.py
@@ -92,8 +92,8 @@ class TileMonitor(TileCommon):
                 expression=make_literal_value(self.blind_spot_second),
             )
             expected_created_at_expr = self.adapter.dateadd_microsecond(
-                get_qualified_column_identifier(InternalName.TILE_START_DATE, "a"),
-                expressions.Mul(this=offset_expr, expression=make_literal_value(1e6)),
+                quantity_expr=expressions.Mul(this=offset_expr, expression=make_literal_value(1e6)),
+                timestamp_expr=get_qualified_column_identifier(InternalName.TILE_START_DATE, "a"),
             )
             compare_sql = f"""
                 select * from

--- a/featurebyte/sql/tile_schedule_online_store.py
+++ b/featurebyte/sql/tile_schedule_online_store.py
@@ -183,7 +183,7 @@ class TileScheduleOnlineStore(BaseSqlModel):
         else:
             # Retrieve all entries for the aggregation_id (e.g. a_sum_24h, a_sum_7d, a_sum_30d, etc)
             query = query.where(
-                expressions.ILike(
+                expressions.EQ(
                     this="AGGREGATION_ID", expression=make_literal_value(self.aggregation_id)
                 )
             )


### PR DESCRIPTION
## Description

This removes unnecessary usage of SQL functions: `ILIKE` and `DATEADD` which are incompatible with Spark 3.2.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
