### PR TITLE
[DEV-1894] Fix compatibility of string contains operation with Spark 3.2

### DIFF
--- a/.changelog/DEV-1894.yaml
+++ b/.changelog/DEV-1894.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix compatibility of string contains operation with Spark 3.2"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/query_graph/sql/adapter.py
+++ b/featurebyte/query_graph/sql/adapter.py
@@ -73,6 +73,26 @@ class BaseAdapter:  # pylint: disable=too-many-public-methods
         """
 
     @classmethod
+    def str_contains(cls, expr: Expression, pattern: str) -> Expression:
+        """
+        Expression to check if string contains a pattern
+
+        Parameters
+        ----------
+        expr: Expression
+            String expression to check if it contains a pattern
+        pattern: str
+            Pattern to check if it is contained in the string
+
+        Returns
+        ------
+        Expression
+        """
+        return expressions.Anonymous(
+            this="CONTAINS", expressions=[expr, make_literal_value(pattern)]
+        )
+
+    @classmethod
     @abstractmethod
     def adjust_dayofweek(cls, extracted_expr: Expression) -> Expression:
         """
@@ -1111,6 +1131,11 @@ class SparkAdapter(DatabricksAdapter):
                 expression=_to_microseconds(timestamp_expr_1),
             )
         )
+
+    @classmethod
+    def str_contains(cls, expr: Expression, pattern: str) -> Expression:
+        pattern = "%{}%".format(pattern.replace("%", "\\%"))
+        return expressions.Like(this=expr, expression=make_literal_value(pattern))
 
 
 def get_sql_adapter(source_type: SourceType) -> BaseAdapter:

--- a/featurebyte/query_graph/sql/ast/string.py
+++ b/featurebyte/query_graph/sql/ast/string.py
@@ -54,13 +54,10 @@ class StringContains(ExpressionNode):
     @property
     def sql(self) -> Expression:
         if self.case:
-            return fb_expressions.Contains(
-                this=self.expr.sql,
-                pattern=make_literal_value(self.pattern),
-            )
-        return fb_expressions.Contains(
-            this=expressions.Lower(this=self.expr.sql),
-            pattern=expressions.Lower(this=make_literal_value(self.pattern)),
+            return self.context.adapter.str_contains(self.expr.sql, self.pattern)
+        return self.context.adapter.str_contains(
+            expressions.Lower(this=self.expr.sql),
+            self.pattern.lower(),
         )
 
     @classmethod

--- a/featurebyte/query_graph/sql/expression.py
+++ b/featurebyte/query_graph/sql/expression.py
@@ -64,12 +64,6 @@ class RPad(Func):
     arg_types = {"this": True, "length": True, "pad": True}
 
 
-class Contains(Func):
-    """Contains function"""
-
-    arg_types = {"this": True, "pattern": True}
-
-
 class Concat(Func):
     """Concat function"""
 

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -710,6 +710,8 @@ def check_string_operations(event_view, column_name, limit=100):
     event_view["str_replace"] = varchar_series.str.replace("a", "i")
     event_view["str_pad"] = varchar_series.str.pad(10, side="both", fillchar="-")
     event_view["str_contains"] = varchar_series.str.contains("ai")
+    event_view["str_new"] = varchar_series.str.replace("ai", "a%i")
+    event_view["str_contains_special_char"] = event_view["str_new"].str.contains("a%i")
     event_view["str_slice"] = varchar_series.str[:5]
 
     str_columns = [col for col in event_view.columns if col.startswith("str_")]
@@ -744,6 +746,12 @@ def check_string_operations(event_view, column_name, limit=100):
     pd.testing.assert_series_equal(
         str_df["str_contains"],
         pandas_series.str.contains("ai"),
+        check_names=False,
+    )
+    new_series = pandas_series.str.replace("ai", "a%i")
+    pd.testing.assert_series_equal(
+        str_df["str_contains_special_char"],
+        new_series.str.contains("a%i"),
         check_names=False,
     )
     pd.testing.assert_series_equal(str_df["str_slice"], pandas_series.str[:5], check_names=False)

--- a/tests/unit/core/accessor/test_string.py
+++ b/tests/unit/core/accessor/test_string.py
@@ -146,7 +146,7 @@ def test_pad_expression(
         (lambda s: s.str.contains("abc", case=True), "CONTAINS(\"PRODUCT_ACTION\", 'abc')"),
         (
             lambda s: s.str.contains("abc", case=False),
-            "CONTAINS(LOWER(\"PRODUCT_ACTION\"), LOWER('abc'))",
+            "CONTAINS(LOWER(\"PRODUCT_ACTION\"), 'abc')",
         ),
     ],
 )

--- a/tests/unit/core/accessor/test_string.py
+++ b/tests/unit/core/accessor/test_string.py
@@ -143,9 +143,9 @@ def test_pad_expression(
     "accessor_func, exp_expression",
     [
         (lambda s: s.str.contains("abc"), "CONTAINS(\"PRODUCT_ACTION\", 'abc')"),
-        (lambda s: s.str.contains("abc", case=True), "CONTAINS(\"PRODUCT_ACTION\", 'abc')"),
+        (lambda s: s.str.contains("aBc", case=True), "CONTAINS(\"PRODUCT_ACTION\", 'aBc')"),
         (
-            lambda s: s.str.contains("abc", case=False),
+            lambda s: s.str.contains("aBc", case=False),
             "CONTAINS(LOWER(\"PRODUCT_ACTION\"), 'abc')",
         ),
     ],


### PR DESCRIPTION
## Description

This fixes an error when using the string contains operation with Spark 3.2 because the `CONTAINS` function is not available in older versions of Spark.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
