### PR TITLE
[DEV-1919] series: add validation check in setitem

### DIFF
--- a/.changelog/DEV-1919.yaml
+++ b/.changelog/DEV-1919.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: target
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add gates to prevent target from setting item to non-target series."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/target.py
+++ b/featurebyte/api/target.py
@@ -27,7 +27,7 @@ from featurebyte.api.templates.feature_or_target_doc import (
     VERSION_DOC,
 )
 from featurebyte.common.utils import dataframe_to_arrow_bytes, enforce_observation_set_row_order
-from featurebyte.core.series import Series
+from featurebyte.core.series import FrozenSeries, Series
 from featurebyte.exception import RecordRetrievalException
 from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.models.target import TargetModel
@@ -60,6 +60,21 @@ class Target(Series, SavableApiObject, FeatureOrTargetMixin):
 
     def _get_init_params_from_object(self) -> dict[str, Any]:
         return {"feature_store": self.feature_store}
+
+    def validate_series_operation(self, other_series: Series) -> bool:
+        """
+        Validate that the other series is a Target.
+
+        Parameters
+        ----------
+        other_series: FrozenSeries
+            The other series to validate.
+
+        Returns
+        -------
+        bool
+        """
+        return isinstance(other_series, Target)
 
     @root_validator(pre=True)
     @classmethod

--- a/featurebyte/api/target.py
+++ b/featurebyte/api/target.py
@@ -27,7 +27,7 @@ from featurebyte.api.templates.feature_or_target_doc import (
     VERSION_DOC,
 )
 from featurebyte.common.utils import dataframe_to_arrow_bytes, enforce_observation_set_row_order
-from featurebyte.core.series import FrozenSeries, Series
+from featurebyte.core.series import Series
 from featurebyte.exception import RecordRetrievalException
 from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.models.target import TargetModel
@@ -67,7 +67,7 @@ class Target(Series, SavableApiObject, FeatureOrTargetMixin):
 
         Parameters
         ----------
-        other_series: FrozenSeries
+        other_series: Series
             The other series to validate.
 
         Returns

--- a/featurebyte/core/series.py
+++ b/featurebyte/core/series.py
@@ -1063,10 +1063,26 @@ class Series(FrozenSeries):
     This class supports in-place column modification, and is the primary interface for column.
     """
 
+    def validate_series_operation(self, other_series: FrozenSeries) -> bool:
+        """
+        Validate the other series for series operation. This method is when performing the __setitem__ operation
+        between two series.
+        """
+        return True
+
     @typechecked
     def __setitem__(
-        self, key: FrozenSeries, value: Union[int, float, str, bool, None, FrozenSeries]
+        self, key: FrozenSeries, value: Union[int, float, str, bool, None, Series]
     ) -> None:
+        if isinstance(value, Series):
+            if not self.validate_series_operation(value) or not value.validate_series_operation(
+                self
+            ):
+                raise TypeError(
+                    f"Operation between {self.__class__.__name__} and {value.__class__.__name__} "
+                    f"is not supported"
+                )
+
         if self.row_index_lineage != key.row_index_lineage:
             raise ValueError(f"Row indices between '{self}' and '{key}' are not aligned!")
         if key.dtype != DBVarType.BOOL:

--- a/featurebyte/core/series.py
+++ b/featurebyte/core/series.py
@@ -1063,14 +1063,14 @@ class Series(FrozenSeries):
     This class supports in-place column modification, and is the primary interface for column.
     """
 
-    def validate_series_operation(self, other_series: FrozenSeries) -> bool:
+    def validate_series_operation(self, other_series: Series) -> bool:
         """
         Validate the other series for series operation. This method is when performing the __setitem__ operation
         between two series.
 
         Parameters
         ----------
-        other_series: FrozenSeries
+        other_series: Series
             The other series to validate
 
         Returns

--- a/featurebyte/core/series.py
+++ b/featurebyte/core/series.py
@@ -1067,6 +1067,15 @@ class Series(FrozenSeries):
         """
         Validate the other series for series operation. This method is when performing the __setitem__ operation
         between two series.
+
+        Parameters
+        ----------
+        other_series: FrozenSeries
+            The other series to validate
+
+        Returns
+        -------
+        bool
         """
         _ = other_series
         return True

--- a/featurebyte/core/series.py
+++ b/featurebyte/core/series.py
@@ -1068,6 +1068,7 @@ class Series(FrozenSeries):
         Validate the other series for series operation. This method is when performing the __setitem__ operation
         between two series.
         """
+        _ = other_series
         return True
 
     @typechecked

--- a/featurebyte/core/series.py
+++ b/featurebyte/core/series.py
@@ -1082,7 +1082,7 @@ class Series(FrozenSeries):
 
     @typechecked
     def __setitem__(
-        self, key: FrozenSeries, value: Union[int, float, str, bool, None, Series]
+        self, key: FrozenSeries, value: Union[int, float, str, bool, None, FrozenSeries]
     ) -> None:
         if isinstance(value, Series):
             if not self.validate_series_operation(value) or not value.validate_series_operation(

--- a/tests/unit/api/test_target.py
+++ b/tests/unit/api/test_target.py
@@ -1,6 +1,8 @@
 """
 Test target module
 """
+import pytest
+
 from tests.unit.api.base_feature_or_target_test import FeatureOrTargetBaseTestSuite, TestItemType
 
 
@@ -55,3 +57,17 @@ class TestTargetTestSuite(FeatureOrTargetBaseTestSuite):
     output = feat
     output.save(_id=ObjectId("{item_id}"))
     """
+
+    def test_invalid_operations_with_feature(self, bool_feature, float_target, float_feature):
+        """
+        Test invalid operations with feature
+        """
+        # Test binary series operation
+        with pytest.raises(TypeError) as exc_info:
+            _ = float_target + float_feature
+        assert "Operation between Target and Feature is not supported" in str(exc_info)
+
+        # Test series assignment
+        with pytest.raises(TypeError) as exc_info:
+            float_target[bool_feature] = float_feature
+        assert "Operation between Target and Feature is not supported" in str(exc_info)


### PR DESCRIPTION
## Description
Add validation check when trying to perform setitem. Binary series operations already have a validation check https://github.com/featurebyte/featurebyte/blob/55e8650e3b875925e4bf3ae6efd0c9066087bf64/featurebyte/core/series.py#L58-L77

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-1919

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
