### PR TITLE
[DEV-1938] Disable tile monitoring by default

### DIFF
--- a/.changelog/DEV-1938.yaml
+++ b/.changelog/DEV-1938.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Disable tile monitoring by default"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/sql/tile_monitor.py
+++ b/featurebyte/sql/tile_monitor.py
@@ -1,6 +1,8 @@
 """
 Tile Monitor Job
 """
+import os
+
 from sqlglot import expressions
 
 from featurebyte.enum import InternalName
@@ -28,6 +30,8 @@ class TileMonitor(TileCommon):
         """
         Execute tile monitor operation
         """
+        if not int(os.environ.get("FEATUREBYTE_TILE_MONITORING_ENABLED", "0")):
+            return
 
         tile_table_exist_flag = await self.table_exists(self.tile_id)
         logger.debug(f"tile_table_exist_flag: {tile_table_exist_flag}")

--- a/featurebyte/sql/tile_monitor.py
+++ b/featurebyte/sql/tile_monitor.py
@@ -30,6 +30,8 @@ class TileMonitor(TileCommon):
         """
         Execute tile monitor operation
         """
+        # Disable tile monitoring for now since it is not yet user facing but the current
+        # implementation incurs significant cost when many features are deployed.
         if not int(os.environ.get("FEATUREBYTE_TILE_MONITORING_ENABLED", "0")):
             return
 

--- a/tests/integration/tile/conftest.py
+++ b/tests/integration/tile/conftest.py
@@ -1,8 +1,11 @@
 """
 Tile Tests for Spark Session
 """
+import os
 from datetime import datetime
+from unittest.mock import patch
 
+import pytest
 import pytest_asyncio
 from bson import ObjectId
 
@@ -124,3 +127,12 @@ async def tile_manager_service_fixture(
 @pytest_asyncio.fixture(name="base_sql_model")
 async def base_sql_model(session):
     return BaseSqlModel(session)
+
+
+@pytest.fixture(name="enable_tile_monitoring")
+def enable_tile_monitoring_fixture():
+    """
+    Fixture to enable tile monitoring
+    """
+    with patch.dict(os.environ, {"FEATUREBYTE_TILE_MONITORING_ENABLED": "1"}):
+        yield

--- a/tests/integration/tile/test_monitor_tile.py
+++ b/tests/integration/tile/test_monitor_tile.py
@@ -11,6 +11,14 @@ from featurebyte.sql.tile_generate import TileGenerate
 from featurebyte.sql.tile_monitor import TileMonitor
 
 
+@pytest.fixture(autouse=True)
+def auto_enable_tile_monitoring(enable_tile_monitoring):
+    """
+    Enable tile monitoring for all tests in this module
+    """
+    yield
+
+
 @pytest.mark.parametrize("source_type", ["spark", "snowflake"], indirect=True)
 @pytest.mark.asyncio
 async def test_monitor_tile__missing_tile(session, base_sql_model, tile_registry_service):

--- a/tests/integration/tile/test_schedule_generate_tile.py
+++ b/tests/integration/tile/test_schedule_generate_tile.py
@@ -94,6 +94,7 @@ async def test_schedule_generate_tile_online(
     assert result["CREATED_AT"].iloc[3] > result["CREATED_AT"].iloc[2]
 
 
+@pytest.mark.usefixtures("enable_tile_monitoring")
 @pytest.mark.parametrize("source_type", ["spark", "snowflake"], indirect=True)
 @pytest.mark.asyncio
 async def test_schedule_monitor_tile_online(session, base_sql_model, tile_task_executor):


### PR DESCRIPTION
## Description

This disables tile monitoring by default which is currently not user facing. The current implementation incurs significant cost when many features are deployed.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
