### PR TITLE
[wip][chore] session_validator: rm get_credential since we always read from mongo

### DIFF
--- a/featurebyte/routes/feature_store/api.py
+++ b/featurebyte/routes/feature_store/api.py
@@ -41,9 +41,7 @@ async def create_feature_store(request: Request, data: FeatureStoreCreate) -> Fe
     Create Feature Store
     """
     controller = request.state.app_container.feature_store_controller
-    feature_store: FeatureStoreModel = await controller.create_feature_store(
-        data=data, get_credential=request.state.get_credential
-    )
+    feature_store: FeatureStoreModel = await controller.create_feature_store(data=data)
     return feature_store
 
 

--- a/featurebyte/routes/feature_store/controller.py
+++ b/featurebyte/routes/feature_store/controller.py
@@ -60,7 +60,6 @@ class FeatureStoreController(
     async def create_feature_store(
         self,
         data: FeatureStoreCreate,
-        get_credential: Any,
     ) -> FeatureStoreModel:
         """
         Create Feature Store at persistent
@@ -69,8 +68,6 @@ class FeatureStoreController(
         ----------
         data: FeatureStoreCreate
             FeatureStore creation payload
-        get_credential: Any
-            credential handler function
 
         Returns
         -------
@@ -108,36 +105,10 @@ class FeatureStoreController(
                 storage_credential=data.storage_credential,
             )
 
-            async def _updated_get_credential(user_id: str, feature_store_name: str) -> Any:
-                """
-                Updated get_credential will try to look up the credentials from config.
-
-                If there are credentials in the config, we will ignore whatever is passed in here.
-                If not, we will use the params that are passed in.
-
-                Parameters
-                ----------
-                user_id: str
-                    user id
-                feature_store_name: str
-                    feature store name
-
-                Returns
-                -------
-                Any
-                    credentials
-                """
-                cred = await get_credential(user_id, feature_store_name)
-                if cred is not None:
-                    return cred
-                return credential
-
-            get_credential_to_use = _updated_get_credential
             await self.session_validator_service.validate_feature_store_id_not_used_in_warehouse(
                 feature_store_name=data.name,
                 session_type=data.type,
                 details=data.details,
-                get_credential=get_credential_to_use,
                 users_feature_store_id=document.id,
             )
             logger.debug("End validate_feature_store_id_not_used_in_warehouse")
@@ -147,7 +118,6 @@ class FeatureStoreController(
                 feature_store=FeatureStoreModel(
                     name=data.name, type=data.type, details=data.details
                 ),
-                get_credential=get_credential_to_use,
             )
             # Try to persist credential
             credential_doc = await self.credential_service.create_document(

--- a/featurebyte/service/session_manager.py
+++ b/featurebyte/service/session_manager.py
@@ -32,7 +32,7 @@ class SessionManagerService:
     async def get_feature_store_session(
         self,
         feature_store: FeatureStoreModel,
-        get_credential: Any,
+        get_credential: Any = None,
         user_override: Optional[User] = None,
     ) -> BaseSession:
         """
@@ -57,18 +57,14 @@ class SessionManagerService:
         CredentialsError
             When the credentials used to access the feature store is missing or invalid
         """
+        _ = get_credential
         user_to_use = self.user
         if user_override is not None:
             user_to_use = user_override
         try:
-            if get_credential is not None:
-                credential = await get_credential(
-                    user_id=user_to_use.id, feature_store_name=feature_store.name
-                )
-            else:
-                credential = await self.credential_provider.get_credential(
-                    user_id=user_to_use.id, feature_store_name=feature_store.name
-                )
+            credential = await self.credential_provider.get_credential(
+                user_id=user_to_use.id, feature_store_name=feature_store.name
+            )
             credentials = {feature_store.name: credential}
             session_manager = SessionManager(credentials=credentials)
             session = await session_manager.get_session(feature_store)


### PR DESCRIPTION
## Description
We can cleanup the session validator, and remove the `get_credential` function that is passed around, since we now always write and read credentials from mongo.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
