### PR TITLE
[DEV-1914] service/target: refactor compute target and compute historical features

### DIFF
--- a/.changelog/DEV-1914.yaml
+++ b/.changelog/DEV-1914.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: target
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Refactor compute_target and compute_historical_feature"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -97,7 +97,7 @@ from featurebyte.service.table_columns_info import TableColumnsInfoService
 from featurebyte.service.table_info import TableInfoService
 from featurebyte.service.table_status import TableStatusService
 from featurebyte.service.target import TargetService
-from featurebyte.service.target_helper.compute_target import TargetComputer
+from featurebyte.service.target_helper.compute_target import TargetComputer, TargetExecutor
 from featurebyte.service.target_namespace import TargetNamespaceService
 from featurebyte.service.target_table import TargetTableService
 from featurebyte.service.task_manager import TaskManager
@@ -218,10 +218,13 @@ app_container_config.register_class(
 app_container_config.register_class(TableInfoService)
 app_container_config.register_class(TableService)
 app_container_config.register_class(TableStatusService)
-app_container_config.register_class(TargetComputer)
+app_container_config.register_class(
+    TargetComputer, dependency_override={"query_executor": "target_executor"}
+)
 app_container_config.register_class(
     TargetController, dependency_override={"service": "target_service"}
 )
+app_container_config.register_class(TargetExecutor)
 app_container_config.register_class(TargetService)
 app_container_config.register_class(
     TargetNamespaceController, dependency_override={"service": "target_namespace_service"}

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -97,6 +97,7 @@ from featurebyte.service.table_columns_info import TableColumnsInfoService
 from featurebyte.service.table_info import TableInfoService
 from featurebyte.service.table_status import TableStatusService
 from featurebyte.service.target import TargetService
+from featurebyte.service.target_helper.compute_target import TargetComputer
 from featurebyte.service.target_namespace import TargetNamespaceService
 from featurebyte.service.target_table import TargetTableService
 from featurebyte.service.task_manager import TaskManager
@@ -217,6 +218,7 @@ app_container_config.register_class(
 app_container_config.register_class(TableInfoService)
 app_container_config.register_class(TableService)
 app_container_config.register_class(TableStatusService)
+app_container_config.register_class(TargetComputer)
 app_container_config.register_class(
     TargetController, dependency_override={"service": "target_service"}
 )

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -74,7 +74,10 @@ from featurebyte.service.feature_readiness import FeatureReadinessService
 from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.service.feature_store_warehouse import FeatureStoreWarehouseService
 from featurebyte.service.historical_feature_table import HistoricalFeatureTableService
-from featurebyte.service.historical_features import HistoricalFeaturesService
+from featurebyte.service.historical_features import (
+    HistoricalFeatureExecutor,
+    HistoricalFeaturesService,
+)
 from featurebyte.service.item_table import ItemTableService
 from featurebyte.service.namespace_handler import NamespaceHandler
 from featurebyte.service.observation_table import ObservationTableService
@@ -174,9 +177,12 @@ app_container_config.register_class(FeatureReadinessService)
 app_container_config.register_class(FeatureStoreController)
 app_container_config.register_class(FeatureStoreService)
 app_container_config.register_class(FeatureStoreWarehouseService)
+app_container_config.register_class(HistoricalFeatureExecutor)
 app_container_config.register_class(HistoricalFeatureTableController)
 app_container_config.register_class(HistoricalFeatureTableService)
-app_container_config.register_class(HistoricalFeaturesService)
+app_container_config.register_class(
+    HistoricalFeaturesService, dependency_override={"query_executor": "historical_feature_executor"}
+)
 app_container_config.register_class(ItemTableController)
 app_container_config.register_class(ItemTableService)
 app_container_config.register_class(MongoBackedCredentialProvider)

--- a/featurebyte/schema/common/feature_or_target.py
+++ b/featurebyte/schema/common/feature_or_target.py
@@ -18,3 +18,9 @@ class FeatureOrTargetTableCreate(FeatureByteBaseModel):
     name: StrictStr
     feature_store_id: PydanticObjectId
     observation_table_id: Optional[PydanticObjectId]
+
+
+class ComputeRequest(FeatureByteBaseModel):
+    """
+    Compute request
+    """

--- a/featurebyte/schema/common/feature_or_target.py
+++ b/featurebyte/schema/common/feature_or_target.py
@@ -1,7 +1,7 @@
 """
 Feature or target schema
 """
-from typing import Optional
+from typing import Dict, Optional
 
 from bson import ObjectId
 from pydantic import Field, StrictStr
@@ -24,3 +24,5 @@ class ComputeRequest(FeatureByteBaseModel):
     """
     Compute request
     """
+
+    serving_names_mapping: Optional[Dict[str, str]]

--- a/featurebyte/schema/feature_list.py
+++ b/featurebyte/schema/feature_list.py
@@ -165,7 +165,6 @@ class FeatureListGetHistoricalFeatures(ComputeRequest):
     """
 
     feature_clusters: List[FeatureCluster]
-    serving_names_mapping: Optional[Dict[str, str]]
     feature_list_id: Optional[PydanticObjectId]
 
 

--- a/featurebyte/schema/feature_list.py
+++ b/featurebyte/schema/feature_list.py
@@ -19,6 +19,7 @@ from featurebyte.models.feature_list import (
 )
 from featurebyte.query_graph.node.validator import construct_unique_name_validator
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema, PaginationMixin
+from featurebyte.schema.common.feature_or_target import ComputeRequest
 from featurebyte.schema.feature import BatchFeatureCreate, BatchFeatureCreatePayload
 
 
@@ -158,7 +159,7 @@ class FeatureListPreview(FeatureListSQL):
     point_in_time_and_serving_name_list: List[Dict[str, Any]] = Field(min_items=1, max_items=50)
 
 
-class FeatureListGetHistoricalFeatures(FeatureByteBaseModel):
+class FeatureListGetHistoricalFeatures(ComputeRequest):
     """
     FeatureList get historical features schema
     """

--- a/featurebyte/schema/target.py
+++ b/featurebyte/schema/target.py
@@ -21,6 +21,7 @@ from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.query_graph.model.common_table import TabularSource
 from featurebyte.query_graph.node import Node
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema, PaginationMixin
+from featurebyte.schema.common.feature_or_target import ComputeRequest
 from featurebyte.schema.info import EntityBriefInfoList
 
 
@@ -84,12 +85,6 @@ class TargetInfo(FeatureByteBaseModel):
     updated_at: Optional[datetime]
     input_data: InputData
     metadata: Any
-
-
-class ComputeRequest(FeatureByteBaseModel):
-    """
-    Compute request
-    """
 
 
 class ComputeTargetRequest(ComputeRequest):

--- a/featurebyte/schema/target.py
+++ b/featurebyte/schema/target.py
@@ -86,7 +86,13 @@ class TargetInfo(FeatureByteBaseModel):
     metadata: Any
 
 
-class ComputeTargetRequest(FeatureByteBaseModel):
+class ComputeRequest(FeatureByteBaseModel):
+    """
+    Compute request
+    """
+
+
+class ComputeTargetRequest(ComputeRequest):
     """
     Compute target request schema
     """

--- a/featurebyte/schema/target.py
+++ b/featurebyte/schema/target.py
@@ -3,7 +3,7 @@ Target API payload schema
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from datetime import datetime
 
@@ -95,7 +95,6 @@ class ComputeTargetRequest(ComputeRequest):
     feature_store_id: PydanticObjectId
     graph: QueryGraph
     node_names: List[StrictStr]
-    serving_names_mapping: Optional[Dict[str, str]]
     target_id: Optional[PydanticObjectId]
 
     @property

--- a/featurebyte/service/historical_features.py
+++ b/featurebyte/service/historical_features.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Any, Callable, Optional, Union
 
 import time
+from dataclasses import dataclass
 
 import pandas as pd
 from bson import ObjectId
@@ -32,11 +33,18 @@ from featurebyte.query_graph.sql.feature_historical import (
     validate_request_schema,
 )
 from featurebyte.query_graph.sql.parent_serving import construct_request_table_with_parent_entities
+from featurebyte.routes.common.feature_or_target_table import ValidationParameters
 from featurebyte.schema.feature_list import FeatureListGetHistoricalFeatures
 from featurebyte.service.entity_validation import EntityValidationService
 from featurebyte.service.feature_list import FeatureListService
 from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.service.session_manager import SessionManagerService
+from featurebyte.service.target_helper.base_feature_or_target_computer import (
+    BasicExecutorParams,
+    Computer,
+    ExecutorParams,
+    QueryExecutor,
+)
 from featurebyte.service.tile_cache import TileCacheService
 from featurebyte.session.base import BaseSession
 
@@ -245,7 +253,45 @@ async def get_historical_features(  # pylint: disable=too-many-locals, too-many-
     logger.debug(f"compute_historical_features in total took {time.time() - tic_:.2f}s")
 
 
-class HistoricalFeaturesService:
+@dataclass
+class HistoricalFeatureExecutorParams(ExecutorParams):
+    """
+    Historical feature executor params
+    """
+
+    # Whether the feature list that triggered this historical request is deployed. If so, tile
+    # tables would have already been back-filled and there is no need to check and calculate tiles
+    # on demand.
+    is_feature_list_deployed: bool = False
+
+
+class HistoricalFeatureExecutor(QueryExecutor[HistoricalFeatureExecutorParams]):
+    """
+    Historical feature Executor
+    """
+
+    def __init__(self, tile_cache_service: TileCacheService):
+        self.tile_cache_service = tile_cache_service
+
+    async def execute(self, executor_params: HistoricalFeatureExecutorParams) -> None:
+        await get_historical_features(
+            session=executor_params.session,
+            tile_cache_service=self.tile_cache_service,
+            graph=executor_params.graph,
+            nodes=executor_params.nodes,
+            observation_set=executor_params.observation_set,
+            serving_names_mapping=executor_params.serving_names_mapping,
+            feature_store=executor_params.feature_store,
+            is_feature_list_deployed=executor_params.is_feature_list_deployed,
+            parent_serving_preparation=executor_params.parent_serving_preparation,
+            output_table_details=executor_params.output_table_details,
+            progress_callback=executor_params.progress_callback,
+        )
+
+
+class HistoricalFeaturesService(
+    Computer[FeatureListGetHistoricalFeatures, HistoricalFeatureExecutorParams]
+):
     """
     HistoricalFeaturesService is responsible for requesting for historical features for a Feature List.
     """
@@ -255,69 +301,42 @@ class HistoricalFeaturesService:
         feature_store_service: FeatureStoreService,
         entity_validation_service: EntityValidationService,
         session_manager_service: SessionManagerService,
+        query_executor: QueryExecutor[HistoricalFeatureExecutorParams],
         feature_list_service: FeatureListService,
-        tile_cache_service: TileCacheService,
     ):
-        self.feature_store_service = feature_store_service
-        self.entity_validation_service = entity_validation_service
-        self.session_manager_service = session_manager_service
+        super().__init__(
+            feature_store_service,
+            entity_validation_service,
+            session_manager_service,
+            query_executor,
+        )
         self.feature_list_service = feature_list_service
-        self.tile_cache_service = tile_cache_service
 
-    async def compute_historical_features(
-        self,
-        observation_set: Union[pd.DataFrame, ObservationTableModel],
-        featurelist_get_historical_features: FeatureListGetHistoricalFeatures,
-        get_credential: Any,
-        output_table_details: TableDetails,
-        progress_callback: Optional[Callable[[int, str], None]] = None,
-    ) -> None:
-        """
-        Get historical features for Feature List
-
-        Parameters
-        ----------
-        observation_set: pd.DataFrame
-            Observation set data
-        featurelist_get_historical_features: FeatureListGetHistoricalFeatures
-            FeatureListGetHistoricalFeatures object
-        get_credential: Any
-            Get credential handler function
-        output_table_details: TableDetails
-            Table details to write the results to
-        progress_callback: Optional[Callable[[int, str], None]]
-            Optional progress callback function
-        """
+    async def get_validation_parameters(
+        self, request: FeatureListGetHistoricalFeatures
+    ) -> ValidationParameters:
         # multiple feature stores not supported
-        feature_clusters = featurelist_get_historical_features.feature_clusters
+        feature_clusters = request.feature_clusters
         assert len(feature_clusters) == 1
 
         feature_cluster = feature_clusters[0]
         feature_store = await self.feature_store_service.get_document(
             document_id=feature_cluster.feature_store_id
         )
-
-        if isinstance(observation_set, pd.DataFrame):
-            request_column_names = set(observation_set.columns)
-        else:
-            request_column_names = {col.name for col in observation_set.columns_info}
-
-        parent_serving_preparation = (
-            await self.entity_validation_service.validate_entities_or_prepare_for_parent_serving(
-                graph=feature_cluster.graph,
-                nodes=feature_cluster.nodes,
-                request_column_names=request_column_names,
-                feature_store=feature_store,
-                serving_names_mapping=featurelist_get_historical_features.serving_names_mapping,
-            )
-        )
-
-        db_session = await self.session_manager_service.get_feature_store_session(
+        return ValidationParameters(
+            graph=feature_cluster.graph,
+            nodes=feature_cluster.nodes,
             feature_store=feature_store,
-            get_credential=get_credential,
+            serving_names_mapping=request.serving_names_mapping,
         )
 
-        feature_list_id = featurelist_get_historical_features.feature_list_id
+    async def get_executor_params(
+        self,
+        request: FeatureListGetHistoricalFeatures,
+        basic_executor_params: BasicExecutorParams,
+        validation_parameters: ValidationParameters,
+    ) -> HistoricalFeatureExecutorParams:
+        feature_list_id = request.feature_list_id
         try:
             if feature_list_id is None:
                 is_feature_list_deployed = False
@@ -327,16 +346,15 @@ class HistoricalFeaturesService:
         except DocumentNotFoundError:
             is_feature_list_deployed = False
 
-        await get_historical_features(
-            session=db_session,
-            tile_cache_service=self.tile_cache_service,
-            graph=feature_cluster.graph,
-            nodes=feature_cluster.nodes,
-            observation_set=observation_set,
-            serving_names_mapping=featurelist_get_historical_features.serving_names_mapping,
-            feature_store=feature_store,
+        return HistoricalFeatureExecutorParams(
+            session=basic_executor_params.session,
+            output_table_details=basic_executor_params.output_table_details,
+            parent_serving_preparation=basic_executor_params.parent_serving_preparation,
+            progress_callback=basic_executor_params.progress_callback,
+            observation_set=basic_executor_params.observation_set,
+            graph=validation_parameters.graph,
+            nodes=validation_parameters.nodes,
+            serving_names_mapping=validation_parameters.serving_names_mapping,
+            feature_store=validation_parameters.feature_store,
             is_feature_list_deployed=is_feature_list_deployed,
-            parent_serving_preparation=parent_serving_preparation,
-            output_table_details=output_table_details,
-            progress_callback=progress_callback,
         )

--- a/featurebyte/service/historical_features.py
+++ b/featurebyte/service/historical_features.py
@@ -3,7 +3,7 @@ HistoricalFeaturesService
 """
 from __future__ import annotations
 
-from typing import Any, Callable, Optional, Union
+from typing import Callable, Optional, Union
 
 import time
 from dataclasses import dataclass

--- a/featurebyte/service/target_helper/base_feature_or_target_computer.py
+++ b/featurebyte/service/target_helper/base_feature_or_target_computer.py
@@ -1,6 +1,8 @@
 """
 Base class for feature or target computer
 """
+from __future__ import annotations
+
 from typing import Any, Callable, Generic, List, Optional, TypeVar, Union
 
 from abc import abstractmethod

--- a/featurebyte/service/target_helper/base_feature_or_target_computer.py
+++ b/featurebyte/service/target_helper/base_feature_or_target_computer.py
@@ -1,0 +1,191 @@
+"""
+Base class for feature or target computer
+"""
+from typing import Any, Callable, Generic, List, Optional, TypeVar, Union
+
+from abc import abstractmethod
+from dataclasses import dataclass
+
+import pandas as pd
+
+from featurebyte.models import FeatureStoreModel
+from featurebyte.models.observation_table import ObservationTableModel
+from featurebyte.models.parent_serving import ParentServingPreparation
+from featurebyte.query_graph.graph import QueryGraph
+from featurebyte.query_graph.node import Node
+from featurebyte.query_graph.node.schema import TableDetails
+from featurebyte.routes.common.feature_or_target_table import ValidationParameters
+from featurebyte.schema.target import ComputeRequest
+from featurebyte.service.entity_validation import EntityValidationService
+from featurebyte.service.feature_store import FeatureStoreService
+from featurebyte.service.session_manager import SessionManagerService
+from featurebyte.session.base import BaseSession
+
+ComputeRequestT = TypeVar("ComputeRequestT", bound=ComputeRequest)
+
+
+@dataclass
+class BasicExecutorParams:
+    """
+    Basic executor params
+    """
+
+    # Observation set
+    observation_set: Union[pd.DataFrame, ObservationTableModel]
+    # Session to use to make queries
+    session: BaseSession
+    # Output table details to write the results to
+    output_table_details: TableDetails
+    # Preparation required for serving parent features
+    parent_serving_preparation: Optional[ParentServingPreparation]
+    # Optional progress callback function)
+    progress_callback: Optional[Callable[[int, str], None]]
+
+
+@dataclass
+class ExecutorParams(BasicExecutorParams):
+    """
+    Executor params
+    """
+
+    # Query graph
+    graph: QueryGraph
+    # List of query graph node
+    nodes: List[Node]
+    # Feature store. We need the feature store id and source type information.
+    feature_store: FeatureStoreModel
+    # Optional serving names mapping if the observations set has different serving name columns
+    # than those defined in Entities
+    serving_names_mapping: Optional[dict[str, str]] = None
+
+
+ExecutorParamsT = TypeVar("ExecutorParamsT", bound=ExecutorParams)
+
+
+class QueryExecutor(Generic[ExecutorParamsT]):
+    """
+    Query executor
+    """
+
+    @abstractmethod
+    async def execute(self, executor_params: ExecutorParamsT) -> None:
+        """
+        Execute queries
+
+        Parameters
+        ----------
+        executor_params: ExecutorParamsT
+            Executor parameters
+        """
+
+
+class Computer(Generic[ComputeRequestT, ExecutorParamsT]):
+    """
+    Base target or feature computer
+    """
+
+    def __init__(
+        self,
+        feature_store_service: FeatureStoreService,
+        entity_validation_service: EntityValidationService,
+        session_manager_service: SessionManagerService,
+        query_executor: QueryExecutor[ExecutorParamsT],
+    ):
+        self.feature_store_service = feature_store_service
+        self.entity_validation_service = entity_validation_service
+        self.session_manager_service = session_manager_service
+        self.query_executor = query_executor
+
+    @abstractmethod
+    async def get_validation_parameters(self, request: ComputeRequestT) -> ValidationParameters:
+        """
+        Get validation parameters
+
+        Parameters
+        ----------
+        request: ComputeRequestT
+            Compute request
+
+        Returns
+        -------
+        ValidationParameters
+            Validation parameters
+        """
+
+    @abstractmethod
+    async def get_executor_params(
+        self,
+        basic_executor_params: BasicExecutorParams,
+        validation_parameters: ValidationParameters,
+    ) -> ExecutorParamsT:
+        """
+        Get executor parameters
+
+        Parameters
+        ----------
+        basic_executor_params: BasicExecutorParams
+            Basic executor parameters
+        validation_parameters: ValidationParameters
+            Validation parameters
+
+        Returns
+        -------
+        ExecutorParamsT
+            Executor parameters
+        """
+
+    async def compute(
+        self,
+        observation_set: Union[pd.DataFrame, ObservationTableModel],
+        compute_request: ComputeRequestT,
+        get_credential: Any,
+        output_table_details: TableDetails,
+        progress_callback: Optional[Callable[[int, str], None]] = None,
+    ):
+        """
+        Compute targets or features
+
+        Parameters
+        ----------
+        observation_set: pd.DataFrame
+            Observation set data
+        compute_request: ComputeRequest
+            Compute request
+        get_credential: Any
+            Get credential handler function
+        output_table_details: TableDetails
+            Table details to write the results to
+        progress_callback: Optional[Callable[[int, str], None]]
+            Optional progress callback function
+        """
+        validation_parameters = await self.get_validation_parameters(compute_request)
+
+        if isinstance(observation_set, pd.DataFrame):
+            request_column_names = set(observation_set.columns)
+        else:
+            request_column_names = {col.name for col in observation_set.columns_info}
+
+        parent_serving_preparation = (
+            await self.entity_validation_service.validate_entities_or_prepare_for_parent_serving(
+                graph=validation_parameters.graph,
+                nodes=validation_parameters.nodes,
+                request_column_names=request_column_names,
+                feature_store=validation_parameters.feature_store,
+                serving_names_mapping=validation_parameters.serving_names_mapping,
+            )
+        )
+        db_session = await self.session_manager_service.get_feature_store_session(
+            feature_store=validation_parameters.feature_store,
+            get_credential=get_credential,
+        )
+        params = await self.get_executor_params(
+            basic_executor_params=BasicExecutorParams(
+                session=db_session,
+                output_table_details=output_table_details,
+                parent_serving_preparation=parent_serving_preparation,
+                progress_callback=progress_callback,
+                observation_set=observation_set,
+            ),
+            validation_parameters=validation_parameters,
+        )
+        await self.query_executor.execute(params)

--- a/featurebyte/service/target_helper/base_feature_or_target_computer.py
+++ b/featurebyte/service/target_helper/base_feature_or_target_computer.py
@@ -115,6 +115,7 @@ class Computer(Generic[ComputeRequestT, ExecutorParamsT]):
     @abstractmethod
     async def get_executor_params(
         self,
+        request: ComputeRequestT,
         basic_executor_params: BasicExecutorParams,
         validation_parameters: ValidationParameters,
     ) -> ExecutorParamsT:
@@ -123,6 +124,8 @@ class Computer(Generic[ComputeRequestT, ExecutorParamsT]):
 
         Parameters
         ----------
+        request: ComputeRequestT
+            Compute request
         basic_executor_params: BasicExecutorParams
             Basic executor parameters
         validation_parameters: ValidationParameters
@@ -179,6 +182,7 @@ class Computer(Generic[ComputeRequestT, ExecutorParamsT]):
             get_credential=get_credential,
         )
         params = await self.get_executor_params(
+            request=compute_request,
             basic_executor_params=BasicExecutorParams(
                 session=db_session,
                 output_table_details=output_table_details,

--- a/featurebyte/service/target_helper/base_feature_or_target_computer.py
+++ b/featurebyte/service/target_helper/base_feature_or_target_computer.py
@@ -10,14 +10,14 @@ from dataclasses import dataclass
 
 import pandas as pd
 
-from featurebyte.models import FeatureStoreModel
+from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.models.observation_table import ObservationTableModel
 from featurebyte.models.parent_serving import ParentServingPreparation
 from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.query_graph.node import Node
 from featurebyte.query_graph.node.schema import TableDetails
 from featurebyte.routes.common.feature_or_target_table import ValidationParameters
-from featurebyte.schema.target import ComputeRequest
+from featurebyte.schema.common.feature_or_target import ComputeRequest
 from featurebyte.service.entity_validation import EntityValidationService
 from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.service.session_manager import SessionManagerService
@@ -146,7 +146,7 @@ class Computer(Generic[ComputeRequestT, ExecutorParamsT]):
         get_credential: Any,
         output_table_details: TableDetails,
         progress_callback: Optional[Callable[[int, str], None]] = None,
-    ):
+    ) -> None:
         """
         Compute targets or features
 

--- a/featurebyte/service/target_helper/base_feature_or_target_computer.py
+++ b/featurebyte/service/target_helper/base_feature_or_target_computer.py
@@ -154,7 +154,7 @@ class Computer(Generic[ComputeRequestT, ExecutorParamsT]):
         ----------
         observation_set: pd.DataFrame
             Observation set data
-        compute_request: ComputeRequest
+        compute_request: ComputeRequestT
             Compute request
         get_credential: Any
             Get credential handler function

--- a/featurebyte/service/target_helper/compute_target.py
+++ b/featurebyte/service/target_helper/compute_target.py
@@ -3,22 +3,12 @@ Get targets module
 """
 from __future__ import annotations
 
-from typing import Any, Callable, Generic, Optional, TypeVar, Union
-
 import time
 from abc import abstractmethod
 from dataclasses import dataclass
 
-import pandas as pd
-
 from featurebyte.common.progress import get_ranged_progress_callback
 from featurebyte.logging import get_logger
-from featurebyte.models.feature_store import FeatureStoreModel
-from featurebyte.models.observation_table import ObservationTableModel
-from featurebyte.models.parent_serving import ParentServingPreparation
-from featurebyte.query_graph.graph import QueryGraph
-from featurebyte.query_graph.node import Node
-from featurebyte.query_graph.node.schema import TableDetails
 from featurebyte.query_graph.sql.common import REQUEST_TABLE_NAME
 from featurebyte.query_graph.sql.feature_historical import (
     NUM_FEATURES_PER_QUERY,
@@ -29,48 +19,18 @@ from featurebyte.query_graph.sql.feature_historical import (
     validate_request_schema,
 )
 from featurebyte.routes.common.feature_or_target_table import ValidationParameters
-from featurebyte.schema.target import ComputeRequest, ComputeTargetRequest
+from featurebyte.schema.target import ComputeTargetRequest
 from featurebyte.service.entity_validation import EntityValidationService
 from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.service.session_manager import SessionManagerService
-from featurebyte.session.base import BaseSession
+from featurebyte.service.target_helper.base_feature_or_target_computer import (
+    BasicExecutorParams,
+    Computer,
+    ExecutorParams,
+    QueryExecutor,
+)
 
 logger = get_logger(__name__)
-
-
-@dataclass
-class BasicExecutorParams:
-    """
-    Basic executor params
-    """
-
-    # Observation set
-    observation_set: Union[pd.DataFrame, ObservationTableModel]
-    # Session to use to make queries
-    session: BaseSession
-    # Output table details to write the results to
-    output_table_details: TableDetails
-    # Preparation required for serving parent features
-    parent_serving_preparation: Optional[ParentServingPreparation]
-    # Optional progress callback function)
-    progress_callback: Optional[Callable[[int, str], None]]
-
-
-@dataclass
-class ExecutorParams(BasicExecutorParams):
-    """
-    Executor params
-    """
-
-    # Query graph
-    graph: QueryGraph
-    # List of query graph node
-    nodes: list[Node]
-    # Feature store. We need the feature store id and source type information.
-    feature_store: FeatureStoreModel
-    # Optional serving names mapping if the observations set has different serving name columns
-    # than those defined in Entities
-    serving_names_mapping: dict[str, str] | None = None
 
 
 @dataclass
@@ -85,146 +45,64 @@ class HistoricalFeatureExecutorParams(ExecutorParams):
     is_feature_list_deployed: bool = False
 
 
-ComputeRequestT = TypeVar("ComputeRequestT", bound=ComputeRequest)
-ExecutorParamsT = TypeVar("ExecutorParamsT", bound=ExecutorParams)
-
-
-class QueryExecutor(Generic[ExecutorParamsT]):
-    """
-    Query executor
-    """
-
-    @abstractmethod
-    async def execute(self, executor_params: ExecutorParamsT) -> None:
-        """
-        Execute queries
-
-        Parameters
-        ----------
-        executor_params: ExecutorParamsT
-            Executor parameters
-        """
-
-
-class Computer(Generic[ComputeRequestT, ExecutorParamsT]):
-    """
-    Base target or feature computer
-    """
-
-    def __init__(
-        self,
-        feature_store_service: FeatureStoreService,
-        entity_validation_service: EntityValidationService,
-        session_manager_service: SessionManagerService,
-        query_executor: QueryExecutor[ExecutorParamsT],
-    ):
-        self.feature_store_service = feature_store_service
-        self.entity_validation_service = entity_validation_service
-        self.session_manager_service = session_manager_service
-        self.query_executor = query_executor
-
-    @abstractmethod
-    async def get_validation_parameters(self, request: ComputeRequestT) -> ValidationParameters:
-        """
-        Get validation parameters
-
-        Parameters
-        ----------
-        request: ComputeRequestT
-            Compute request
-
-        Returns
-        -------
-        ValidationParameters
-            Validation parameters
-        """
-
-    @abstractmethod
-    async def get_executor_params(
-        self,
-        basic_executor_params: BasicExecutorParams,
-        validation_parameters: ValidationParameters,
-    ) -> ExecutorParamsT:
-        """
-        Get executor parameters
-
-        Parameters
-        ----------
-        basic_executor_params: BasicExecutorParams
-            Basic executor parameters
-        validation_parameters: ValidationParameters
-            Validation parameters
-
-        Returns
-        -------
-        ExecutorParamsT
-            Executor parameters
-        """
-
-    async def compute(
-        self,
-        observation_set: Union[pd.DataFrame, ObservationTableModel],
-        compute_request: ComputeRequestT,
-        get_credential: Any,
-        output_table_details: TableDetails,
-        progress_callback: Optional[Callable[[int, str], None]] = None,
-    ):
-        """
-        Compute targets or features
-
-        Parameters
-        ----------
-        observation_set: pd.DataFrame
-            Observation set data
-        compute_request: ComputeRequest
-            Compute request
-        get_credential: Any
-            Get credential handler function
-        output_table_details: TableDetails
-            Table details to write the results to
-        progress_callback: Optional[Callable[[int, str], None]]
-            Optional progress callback function
-        """
-        validation_parameters = await self.get_validation_parameters(compute_request)
-
-        if isinstance(observation_set, pd.DataFrame):
-            request_column_names = set(observation_set.columns)
-        else:
-            request_column_names = {col.name for col in observation_set.columns_info}
-
-        parent_serving_preparation = (
-            await self.entity_validation_service.validate_entities_or_prepare_for_parent_serving(
-                graph=validation_parameters.graph,
-                nodes=validation_parameters.nodes,
-                request_column_names=request_column_names,
-                feature_store=validation_parameters.feature_store,
-                serving_names_mapping=validation_parameters.serving_names_mapping,
-            )
-        )
-        db_session = await self.session_manager_service.get_feature_store_session(
-            feature_store=validation_parameters.feature_store,
-            get_credential=get_credential,
-        )
-        params = await self.get_executor_params(
-            basic_executor_params=BasicExecutorParams(
-                session=db_session,
-                output_table_details=output_table_details,
-                parent_serving_preparation=parent_serving_preparation,
-                progress_callback=progress_callback,
-                observation_set=observation_set,
-            ),
-            validation_parameters=validation_parameters,
-        )
-        await self.query_executor.execute(params)
-
-
 class TargetExecutor(QueryExecutor[ExecutorParams]):
     """
     Target Executor
     """
 
-    async def execute(self, executor_params: ExecutorParams) -> None:
-        await get_targets(executor_params)
+    async def execute(  # pylint: disable=too-many-locals
+        self, executor_params: ExecutorParams
+    ) -> None:
+        """
+        Get targets.
+
+        Parameters
+        ----------
+        executor_params: ExecutorParams
+            Executor parameters
+        """
+        tic_ = time.time()
+
+        observation_set = get_internal_observation_set(executor_params.observation_set)
+
+        # Validate request
+        validate_request_schema(observation_set)
+
+        # use a unique request table name
+        request_id = executor_params.session.generate_session_unique_id()
+        request_table_name = f"{REQUEST_TABLE_NAME}_{request_id}"
+        request_table_columns = observation_set.columns
+
+        # Execute feature SQL code
+        await observation_set.register_as_request_table(
+            executor_params.session,
+            request_table_name,
+            add_row_index=len(executor_params.nodes) > NUM_FEATURES_PER_QUERY,
+        )
+
+        # Generate SQL code that computes the targets
+        historical_feature_query_set = get_historical_features_query_set(
+            graph=executor_params.graph,
+            nodes=executor_params.nodes,
+            request_table_columns=request_table_columns,
+            serving_names_mapping=executor_params.serving_names_mapping,
+            source_type=executor_params.feature_store.type,
+            output_table_details=executor_params.output_table_details,
+            output_feature_names=get_feature_names(executor_params.graph, executor_params.nodes),
+            request_table_name=request_table_name,
+            parent_serving_preparation=executor_params.parent_serving_preparation,
+        )
+        await historical_feature_query_set.execute(
+            executor_params.session,
+            get_ranged_progress_callback(
+                executor_params.progress_callback,
+                TILE_COMPUTE_PROGRESS_MAX_PERCENT,
+                100,
+            )
+            if executor_params.progress_callback
+            else None,
+        )
+        logger.debug(f"compute_targets in total took {time.time() - tic_:.2f}s")
 
 
 class TargetComputer(Computer[ComputeTargetRequest, ExecutorParams]):
@@ -237,7 +115,7 @@ class TargetComputer(Computer[ComputeTargetRequest, ExecutorParams]):
         feature_store_service: FeatureStoreService,
         entity_validation_service: EntityValidationService,
         session_manager_service: SessionManagerService,
-        query_executor: QueryExecutor[ExecutorParamsT],
+        query_executor: QueryExecutor[ExecutorParams],
     ):
         super().__init__(
             feature_store_service,
@@ -276,58 +154,3 @@ class TargetComputer(Computer[ComputeTargetRequest, ExecutorParams]):
             serving_names_mapping=validation_parameters.serving_names_mapping,
             feature_store=validation_parameters.feature_store,
         )
-
-
-async def get_targets(  # pylint: disable=too-many-locals
-    executor_params: ExecutorParams,
-) -> None:
-    """
-    Get targets.
-
-    Parameters
-    ----------
-    executor_params: ExecutorParams
-        Executor parameters
-    """
-    tic_ = time.time()
-
-    observation_set = get_internal_observation_set(executor_params.observation_set)
-
-    # Validate request
-    validate_request_schema(observation_set)
-
-    # use a unique request table name
-    request_id = executor_params.session.generate_session_unique_id()
-    request_table_name = f"{REQUEST_TABLE_NAME}_{request_id}"
-    request_table_columns = observation_set.columns
-
-    # Execute feature SQL code
-    await observation_set.register_as_request_table(
-        executor_params.session,
-        request_table_name,
-        add_row_index=len(executor_params.nodes) > NUM_FEATURES_PER_QUERY,
-    )
-
-    # Generate SQL code that computes the targets
-    historical_feature_query_set = get_historical_features_query_set(
-        graph=executor_params.graph,
-        nodes=executor_params.nodes,
-        request_table_columns=request_table_columns,
-        serving_names_mapping=executor_params.serving_names_mapping,
-        source_type=executor_params.feature_store.type,
-        output_table_details=executor_params.output_table_details,
-        output_feature_names=get_feature_names(executor_params.graph, executor_params.nodes),
-        request_table_name=request_table_name,
-        parent_serving_preparation=executor_params.parent_serving_preparation,
-    )
-    await historical_feature_query_set.execute(
-        executor_params.session,
-        get_ranged_progress_callback(
-            executor_params.progress_callback,
-            TILE_COMPUTE_PROGRESS_MAX_PERCENT,
-            100,
-        )
-        if executor_params.progress_callback
-        else None,
-    )
-    logger.debug(f"compute_targets in total took {time.time() - tic_:.2f}s")

--- a/featurebyte/service/target_helper/compute_target.py
+++ b/featurebyte/service/target_helper/compute_target.py
@@ -33,18 +33,6 @@ from featurebyte.service.target_helper.base_feature_or_target_computer import (
 logger = get_logger(__name__)
 
 
-@dataclass
-class HistoricalFeatureExecutorParams(ExecutorParams):
-    """
-    Historical feature executor params
-    """
-
-    # Whether the feature list that triggered this historical request is deployed. If so, tile
-    # tables would have already been back-filled and there is no need to check and calculate tiles
-    # on demand.
-    is_feature_list_deployed: bool = False
-
-
 class TargetExecutor(QueryExecutor[ExecutorParams]):
     """
     Target Executor
@@ -137,12 +125,13 @@ class TargetComputer(Computer[ComputeTargetRequest, ExecutorParams]):
             serving_names_mapping=request.serving_names_mapping,
         )
 
-    @abstractmethod
     async def get_executor_params(
         self,
+        request: ComputeTargetRequest,
         basic_executor_params: BasicExecutorParams,
         validation_parameters: ValidationParameters,
     ) -> ExecutorParams:
+        _ = request
         return ExecutorParams(
             session=basic_executor_params.session,
             output_table_details=basic_executor_params.output_table_details,

--- a/featurebyte/service/target_helper/compute_target.py
+++ b/featurebyte/service/target_helper/compute_target.py
@@ -3,9 +3,11 @@ Get targets module
 """
 from __future__ import annotations
 
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Callable, Generic, Optional, TypeVar, Union
 
 import time
+from abc import abstractmethod
+from dataclasses import dataclass
 
 import pandas as pd
 
@@ -26,7 +28,8 @@ from featurebyte.query_graph.sql.feature_historical import (
     get_internal_observation_set,
     validate_request_schema,
 )
-from featurebyte.schema.target import ComputeTargetRequest
+from featurebyte.routes.common.feature_or_target_table import ValidationParameters
+from featurebyte.schema.target import ComputeRequest, ComputeTargetRequest
 from featurebyte.service.entity_validation import EntityValidationService
 from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.service.session_manager import SessionManagerService
@@ -35,7 +38,196 @@ from featurebyte.session.base import BaseSession
 logger = get_logger(__name__)
 
 
-class TargetComputer:
+@dataclass
+class BasicExecutorParams:
+    """
+    Basic executor params
+    """
+
+    # Observation set
+    observation_set: Union[pd.DataFrame, ObservationTableModel]
+    # Session to use to make queries
+    session: BaseSession
+    # Output table details to write the results to
+    output_table_details: TableDetails
+    # Preparation required for serving parent features
+    parent_serving_preparation: Optional[ParentServingPreparation]
+    # Optional progress callback function)
+    progress_callback: Optional[Callable[[int, str], None]]
+
+
+@dataclass
+class ExecutorParams(BasicExecutorParams):
+    """
+    Executor params
+    """
+
+    # Query graph
+    graph: QueryGraph
+    # List of query graph node
+    nodes: list[Node]
+    # Feature store. We need the feature store id and source type information.
+    feature_store: FeatureStoreModel
+    # Optional serving names mapping if the observations set has different serving name columns
+    # than those defined in Entities
+    serving_names_mapping: dict[str, str] | None = None
+
+
+@dataclass
+class HistoricalFeatureExecutorParams(ExecutorParams):
+    """
+    Historical feature executor params
+    """
+
+    # Whether the feature list that triggered this historical request is deployed. If so, tile
+    # tables would have already been back-filled and there is no need to check and calculate tiles
+    # on demand.
+    is_feature_list_deployed: bool = False
+
+
+ComputeRequestT = TypeVar("ComputeRequestT", bound=ComputeRequest)
+ExecutorParamsT = TypeVar("ExecutorParamsT", bound=ExecutorParams)
+
+
+class QueryExecutor(Generic[ExecutorParamsT]):
+    """
+    Query executor
+    """
+
+    @abstractmethod
+    async def execute(self, executor_params: ExecutorParamsT) -> None:
+        """
+        Execute queries
+
+        Parameters
+        ----------
+        executor_params: ExecutorParamsT
+            Executor parameters
+        """
+
+
+class Computer(Generic[ComputeRequestT, ExecutorParamsT]):
+    """
+    Base target or feature computer
+    """
+
+    def __init__(
+        self,
+        feature_store_service: FeatureStoreService,
+        entity_validation_service: EntityValidationService,
+        session_manager_service: SessionManagerService,
+        query_executor: QueryExecutor[ExecutorParamsT],
+    ):
+        self.feature_store_service = feature_store_service
+        self.entity_validation_service = entity_validation_service
+        self.session_manager_service = session_manager_service
+        self.query_executor = query_executor
+
+    @abstractmethod
+    async def get_validation_parameters(self, request: ComputeRequestT) -> ValidationParameters:
+        """
+        Get validation parameters
+
+        Parameters
+        ----------
+        request: ComputeRequestT
+            Compute request
+
+        Returns
+        -------
+        ValidationParameters
+            Validation parameters
+        """
+
+    @abstractmethod
+    async def get_executor_params(
+        self,
+        basic_executor_params: BasicExecutorParams,
+        validation_parameters: ValidationParameters,
+    ) -> ExecutorParamsT:
+        """
+        Get executor parameters
+
+        Parameters
+        ----------
+        basic_executor_params: BasicExecutorParams
+            Basic executor parameters
+        validation_parameters: ValidationParameters
+            Validation parameters
+
+        Returns
+        -------
+        ExecutorParamsT
+            Executor parameters
+        """
+
+    async def compute(
+        self,
+        observation_set: Union[pd.DataFrame, ObservationTableModel],
+        compute_request: ComputeRequestT,
+        get_credential: Any,
+        output_table_details: TableDetails,
+        progress_callback: Optional[Callable[[int, str], None]] = None,
+    ):
+        """
+        Compute targets or features
+
+        Parameters
+        ----------
+        observation_set: pd.DataFrame
+            Observation set data
+        compute_request: ComputeRequest
+            Compute request
+        get_credential: Any
+            Get credential handler function
+        output_table_details: TableDetails
+            Table details to write the results to
+        progress_callback: Optional[Callable[[int, str], None]]
+            Optional progress callback function
+        """
+        validation_parameters = await self.get_validation_parameters(compute_request)
+
+        if isinstance(observation_set, pd.DataFrame):
+            request_column_names = set(observation_set.columns)
+        else:
+            request_column_names = {col.name for col in observation_set.columns_info}
+
+        parent_serving_preparation = (
+            await self.entity_validation_service.validate_entities_or_prepare_for_parent_serving(
+                graph=validation_parameters.graph,
+                nodes=validation_parameters.nodes,
+                request_column_names=request_column_names,
+                feature_store=validation_parameters.feature_store,
+                serving_names_mapping=validation_parameters.serving_names_mapping,
+            )
+        )
+        db_session = await self.session_manager_service.get_feature_store_session(
+            feature_store=validation_parameters.feature_store,
+            get_credential=get_credential,
+        )
+        params = await self.get_executor_params(
+            basic_executor_params=BasicExecutorParams(
+                session=db_session,
+                output_table_details=output_table_details,
+                parent_serving_preparation=parent_serving_preparation,
+                progress_callback=progress_callback,
+                observation_set=observation_set,
+            ),
+            validation_parameters=validation_parameters,
+        )
+        await self.query_executor.execute(params)
+
+
+class TargetExecutor(QueryExecutor[ExecutorParams]):
+    """
+    Target Executor
+    """
+
+    async def execute(self, executor_params: ExecutorParams) -> None:
+        await get_targets(executor_params)
+
+
+class TargetComputer(Computer[ComputeTargetRequest, ExecutorParams]):
     """
     Target computer
     """
@@ -45,145 +237,97 @@ class TargetComputer:
         feature_store_service: FeatureStoreService,
         entity_validation_service: EntityValidationService,
         session_manager_service: SessionManagerService,
+        query_executor: QueryExecutor[ExecutorParamsT],
     ):
-        self.feature_store_service = feature_store_service
-        self.entity_validation_service = entity_validation_service
-        self.session_manager_service = session_manager_service
+        super().__init__(
+            feature_store_service,
+            entity_validation_service,
+            session_manager_service,
+            query_executor,
+        )
 
-    async def compute_targets(
-        self,
-        observation_set: Union[pd.DataFrame, ObservationTableModel],
-        compute_target_request: ComputeTargetRequest,
-        get_credential: Any,
-        output_table_details: TableDetails,
-        progress_callback: Optional[Callable[[int, str], None]] = None,
-    ) -> None:
-        """
-        Get target values for a target
-
-        Parameters
-        ----------
-        observation_set: pd.DataFrame
-            Observation set data
-        compute_target_request: ComputeTargetRequest
-            Compute target request
-        get_credential: Any
-            Get credential handler function
-        output_table_details: TableDetails
-            Table details to write the results to
-        progress_callback: Optional[Callable[[int, str], None]]
-            Optional progress callback function
-        """
+    async def get_validation_parameters(
+        self, request: ComputeTargetRequest
+    ) -> ValidationParameters:
         feature_store = await self.feature_store_service.get_document(
-            document_id=compute_target_request.feature_store_id
+            document_id=request.feature_store_id
         )
-
-        if isinstance(observation_set, pd.DataFrame):
-            request_column_names = set(observation_set.columns)
-        else:
-            request_column_names = {col.name for col in observation_set.columns_info}
-
-        parent_serving_preparation = (
-            await self.entity_validation_service.validate_entities_or_prepare_for_parent_serving(
-                graph=compute_target_request.graph,
-                nodes=compute_target_request.nodes,
-                request_column_names=request_column_names,
-                feature_store=feature_store,
-                serving_names_mapping=compute_target_request.serving_names_mapping,
-            )
-        )
-
-        db_session = await self.session_manager_service.get_feature_store_session(
+        return ValidationParameters(
+            graph=request.graph,
+            nodes=request.nodes,
             feature_store=feature_store,
-            get_credential=get_credential,
+            serving_names_mapping=request.serving_names_mapping,
         )
 
-        await get_targets(
-            session=db_session,
-            graph=compute_target_request.graph,
-            nodes=compute_target_request.nodes,
-            observation_set=observation_set,
-            serving_names_mapping=compute_target_request.serving_names_mapping,
-            feature_store=feature_store,
-            parent_serving_preparation=parent_serving_preparation,
-            output_table_details=output_table_details,
-            progress_callback=progress_callback,
+    @abstractmethod
+    async def get_executor_params(
+        self,
+        basic_executor_params: BasicExecutorParams,
+        validation_parameters: ValidationParameters,
+    ) -> ExecutorParams:
+        return ExecutorParams(
+            session=basic_executor_params.session,
+            output_table_details=basic_executor_params.output_table_details,
+            parent_serving_preparation=basic_executor_params.parent_serving_preparation,
+            progress_callback=basic_executor_params.progress_callback,
+            observation_set=basic_executor_params.observation_set,
+            graph=validation_parameters.graph,
+            nodes=validation_parameters.nodes,
+            serving_names_mapping=validation_parameters.serving_names_mapping,
+            feature_store=validation_parameters.feature_store,
         )
 
 
-async def get_targets(  # pylint: disable=too-many-locals, too-many-arguments
-    session: BaseSession,
-    graph: QueryGraph,
-    nodes: List[Node],
-    observation_set: Union[pd.DataFrame, ObservationTableModel],
-    feature_store: FeatureStoreModel,
-    output_table_details: TableDetails,
-    serving_names_mapping: dict[str, str] | None = None,
-    parent_serving_preparation: Optional[ParentServingPreparation] = None,
-    progress_callback: Optional[Callable[[int, str], None]] = None,
+async def get_targets(  # pylint: disable=too-many-locals
+    executor_params: ExecutorParams,
 ) -> None:
     """
     Get targets.
 
     Parameters
     ----------
-    session: BaseSession
-        Session to use to make queries
-    graph : QueryGraph
-        Query graph
-    nodes : list[Node]
-        List of query graph node
-    observation_set : Union[pd.DataFrame, ObservationTableModel]
-        Observation set
-    feature_store: FeatureStoreModel
-        Feature store. We need the feature store id and source type information.
-    serving_names_mapping : dict[str, str] | None
-        Optional serving names mapping if the observations set has different serving name columns
-        than those defined in Entities
-    parent_serving_preparation: Optional[ParentServingPreparation]
-        Preparation required for serving parent features
-    output_table_details: TableDetails
-        Output table details to write the results to
-    progress_callback: Optional[Callable[[int, str], None]]
-        Optional progress callback function
+    executor_params: ExecutorParams
+        Executor parameters
     """
     tic_ = time.time()
 
-    observation_set = get_internal_observation_set(observation_set)
+    observation_set = get_internal_observation_set(executor_params.observation_set)
 
     # Validate request
     validate_request_schema(observation_set)
 
     # use a unique request table name
-    request_id = session.generate_session_unique_id()
+    request_id = executor_params.session.generate_session_unique_id()
     request_table_name = f"{REQUEST_TABLE_NAME}_{request_id}"
     request_table_columns = observation_set.columns
 
     # Execute feature SQL code
     await observation_set.register_as_request_table(
-        session, request_table_name, add_row_index=len(nodes) > NUM_FEATURES_PER_QUERY
+        executor_params.session,
+        request_table_name,
+        add_row_index=len(executor_params.nodes) > NUM_FEATURES_PER_QUERY,
     )
 
     # Generate SQL code that computes the targets
     historical_feature_query_set = get_historical_features_query_set(
-        graph=graph,
-        nodes=nodes,
+        graph=executor_params.graph,
+        nodes=executor_params.nodes,
         request_table_columns=request_table_columns,
-        serving_names_mapping=serving_names_mapping,
-        source_type=feature_store.type,
-        output_table_details=output_table_details,
-        output_feature_names=get_feature_names(graph, nodes),
+        serving_names_mapping=executor_params.serving_names_mapping,
+        source_type=executor_params.feature_store.type,
+        output_table_details=executor_params.output_table_details,
+        output_feature_names=get_feature_names(executor_params.graph, executor_params.nodes),
         request_table_name=request_table_name,
-        parent_serving_preparation=parent_serving_preparation,
+        parent_serving_preparation=executor_params.parent_serving_preparation,
     )
     await historical_feature_query_set.execute(
-        session,
+        executor_params.session,
         get_ranged_progress_callback(
-            progress_callback,
+            executor_params.progress_callback,
             TILE_COMPUTE_PROGRESS_MAX_PERCENT,
             100,
         )
-        if progress_callback
+        if executor_params.progress_callback
         else None,
     )
     logger.debug(f"compute_targets in total took {time.time() - tic_:.2f}s")

--- a/featurebyte/worker/task/historical_feature_table.py
+++ b/featurebyte/worker/task/historical_feature_table.py
@@ -54,9 +54,9 @@ class HistoricalFeatureTableTask(DataWarehouseMixin, BaseTask):
             historical_features_service: HistoricalFeaturesService = (
                 self.app_container.historical_features_service
             )
-            await historical_features_service.compute_historical_features(
+            await historical_features_service.compute(
                 observation_set=observation_set,
-                featurelist_get_historical_features=payload.featurelist_get_historical_features,
+                compute_request=payload.featurelist_get_historical_features,
                 get_credential=self.get_credential,
                 output_table_details=location.table_details,
                 progress_callback=self.update_progress,

--- a/featurebyte/worker/task/target_table.py
+++ b/featurebyte/worker/task/target_table.py
@@ -9,7 +9,7 @@ from featurebyte.logging import get_logger
 from featurebyte.models.target_table import TargetTableModel
 from featurebyte.schema.target import ComputeTargetRequest
 from featurebyte.schema.worker.task.target_table import TargetTableTaskPayload
-from featurebyte.service.target import TargetService
+from featurebyte.service.target_helper.compute_target import TargetComputer
 from featurebyte.service.target_table import TargetTableService
 from featurebyte.worker.task.base import BaseTask
 from featurebyte.worker.task.mixin import DataWarehouseMixin
@@ -47,8 +47,8 @@ class TargetTableTask(DataWarehouseMixin, BaseTask):
         async with self.drop_table_on_error(
             db_session=db_session, table_details=location.table_details
         ):
-            target_service: TargetService = self.app_container.target_service
-            await target_service.compute_targets(
+            target_computer: TargetComputer = self.app_container.target_computer
+            await target_computer.compute_targets(
                 observation_set=observation_set,
                 compute_target_request=ComputeTargetRequest(
                     feature_store_id=payload.feature_store_id,

--- a/featurebyte/worker/task/target_table.py
+++ b/featurebyte/worker/task/target_table.py
@@ -48,9 +48,9 @@ class TargetTableTask(DataWarehouseMixin, BaseTask):
             db_session=db_session, table_details=location.table_details
         ):
             target_computer: TargetComputer = self.app_container.target_computer
-            await target_computer.compute_targets(
+            await target_computer.compute(
                 observation_set=observation_set,
-                compute_target_request=ComputeTargetRequest(
+                compute_request=ComputeTargetRequest(
                     feature_store_id=payload.feature_store_id,
                     graph=payload.graph,
                     node_names=payload.node_names,

--- a/tests/unit/service/test_historical_features.py
+++ b/tests/unit/service/test_historical_features.py
@@ -68,7 +68,7 @@ async def test_get_historical_features__feature_list_not_deployed(
     )
     training_events = pd.DataFrame({"cust_id": [1], "POINT_IN_TIME": ["2022-01-01"]})
 
-    await historical_features_service.compute_historical_features(
+    await historical_features_service.compute(
         training_events,
         featurelist_get_historical_features,
         get_credential,
@@ -99,7 +99,7 @@ async def test_get_historical_features__feature_list_not_saved(
     )
     training_events = pd.DataFrame({"cust_id": [1], "POINT_IN_TIME": ["2022-01-01"]})
 
-    await historical_features_service.compute_historical_features(
+    await historical_features_service.compute(
         training_events,
         featurelist_get_historical_features,
         get_credential,
@@ -127,7 +127,7 @@ async def test_get_historical_features__feature_list_deployed(
     )
     training_events = pd.DataFrame({"cust_id": [1], "POINT_IN_TIME": ["2022-01-01"]})
 
-    await historical_features_service.compute_historical_features(
+    await historical_features_service.compute(
         training_events,
         featurelist_get_historical_features,
         get_credential,


### PR DESCRIPTION
## Description
Refactor some of the common logic used between `compute_target` and `compute_historical_features`.

Also moves the `compute_target` function out of the target document service.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-1914

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
