### PR TITLE
[DEV-1897] Update describe query to be compatible with Spark 3.2

### DIFF
--- a/.changelog/DEV-1897.yaml
+++ b/.changelog/DEV-1897.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update describe query to be compatible with Spark 3.2"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/query_graph/sql/interpreter/base.py
+++ b/featurebyte/query_graph/sql/interpreter/base.py
@@ -11,6 +11,7 @@ from featurebyte.enum import SourceType
 from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.query_graph.model.graph import QueryGraphModel
 from featurebyte.query_graph.node import Node
+from featurebyte.query_graph.sql.adapter import get_sql_adapter
 from featurebyte.query_graph.sql.ast.base import TableNode
 from featurebyte.query_graph.sql.builder import SQLOperationGraph
 from featurebyte.query_graph.sql.common import SQLType, construct_cte_sql, sql_to_string
@@ -31,6 +32,7 @@ class BaseGraphInterpreter:
     def __init__(self, query_graph: QueryGraphModel, source_type: SourceType):
         self.query_graph = query_graph
         self.source_type = source_type
+        self.adapter = get_sql_adapter(source_type)
 
     def flatten_graph(self, node_name: str) -> Tuple[QueryGraphModel, Node]:
         """

--- a/featurebyte/query_graph/sql/interpreter/preview.py
+++ b/featurebyte/query_graph/sql/interpreter/preview.py
@@ -252,9 +252,8 @@ class PreviewMixin(BaseGraphInterpreter):
         expr = expressions.alias_(make_literal_value(None), column_name, quoted=True)
         return cast(expressions.Expression, expr)
 
-    @staticmethod
     def _percentile_expr(
-        expression: expressions.Expression, quantile: float
+        self, expression: expressions.Expression, quantile: float
     ) -> expressions.Expression:
         """
         Create expression for percentile of column
