### PR TITLE
[DEV-1946] Ensure FeatureModel's derived attributes are derived from pruned graph

### DIFF
--- a/.changelog/DEV-1946.yaml
+++ b/.changelog/DEV-1946.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Ensure FeatureModel's derived attributes are derived from pruned graph"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/models/feature.py
+++ b/featurebyte/models/feature.py
@@ -70,7 +70,10 @@ class BaseFeatureModel(FeatureByteCatalogBaseDocumentModel):
         if any(not x for x in derived_attributes):
             # only derive attributes if any of them is missing
             # extract table ids & entity ids from the graph
-            graph = QueryGraph(**values["internal_graph"])
+            graph_dict = values["internal_graph"]
+            if isinstance(graph_dict, QueryGraphModel):
+                graph_dict = graph_dict.dict(by_alias=True)
+            graph = QueryGraph(**graph_dict)
             node_name = values["node_name"]
             values["primary_table_ids"] = graph.get_primary_table_ids(node_name=node_name)
             values["table_ids"] = graph.get_table_ids(node_name=node_name)

--- a/featurebyte/query_graph/sql/online_store_compute_query.py
+++ b/featurebyte/query_graph/sql/online_store_compute_query.py
@@ -306,16 +306,6 @@ def get_online_store_precompute_queries(
     -------
     list[OnlineStoreComputeQueryModel]
     """
-    # Prune the graph to only include the aggregations that are required. This is necessary when
-    # this function is called from FeatureModel._add_tile_derived_attributes() root validator
-    # because the graph may not have been pruned yet.
-    pruned_graph_model, node_name_map = graph.prune(node)
-    pruned_node = pruned_graph_model.get_node_by_name(node_name_map[node.name])
-    pruned_graph, loaded_node_name_map = QueryGraph().load(pruned_graph_model)
-    pruned_node = pruned_graph.get_node_by_name(loaded_node_name_map[pruned_node.name])
-
-    universe_plan = OnlineStorePrecomputePlan(
-        pruned_graph, pruned_node, adapter=get_sql_adapter(source_type)
-    )
+    universe_plan = OnlineStorePrecomputePlan(graph, node, adapter=get_sql_adapter(source_type))
     queries = universe_plan.construct_online_store_precompute_queries(source_type=source_type)
     return queries

--- a/featurebyte/service/feature.py
+++ b/featurebyte/service/feature.py
@@ -68,9 +68,9 @@ class FeatureService(BaseNamespaceService[FeatureModel, FeatureServiceCreate]):
         data_dict = data.dict(by_alias=True)
         graph = QueryGraph(**data_dict.pop("graph"))
         node = graph.get_node_by_name(data_dict.pop("node_name"))
-        # Prepare the graph to store. This performs the necessary pruning steps to ensure the graph
-        # does not contain unnecessary operations.
-        graph, node_name = await self.namespace_handler.prepare_graph_to_store(
+        # Prepare the graph to store. This performs the required pruning steps to remove any
+        # unnecessary operations or parameters from the graph.
+        prepared_graph, prepared_node_name = await self.namespace_handler.prepare_graph_to_store(
             graph=graph,
             node=node,
             sanitize_for_definition=sanitize_for_definition,
@@ -78,8 +78,8 @@ class FeatureService(BaseNamespaceService[FeatureModel, FeatureServiceCreate]):
         return FeatureModel(
             **{
                 **data_dict,
-                "graph": graph,
-                "node_name": node_name,
+                "graph": prepared_graph,
+                "node_name": prepared_node_name,
                 "readiness": FeatureReadiness.DRAFT,
                 "version": await self.get_document_version(data.name),
                 "user_id": self.user.id,

--- a/featurebyte/service/namespace_handler.py
+++ b/featurebyte/service/namespace_handler.py
@@ -92,7 +92,10 @@ class NamespaceHandler:
         -------
         QueryGraphModel
         """
-        # reconstruct view graph node to remove unused column cleaning operations
+        # Using a pruned graph, reconstruct view graph node to remove unused column cleaning
+        # operations
+        graph, node_name_map = QueryGraph(**graph.dict(by_alias=True)).prune(target_node=node)
+        node = graph.get_node_by_name(node_name_map[node.name])
         constructed_graph, node_name_map = await self.view_construction_service.construct_graph(
             query_graph=graph,
             target_node=node,
@@ -100,7 +103,7 @@ class NamespaceHandler:
         )
         node = constructed_graph.get_node_by_name(node_name_map[node.name])
 
-        # prune the graph to remove unused nodes
+        # Prune the graph to remove unused nodes and parameters
         pruned_graph, pruned_node_name_map = QueryGraph(
             **constructed_graph.dict(by_alias=True)
         ).prune(target_node=node)

--- a/tests/unit/models/test_feature.py
+++ b/tests/unit/models/test_feature.py
@@ -90,7 +90,9 @@ def test_feature_model(feature_model_dict, api_object_to_id):
         "block_modification_by": [],
         "aggregation_ids": ["sum_aed233b0e8a6e1c1e0d5427b126b03c949609481"],
         "aggregation_result_names": [
-            "_fb_internal_window_w1800_sum_aed233b0e8a6e1c1e0d5427b126b03c949609481"
+            "_fb_internal_window_w1800_sum_aed233b0e8a6e1c1e0d5427b126b03c949609481",
+            "_fb_internal_window_w7200_sum_aed233b0e8a6e1c1e0d5427b126b03c949609481",
+            "_fb_internal_window_w86400_sum_aed233b0e8a6e1c1e0d5427b126b03c949609481",
         ],
     }
 

--- a/tests/unit/routes/test_feature.py
+++ b/tests/unit/routes/test_feature.py
@@ -857,3 +857,15 @@ class TestFeatureApi(BaseCatalogApiTestSuite):
         # check feature is not created
         response = test_api_client.get(f"{self.base_route}/{feature_create.id}")
         assert response.status_code == HTTPStatus.NOT_FOUND
+
+    def test_aggregation_result_names_based_on_pruned_graph(self, create_success_response):
+        """
+        Test that aggregation_result_names are derived based on pruned graph.
+
+        The feature_sum_30m.json fixture's groupby node has unpruned parameters. If the
+        aggregation_result_names is derived from the graph directly without pruning, there will be
+        multiple items in aggregation_result_names which is wrong for this feature.
+        """
+        assert create_success_response.json()["aggregation_result_names"] == [
+            "_fb_internal_window_w1800_sum_aed233b0e8a6e1c1e0d5427b126b03c949609481"
+        ]


### PR DESCRIPTION
## Description

This updates the logic in `FeatureService.prepare_feature_model()` and `NamespaceHandler.prepare_graph_to_store()` to ensure that FeatureModel's derived attributes are derived from a fully pruned graph. 

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
