### PR TITLE
[DEV-1892][DEV-1893] Fix listing of databases and schemas in Spark 3.2

### DIFF
--- a/.changelog/DEV-1892.yaml
+++ b/.changelog/DEV-1892.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix listing of databases and schemas in Spark 3.2"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/session/base.py
+++ b/featurebyte/session/base.py
@@ -553,14 +553,6 @@ class BaseSchemaInitializer(ABC):
     async def create_schema(self) -> None:
         """Create the featurebyte working schema"""
 
-    @abstractmethod
-    async def list_functions(self) -> list[str]:
-        """Retrieve list of functions in the working schema"""
-
-    @abstractmethod
-    async def list_procedures(self) -> list[str]:
-        """Retrieve list of procedures in the working schema"""
-
     @property
     @abstractmethod
     def sql_directory_name(self) -> str:
@@ -799,7 +791,7 @@ class BaseSchemaInitializer(ABC):
     @classmethod
     def _normalize_casing(cls, identifier: str) -> str:
         # Some database warehouses convert the names returned from list_tables(), list_schemas(),
-        # list_functions() etc to always upper case (Snowflake) or lower case (Databricks). To unify
+        # list_objects() etc to always upper case (Snowflake) or lower case (Databricks). To unify
         # the handling between different engines, this converts the identifiers used internally for
         # initialization purpose to be always upper case.
         return identifier.upper()

--- a/featurebyte/session/snowflake.py
+++ b/featurebyte/session/snowflake.py
@@ -321,22 +321,6 @@ class SnowflakeSchemaInitializer(BaseSchemaInitializer):
         query = f"DROP {object_type} {self._fully_qualified(name)}"
         await self.session.execute_query(query)
 
-    async def list_functions(self) -> list[str]:
-        df_result = await self.list_objects("USER FUNCTIONS")
-        out = []
-        if df_result is not None:
-            df_result = df_result[df_result["schema_name"] == self.session.schema_name]
-            out.extend(df_result["name"])
-        return out
-
-    async def list_procedures(self) -> list[str]:
-        df_result = await self.list_objects("PROCEDURES")
-        out = []
-        if df_result is not None:
-            df_result = df_result[df_result["schema_name"] == self.session.schema_name]
-            out.extend(df_result["name"])
-        return out
-
     @staticmethod
     def _format_arguments_to_be_droppable(arguments_list: list[str]) -> list[str]:
         return [arguments.split(" RETURN", 1)[0] for arguments in arguments_list]

--- a/tests/unit/session/test_base.py
+++ b/tests/unit/session/test_base.py
@@ -94,12 +94,6 @@ def base_schema_initializer_test_fixture():
         async def create_schema(self) -> None:
             return
 
-        async def list_functions(self) -> list[str]:
-            return []
-
-        async def list_procedures(self) -> list[str]:
-            return []
-
         async def drop_all_objects_in_working_schema(self) -> None:
             return
 

--- a/tests/unit/session/test_databricks_session.py
+++ b/tests/unit/session/test_databricks_session.py
@@ -263,16 +263,3 @@ def test_databricks_schema_initializer__sql_objects(patched_databricks_session_c
         return sorted(lst, key=lambda x: x["filename"])
 
     assert _sorted_result(sql_objects) == _sorted_result(expected)
-
-
-@pytest.mark.asyncio
-async def test_databricks_schema_initializer__commands(patched_databricks_session_cls):
-    """Test Databricks schema initializer dispatches the correct queries"""
-    session = patched_databricks_session_cls()
-    initializer = BaseSparkSchemaInitializer(session)
-
-    await initializer.list_functions()
-    assert session.execute_query.call_args_list == [call("SHOW USER FUNCTIONS IN featurebyte")]
-
-    assert await initializer.list_procedures() == []
-    assert session.execute_query.call_args_list == [call("SHOW USER FUNCTIONS IN featurebyte")]


### PR DESCRIPTION
## Description

This fixes the listing of databases and schemas in Spark 3.2 and older versions since newer syntaxes like `SHOW CATALOGS` were not yet supported.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