@@ -270,13 +269,7 @@ class PreviewMixin(BaseGraphInterpreter):
         -------
         expressions.Expression
         """
-        order_expr = expressions.Order(expressions=[expressions.Ordered(this=expression)])
-        return expressions.WithinGroup(
-            this=expressions.Anonymous(
-                this="percentile_cont", expressions=[parse_one(f"{quantile}")]
-            ),
-            expression=order_expr,
-        )
+        return self.adapter.get_percentile_expr(expression, quantile)
 
     @staticmethod
     def _tz_offset_expr(timestamp_tz_expr: expressions.Expression) -> expressions.Expression:

--- a/tests/fixtures/query_graph/expected_describe_snowflake.sql
+++ b/tests/fixtures/query_graph/expected_describe_snowflake.sql
@@ -1,0 +1,285 @@
+WITH data AS (
+  SELECT
+    "ts" AS "ts",
+    "cust_id" AS "cust_id",
+    "a" AS "a",
+    "b" AS "b",
+    "a" AS "a_copy"
+  FROM "db"."public"."event_table"
+  ORDER BY
+    RANDOM(1234)
+  LIMIT 10
+), casted_data AS (
+  SELECT
+    CAST("ts" AS STRING) AS "ts",
+    CAST("cust_id" AS STRING) AS "cust_id",
+    CAST("a" AS STRING) AS "a",
+    CAST("b" AS STRING) AS "b",
+    CAST("a_copy" AS STRING) AS "a_copy"
+  FROM data
+), counts__0 AS (
+  SELECT
+    F_COUNT_DICT_MOST_FREQUENT(count_dict."COUNT_DICT") AS "top__0",
+    F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__0"
+  FROM (
+    SELECT
+      OBJECT_AGG("ts", "COUNTS") AS "COUNT_DICT"
+    FROM (
+      SELECT
+        "ts",
+        COUNT('*') AS "COUNTS"
+      FROM casted_data
+      GROUP BY
+        "ts"
+      ORDER BY
+        COUNTS DESC NULLS LAST
+      LIMIT 500
+    ) AS cat_counts
+  ) AS count_dict
+), counts__1 AS (
+  SELECT
+    F_COUNT_DICT_ENTROPY(count_dict."COUNT_DICT") AS "entropy__1",
+    F_COUNT_DICT_MOST_FREQUENT(count_dict."COUNT_DICT") AS "top__1",
+    F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__1"
+  FROM (
+    SELECT
+      OBJECT_AGG("cust_id", "COUNTS") AS "COUNT_DICT"
+    FROM (
+      SELECT
+        "cust_id",
+        COUNT('*') AS "COUNTS"
+      FROM casted_data
+      GROUP BY
+        "cust_id"
+      ORDER BY
+        COUNTS DESC NULLS LAST
+      LIMIT 500
+    ) AS cat_counts
+  ) AS count_dict
+), counts__2 AS (
+  SELECT
+    F_COUNT_DICT_MOST_FREQUENT(count_dict."COUNT_DICT") AS "top__2",
+    F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__2"
+  FROM (
+    SELECT
+      OBJECT_AGG("a", "COUNTS") AS "COUNT_DICT"
+    FROM (
+      SELECT
+        "a",
+        COUNT('*') AS "COUNTS"
+      FROM casted_data
+      GROUP BY
+        "a"
+      ORDER BY
+        COUNTS DESC NULLS LAST
+      LIMIT 500
+    ) AS cat_counts
+  ) AS count_dict
+), counts__3 AS (
+  SELECT
+    F_COUNT_DICT_MOST_FREQUENT(count_dict."COUNT_DICT") AS "top__3",
+    F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__3"
+  FROM (
+    SELECT
+      OBJECT_AGG("b", "COUNTS") AS "COUNT_DICT"
+    FROM (
+      SELECT
+        "b",
+        COUNT('*') AS "COUNTS"
+      FROM casted_data
+      GROUP BY
+        "b"
+      ORDER BY
+        COUNTS DESC NULLS LAST
+      LIMIT 500
+    ) AS cat_counts
+  ) AS count_dict
+), counts__4 AS (
+  SELECT
+    F_COUNT_DICT_MOST_FREQUENT(count_dict."COUNT_DICT") AS "top__4",
+    F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__4"
+  FROM (
+    SELECT
+      OBJECT_AGG("a_copy", "COUNTS") AS "COUNT_DICT"
+    FROM (
+      SELECT
+        "a_copy",
+        COUNT('*') AS "COUNTS"
+      FROM casted_data
+      GROUP BY
+        "a_copy"
+      ORDER BY
+        COUNTS DESC NULLS LAST
+      LIMIT 500
+    ) AS cat_counts
+  ) AS count_dict
+), stats AS (
+  SELECT
+    COUNT(DISTINCT "ts") AS "unique__0",
+    (
+      1.0 - COUNT("ts") / COUNT('*')
+    ) * 100 AS "%missing__0",
+    NULL AS "%empty__0",
+    NULL AS "mean__0",
+    NULL AS "std__0",
+    MIN("ts") AS "min__0",
+    NULL AS "25%__0",
+    NULL AS "50%__0",
+    NULL AS "75%__0",
+    MAX("ts") AS "max__0",
+    NULL AS "min TZ offset__0",
+    NULL AS "max TZ offset__0",
+    COUNT(DISTINCT "cust_id") AS "unique__1",
+    (
+      1.0 - COUNT("cust_id") / COUNT('*')
+    ) * 100 AS "%missing__1",
+    COUNT_IF("cust_id" = '') AS "%empty__1",
+    NULL AS "mean__1",
+    NULL AS "std__1",
+    NULL AS "min__1",
+    NULL AS "25%__1",
+    NULL AS "50%__1",
+    NULL AS "75%__1",
+    NULL AS "max__1",
+    NULL AS "min TZ offset__1",
+    NULL AS "max TZ offset__1",
+    COUNT(DISTINCT "a") AS "unique__2",
+    (
+      1.0 - COUNT("a") / COUNT('*')
+    ) * 100 AS "%missing__2",
+    NULL AS "%empty__2",
+    AVG(CAST("a" AS DOUBLE)) AS "mean__2",
+    STDDEV(CAST("a" AS DOUBLE)) AS "std__2",
+    MIN("a") AS "min__2",
+    PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY
+      "a") AS "25%__2",
+    PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY
+      "a") AS "50%__2",
+    PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY
+      "a") AS "75%__2",
+    MAX("a") AS "max__2",
+    NULL AS "min TZ offset__2",
+    NULL AS "max TZ offset__2",
+    COUNT(DISTINCT "b") AS "unique__3",
+    (
+      1.0 - COUNT("b") / COUNT('*')
+    ) * 100 AS "%missing__3",
+    NULL AS "%empty__3",
+    AVG(CAST("b" AS DOUBLE)) AS "mean__3",
+    STDDEV(CAST("b" AS DOUBLE)) AS "std__3",
+    MIN("b") AS "min__3",
+    PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY
+      "b") AS "25%__3",
+    PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY
+      "b") AS "50%__3",
+    PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY
+      "b") AS "75%__3",
+    MAX("b") AS "max__3",
+    NULL AS "min TZ offset__3",
+    NULL AS "max TZ offset__3",
+    COUNT(DISTINCT "a_copy") AS "unique__4",
+    (
+      1.0 - COUNT("a_copy") / COUNT('*')
+    ) * 100 AS "%missing__4",
+    NULL AS "%empty__4",
+    AVG(CAST("a_copy" AS DOUBLE)) AS "mean__4",
+    STDDEV(CAST("a_copy" AS DOUBLE)) AS "std__4",
+    MIN("a_copy") AS "min__4",
+    PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY
+      "a_copy") AS "25%__4",
+    PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY
+      "a_copy") AS "50%__4",
+    PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY
+      "a_copy") AS "75%__4",
+    MAX("a_copy") AS "max__4",
+    NULL AS "min TZ offset__4",
+    NULL AS "max TZ offset__4"
+  FROM data
+)
+SELECT
+  'TIMESTAMP' AS "dtype__0",
+  stats."unique__0",
+  stats."%missing__0",
+  stats."%empty__0",
+  NULL AS "entropy__0",
+  counts__0."top__0",
+  counts__0."freq__0",
+  stats."mean__0",
+  stats."std__0",
+  stats."min__0",
+  stats."25%__0",
+  stats."50%__0",
+  stats."75%__0",
+  stats."max__0",
+  stats."min TZ offset__0",
+  stats."max TZ offset__0",
+  'VARCHAR' AS "dtype__1",
+  stats."unique__1",
+  stats."%missing__1",
+  stats."%empty__1",
+  counts__1."entropy__1",
+  counts__1."top__1",
+  counts__1."freq__1",
+  stats."mean__1",
+  stats."std__1",
+  stats."min__1",
+  stats."25%__1",
+  stats."50%__1",
+  stats."75%__1",
+  stats."max__1",
+  stats."min TZ offset__1",
+  stats."max TZ offset__1",
+  'FLOAT' AS "dtype__2",
+  stats."unique__2",
+  stats."%missing__2",
+  stats."%empty__2",
+  NULL AS "entropy__2",
+  counts__2."top__2",
+  counts__2."freq__2",
+  stats."mean__2",
+  stats."std__2",
+  stats."min__2",
+  stats."25%__2",
+  stats."50%__2",
+  stats."75%__2",
+  stats."max__2",
+  stats."min TZ offset__2",
+  stats."max TZ offset__2",
+  'INT' AS "dtype__3",
+  stats."unique__3",
+  stats."%missing__3",
+  stats."%empty__3",
+  NULL AS "entropy__3",
+  counts__3."top__3",
+  counts__3."freq__3",
+  stats."mean__3",
+  stats."std__3",
+  stats."min__3",
+  stats."25%__3",
+  stats."50%__3",
+  stats."75%__3",
+  stats."max__3",
+  stats."min TZ offset__3",
+  stats."max TZ offset__3",
+  'FLOAT' AS "dtype__4",
+  stats."unique__4",
+  stats."%missing__4",
+  stats."%empty__4",
+  NULL AS "entropy__4",
+  counts__4."top__4",
+  counts__4."freq__4",
+  stats."mean__4",
+  stats."std__4",
+  stats."min__4",
+  stats."25%__4",
+  stats."50%__4",
+  stats."75%__4",
+  stats."max__4",
+  stats."min TZ offset__4",
+  stats."max TZ offset__4"
+FROM stats
+LEFT JOIN counts__0
+LEFT JOIN counts__1
+LEFT JOIN counts__2
+LEFT JOIN counts__3
+LEFT JOIN counts__4

--- a/tests/fixtures/query_graph/expected_describe_spark.sql
+++ b/tests/fixtures/query_graph/expected_describe_spark.sql
@@ -1,0 +1,276 @@
+WITH data AS (
+  SELECT
+    `ts` AS `ts`,
+    `cust_id` AS `cust_id`,
+    `a` AS `a`,
+    `b` AS `b`,
+    `a` AS `a_copy`
+  FROM `db`.`public`.`event_table`
+  ORDER BY
+    RANDOM(1234)
+  LIMIT 10
+), casted_data AS (
+  SELECT
+    CAST(`ts` AS STRING) AS `ts`,
+    CAST(`cust_id` AS STRING) AS `cust_id`,
+    CAST(`a` AS STRING) AS `a`,
+    CAST(`b` AS STRING) AS `b`,
+    CAST(`a_copy` AS STRING) AS `a_copy`
+  FROM data
+), counts__0 AS (
+  SELECT
+    F_COUNT_DICT_MOST_FREQUENT(count_dict.`COUNT_DICT`) AS `top__0`,
+    F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict.`COUNT_DICT`) AS `freq__0`
+  FROM (
+    SELECT
+      OBJECT_AGG(`ts`, `COUNTS`) AS `COUNT_DICT`
+    FROM (
+      SELECT
+        `ts`,
+        COUNT('*') AS `COUNTS`
+      FROM casted_data
+      GROUP BY
+        `ts`
+      ORDER BY
+        COUNTS DESC
+      LIMIT 500
+    ) AS cat_counts
+  ) AS count_dict
+), counts__1 AS (
+  SELECT
+    F_COUNT_DICT_ENTROPY(count_dict.`COUNT_DICT`) AS `entropy__1`,
+    F_COUNT_DICT_MOST_FREQUENT(count_dict.`COUNT_DICT`) AS `top__1`,
+    F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict.`COUNT_DICT`) AS `freq__1`
+  FROM (
+    SELECT
+      OBJECT_AGG(`cust_id`, `COUNTS`) AS `COUNT_DICT`
+    FROM (
+      SELECT
+        `cust_id`,
+        COUNT('*') AS `COUNTS`
+      FROM casted_data
+      GROUP BY
+        `cust_id`
+      ORDER BY
+        COUNTS DESC
+      LIMIT 500
+    ) AS cat_counts
+  ) AS count_dict
+), counts__2 AS (
+  SELECT
+    F_COUNT_DICT_MOST_FREQUENT(count_dict.`COUNT_DICT`) AS `top__2`,
+    F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict.`COUNT_DICT`) AS `freq__2`
+  FROM (
+    SELECT
+      OBJECT_AGG(`a`, `COUNTS`) AS `COUNT_DICT`
+    FROM (
+      SELECT
+        `a`,
+        COUNT('*') AS `COUNTS`
+      FROM casted_data
+      GROUP BY
+        `a`
+      ORDER BY
+        COUNTS DESC
+      LIMIT 500
+    ) AS cat_counts
+  ) AS count_dict
+), counts__3 AS (
+  SELECT
+    F_COUNT_DICT_MOST_FREQUENT(count_dict.`COUNT_DICT`) AS `top__3`,
+    F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict.`COUNT_DICT`) AS `freq__3`
+  FROM (
+    SELECT
+      OBJECT_AGG(`b`, `COUNTS`) AS `COUNT_DICT`
+    FROM (
+      SELECT
+        `b`,
+        COUNT('*') AS `COUNTS`
+      FROM casted_data
+      GROUP BY
+        `b`
+      ORDER BY
+        COUNTS DESC
+      LIMIT 500
+    ) AS cat_counts
+  ) AS count_dict
+), counts__4 AS (
+  SELECT
+    F_COUNT_DICT_MOST_FREQUENT(count_dict.`COUNT_DICT`) AS `top__4`,
+    F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict.`COUNT_DICT`) AS `freq__4`
+  FROM (
+    SELECT
+      OBJECT_AGG(`a_copy`, `COUNTS`) AS `COUNT_DICT`
+    FROM (
+      SELECT
+        `a_copy`,
+        COUNT('*') AS `COUNTS`
+      FROM casted_data
+      GROUP BY
+        `a_copy`
+      ORDER BY
+        COUNTS DESC
+      LIMIT 500
+    ) AS cat_counts
+  ) AS count_dict
+), stats AS (
+  SELECT
+    COUNT(DISTINCT `ts`) AS `unique__0`,
+    (
+      1.0 - COUNT(`ts`) / COUNT('*')
+    ) * 100 AS `%missing__0`,
+    NULL AS `%empty__0`,
+    NULL AS `mean__0`,
+    NULL AS `std__0`,
+    MIN(`ts`) AS `min__0`,
+    NULL AS `25%__0`,
+    NULL AS `50%__0`,
+    NULL AS `75%__0`,
+    MAX(`ts`) AS `max__0`,
+    NULL AS `min TZ offset__0`,
+    NULL AS `max TZ offset__0`,
+    COUNT(DISTINCT `cust_id`) AS `unique__1`,
+    (
+      1.0 - COUNT(`cust_id`) / COUNT('*')
+    ) * 100 AS `%missing__1`,
+    COUNT_IF(`cust_id` = '') AS `%empty__1`,
+    NULL AS `mean__1`,
+    NULL AS `std__1`,
+    NULL AS `min__1`,
+    NULL AS `25%__1`,
+    NULL AS `50%__1`,
+    NULL AS `75%__1`,
+    NULL AS `max__1`,
+    NULL AS `min TZ offset__1`,
+    NULL AS `max TZ offset__1`,
+    COUNT(DISTINCT `a`) AS `unique__2`,
+    (
+      1.0 - COUNT(`a`) / COUNT('*')
+    ) * 100 AS `%missing__2`,
+    NULL AS `%empty__2`,
+    AVG(CAST(`a` AS DOUBLE)) AS `mean__2`,
+    STDDEV(CAST(`a` AS DOUBLE)) AS `std__2`,
+    MIN(`a`) AS `min__2`,
+    PERCENTILE(`a`, 0.25) AS `25%__2`,
+    PERCENTILE(`a`, 0.5) AS `50%__2`,
+    PERCENTILE(`a`, 0.75) AS `75%__2`,
+    MAX(`a`) AS `max__2`,
+    NULL AS `min TZ offset__2`,
+    NULL AS `max TZ offset__2`,
+    COUNT(DISTINCT `b`) AS `unique__3`,
+    (
+      1.0 - COUNT(`b`) / COUNT('*')
+    ) * 100 AS `%missing__3`,
+    NULL AS `%empty__3`,
+    AVG(CAST(`b` AS DOUBLE)) AS `mean__3`,
+    STDDEV(CAST(`b` AS DOUBLE)) AS `std__3`,
+    MIN(`b`) AS `min__3`,
+    PERCENTILE(`b`, 0.25) AS `25%__3`,
+    PERCENTILE(`b`, 0.5) AS `50%__3`,
+    PERCENTILE(`b`, 0.75) AS `75%__3`,
+    MAX(`b`) AS `max__3`,
+    NULL AS `min TZ offset__3`,
+    NULL AS `max TZ offset__3`,
+    COUNT(DISTINCT `a_copy`) AS `unique__4`,
+    (
+      1.0 - COUNT(`a_copy`) / COUNT('*')
+    ) * 100 AS `%missing__4`,
+    NULL AS `%empty__4`,
+    AVG(CAST(`a_copy` AS DOUBLE)) AS `mean__4`,
+    STDDEV(CAST(`a_copy` AS DOUBLE)) AS `std__4`,
+    MIN(`a_copy`) AS `min__4`,
+    PERCENTILE(`a_copy`, 0.25) AS `25%__4`,
+    PERCENTILE(`a_copy`, 0.5) AS `50%__4`,
+    PERCENTILE(`a_copy`, 0.75) AS `75%__4`,
+    MAX(`a_copy`) AS `max__4`,
+    NULL AS `min TZ offset__4`,
+    NULL AS `max TZ offset__4`
+  FROM data
+)
+SELECT
+  'TIMESTAMP' AS `dtype__0`,
+  stats.`unique__0`,
+  stats.`%missing__0`,
+  stats.`%empty__0`,
+  NULL AS `entropy__0`,
+  counts__0.`top__0`,
+  counts__0.`freq__0`,
+  stats.`mean__0`,
+  stats.`std__0`,
+  stats.`min__0`,
+  stats.`25%__0`,
+  stats.`50%__0`,
+  stats.`75%__0`,
+  stats.`max__0`,
+  stats.`min TZ offset__0`,
+  stats.`max TZ offset__0`,
+  'VARCHAR' AS `dtype__1`,
+  stats.`unique__1`,
+  stats.`%missing__1`,
+  stats.`%empty__1`,
+  counts__1.`entropy__1`,
+  counts__1.`top__1`,
+  counts__1.`freq__1`,
+  stats.`mean__1`,
+  stats.`std__1`,
+  stats.`min__1`,
+  stats.`25%__1`,
+  stats.`50%__1`,
+  stats.`75%__1`,
+  stats.`max__1`,
+  stats.`min TZ offset__1`,
+  stats.`max TZ offset__1`,
+  'FLOAT' AS `dtype__2`,
+  stats.`unique__2`,
+  stats.`%missing__2`,
+  stats.`%empty__2`,
+  NULL AS `entropy__2`,
+  counts__2.`top__2`,
+  counts__2.`freq__2`,
+  stats.`mean__2`,
+  stats.`std__2`,
+  stats.`min__2`,
+  stats.`25%__2`,
+  stats.`50%__2`,
+  stats.`75%__2`,
+  stats.`max__2`,
+  stats.`min TZ offset__2`,
+  stats.`max TZ offset__2`,
+  'INT' AS `dtype__3`,
+  stats.`unique__3`,
+  stats.`%missing__3`,
+  stats.`%empty__3`,
+  NULL AS `entropy__3`,
+  counts__3.`top__3`,
+  counts__3.`freq__3`,
+  stats.`mean__3`,
+  stats.`std__3`,
+  stats.`min__3`,
+  stats.`25%__3`,
+  stats.`50%__3`,
+  stats.`75%__3`,
+  stats.`max__3`,
+  stats.`min TZ offset__3`,
+  stats.`max TZ offset__3`,
+  'FLOAT' AS `dtype__4`,
+  stats.`unique__4`,
+  stats.`%missing__4`,
+  stats.`%empty__4`,
+  NULL AS `entropy__4`,
+  counts__4.`top__4`,
+  counts__4.`freq__4`,
+  stats.`mean__4`,
+  stats.`std__4`,
+  stats.`min__4`,
+  stats.`25%__4`,
+  stats.`50%__4`,
+  stats.`75%__4`,
+  stats.`max__4`,
+  stats.`min TZ offset__4`,
+  stats.`max TZ offset__4`
+FROM stats
+LEFT JOIN counts__0
+LEFT JOIN counts__1
+LEFT JOIN counts__2
+LEFT JOIN counts__3
+LEFT JOIN counts__4

--- a/tests/unit/query_graph/interpreter/conftest.py
+++ b/tests/unit/query_graph/interpreter/conftest.py
@@ -1,0 +1,66 @@
+import pytest
+
+from featurebyte.query_graph.enum import NodeOutputType, NodeType
+from tests.util.helper import reset_global_graph
+
+
+@pytest.fixture(name="graph", scope="function")
+def query_graph():
+    """
+    Empty query graph fixture
+    """
+    yield reset_global_graph()
+
+
+@pytest.fixture(name="node_input")
+def node_input_fixture(graph):
+    """Fixture for a generic input node"""
+    node_params = {
+        "type": "event_table",
+        "columns": [
+            {"name": "ts", "dtype": "TIMESTAMP"},
+            {"name": "cust_id", "dtype": "VARCHAR"},
+            {"name": "a", "dtype": "FLOAT"},
+            {"name": "b", "dtype": "INT"},
+        ],
+        "timestamp_column": "ts",
+        "table_details": {
+            "database_name": "db",
+            "schema_name": "public",
+            "table_name": "event_table",
+        },
+        "feature_store_details": {
+            "type": "snowflake",
+            "details": {
+                "database": "db",
+                "sf_schema": "public",
+                "account": "account",
+                "warehouse": "warehouse",
+            },
+        },
+    }
+    node_input = graph.add_operation(
+        node_type=NodeType.INPUT,
+        node_params=node_params,
+        node_output_type=NodeOutputType.FRAME,
+        input_nodes=[],
+    )
+    return node_input
+
+
+@pytest.fixture(name="simple_graph", scope="function")
+def simple_graph_fixture(graph, node_input):
+    """Simple graph"""
+    proj_a = graph.add_operation(
+        node_type=NodeType.PROJECT,
+        node_params={"columns": ["a"]},
+        node_output_type=NodeOutputType.SERIES,
+        input_nodes=[node_input],
+    )
+    assign = graph.add_operation(
+        node_type=NodeType.ASSIGN,
+        node_params={"name": "a_copy"},
+        node_output_type=NodeOutputType.FRAME,
+        input_nodes=[node_input, proj_a],
+    )
+    return graph, assign

--- a/tests/unit/query_graph/interpreter/test_interpreter.py
+++ b/tests/unit/query_graph/interpreter/test_interpreter.py
@@ -12,64 +12,6 @@ from featurebyte.query_graph.enum import NodeOutputType, NodeType
 from featurebyte.query_graph.sql.builder import SQLOperationGraph
 from featurebyte.query_graph.sql.common import SQLType
 from featurebyte.query_graph.sql.interpreter import GraphInterpreter
-from tests.util.helper import reset_global_graph
-
-
-@pytest.fixture(name="graph", scope="function")
-def query_graph():
-    """
-    Empty query graph fixture
-    """
-    yield reset_global_graph()
-
-
-@pytest.fixture(name="node_input")
-def node_input_fixture(graph):
-    """Fixture for a generic input node"""
-    node_params = {
-        "type": "event_table",
-        "columns": ["ts", "cust_id", "a", "b"],
-        "timestamp_column": "ts",
-        "table_details": {
-            "database_name": "db",
-            "schema_name": "public",
-            "table_name": "event_table",
-        },
-        "feature_store_details": {
-            "type": "snowflake",
-            "details": {
-                "database": "db",
-                "sf_schema": "public",
-                "account": "account",
-                "warehouse": "warehouse",
-            },
-        },
-    }
-    node_input = graph.add_operation(
-        node_type=NodeType.INPUT,
-        node_params=node_params,
-        node_output_type=NodeOutputType.FRAME,
-        input_nodes=[],
-    )
-    return node_input
-
-
-@pytest.fixture(name="simple_graph", scope="function")
-def simple_graph_fixture(graph, node_input):
-    """Simple graph"""
-    proj_a = graph.add_operation(
-        node_type=NodeType.PROJECT,
-        node_params={"columns": ["a"]},
-        node_output_type=NodeOutputType.SERIES,
-        input_nodes=[node_input],
-    )
-    assign = graph.add_operation(
-        node_type=NodeType.ASSIGN,
-        node_params={"name": "a_copy"},
-        node_output_type=NodeOutputType.FRAME,
-        input_nodes=[node_input, proj_a],
-    )
-    return graph, assign
 
 
 def test_graph_interpreter_super_simple(simple_graph):

--- a/tests/unit/query_graph/interpreter/test_preview.py
+++ b/tests/unit/query_graph/interpreter/test_preview.py
@@ -1,0 +1,19 @@
+"""
+Unit tests for describe query
+"""
+import pytest
+
+from featurebyte.enum import SourceType
+from featurebyte.query_graph.sql.interpreter import GraphInterpreter
+from tests.util.helper import assert_equal_with_expected_fixture
+
+
+@pytest.mark.parametrize("source_type", [SourceType.SNOWFLAKE, SourceType.SPARK])
+def test_graph_interpreter_describe(simple_graph, source_type, update_fixtures):
+    """Test graph sample"""
+    graph, node = simple_graph
+    interpreter = GraphInterpreter(graph, source_type)
+
+    sql_code = interpreter.construct_describe_sql(node.name, num_rows=10, seed=1234)[0]
+    expected_filename = f"tests/fixtures/query_graph/expected_describe_{source_type.lower()}.sql"
+    assert_equal_with_expected_fixture(sql_code, expected_filename, update_fixtures)

--- a/tests/util/helper.py
+++ b/tests/util/helper.py
@@ -2,10 +2,12 @@
 This module contains utility functions used in tests
 """
 import json
+import os
 import re
 import sys
 import textwrap
 from contextlib import contextmanager
+from pathlib import Path
 from unittest.mock import Mock
 
 import numpy as np
@@ -42,6 +44,7 @@ def assert_equal_with_expected_fixture(actual, fixture_filename, update_fixture=
     To update all fixtures automatically, pass --update-fixtures option when invoking pytest.
     """
     if update_fixture:
+        Path(os.path.dirname(fixture_filename)).mkdir(parents=True, exist_ok=True)
         with open(fixture_filename, "w", encoding="utf-8") as f_handle:
             f_handle.write(actual)
             f_handle.write("\n")


### PR DESCRIPTION
## Description

This updates the percentile function used in the describe query so that it is compatible with Spark 3.2. The `WITHIN GROUP` clause is not available in older versions of Spark.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
