### PR TITLE
[chore] Update `extract_operation_structure`'s `keep_all_source_columns` parameter

### DIFF
--- a/featurebyte/api/feature.py
+++ b/featurebyte/api/feature.py
@@ -606,7 +606,9 @@ class Feature(
         bool
             True if the feature is time based, False otherwise.
         """
-        operation_structure = self.graph.extract_operation_structure(self.node)
+        operation_structure = self.graph.extract_operation_structure(
+            self.node, keep_all_source_columns=True
+        )
         return operation_structure.is_time_based
 
     @property

--- a/featurebyte/api/item_view.py
+++ b/featurebyte/api/item_view.py
@@ -303,7 +303,9 @@ class ItemView(View, GroupByMixin, RawMixin):
         -------
         bool
         """
-        operation_structure = self.graph.extract_operation_structure(self.node)
+        operation_structure = self.graph.extract_operation_structure(
+            self.node, keep_all_source_columns=True
+        )
         for column_name in column_names:
             column_structure = next(
                 column for column in operation_structure.columns if column.name == column_name

--- a/featurebyte/core/accessor/count_dict.py
+++ b/featurebyte/core/accessor/count_dict.py
@@ -322,7 +322,9 @@ class CountDictAccessor:
             # We only need to assign value if we have been passed in a single scalar value.
             additional_node_params["value"] = key
         # construct operation structure of the get value node output
-        op_struct = self._feature_obj.graph.extract_operation_structure(node=self._feature_obj.node)
+        op_struct = self._feature_obj.graph.extract_operation_structure(
+            node=self._feature_obj.node, keep_all_source_columns=True
+        )
         get_value_node = GetValueFromDictionaryNode(name="temp", parameters=additional_node_params)
 
         series_operator = DefaultSeriesBinaryOperator(self._feature_obj, key)

--- a/featurebyte/core/generic.py
+++ b/featurebyte/core/generic.py
@@ -94,7 +94,7 @@ class QueryObject(FeatureByteBaseModel):
         -------
         OperationStructure
         """
-        return self.graph.extract_operation_structure(self.node)
+        return self.graph.extract_operation_structure(self.node, keep_all_source_columns=True)
 
     @property
     def row_index_lineage(self) -> Tuple[str, ...]:

--- a/featurebyte/models/feature.py
+++ b/featurebyte/models/feature.py
@@ -78,7 +78,7 @@ class BaseFeatureModel(FeatureByteCatalogBaseDocumentModel):
 
             # extract dtype from the graph
             node = graph.get_node_by_name(node_name)
-            op_struct = graph.extract_operation_structure(node=node)
+            op_struct = graph.extract_operation_structure(node=node, keep_all_source_columns=True)
             if len(op_struct.aggregations) != 1:
                 raise ValueError("Feature or target graph must have exactly one aggregation output")
 
@@ -142,14 +142,17 @@ class BaseFeatureModel(FeatureByteCatalogBaseDocumentModel):
 
     def extract_operation_structure(self) -> GroupOperationStructure:
         """
-        Extract feature or target operation structure based on query graph.
+        Extract feature or target operation structure based on query graph. This method is mainly
+        used for deriving feature or target metadata used in feature/target info.
 
         Returns
         -------
         GroupOperationStructure
         """
         # group the view columns by source columns & derived columns
-        operation_structure = self.graph.extract_operation_structure(self.node)
+        operation_structure = self.graph.extract_operation_structure(
+            self.node, keep_all_source_columns=False
+        )
         return operation_structure.to_group_operation_structure()
 
     class Settings(FeatureByteCatalogBaseDocumentModel.Settings):

--- a/featurebyte/query_graph/graph.py
+++ b/featurebyte/query_graph/graph.py
@@ -280,7 +280,12 @@ class QueryGraph(QueryGraphModel):
             node_name_map[node.name] = node_global.name
         return self, node_name_map
 
-    def extract_operation_structure(self, node: Node, **kwargs: Any) -> OperationStructure:
+    def extract_operation_structure(
+        self,
+        node: Node,
+        keep_all_source_columns: bool,
+        **kwargs: Any,
+    ) -> OperationStructure:
         """
         Extract operation structure from the graph given target node
 
@@ -288,6 +293,8 @@ class QueryGraph(QueryGraphModel):
         ----------
         node: Node
             Target node used to construct the operation structure
+        keep_all_source_columns: bool
+            Whether to keep all source columns in the operation structure
         kwargs: Any
             Additional arguments to be passed to the OperationStructureExtractor.extract() method
 
@@ -295,7 +302,9 @@ class QueryGraph(QueryGraphModel):
         -------
         OperationStructure
         """
-        op_struct_info = OperationStructureExtractor(graph=self).extract(node=node, **kwargs)
+        op_struct_info = OperationStructureExtractor(graph=self).extract(
+            node=node, keep_all_source_columns=keep_all_source_columns, **kwargs
+        )
         return op_struct_info.operation_structure_map[node.name]
 
     def prune(self, target_node: Node) -> GraphNodeNameMap:

--- a/featurebyte/query_graph/node/metadata/operation.py
+++ b/featurebyte/query_graph/node/metadata/operation.py
@@ -412,7 +412,7 @@ FeatureDataColumn = Annotated[
 
 
 class GroupOperationStructure(BaseModel):
-    """GroupOperationStructure class"""
+    """GroupOperationStructure class is used to construct feature/target info's metadata attribute."""
 
     source_columns: List[SourceDataColumn] = Field(default_factory=list)
     derived_columns: List[DerivedDataColumn] = Field(default_factory=list)

--- a/featurebyte/query_graph/sql/interpreter/base.py
+++ b/featurebyte/query_graph/sql/interpreter/base.py
@@ -65,7 +65,9 @@ class BaseGraphInterpreter:
             SQL code to execute, and column count
         """
         flat_graph, flat_node = self.flatten_graph(node_name=node_name)
-        operation_structure = QueryGraph(**flat_graph.dict()).extract_operation_structure(flat_node)
+        operation_structure = QueryGraph(**flat_graph.dict()).extract_operation_structure(
+            flat_node, keep_all_source_columns=True
+        )
         sql_tree = (
             SQLOperationGraph(
                 flat_graph, sql_type=SQLType.MATERIALIZE, source_type=self.source_type

--- a/featurebyte/query_graph/sql/interpreter/preview.py
+++ b/featurebyte/query_graph/sql/interpreter/preview.py
@@ -128,7 +128,7 @@ class PreviewMixin(BaseGraphInterpreter):
 
         # apply type conversions
         operation_structure = QueryGraph(**self.query_graph.dict()).extract_operation_structure(
-            self.query_graph.get_node_by_name(node_name)
+            self.query_graph.get_node_by_name(node_name), keep_all_source_columns=True
         )
         if skip_conversion:
             type_conversions: dict[Optional[str], DBVarType] = {}
@@ -735,7 +735,7 @@ class PreviewMixin(BaseGraphInterpreter):
             SQL code, type conversions to apply on result, row indices, columns
         """
         operation_structure = QueryGraph(**self.query_graph.dict()).extract_operation_structure(
-            self.query_graph.get_node_by_name(node_name)
+            self.query_graph.get_node_by_name(node_name), keep_all_source_columns=True
         )
 
         sql_tree, type_conversions = self._construct_sample_sql(

--- a/featurebyte/query_graph/sql/online_serving.py
+++ b/featurebyte/query_graph/sql/online_serving.py
@@ -53,7 +53,7 @@ def is_online_store_eligible(graph: QueryGraph, node: Node) -> bool:
     -------
     bool
     """
-    op_struct = graph.extract_operation_structure(node)
+    op_struct = graph.extract_operation_structure(node, keep_all_source_columns=True)
     if not op_struct.is_time_based:
         return False
     has_point_in_time_groupby = False

--- a/featurebyte/query_graph/transform/operation_structure.py
+++ b/featurebyte/query_graph/transform/operation_structure.py
@@ -143,7 +143,7 @@ class OperationStructureExtractor(
         proxy_input_operation_structures: Optional[List[OperationStructure]] = None,
         **kwargs: Any,
     ) -> OperationStructureInfo:
-        state_params: Dict[str, Any] = {"keep_all_source_columns": False}
+        state_params: Dict[str, Any] = {"keep_all_source_columns": True}
         if "keep_all_source_columns" in kwargs:
             # if this parameter is set, then the operation structure will keep all the source columns
             # even if they are not directly used in the operation (for example, event timestamp & entity columns

--- a/featurebyte/service/context.py
+++ b/featurebyte/service/context.py
@@ -122,7 +122,9 @@ class ContextService(BaseDocumentService[ContextModel, ContextCreate, ContextUpd
         document = await self.get_document(document_id=document_id)
         if data.graph and data.node_name:
             node = data.graph.get_node_by_name(data.node_name)
-            operation_structure = data.graph.extract_operation_structure(node=node)
+            operation_structure = data.graph.extract_operation_structure(
+                node=node, keep_all_source_columns=True
+            )
             await self._validate_view(operation_structure=operation_structure, context=document)
 
         document = await super().update_document(

--- a/featurebyte/service/preview.py
+++ b/featurebyte/service/preview.py
@@ -322,7 +322,7 @@ class PreviewService(BaseService):
         graph = feature_or_target_preview.graph
         feature_node = graph.get_node_by_name(feature_or_target_preview.node_name)
         operation_struction = feature_or_target_preview.graph.extract_operation_structure(
-            feature_node
+            feature_node, keep_all_source_columns=True
         )
 
         # We only need to ensure that the point in time column is provided,
@@ -389,7 +389,7 @@ class PreviewService(BaseService):
             for feature_node_name in feature_cluster.node_names:
                 feature_node = feature_cluster.graph.get_node_by_name(feature_node_name)
                 operation_struction = feature_cluster.graph.extract_operation_structure(
-                    feature_node
+                    feature_node, keep_all_source_columns=True
                 )
                 if operation_struction.is_time_based:
                     has_time_based_feature = True

--- a/tests/unit/api/aggregator/test_forward_aggregator.py
+++ b/tests/unit/api/aggregator/test_forward_aggregator.py
@@ -66,7 +66,10 @@ def test_forward_aggregate(forward_aggregator):
     }
 
     # Get operation structure to verify output category
-    operation_structure = target.graph.extract_operation_structure(target_node)
+    operation_structure = target.graph.extract_operation_structure(
+        target_node,
+        keep_all_source_columns=True,
+    )
     assert operation_structure.output_category == "target"
 
 

--- a/tests/unit/core/accessor/test_count_dict.py
+++ b/tests/unit/core/accessor/test_count_dict.py
@@ -153,7 +153,7 @@ def test_get_value_from_dictionary__success(
     for per_cat_feat in [count_per_category_feature, sum_per_category_feature]:
         # check the count_dict has a proper dtype
         count_dict_op_struct = per_cat_feat.graph.extract_operation_structure(
-            node=per_cat_feat.node
+            node=per_cat_feat.node, keep_all_source_columns=True
         )
         assert len(count_dict_op_struct.aggregations) == 1
         assert count_dict_op_struct.aggregations[0].dtype == "OBJECT"

--- a/tests/unit/query_graph/test_graph_node.py
+++ b/tests/unit/query_graph/test_graph_node.py
@@ -119,7 +119,9 @@ def test_graph_node_create__non_empty_input_nodes(input_node_params):
     inserted_graph_node = graph.add_node(
         node=graph_node, input_nodes=[proj_int_node, proj_float_node]
     )
-    operation_structure = graph.extract_operation_structure(node=inserted_graph_node)
+    operation_structure = graph.extract_operation_structure(
+        node=inserted_graph_node, keep_all_source_columns=True
+    )
     # internal node names should not be included (node_names: add_1)
     assert to_dict(operation_structure) == {
         "aggregations": [],
@@ -199,7 +201,9 @@ def nested_input_graph_fixture(input_node_params):
     assert graph.edges == [{"source": "graph_1", "target": "add_1"}]
 
     # internal node names should not be included (node_names: input_1, project_1)
-    operation_structure = graph.extract_operation_structure(node=add_node)
+    operation_structure = graph.extract_operation_structure(
+        node=add_node, keep_all_source_columns=True
+    )
     assert to_dict(operation_structure) == {
         "aggregations": [],
         "columns": [
@@ -267,7 +271,9 @@ def nested_output_graph_fixture(input_node_params):
     assert graph.edges == [{"source": "input_1", "target": "graph_1"}]
 
     # internal node names should not be included (node_names: project_1, add_1)
-    operation_structure = graph.extract_operation_structure(node=inserted_graph_node)
+    operation_structure = graph.extract_operation_structure(
+        node=inserted_graph_node, keep_all_source_columns=True
+    )
     assert to_dict(operation_structure) == {
         "aggregations": [],
         "columns": [
@@ -357,7 +363,9 @@ def deep_nested_graph_fixture(input_node_params):
     assert inserted_deepest_graph.edges == []
 
     # internal node names should not be included (node_names: project_1, add_1)
-    operation_structure = graph.extract_operation_structure(node=inserted_graph_node)
+    operation_structure = graph.extract_operation_structure(
+        node=inserted_graph_node, keep_all_source_columns=True
+    )
     assert to_dict(operation_structure) == {
         "aggregations": [],
         "columns": [
@@ -473,7 +481,9 @@ def test_graph_node__redundant_graph_node(input_node_params):
         node_output_type=NodeOutputType.SERIES,
         input_nodes=[graph_node],
     )
-    operation_structure = graph.extract_operation_structure(node=proj_node)
+    operation_structure = graph.extract_operation_structure(
+        node=proj_node, keep_all_source_columns=True
+    )
     assert to_dict(operation_structure) == {
         "aggregations": [],
         "columns": [

--- a/tests/unit/query_graph/test_nested_graph_pruning.py
+++ b/tests/unit/query_graph/test_nested_graph_pruning.py
@@ -93,7 +93,17 @@ def test_nested_graph_pruning(input_details, groupby_node_params):
     )
 
     # check operation structure
-    operation_structure = graph.extract_operation_structure(node=node_proj_2h_avg)
+    operation_structure = graph.extract_operation_structure(
+        node=node_proj_2h_avg, keep_all_source_columns=True
+    )
+    common_column_params = {
+        "node_names": {"input_1"},
+        "node_name": "input_1",
+        "table_id": None,
+        "table_type": "event_table",
+        "type": "source",
+        "filter": False,
+    }
     assert to_dict(operation_structure) == {
         "aggregations": [
             {
@@ -121,16 +131,9 @@ def test_nested_graph_pruning(input_details, groupby_node_params):
             }
         ],
         "columns": [
-            {
-                "filter": False,
-                "name": "a",
-                "node_names": {"input_1"},
-                "node_name": "input_1",
-                "table_id": None,
-                "table_type": "event_table",
-                "type": "source",
-                "dtype": "FLOAT",
-            }
+            {"name": "ts", "dtype": "TIMESTAMP", **common_column_params},
+            {"name": "cust_id", "dtype": "INT", **common_column_params},
+            {"name": "a", "dtype": "FLOAT", **common_column_params},
         ],
         "output_category": "feature",
         "output_type": "series",


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

Update `OperationStructureExtractor`'s `keep_all_source_columns` parameter handling so that it is `True` for all cases except when using to derive feature/target info's `metadata` field.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

The rationale of this change is due to https://featurebyte.atlassian.net/browse/DEV-1943. Currently, `keep_all_source_columns` is `False` by default. This is very risky as it may drops those columns that contributes only to the changes of the row index lineage. To prevent similar issue happens in the future, this PR makes `keep_all_source_columns` to be `True` for most cases.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
