### PR TITLE
[chore] simplify logic around get_credentials during feature store creation

### DIFF
--- a/featurebyte/routes/feature_store/api.py
+++ b/featurebyte/routes/feature_store/api.py
@@ -41,9 +41,7 @@ async def create_feature_store(request: Request, data: FeatureStoreCreate) -> Fe
     Create Feature Store
     """
     controller = request.state.app_container.feature_store_controller
-    feature_store: FeatureStoreModel = await controller.create_feature_store(
-        data=data, get_credential=request.state.get_credential
-    )
+    feature_store: FeatureStoreModel = await controller.create_feature_store(data=data)
     return feature_store
 
 

--- a/featurebyte/routes/feature_store/controller.py
+++ b/featurebyte/routes/feature_store/controller.py
@@ -68,8 +68,6 @@ class FeatureStoreController(
         ----------
         data: FeatureStoreCreate
             FeatureStore creation payload
-        get_credential: Any
-            credential handler function
 
         Returns
         -------
@@ -107,33 +105,10 @@ class FeatureStoreController(
                 storage_credential=data.storage_credential,
             )
 
-            async def _updated_get_credential(user_id: str, feature_store_name: str) -> Any:
-                """
-                Updated get_credential will try to look up the credentials from config.
-
-                If there are credentials in the config, we will ignore whatever is passed in here.
-                If not, we will use the params that are passed in.
-
-                Parameters
-                ----------
-                user_id: str
-                    user id
-                feature_store_name: str
-                    feature store name
-
-                Returns
-                -------
-                Any
-                    credentials
-                """
-                return credential
-
-            get_credential_to_use = _updated_get_credential
             await self.session_validator_service.validate_feature_store_id_not_used_in_warehouse(
                 feature_store_name=data.name,
                 session_type=data.type,
                 details=data.details,
-                get_credential=get_credential_to_use,
                 users_feature_store_id=document.id,
             )
             logger.debug("End validate_feature_store_id_not_used_in_warehouse")
@@ -143,7 +118,6 @@ class FeatureStoreController(
                 feature_store=FeatureStoreModel(
                     name=data.name, type=data.type, details=data.details
                 ),
-                get_credential=get_credential_to_use,
             )
             # Try to persist credential
             credential_doc = await self.credential_service.create_document(

--- a/featurebyte/routes/feature_store/controller.py
+++ b/featurebyte/routes/feature_store/controller.py
@@ -114,10 +114,29 @@ class FeatureStoreController(
             logger.debug("End validate_feature_store_id_not_used_in_warehouse")
 
             # Retrieve a session for initializing
+            async def _temp_get_credential(user_id: str, feature_store_name: str) -> Any:
+                """
+                Use the temporary credential to try to initialize the session.
+
+                Parameters
+                ----------
+                user_id: str
+                    user id
+                feature_store_name: str
+                    feature store name
+
+                Returns
+                -------
+                Any
+                    credentials
+                """
+                return credential
+
             session = await self.session_manager_service.get_feature_store_session(
                 feature_store=FeatureStoreModel(
                     name=data.name, type=data.type, details=data.details
                 ),
+                get_credential=_temp_get_credential,
             )
             # Try to persist credential
             credential_doc = await self.credential_service.create_document(

--- a/featurebyte/routes/feature_store/controller.py
+++ b/featurebyte/routes/feature_store/controller.py
@@ -60,7 +60,6 @@ class FeatureStoreController(
     async def create_feature_store(
         self,
         data: FeatureStoreCreate,
-        get_credential: Any,
     ) -> FeatureStoreModel:
         """
         Create Feature Store at persistent
