### PR TITLE
[DEV-1943] Fix `JoinNode` operation structure extraction bug

### DIFF
--- a/.changelog/DEV-1943.yaml
+++ b/.changelog/DEV-1943.yaml
@@ -1,0 +1,16 @@
+# Type of change
+change_type: bug_fix
+
+# The name of the component
+component: feature
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.
+note: "fix view join operation bug which causes improper query graph pruning"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/featurebyte/api/item_view.py
+++ b/featurebyte/api/item_view.py
@@ -303,8 +303,9 @@ class ItemView(View, GroupByMixin, RawMixin):
         -------
         bool
         """
+        # FIXME: This method is may not work correctly when the column is from SCD table joined with EventTable
         operation_structure = self.graph.extract_operation_structure(
-            self.node, keep_all_source_columns=True
+            self.node, keep_all_source_columns=False
         )
         for column_name in column_names:
             column_structure = next(

--- a/featurebyte/query_graph/graph.py
+++ b/featurebyte/query_graph/graph.py
@@ -283,7 +283,7 @@ class QueryGraph(QueryGraphModel):
     def extract_operation_structure(
         self,
         node: Node,
-        keep_all_source_columns: bool,
+        keep_all_source_columns: bool = True,
         **kwargs: Any,
     ) -> OperationStructure:
         """

--- a/featurebyte/query_graph/node/generic.py
+++ b/featurebyte/query_graph/node/generic.py
@@ -1069,6 +1069,7 @@ class JoinNode(BasePrunableNode):
             for col in inputs[0].columns
             if col.name in left_col_map
         }
