### PR TITLE
[DEV-1909] target_table: add API object

### DIFF
--- a/.changelog/DEV-1909.yaml
+++ b/.changelog/DEV-1909.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: target
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Create target_table API object"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Create the TargetTable API object, and stub out the compute_target endpoint.
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/catalog.py
+++ b/featurebyte/api/catalog.py
@@ -33,6 +33,7 @@ from featurebyte.api.savable_api_object import SavableApiObject
 from featurebyte.api.static_source_table import StaticSourceTable
 from featurebyte.api.table import Table
 from featurebyte.api.target import Target
+from featurebyte.api.target_table import TargetTable
 from featurebyte.api.user_defined_function import UserDefinedFunction
 from featurebyte.api.view import View
 from featurebyte.common.doc_util import FBAutoDoc
@@ -851,6 +852,29 @@ class Catalog(NameAttributeUpdatableMixin, SavableApiObject, CatalogGetByIdMixin
         return UserDefinedFunction.list(include_id=include_id)
 
     @update_and_reset_catalog
+    def list_target_tables(self, include_id: Optional[bool] = True) -> pd.DataFrame:
+        """
+        List saved target tables.
+
+        Parameters
+        ----------
+        include_id: Optional[bool]
+            Whether to include id in the list.
+
+        Returns
+        -------
+        pd.DataFrame
+            Table of target tables.
+
+        Examples
+        --------
+        List saved target tables.
+
+        >>> target_tables = catalog.list_target_tables()
+        """
+        return TargetTable.list(include_id=include_id)
+
+    @update_and_reset_catalog
     def get_data_source(self) -> DataSource:
         """
         Gets the data source from the catalog to access source tables from the data warehouse.
@@ -1275,3 +1299,26 @@ class Catalog(NameAttributeUpdatableMixin, SavableApiObject, CatalogGetByIdMixin
         >>> user_defined_function = catalog.get_user_defined_function("user_defined_function_name")  # doctest: +SKIP
         """
         return UserDefinedFunction.get(name=name)
+
+    @update_and_reset_catalog
+    def get_target_table(self, name: str) -> TargetTable:
+        """
+        Get target table by name.
+
+        Parameters
+        ----------
+        name: str
+            Target table name.
+
+        Returns
+        -------
+        TargetTable
+            Target table object.
+
+        Examples
+        --------
+        Get a saved target table.
+
+        >>> target_table = catalog.get_target_table("target_table_name")  # doctest: +SKIP
+        """
+        return TargetTable.get(name=name)

--- a/featurebyte/api/catalog_get_by_id_mixin.py
+++ b/featurebyte/api/catalog_get_by_id_mixin.py
@@ -23,6 +23,7 @@ from featurebyte.api.periodic_task import PeriodicTask
 from featurebyte.api.relationship import Relationship
 from featurebyte.api.static_source_table import StaticSourceTable
 from featurebyte.api.table import Table
+from featurebyte.api.target_table import TargetTable
 from featurebyte.api.user_defined_function import UserDefinedFunction
 from featurebyte.api.view import View
 
@@ -458,3 +459,28 @@ class CatalogGetByIdMixin:
         >>> user_defined_function = catalog.get_user_defined_function_by_id(ObjectId())  # doctest: +SKIP
         """
         return UserDefinedFunction.get_by_id(id=id)
+
+    @update_and_reset_catalog
+    def get_target_table_by_id(
+        self, id: ObjectId  # pylint: disable=redefined-builtin,invalid-name
+    ) -> TargetTable:
+        """
+        Get target table by id.
+
+        Parameters
+        ----------
+        id: ObjectId
+            Target table id.
+
+        Returns
+        -------
+        TargetTable
+            Target table object.
+
+        Examples
+        --------
+        Get a saved target table.
+
+        >>> target_table = catalog.get_target_table_by_id(ObjectId())  # doctest: +SKIP
+        """
+        return TargetTable.get_by_id(id=id)

--- a/featurebyte/api/target.py
+++ b/featurebyte/api/target.py
@@ -3,19 +3,26 @@ Target API object
 """
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from http import HTTPStatus
 
 import pandas as pd
+from bson import ObjectId
 from pydantic import Field, StrictStr, root_validator
 from typeguard import typechecked
 
 from featurebyte.api.api_object_util import ForeignKeyMapping
 from featurebyte.api.entity import Entity
 from featurebyte.api.feature_store import FeatureStore
+from featurebyte.api.observation_table import ObservationTable
 from featurebyte.api.savable_api_object import SavableApiObject
-from featurebyte.common.utils import dataframe_from_json, enforce_observation_set_row_order
+from featurebyte.api.target_table import TargetTable
+from featurebyte.common.utils import (
+    dataframe_from_json,
+    dataframe_to_arrow_bytes,
+    enforce_observation_set_row_order,
+)
 from featurebyte.config import Configurations
 from featurebyte.core.series import Series
 from featurebyte.enum import DBVarType
@@ -26,6 +33,7 @@ from featurebyte.models.target import TargetModel
 from featurebyte.query_graph.model.common_table import TabularSource
 from featurebyte.schema.preview import FeatureOrTargetPreview
 from featurebyte.schema.target import TargetUpdate
+from featurebyte.schema.target_table import TargetTableCreate
 
 
 class Target(Series, SavableApiObject):
@@ -165,3 +173,95 @@ class Target(Series, SavableApiObject):
         result = response.json()
 
         return dataframe_from_json(result)  # pylint: disable=no-member
+
+    @enforce_observation_set_row_order
+    @typechecked
+    def compute_target(
+        self,
+        observation_set: pd.DataFrame,
+        serving_names_mapping: Optional[Dict[str, str]] = None,
+    ) -> pd.DataFrame:
+        """
+        Returns a DataFrame with target values for analysis, model training, or evaluation. The target
+        request data consists of an observation set that combines points-in-time and key values of the
+        primary entity from the target.
+
+        Associated serving entities can also be utilized.
+
+        Parameters
+        ----------
+        observation_set : pd.DataFrame
+            Observation set DataFrame or ObservationTable object, which combines points-in-time and values
+            of the target primary entity or its descendant (serving entities). The column containing the point-in-time
+            values should be named `POINT_IN_TIME`, while the columns representing entity values should be named using
+            accepted serving names for the entity.
+        serving_names_mapping : Optional[Dict[str, str]]
+            Optional serving names mapping if the training events table has different serving name columns than those
+            defined in Entities, mapping from original serving name to new name.
+
+        Returns
+        -------
+        pd.DataFrame
+            Materialized target.
+
+            **Note**: `POINT_IN_TIME` values will be converted to UTC time.
+        """
+        temp_target_table_name = f"__TEMPORARY_TARGET_TABLE_{ObjectId()}"
+        temp_target_table = self.compute_target_table(
+            observation_table=observation_set,
+            target_table_name=temp_target_table_name,
+            serving_names_mapping=serving_names_mapping,
+        )
+        try:
+            return temp_target_table.to_pandas()
+        finally:
+            temp_target_table.delete()
+
+    @typechecked
+    def compute_target_table(
+        self,
+        observation_table: Union[ObservationTable, pd.DataFrame],
+        target_table_name: str,
+        serving_names_mapping: Optional[Dict[str, str]] = None,
+    ) -> TargetTable:
+        """
+        Materialize feature list using an observation table asynchronously. The historical features
+        will be materialized into a historical feature table.
+
+        Parameters
+        ----------
+        observation_table: Union[ObservationTable, pd.DataFrame]
+            Observation set with `POINT_IN_TIME` and serving names columns. This can be either an
+            ObservationTable of a pandas DataFrame.
+        target_table_name: str
+            Name of the historical feature table to be created
+        serving_names_mapping : Optional[Dict[str, str]]
+            Optional serving names mapping if the training events table has different serving name
+
+        Returns
+        -------
+        TargetTable
+        """
+        target_table_create_params = TargetTableCreate(
+            name=target_table_name,
+            observation_table_id=(
+                observation_table.id if isinstance(observation_table, ObservationTable) else None
+            ),
+            feature_store_id=self.feature_store.id,
+            serving_names_mapping=serving_names_mapping,
+            target_id=self.id,
+            graph=self.graph,
+            node_names=[self.node.name],
+        )
+        if isinstance(observation_table, ObservationTable):
+            files = None
+        else:
+            assert isinstance(observation_table, pd.DataFrame)
+            files = {"observation_set": dataframe_to_arrow_bytes(observation_table)}
+        target_table_doc = self.post_async_task(
+            route="/target_table",
+            payload={"payload": target_table_create_params.json()},
+            is_payload_json=False,
+            files=files,
+        )
+        return TargetTable.get_by_id(target_table_doc["_id"])

--- a/featurebyte/api/target.py
+++ b/featurebyte/api/target.py
@@ -131,13 +131,13 @@ class Target(Series, SavableApiObject):
         """
         Materializes a Target object using a small observation set of up to 50 rows.
 
-        The small observation set should combine historical points-in-time and key values of the primary entity from
+        The small observation set should combine points-in-time and key values of the primary entity from
         the target. Associated serving entities can also be utilized.
 
         Parameters
         ----------
         observation_set : pd.DataFrame
-            Observation set DataFrame which combines historical points-in-time and values of the target primary entity
+            Observation set DataFrame which combines points-in-time and values of the target primary entity
             or its descendant (serving entities). The column containing the point-in-time values should be named
             `POINT_IN_TIME`, while the columns representing entity values should be named using accepted serving
             names for the entity.
@@ -225,8 +225,8 @@ class Target(Series, SavableApiObject):
         serving_names_mapping: Optional[Dict[str, str]] = None,
     ) -> TargetTable:
         """
-        Materialize feature list using an observation table asynchronously. The historical features
-        will be materialized into a historical feature table.
+        Materialize feature list using an observation table asynchronously. The targets
+        will be materialized into a target table.
 
         Parameters
         ----------
@@ -234,7 +234,7 @@ class Target(Series, SavableApiObject):
             Observation set with `POINT_IN_TIME` and serving names columns. This can be either an
             ObservationTable of a pandas DataFrame.
         target_table_name: str
-            Name of the historical feature table to be created
+            Name of the target table to be created
         serving_names_mapping : Optional[Dict[str, str]]
             Optional serving names mapping if the training events table has different serving name
 

--- a/featurebyte/api/target_table.py
+++ b/featurebyte/api/target_table.py
@@ -1,0 +1,157 @@
+"""
+TargetTable class
+"""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+from pathlib import Path
+
+import pandas as pd
+
+from featurebyte.api.api_object import ApiObject
+from featurebyte.api.api_object_util import ForeignKeyMapping
+from featurebyte.api.feature_store import FeatureStore
+from featurebyte.api.materialized_table import MaterializedTableMixin
+from featurebyte.api.observation_table import ObservationTable
+from featurebyte.common.doc_util import FBAutoDoc
+from featurebyte.models.target_table import TargetTableModel
+from featurebyte.schema.target_table import TargetTableListRecord
+
+
+class TargetTable(TargetTableModel, ApiObject, MaterializedTableMixin):
+    """
+    TargetTable class
+    """
+
+    __fbautodoc__ = FBAutoDoc(proxy_class="featurebyte.TargetTable")
+
+    _route = "/target_table"
+    _list_schema = TargetTableListRecord
+    _get_schema = TargetTableModel
+    _list_fields = [
+        "name",
+        "feature_store_name",
+        "observation_table_name",
+        "shape",
+        "created_at",
+    ]
+    _list_foreign_keys = [
+        ForeignKeyMapping("feature_store_id", FeatureStore, "feature_store_name"),
+        ForeignKeyMapping("observation_table_id", ObservationTable, "observation_table_name"),
+    ]
+
+    def preview(self, limit: int = 10) -> pd.DataFrame:
+        """
+        Returns a DataFrame that contains a selection of rows of the target table.
+
+        Parameters
+        ----------
+        limit: int
+            Maximum number of return rows.
+
+        Returns
+        -------
+        pd.DataFrame
+            Preview rows of the table.
+
+        Examples
+        --------
+        >>> target_table = catalog.get_target_table("target_table_name")  # doctest: +SKIP
+        >>> target_table.preview()  # doctest: +SKIP
+        """
+        return super().preview(limit=limit)
+
+    def sample(self, size: int = 10, seed: int = 1234) -> pd.DataFrame:
+        """
+        Returns a DataFrame that contains a random selection of rows of the target table based on a
+        specified size and seed for sampling control.
+
+        Parameters
+        ----------
+        size: int
+            Maximum number of rows to sample.
+        seed: int
+            Seed to use for random sampling.
+
+        Returns
+        -------
+        pd.DataFrame
+            Sampled rows from the table.
+
+        Examples
+        --------
+        >>> target_table = catalog.get_target_table("target_table_name")  # doctest: +SKIP
+        >>> target_table.sample()  # doctest: +SKIP
+        """
+        return super().sample(size=size, seed=seed)
+
+    def describe(self, size: int = 0, seed: int = 1234) -> pd.DataFrame:
+        """
+        Returns descriptive statistics of the target table.
+
+        Parameters
+        ----------
+        size: int
+            Maximum number of rows to sample. If 0, all rows will be used.
+        seed: int
+            Seed to use for random sampling.
+
+        Returns
+        -------
+        pd.DataFrame
+            Summary of the table.
+
+        Examples
+        --------
+        >>> target_table = catalog.get_target_table("target_table_name")  # doctest: +SKIP
+        >>> target_table.describe()  # doctest: +SKIP
+        """
+        return super().describe(size=size, seed=seed)
+
+    def download(self, output_path: Optional[Union[str, Path]] = None) -> Path:
+        """
+        Downloads the target table from the database.
+
+        Parameters
+        ----------
+        output_path: Optional[Union[str, Path]]
+            Location to save downloaded parquet file.
+
+        Returns
+        -------
+        Path
+
+        Raises
+        ------
+        FileExistsError
+            File already exists at output path.
+        RecordRetrievalException
+            Error retrieving record from API.
+
+        Examples
+        --------
+        >>> target_table = catalog.get_target_table("target_table_name")  # doctest: +SKIP
+        >>> downloaded_path = target_table.download(output_path="path/to/download")  # doctest: +SKIP
+
+        # noqa: DAR402
+        """
+        return super().download(output_path=output_path)
+
+    def delete(self) -> None:
+        """
+        Deletes the target table.
+
+        Raises
+        ------
+        RecordDeletionException
+            When the record cannot be deleted properly
+
+        Examples
+        --------
+        >>> target_table = catalog.get_target_table("target_table_name")  # doctest: +SKIP
+        >>> target_table.delete()  # doctest: +SKIP
+
+        # noqa: DAR402
+        """
+        super().delete()

--- a/featurebyte/api/target_table.py
+++ b/featurebyte/api/target_table.py
@@ -19,7 +19,7 @@ from featurebyte.models.target_table import TargetTableModel
 from featurebyte.schema.target_table import TargetTableListRecord
 
 
-class TargetTable(TargetTableModel, ApiObject, MaterializedTableMixin):
+class TargetTable(ApiObject, MaterializedTableMixin):
     """
     TargetTable class
     """

--- a/tests/unit/api/test_catalog.py
+++ b/tests/unit/api/test_catalog.py
@@ -45,6 +45,7 @@ from featurebyte.api.scd_table import SCDTable
 from featurebyte.api.static_source_table import StaticSourceTable
 from featurebyte.api.table import Table
 from featurebyte.api.target import Target
+from featurebyte.api.target_table import TargetTable
 from featurebyte.api.user_defined_function import UserDefinedFunction
 from featurebyte.exception import (
     DuplicatedRecordException,
@@ -96,6 +97,7 @@ def catalog_list_methods_to_test_list():
         MethodMetadata("list_static_source_tables", StaticSourceTable, "list"),
         MethodMetadata("list_targets", Target, "list"),
         MethodMetadata("list_user_defined_functions", UserDefinedFunction, "list"),
+        MethodMetadata("list_target_tables", TargetTable, "list"),
     ]
 
 
@@ -117,6 +119,7 @@ def catalog_get_methods_to_test_list():
         MethodMetadata("get_static_source_table", StaticSourceTable, "get"),
         MethodMetadata("get_target", Target, "get"),
         MethodMetadata("get_user_defined_function", UserDefinedFunction, "get"),
+        MethodMetadata("get_target_table", TargetTable, "get"),
     ]
 
 