@@ -127,9 +126,6 @@ class FeatureStoreController(
                 Any
                     credentials
                 """
-                cred = await get_credential(user_id, feature_store_name)
-                if cred is not None:
-                    return cred
                 return credential
 
             get_credential_to_use = _updated_get_credential

--- a/featurebyte/routes/feature_store/controller.py
+++ b/featurebyte/routes/feature_store/controller.py
@@ -130,6 +130,7 @@ class FeatureStoreController(
                 Any
                     credentials
                 """
+                _ = user_id, feature_store_name
                 return credential
 
             session = await self.session_manager_service.get_feature_store_session(

--- a/featurebyte/routes/feature_store/controller.py
+++ b/featurebyte/routes/feature_store/controller.py
@@ -105,15 +105,6 @@ class FeatureStoreController(
                 storage_credential=data.storage_credential,
             )
 
-            await self.session_validator_service.validate_feature_store_id_not_used_in_warehouse(
-                feature_store_name=data.name,
-                session_type=data.type,
-                details=data.details,
-                users_feature_store_id=document.id,
-            )
-            logger.debug("End validate_feature_store_id_not_used_in_warehouse")
-
-            # Retrieve a session for initializing
             async def _temp_get_credential(user_id: str, feature_store_name: str) -> Any:
                 """
                 Use the temporary credential to try to initialize the session.
@@ -132,6 +123,15 @@ class FeatureStoreController(
                 """
                 _ = user_id, feature_store_name
                 return credential
+
+            await self.session_validator_service.validate_feature_store_id_not_used_in_warehouse(
+                feature_store_name=data.name,
+                session_type=data.type,
+                details=data.details,
+                users_feature_store_id=document.id,
+                get_credential=_temp_get_credential,
+            )
+            logger.debug("End validate_feature_store_id_not_used_in_warehouse")
 
             session = await self.session_manager_service.get_feature_store_session(
                 feature_store=FeatureStoreModel(

--- a/featurebyte/service/session_manager.py
+++ b/featurebyte/service/session_manager.py
@@ -32,7 +32,7 @@ class SessionManagerService:
     async def get_feature_store_session(
         self,
         feature_store: FeatureStoreModel,
-        get_credential: Any,
+        get_credential: Any = None,
         user_override: Optional[User] = None,
     ) -> BaseSession:
         """

--- a/featurebyte/service/session_validator.py
+++ b/featurebyte/service/session_validator.py
@@ -139,41 +139,6 @@ class SessionValidatorService:
         if users_feature_store_id is None:
             raise NoFeatureStorePresentError
 
-    async def validate_details(
-        self,
-        feature_store_name: str,
-        session_type: SourceType,
-        details: DatabaseDetails,
-        get_credential: Any,
-    ) -> ValidateStatus:
-        """
-        Validate whether the existing details exist in the persistent layer
-        or in the data warehouse.
-
-        Parameters
-        ----------
-        feature_store_name: str
-            feature store name
-        session_type: SourceType
-            session type
-        details: DatabaseDetails
-            database details
-        get_credential: Any
-            credential handler function
-
-        Returns
-        -------
-        ValidateStatus
-            The status of the validation
-        """
-        # Retrieve the feature store ID
-        users_feature_store_id = await self.get_feature_store_id_from_details(details)
-
-        # Check whether the feature store ID has been used in the data warehouse.
-        return await self.validate_feature_store_id_not_used_in_warehouse(
-            feature_store_name, session_type, details, get_credential, users_feature_store_id
-        )
-
     async def validate_feature_store_id_not_used_in_warehouse(
         self,
         feature_store_name: str,

--- a/featurebyte/service/session_validator.py
+++ b/featurebyte/service/session_validator.py
@@ -144,8 +144,8 @@ class SessionValidatorService:
         feature_store_name: str,
         session_type: SourceType,
         details: DatabaseDetails,
-        get_credential: Any,
         users_feature_store_id: Optional[PydanticObjectId],
+        get_credential: Any = None,
     ) -> ValidateStatus:
         """
         Validate whether the existing details exist in the persistent layer


### PR DESCRIPTION
## Description
We can simplify the get_credential logic during feature store creation, as we no longer look at the config for credentials. Instead, everything is passed in during the method call to create feature store, and we persist the credentials into mongo.

One longer term benefit of this, is that we can reduce the passing around of `get_credential`s through a lot of function calls, as the credentials should now always be accessible via the `MongoBackedCredentialProvider`. This is the first set of changes, as it is the most logically substantive one. Will follow-up with a few more PRs to remove further uses of `get_credential` if this looks good.
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
