### PR TITLE
[chore] Add --ignore-vuln PYSEC-2023-112 temporarily

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -171,7 +171,7 @@ tasks:
       - featurebyte/**/*
     cmds:
       - poetry run pip-licenses --packages '{{ .PACKAGES }}' --allow-only='{{ .PERMISSIVE_LICENSES }}'
-      - poetry run pip-audit --ignore-vuln GHSA-5cpq-8wj7-hf2v --ignore-vuln PYSEC-2023-73 --ignore-vuln GHSA-9jx5-6pgf-crrp --ignore-vuln PYSEC-2023-102
+      - poetry run pip-audit --ignore-vuln GHSA-5cpq-8wj7-hf2v --ignore-vuln PYSEC-2023-73 --ignore-vuln GHSA-9jx5-6pgf-crrp --ignore-vuln PYSEC-2023-102 --ignore-vuln PYSEC-2023-112
 
   lint-bandit:
     desc: "Run the linter[bandit]"


### PR DESCRIPTION
## Description

Add --ignore-vuln PYSEC-2023-112 temporarily to unblock publish workflow.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