@@ -147,6 +150,7 @@ def catalog_get_by_id_list():
         MethodMetadata("get_deployment_by_id", Deployment, "get_by_id"),
         MethodMetadata("get_static_source_table_by_id", StaticSourceTable, "get_by_id"),
         MethodMetadata("get_user_defined_function_by_id", UserDefinedFunction, "get_by_id"),
+        MethodMetadata("get_target_table_by_id", TargetTable, "get_by_id"),
     ]
 
 

--- a/tests/unit/api/test_target_table.py
+++ b/tests/unit/api/test_target_table.py
@@ -56,7 +56,7 @@ def test_delete(target_table):
 
 
 def test_info(target_table):
-    """Test get historical feature table info"""
+    """Test get target table info"""
     info_dict = target_table.info()
     assert info_dict["table_details"]["table_name"].startswith("TARGET_TABLE_")
     assert info_dict == {

--- a/tests/unit/api/test_target_table.py
+++ b/tests/unit/api/test_target_table.py
@@ -1,0 +1,73 @@
+"""
+Unit tests for TargetTable class
+"""
+import pytest
+
+from featurebyte.api.target_table import TargetTable
+from featurebyte.exception import RecordRetrievalException
+
+
+def test_get(target_table):
+    """
+    Test retrieving an TargetTable object by name
+    """
+    retrieved_target_table = TargetTable.get(target_table.name)
+    assert retrieved_target_table == target_table
+
+
+@pytest.mark.usefixtures("target_table")
+def test_list():
+    """
+    Test listing TargetTable objects
+    """
+    df = TargetTable.list()
+    assert df.columns.tolist() == [
+        "id",
+        "name",
+        "feature_store_name",
+        "observation_table_name",
+        "shape",
+        "created_at",
+    ]
+    assert df["name"].tolist() == ["my_target_table"]
+    assert df["feature_store_name"].tolist() == ["sf_featurestore"]
+    assert df["observation_table_name"].tolist() == ["observation_table_from_source_table"]
+    assert (df["shape"] == (500, 1)).all()
+
+
+def test_delete(target_table):
+    """
+    Test delete method
+    """
+    # check table can be retrieved before deletion
+    _ = TargetTable.get(target_table.name)
+
+    target_table.delete()
+
+    # check the deleted batch feature table is not found anymore
+    with pytest.raises(RecordRetrievalException) as exc:
+        TargetTable.get(target_table.name)
+
+    expected_msg = (
+        f'TargetTable (name: "{target_table.name}") not found. '
+        f"Please save the TargetTable object first."
+    )
+    assert expected_msg in str(exc.value)
+
+
+def test_info(target_table):
+    """Test get historical feature table info"""
+    info_dict = target_table.info()
+    assert info_dict["table_details"]["table_name"].startswith("TARGET_TABLE_")
+    assert info_dict == {
+        "name": "my_target_table",
+        "target_name": "float_target",
+        "observation_table_name": "observation_table_from_source_table",
+        "table_details": {
+            "database_name": "sf_database",
+            "schema_name": "sf_schema",
+            "table_name": info_dict["table_details"]["table_name"],
+        },
+        "created_at": info_dict["created_at"],
+        "updated_at": None,
+    }

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -951,6 +951,18 @@ def historical_feature_table_fixture(
     return historical_feature_table
 
 
+@pytest.fixture(name="target_table")
+def target_table_fixture(
+    float_target, observation_table_from_source, snowflake_execute_query_for_materialized_table
+):
+    """
+    Fixture for a TargetTable
+    """
+    _ = snowflake_execute_query_for_materialized_table
+    float_target.save()
+    return float_target.compute_target_table(observation_table_from_source, "my_target_table")
+
+
 @pytest.fixture(name="grouped_event_view")
 def grouped_event_view_fixture(snowflake_event_view_with_entity):
     """


### PR DESCRIPTION
## Description
Add a `TargetTable` API object, and stub out some of the `compute_target` endpoints in the `Target` API object.

This will submit the task to create the target table. We'll finish up the implementation of the task in a follow-up PR to reduce the size of this one.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-1909
<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
