### PR TITLE
[DEV-1845] Fix OnlineStoreComputeQuery prematurely deleted when still in use by other features

### DIFF
--- a/.changelog/DEV-1845.yaml
+++ b/.changelog/DEV-1845.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix OnlineStoreComputeQuery prematurely deleted when still in use by other features"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/query_graph/sql/online_store_compute_query.py
+++ b/featurebyte/query_graph/sql/online_store_compute_query.py
@@ -306,6 +306,16 @@ def get_online_store_precompute_queries(
     -------
     list[OnlineStoreComputeQueryModel]
     """
-    universe_plan = OnlineStorePrecomputePlan(graph, node, adapter=get_sql_adapter(source_type))
+    # Prune the graph to only include the aggregations that are required. This is necessary when
+    # this function is called from FeatureModel._add_tile_derived_attributes() root validator
+    # because the graph may not have been pruned yet.
+    pruned_graph_model, node_name_map = graph.prune(node)
+    pruned_node = pruned_graph_model.get_node_by_name(node_name_map[node.name])
+    pruned_graph, loaded_node_name_map = QueryGraph().load(pruned_graph_model)
+    pruned_node = pruned_graph.get_node_by_name(loaded_node_name_map[pruned_node.name])
+
+    universe_plan = OnlineStorePrecomputePlan(
+        pruned_graph, pruned_node, adapter=get_sql_adapter(source_type)
+    )
     queries = universe_plan.construct_online_store_precompute_queries(source_type=source_type)
     return queries

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -53,6 +53,7 @@ from featurebyte.routes.lazy_app_container import LazyAppContainer
 from featurebyte.routes.registry import app_container_config
 from featurebyte.schema.task import TaskStatus
 from featurebyte.schema.worker.task.base import BaseTaskPayload
+from featurebyte.service.online_store_compute_query_service import OnlineStoreComputeQueryService
 from featurebyte.service.online_store_table_version import OnlineStoreTableVersionService
 from featurebyte.service.task_manager import TaskManager
 from featurebyte.session.base_spark import BaseSparkSchemaInitializer
@@ -1460,7 +1461,7 @@ def tile_registry_service_fixture(app_container):
 
 
 @pytest.fixture(name="online_store_compute_query_service")
-def online_store_compute_query_service_fixture(app_container):
+def online_store_compute_query_service_fixture(app_container) -> OnlineStoreComputeQueryService:
     """
     Online store compute query service fixture
     """

--- a/tests/unit/api/test_feature.py
+++ b/tests/unit/api/test_feature.py
@@ -484,6 +484,7 @@ def test_get_feature(saved_feature):
         "user_defined_function_ids",
         "block_modification_by",
         "aggregation_ids",
+        "aggregation_result_names",
     }
 
     with pytest.raises(RecordRetrievalException) as exc:

--- a/tests/unit/models/test_feature.py
+++ b/tests/unit/models/test_feature.py
@@ -89,6 +89,9 @@ def test_feature_model(feature_model_dict, api_object_to_id):
         "user_defined_function_ids": [],
         "block_modification_by": [],
         "aggregation_ids": ["sum_aed233b0e8a6e1c1e0d5427b126b03c949609481"],
+        "aggregation_result_names": [
+            "_fb_internal_window_w1800_sum_aed233b0e8a6e1c1e0d5427b126b03c949609481"
+        ],
     }
 
 

--- a/tests/unit/query_graph/test_online_serving.py
+++ b/tests/unit/query_graph/test_online_serving.py
@@ -238,15 +238,8 @@ def test_complex_features(complex_feature_query_graph, update_fixtures):
     """
     node, graph = complex_feature_query_graph
 
-    # Prune graph to remove unused windows (in the actual code paths, graph is always pruned before
-    # any sql generation)
-    pruned_graph_model, node_name_map = graph.prune(node)
-    pruned_node = pruned_graph_model.get_node_by_name(node_name_map[node.name])
-    pruned_graph, loaded_node_name_map = QueryGraph().load(pruned_graph_model)
-    pruned_node = pruned_graph.get_node_by_name(loaded_node_name_map[pruned_node.name])
-
     # Check precompute sqls
-    queries = get_online_store_precompute_queries(pruned_graph, pruned_node, SourceType.SNOWFLAKE)
+    queries = get_online_store_precompute_queries(graph, node, SourceType.SNOWFLAKE)
     assert len(queries) == 2
     expected_query_params_tile_1 = {
         "tile_id": "TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725",
@@ -286,6 +279,13 @@ def test_complex_features(complex_feature_query_graph, update_fixtures):
         "tests/fixtures/expected_online_precompute_complex_1.sql",
         update_fixture=update_fixtures,
     )
+
+    # Prune graph to remove unused windows (in the actual code paths, graph is always pruned before
+    # any sql generation)
+    pruned_graph_model, node_name_map = graph.prune(node)
+    pruned_node = pruned_graph_model.get_node_by_name(node_name_map[node.name])
+    pruned_graph, loaded_node_name_map = QueryGraph().load(pruned_graph_model)
+    pruned_node = pruned_graph.get_node_by_name(loaded_node_name_map[pruned_node.name])
 
     # Check retrieval sql
     sql = get_online_store_retrieval_sql(


### PR DESCRIPTION
## Description

This fixes an issue where `OnlineStoreComputeQuery` can sometimes be prematurely deleted when still in use by other features. The `FeatureModel` is updated to keep track of the list of `aggregation_result_names` associated with the feature.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
