### PR TITLE
[chore] app: reduce state stored in request

### DIFF
--- a/featurebyte/app.py
+++ b/featurebyte/app.py
@@ -84,8 +84,6 @@ def _get_api_deps() -> Callable[[Request, PydanticObjectId], None]:
         request.state.get_credential = MongoBackedCredentialProvider(
             persistent=request.state.persistent
         ).get_credential
-        request.state.get_storage = get_storage
-        request.state.get_temp_storage = get_temp_storage
         request.state.app_container = LazyAppContainer(
             user=request.state.user,
             persistent=request.state.persistent,

--- a/featurebyte/routes/historical_feature_table/api.py
+++ b/featurebyte/routes/historical_feature_table/api.py
@@ -48,7 +48,6 @@ async def create_historical_feature_table(
     task_submit: Task = await controller.create_historical_feature_table(
         data=data,
         observation_set=observation_set,
-        temp_storage=request.state.get_temp_storage(),
     )
     return task_submit
 

--- a/featurebyte/routes/historical_feature_table/controller.py
+++ b/featurebyte/routes/historical_feature_table/controller.py
@@ -26,7 +26,6 @@ from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.service.historical_feature_table import HistoricalFeatureTableService
 from featurebyte.service.observation_table import ObservationTableService
 from featurebyte.service.preview import PreviewService
-from featurebyte.storage import Storage
 
 
 class HistoricalFeatureTableController(
@@ -61,7 +60,6 @@ class HistoricalFeatureTableController(
         self,
         data: HistoricalFeatureTableCreate,
         observation_set: Optional[UploadFile],
-        temp_storage: Storage,
     ) -> Task:
         """
         Create HistoricalFeatureTable by submitting an async historical feature request task
@@ -72,8 +70,6 @@ class HistoricalFeatureTableController(
             HistoricalFeatureTable creation payload
         observation_set: Optional[UploadFile]
             Observation set file
-        temp_storage: Storage
-            Storage instance
 
         Returns
         -------
@@ -118,7 +114,7 @@ class HistoricalFeatureTableController(
 
         # prepare task payload and submit task
         payload = await self.service.get_historical_feature_table_task_payload(
-            data=data, storage=temp_storage, observation_set_dataframe=observation_set_dataframe
+            data=data, observation_set_dataframe=observation_set_dataframe
         )
         task_id = await self.task_controller.task_manager.submit(payload=payload)
         return await self.task_controller.get_task(task_id=str(task_id))

--- a/featurebyte/routes/target_table/api.py
+++ b/featurebyte/routes/target_table/api.py
@@ -45,7 +45,6 @@ async def create_target_table(
     task_submit: Task = await controller.create_target_table(
         data=data,
         observation_set=observation_set,
-        temp_storage=request.state.get_temp_storage(),
     )
     return task_submit
 

--- a/featurebyte/routes/target_table/controller.py
+++ b/featurebyte/routes/target_table/controller.py
@@ -23,7 +23,6 @@ from featurebyte.service.observation_table import ObservationTableService
 from featurebyte.service.preview import PreviewService
 from featurebyte.service.target import TargetService
 from featurebyte.service.target_table import TargetTableService
-from featurebyte.storage import Storage
 
 
 class TargetTableController(
@@ -56,7 +55,6 @@ class TargetTableController(
         self,
         data: TargetTableCreate,
         observation_set: Optional[UploadFile],
-        temp_storage: Storage,
     ) -> Task:
         """
         Create TargetTable by submitting an async historical feature request task
@@ -67,8 +65,6 @@ class TargetTableController(
             TargetTable creation payload
         observation_set: Optional[UploadFile]
             Observation set file
-        temp_storage: Storage
-            Storage instance
 
         Returns
         -------
@@ -112,7 +108,7 @@ class TargetTableController(
 
         # prepare task payload and submit task
         payload = await self.service.get_target_table_task_payload(
-            data=data, storage=temp_storage, observation_set_dataframe=observation_set_dataframe
+            data=data, observation_set_dataframe=observation_set_dataframe
         )
         task_id = await self.task_controller.task_manager.submit(payload=payload)
         return await self.task_controller.get_task(task_id=str(task_id))


### PR DESCRIPTION
## Description
These parameters of state are encapsulated in the app_container, and can now be injected directly into services that require it.

This also reduces the need to thread dependencies through requests and function calls, and can inject them directly into the areas where they're actually being used.

Also verified that `featurebyte-app` has no dependencies on this state.
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
