### PR TITLE
[DEV-1857][chore] init: add register_tutorial_api_token SDK command

### DIFF
--- a/featurebyte/__init__.py
+++ b/featurebyte/__init__.py
@@ -192,7 +192,10 @@ def register_tutorial_api_token(api_token: str) -> None:
     # Update API token in existing profile if it's there
     for profile in profiles:
         if profile["name"] == tutorial_profile_name:
-            updated_profile = profile["api_token"] != api_token
+            if "api_token" in profile:
+                updated_profile = profile["api_token"] != api_token
+            else:
+                updated_profile = True
             profile["api_token"] = api_token
             has_tutorial_profile = True
     # Add tutorial profile if it's not already there

--- a/featurebyte/__init__.py
+++ b/featurebyte/__init__.py
@@ -1,8 +1,11 @@
 """Python Library for FeatureOps"""
 from typing import Any, Dict, List, Optional
 
+import os
+import shutil
 import sys
 from http import HTTPStatus
+from pathlib import Path
 
 import pandas as pd
 import yaml
@@ -187,9 +190,8 @@ def register_tutorial_api_token(api_token: str) -> None:
 
     profiles: List[Any] = loaded_config["profile"]
     tutorial_profile_name = "tutorial"
-    has_tutorial_profile = False
-    updated_profile = False
     # Update API token in existing profile if it's there
+    tutorial_url = "https://tutorials.featurebyte.com/api/v1"
     for profile in profiles:
         if profile["name"] == tutorial_profile_name:
             if "api_token" in profile:
@@ -197,13 +199,14 @@ def register_tutorial_api_token(api_token: str) -> None:
             else:
                 updated_profile = True
             profile["api_token"] = api_token
-            has_tutorial_profile = True
+            profile["api_url"] = tutorial_url
+            break
     # Add tutorial profile if it's not already there
-    if not has_tutorial_profile:
+    else:
         profiles.append(
             {
                 "name": tutorial_profile_name,
-                "api_url": "https://tutorials.featurebyte.com/api/v1",
+                "api_url": tutorial_url,
                 "api_token": api_token,
             }
         )
@@ -213,6 +216,11 @@ def register_tutorial_api_token(api_token: str) -> None:
     # Write to config file if profile was updated
     if updated_profile:
         yaml_str = yaml.dump(loaded_config, sort_keys=False)
+        # Backup existing config file before overwriting
+        backup_file_path = os.path.join(
+            os.path.dirname(config_file_path), config_file_path.name + ".bak"
+        )
+        shutil.copyfile(config_file_path, backup_file_path)
         with open(config_file_path, "w", encoding="utf-8") as file_obj:
             file_obj.write(yaml_str)
 

--- a/featurebyte/__init__.py
+++ b/featurebyte/__init__.py
@@ -210,7 +210,7 @@ def register_tutorial_api_token(api_token: str) -> None:
     # Write to config file if profile was updated
     if updated_profile:
         yaml_str = yaml.dump(loaded_config, sort_keys=False)
-        with open(config_file_path, "w") as file_obj:
+        with open(config_file_path, "w", encoding="utf-8") as file_obj:
             file_obj.write(yaml_str)
 
     # Use the tutorial profile

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -30,7 +30,8 @@ def test_register_tutorial_api_token():
     config = Configurations()
     tutorial_profile_name = "tutorial"
     # Verify that there's no profile with tutorial
-    assert not any([tutorial_profile_name == profile.name for profile in config.profiles])
+    for profile in config.profiles:
+        assert profile.name != tutorial_profile_name
     # Verify that the active profile is not tutorial
     original_profile_name = config.profile.name
     assert original_profile_name != "tutorial"

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1,0 +1,48 @@
+"""
+Test init module functions
+"""
+import featurebyte as fb
+from featurebyte.config import Configurations
+
+
+def _assert_tutorial_profile_with_api_token(api_token: str) -> None:
+    """
+    Assert that there's a tutorial profile with the given api token
+    """
+    # Reload configs and verify that there's now a profile with tutorial
+    config = Configurations()
+    has_tutorial_profile = False
+    for profile in config.profiles:
+        if profile.name == "tutorial":
+            assert not has_tutorial_profile  # check that there's only one tutorial profile
+            has_tutorial_profile = True
+            assert profile.api_token == api_token
+    assert has_tutorial_profile
+
+    # Verify that the active profile is now the tutorial profile
+    assert config.profile.name == "tutorial"
+
+
+def test_register_tutorial_api_token():
+    """
+    Test register_tutorial_api_token function
+    """
+    config = Configurations()
+    tutorial_profile_name = "tutorial"
+    # Verify that there's no profile with tutorial
+    assert not any([tutorial_profile_name == profile.name for profile in config.profiles])
+    # Verify that the active profile is not tutorial
+    original_profile_name = config.profile.name
+    assert original_profile_name != "tutorial"
+
+    try:
+        # Register tutorial api token
+        fb.register_tutorial_api_token("test")
+        _assert_tutorial_profile_with_api_token("test")
+
+        # Re-register with different API token
+        fb.register_tutorial_api_token("test2")
+        _assert_tutorial_profile_with_api_token("test2")
+    finally:
+        # Reset back to original profile
+        config.use_profile(original_profile_name)

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1,6 +1,10 @@
 """
 Test init module functions
 """
+from unittest import mock
+
+import pytest
+
 import featurebyte as fb
 from featurebyte.config import Configurations
 
@@ -23,10 +27,29 @@ def _assert_tutorial_profile_with_api_token(api_token: str) -> None:
     assert config.profile.name == "tutorial"
 
 
-def test_register_tutorial_api_token():
+@pytest.fixture(name="noop_check_sdk_versions")
+def patch_check_sdk_versions_fixture():
+    """
+    Patch check_sdk_versions function
+    """
+    with mock.patch("featurebyte.config.Configurations.check_sdk_versions"):
+        yield
+
+
+@pytest.fixture(name="noop_log_env_summary")
+def patch_log_env_summary_fixture():
+    """
+    Patch log_env_summary function to be a no-op
+    """
+    with mock.patch("featurebyte.log_env_summary"):
+        yield
+
+
+def test_register_tutorial_api_token(noop_check_sdk_versions, noop_log_env_summary):
     """
     Test register_tutorial_api_token function
     """
+    _ = noop_check_sdk_versions, noop_log_env_summary
     config = Configurations()
     tutorial_profile_name = "tutorial"
     # Verify that there's no profile with tutorial


### PR DESCRIPTION
## Description
Add `register_tutorial_api_token` SDK command.

We should be able to place this at the top of the notebook

```
import featurebyte as fb
fb.register_tutorial_api_token("<api_token>")
```
and this will store the token in the config file, and change to the `tutorial` profile.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-1857

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
