### PR TITLE
[DEV-1959] Fix TABLESAMPLE syntax error in Spark for very small sample percentage

### DIFF
--- a/.changelog/DEV-1959.yaml
+++ b/.changelog/DEV-1959.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix TABLESAMPLE syntax error in Spark for very small sample percentage"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/query_graph/sql/adapter/base.py
+++ b/featurebyte/query_graph/sql/adapter/base.py
@@ -7,6 +7,7 @@ from typing import Literal, Optional
 
 from abc import abstractmethod
 
+from numpy import format_float_positional
 from sqlglot import expressions
 from sqlglot.expressions import Expression, Select, alias_, select
 
@@ -468,7 +469,11 @@ class BaseAdapter:  # pylint: disable=too-many-public-methods
         # Need to perform syntax tree surgery this way since TABLESAMPLE needs to be attached to the
         # FROM clause so that the result is still a SELECT expression. This way we can do things
         # like limit(), subquery() etc on the result.
-        params = {cls.TABLESAMPLE_PERCENT_KEY: make_literal_value(sample_percent)}
+        params = {
+            cls.TABLESAMPLE_PERCENT_KEY: expressions.Literal(
+                this=format_float_positional(sample_percent, trim="-"), is_string=False
+            )
+        }
         tablesample_expr = expressions.TableSample(
             this=nested_select_expr.args["from"].expressions[0], **params
         )

--- a/tests/unit/api/test_event_view.py
+++ b/tests/unit/api/test_event_view.py
@@ -853,7 +853,7 @@ def test_create_observation_table_from_event_view__with_sample(
               "cust_id" AS "cust_id"
             FROM "sf_database"."sf_schema"."sf_table"
           )
-        ) TABLESAMPLE(14.0)
+        ) TABLESAMPLE(14)
         LIMIT 100
         """,
     )

--- a/tests/unit/api/test_source_table.py
+++ b/tests/unit/api/test_source_table.py
@@ -249,7 +249,7 @@ def test_create_observation_table_with_sample_rows(
           SELECT
             *
           FROM "sf_database"."sf_schema"."sf_table"
-        ) TABLESAMPLE(14.0)
+        ) TABLESAMPLE(14)
         LIMIT 100
         """,
     )


### PR DESCRIPTION
## Description

This fixes an error that occurs when creating observation table using a very small sample percentage. When the sample percentage is formatted using scientific notation, it causes a syntax error in Spark.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