+        left_on_col = next(col for col in inputs[0].columns if col.name == self.parameters.left_on)
         right_columns = {}
         right_on_col = next(
             col for col in inputs[1].columns if col.name == self.parameters.right_on
@@ -1080,7 +1081,7 @@ class JoinNode(BasePrunableNode):
                     # so that any changes on the right_on column can be tracked.
                     right_columns[col.name] = DerivedDataColumn.create(
                         name=right_col_map[col.name],  # type: ignore
-                        columns=[right_on_col, col],
+                        columns=[right_on_col, col, left_on_col],
                         transform=self.transform_info,
                         node_name=self.name,
                         dtype=col.dtype,

--- a/featurebyte/query_graph/node/metadata/operation.py
+++ b/featurebyte/query_graph/node/metadata/operation.py
@@ -177,8 +177,8 @@ class BaseDerivedColumn(BaseColumn):
 
     @staticmethod
     def insert_column(
-        column_map: Dict[str, BaseDataColumn], column: BaseDataColumn
-    ) -> Dict[str, BaseDataColumn]:
+        column_map: Dict[Tuple[str, str], BaseDataColumn], column: BaseDataColumn
+    ) -> Dict[Tuple[str, str], BaseDataColumn]:
         """
         Insert column into dictionary. If more than more columns with the same name, aggregate the node names
         (make sure we don't miss any node which is used for pruning) and combine filter flag (take the max
@@ -186,20 +186,21 @@ class BaseDerivedColumn(BaseColumn):
 
         Parameters
         ----------
-        column_map: Dict[str, BaseDataColumn]
+        column_map: Dict[Tuple[str, str], BaseDataColumn]
             Dictionary map
         column: BaseDataColumn
             Data column object
 
         Returns
         -------
-        Dict[str, BaseDataColumn]
+        Dict[Tuple[str, str], BaseDataColumn]
         """
+        key = (column.name, column.node_name)
         if column.name not in column_map:
-            column_map[column.name] = column
+            column_map[key] = column
         else:
-            cur_col = column_map[column.name]
-            column_map[column.name] = column.clone(
+            cur_col = column_map[key]
+            column_map[key] = column.clone(
                 node_names=cur_col.node_names.union(column.node_names),
                 node_name=cur_col.node_name
                 if len(cur_col.node_names) > len(column.node_names)
@@ -212,7 +213,7 @@ class BaseDerivedColumn(BaseColumn):
     def _flatten_columns(
         cls, columns: Sequence[Union[BaseDataColumn, "BaseDerivedColumn"]]
     ) -> Tuple[Sequence[BaseDataColumn], List[str], Set[str]]:
-        col_map: Dict[str, BaseDataColumn] = {}
+        col_map: Dict[Tuple[str, str], BaseDataColumn] = {}
         transforms: List[str] = []
         node_names: Set[str] = set()
         for column in columns:

--- a/featurebyte/query_graph/node/metadata/operation.py
+++ b/featurebyte/query_graph/node/metadata/operation.py
@@ -196,7 +196,7 @@ class BaseDerivedColumn(BaseColumn):
         Dict[Tuple[str, str], BaseDataColumn]
         """
         key = (column.name, column.node_name)
-        if column.name not in column_map:
+        if key not in column_map:
             column_map[key] = column
         else:
             cur_col = column_map[key]
@@ -560,7 +560,7 @@ class OperationStructure:
         Tuple[List[AggregationColumn], List[PostAggregationColumn]],
     ]:
         _ = self
-        input_column_map: Dict[str, Any] = {}
+        input_column_map: Dict[Tuple[str, str], Any] = {}
         derived_column_map: Dict[Any, None] = {}
         for column in columns:
             if isinstance(column, (DerivedDataColumn, PostAggregationColumn)):

--- a/tests/integration/api/test_scd_view_operations.py
+++ b/tests/integration/api/test_scd_view_operations.py
@@ -243,6 +243,10 @@ async def test_feature_derived_from_multiple_scd_joins(session, data_source, sou
         {"POINT_IN_TIME": ["2022-04-25 10:00:00"], "customer_id": ["c1"]}
     )
     df = features.preview(df_observations)
+    expected = df_observations.copy()
+    expected["POINT_IN_TIME"] = pd.to_datetime(expected["POINT_IN_TIME"])
+    expected["state_code_counts_30d"] = '{\n  "A": 1\n}'
+    pd.testing.assert_frame_equal(df, expected)
 
 
 @pytest.mark.parametrize("source_type", ["snowflake", "spark", "databricks"], indirect=True)

--- a/tests/unit/api/test_feature_store.py
+++ b/tests/unit/api/test_feature_store.py
@@ -80,6 +80,7 @@ def test_list_tables(snowflake_connector, snowflake_execute_query, snowflake_fea
         "fixed_table",
         "non_scalar_table",
         "scd_table",
+        "scd_table_state_map",
         "dimension_table",
         "sf_view",
     ]

--- a/tests/unit/api/test_scd_view.py
+++ b/tests/unit/api/test_scd_view.py
@@ -3,10 +3,8 @@ Unit tests for SCDView class
 """
 import pytest
 
-from featurebyte.api.entity import Entity
 from featurebyte.api.scd_view import SCDView
 from featurebyte.exception import JoinViewMismatchError
-from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
 from tests.unit.api.base_view_test import BaseViewTestSuite, ViewType
 from tests.util.helper import check_sdk_code_generation, get_node
 
@@ -287,5 +285,11 @@ def test_aggregate_asat_sdk_code_generation(saved_scd_table, transaction_entity,
 
 def test_feature_derived_from_multiple_scd_joins(multiple_scd_joined_feature):
     """Test saving a feature derived from multiple SCD joins"""
-    # FIXME: this test is disabled because the feature is not saved
-    _ = multiple_scd_joined_feature
+    # check that the feature can be saved (pruning does not fail)
+    feat = multiple_scd_joined_feature
+    feat.save()
+
+    # check that table names are correct
+    feat_info = feat.info()
+    table_names = [table["name"] for table in feat_info["tables"]]
+    assert table_names == ["scd_table_state_map", "sf_scd_table", "sf_event_table"]

--- a/tests/unit/api/test_scd_view.py
+++ b/tests/unit/api/test_scd_view.py
@@ -1,12 +1,12 @@
 """
 Unit tests for SCDView class
 """
-import textwrap
-
 import pytest
 
+from featurebyte.api.entity import Entity
 from featurebyte.api.scd_view import SCDView
 from featurebyte.exception import JoinViewMismatchError
+from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
 from tests.unit.api.base_view_test import BaseViewTestSuite, ViewType
 from tests.util.helper import check_sdk_code_generation, get_node
 
@@ -283,3 +283,9 @@ def test_aggregate_asat_sdk_code_generation(saved_scd_table, transaction_entity,
         table_id=saved_scd_table.id,
         update_fixtures=update_fixtures,
     )
+
+
+def test_feature_derived_from_multiple_scd_joins(multiple_scd_joined_feature):
+    """Test saving a feature derived from multiple SCD joins"""
+    # FIXME: this test is disabled because the feature is not saved
+    _ = multiple_scd_joined_feature

--- a/tests/unit/query_graph/test_extract_operation_structure.py
+++ b/tests/unit/query_graph/test_extract_operation_structure.py
@@ -458,22 +458,31 @@ def test_extract_operation__join_node(
     if keep_all_source_columns:
         # include columns that affected the row index lineage
         def _get_other_params(column_name):
-            common_column_params = {
-                "table_id": None,
-                "table_type": "item_table",
-                "filter": False,
-                "type": "source",
-                "node_names": {"input_1"},
+            common_column_params = {"table_id": None, "filter": False, "type": "source"}
+            input_1_params = {
                 "node_name": "input_1",
+                "node_names": {"input_1"},
+                "table_type": "item_table",
+            }
+            input_2_params = {
+                "node_name": "input_2",
+                "node_names": {"input_2"},
+                "table_type": "event_table",
             }
             other_params = {
                 "columns": [
-                    {"name": "order_id", "dtype": "INT", **common_column_params},
-                    {"name": column_name, "dtype": "VARCHAR", **common_column_params},
+                    {"name": "order_id", "dtype": "INT", **common_column_params, **input_1_params},
+                    {
+                        "name": column_name,
+                        "dtype": "VARCHAR",
+                        **common_column_params,
+                        **input_1_params,
+                    },
+                    {"name": "order_id", "dtype": "INT", **common_column_params, **input_2_params},
                 ],
                 "filter": False,
                 "node_name": "join_1",
-                "node_names": {"input_1", "join_1"},
+                "node_names": {"input_1", "join_1", "input_2"},
                 "transforms": ["join"],
                 "type": "derived",
             }
@@ -881,7 +890,7 @@ def test_extract_operation__complicated_assignment_case_1(dataframe):
             {
                 "name": "TIMESTAMP_VALUE",
                 "dtype": "TIMESTAMP",
-                **extract_column_parameters(input_node, {"project_1", "project_3"}),
+                **extract_column_parameters(input_node, {"project_1"}),
             }
         ],
         "transforms": ["date_diff", "date_add"],
@@ -977,9 +986,7 @@ def test_extract_operation__complicated_assignment_case_2(dataframe):
                     {
                         "name": "CUST_ID",
                         "dtype": "INT",
-                        **extract_column_parameters(
-                            input_node, {"project_2", "input_1", "project_4"}
-                        ),
+                        **extract_column_parameters(input_node, {"input_1", "project_4"}),
                     },
                 ],
                 "filter": False,

--- a/tests/unit/query_graph/test_extract_operation_structure.py
+++ b/tests/unit/query_graph/test_extract_operation_structure.py
@@ -890,7 +890,7 @@ def test_extract_operation__complicated_assignment_case_1(dataframe):
             {
                 "name": "TIMESTAMP_VALUE",
                 "dtype": "TIMESTAMP",
-                **extract_column_parameters(input_node, {"project_1"}),
+                **extract_column_parameters(input_node, {"project_1", "project_3"}),
             }
         ],
         "transforms": ["date_diff", "date_add"],
@@ -986,7 +986,9 @@ def test_extract_operation__complicated_assignment_case_2(dataframe):
                     {
                         "name": "CUST_ID",
                         "dtype": "INT",
-                        **extract_column_parameters(input_node, {"input_1", "project_4"}),
+                        **extract_column_parameters(
+                            input_node, {"project_2", "input_1", "project_4"}
+                        ),
                     },
                 ],
                 "filter": False,

--- a/tests/unit/query_graph/test_graph_pruning.py
+++ b/tests/unit/query_graph/test_graph_pruning.py
@@ -224,6 +224,13 @@ def test_join_with_assign_node__join_node_parameters_pruning(
     )
 
     # expected values
+    common_column_params = {"filter": False, "table_id": None, "type": "source"}
+    input_1_params = {"node_name": "input_1", "node_names": {"input_1"}, "table_type": "item_table"}
+    input_2_params = {
+        "node_name": "input_2",
+        "node_names": {"input_2"},
+        "table_type": "event_table",
+    }
     expected_op_struct_columns = [
         {
             "dtype": "INT",
@@ -237,32 +244,15 @@ def test_join_with_assign_node__join_node_parameters_pruning(
         },
         {
             "columns": [
-                {
-                    "dtype": "INT",
-                    "filter": False,
-                    "name": "order_id",
-                    "node_name": "input_1",
-                    "node_names": {"input_1"},
-                    "table_id": None,
-                    "table_type": "item_table",
-                    "type": "source",
-                },
-                {
-                    "dtype": "VARCHAR",
-                    "filter": False,
-                    "name": "item_type",
-                    "node_name": "input_1",
-                    "node_names": {"input_1"},
-                    "table_id": None,
-                    "table_type": "item_table",
-                    "type": "source",
-                },
+                {"dtype": "INT", "name": "order_id", **common_column_params, **input_1_params},
+                {"dtype": "VARCHAR", "name": "item_type", **common_column_params, **input_1_params},
+                {"dtype": "INT", "name": "order_id", **common_column_params, **input_2_params},
             ],
             "dtype": "VARCHAR",
             "filter": False,
             "name": "item_type",
             "node_name": "join_1",
-            "node_names": {"join_1", "input_1"},
+            "node_names": {"join_1", "input_1", "input_2"},
             "transforms": ["join"],
             "type": "derived",
         },
@@ -382,7 +372,7 @@ def test_join_is_prunable(
     for i, name in enumerate(input_and_join_names):
         assert to_dict(op_struct.columns[i + 3], **kwargs) == {
             "name": name,
-            "node_names": {pruned_it_node.name, "join_1"},
+            "node_names": {pruned_it_node.name, "join_1", pruned_ev_node.name},
         }
 
     # check join node can be pruned

--- a/tests/unit/query_graph/test_metadata_operation.py
+++ b/tests/unit/query_graph/test_metadata_operation.py
@@ -149,16 +149,26 @@ def test_insert_column():
         DerivedDataColumn.insert_column({}, col1), another_col1
     )
     assert to_dict(col_map) == {
-        "col1": {
+        ("col1", "filter_1"): {
             "name": "col1",
-            "node_names": {"input_1", "project_1", "filter_1"},
+            "node_names": {"input_1", "filter_1"},
             "node_name": "filter_1",
             "table_id": None,
             "table_type": "event_table",
             "type": "source",
             "filter": True,
             "dtype": "FLOAT",
-        }
+        },
+        ("col1", "input_1"): {
+            "name": "col1",
+            "node_names": {"input_1", "project_1"},
+            "node_name": "input_1",
+            "table_id": None,
+            "table_type": "event_table",
+            "type": "source",
+            "filter": False,
+            "dtype": "FLOAT",
+        },
     }
 
 

--- a/tests/unit/session/test_snowflake_session.py
+++ b/tests/unit/session/test_snowflake_session.py
@@ -64,6 +64,7 @@ async def test_snowflake_session__credential_from_config(snowflake_session_dict)
         "fixed_table",
         "non_scalar_table",
         "scd_table",
+        "scd_table_state_map",
         "dimension_table",
         "sf_view",
     ]


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR aims to fix the bug when the feature is created with multiple SCD join. Due to the bug in `JoinNode`, wrong operation structure extraction causes improper graph pruning. This causes invalid graph is constructed after the graph is pruned.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
