### PR TITLE
[DEV-1895] Fix microseconds incorrectly discarded in spark dateadd_microsecond

### DIFF
--- a/.changelog/DEV-1895.yaml
+++ b/.changelog/DEV-1895.yaml
@@ -16,7 +16,7 @@ component: service
 issues: []
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Fix DATEADD undefined function error in Spark 3.2"
+note: "Fix DATEADD undefined function error in Spark 3.2 and re-enable tests"
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/featurebyte/query_graph/sql/adapter.py
+++ b/featurebyte/query_graph/sql/adapter.py
@@ -897,11 +897,10 @@ class DatabricksAdapter(BaseAdapter):
         timestamp_seconds_added = expressions.Add(
             this=timestamp_seconds, expression=seconds_quantity
         )
-        return expressions.Anonymous(
-            this="TO_TIMESTAMP",
-            expressions=[
-                expressions.Anonymous(this="FROM_UNIXTIME", expressions=[timestamp_seconds_added])
-            ],
+        # Note: FROM_UNIXTIME doesn't work as it discards sub-seconds components even if sub-seconds
+        # are included in the specified date format.
+        return expressions.Cast(
+            this=timestamp_seconds_added, to=expressions.DataType.build("TIMESTAMP")
         )
 
     @classmethod

--- a/tests/fixtures/expected_preview_sql_databricks.sql
+++ b/tests/fixtures/expected_preview_sql_databricks.sql
@@ -28,17 +28,13 @@ WITH REQUEST_TABLE AS (
                   UNIX_TIMESTAMP(MAX(POINT_IN_TIME)) - 1800
                 ) / 3600) * 3600 + 1800 - 900
               ) AS `__FB_ENTITY_TABLE_END_DATE`,
-              TO_TIMESTAMP(
-                FROM_UNIXTIME(
-                  CAST(TO_TIMESTAMP(
-                    FLOOR((
-                      UNIX_TIMESTAMP(MIN(POINT_IN_TIME)) - 1800
-                    ) / 3600) * 3600 + 1800 - 900
-                  ) AS DOUBLE) + (
-                    48 * 3600 * CAST(1000000 AS LONG) / CAST(1 AS LONG)
-                  ) * -1 / 1000000.0
-                )
-              ) AS `__FB_ENTITY_TABLE_START_DATE`
+              CAST(CAST(TO_TIMESTAMP(
+                FLOOR((
+                  UNIX_TIMESTAMP(MIN(POINT_IN_TIME)) - 1800
+                ) / 3600) * 3600 + 1800 - 900
+              ) AS DOUBLE) + (
+                48 * 3600 * CAST(1000000 AS LONG) / CAST(1 AS LONG)
+              ) * -1 / 1000000.0 AS TIMESTAMP) AS `__FB_ENTITY_TABLE_START_DATE`
             FROM `REQUEST_TABLE`
             GROUP BY
               `CUSTOMER_ID`


### PR DESCRIPTION
## Description

This is a fix up for https://github.com/featurebyte/featurebyte/pull/1489 where the sub-second component was not being handled properly. This also reenables the `test_datetime_operations` integration test for spark.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
