### PR TITLE
[DEV-1967] Add option to disable audit logging for internal documents

### DIFF
--- a/.changelog/DEV-1967.yaml
+++ b/.changelog/DEV-1967.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add option to disable audit logging for internal documents"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/migration/model.py
+++ b/featurebyte/migration/model.py
@@ -19,7 +19,7 @@ class BaseMigrationMetadataModel(FeatureByteBaseDocumentModel):
     BaseMigrationMetadata model
     """
 
-    class Settings:
+    class Settings(FeatureByteBaseDocumentModel.Settings):
         """
         MongoDB settings
         """

--- a/featurebyte/models/base.py
+++ b/featurebyte/models/base.py
@@ -333,6 +333,8 @@ class FeatureByteBaseDocumentModel(FeatureByteBaseModel):
             IndexModel("updated_at"),
         ]
 
+        auditable: bool = True
+
 
 class VersionIdentifier(BaseModel):
     """

--- a/featurebyte/models/online_store_compute_query.py
+++ b/featurebyte/models/online_store_compute_query.py
@@ -56,3 +56,4 @@ class OnlineStoreComputeQueryModel(FeatureByteCatalogBaseDocumentModel):
             pymongo.operations.IndexModel("aggregation_id"),
             pymongo.operations.IndexModel("result_name"),
         ]
+        auditable = False

--- a/featurebyte/models/online_store_table_version.py
+++ b/featurebyte/models/online_store_table_version.py
@@ -32,10 +32,10 @@ class OnlineStoreTableVersion(FeatureByteCatalogBaseDocumentModel):
                 resolution_signature=None,
             ),
         ]
-
         indexes = FeatureByteCatalogBaseDocumentModel.Settings.indexes + [
             pymongo.operations.IndexModel("aggregation_result_name"),
         ]
+        auditable = False
 
 
 class OnlineStoreTableVersionUpdate(BaseDocumentServiceUpdateSchema):

--- a/featurebyte/models/tile_registry.py
+++ b/featurebyte/models/tile_registry.py
@@ -91,6 +91,7 @@ class TileModel(FeatureByteCatalogBaseDocumentModel):
             pymongo.operations.IndexModel("tile_id"),
             pymongo.operations.IndexModel("aggregation_id"),
         ]
+        auditable = False
 
 
 class TileUpdate(BaseDocumentServiceUpdateSchema):

--- a/featurebyte/persistent/audit.py
+++ b/featurebyte/persistent/audit.py
@@ -279,6 +279,9 @@ def audit_transaction(mode: AuditTransactionMode, action_type: AuditActionType) 
             Any
                 Return value from execution of the function
             """
+            if kwargs.pop("disable_audit", False):
+                return await func(persistent, collection_name=collection_name, *args, **kwargs)
+
             async with persistent.start_transaction() as session:
                 return_value, num_updated, original_docs = await _execute_transaction(
                     persistent=session,

--- a/featurebyte/persistent/base.py
+++ b/featurebyte/persistent/base.py
@@ -58,6 +58,7 @@ class Persistent(ABC):
         collection_name: str,
         document: Document,
         user_id: Optional[ObjectId],  # pylint: disable=unused-argument
+        disable_audit: bool = False,
     ) -> ObjectId:
         """
         Insert record into collection. Note that when using this method inside a non BaseDocumentService,
@@ -86,6 +87,7 @@ class Persistent(ABC):
         collection_name: str,
         documents: Iterable[Document],
         user_id: Optional[ObjectId],  # pylint: disable=unused-argument
+        disable_audit: bool = False,
     ) -> List[ObjectId]:
         """
         Insert records into collection. Note that when using this method inside a non BaseDocumentService,
@@ -189,6 +191,7 @@ class Persistent(ABC):
         query_filter: QueryFilter,
         update: DocumentUpdate,
         user_id: Optional[ObjectId],  # pylint: disable=unused-argument
+        disable_audit: bool = False,
     ) -> int:
         """
         Update one record in collection. Note that when using this method inside a non BaseDocumentService,
@@ -235,6 +238,7 @@ class Persistent(ABC):
         query_filter: QueryFilter,
         update: DocumentUpdate,
         user_id: Optional[ObjectId],  # pylint: disable=unused-argument
+        disable_audit: bool = False,
     ) -> int:
         """
         Update many records in collection. Note that when using this method inside a non BaseDocumentService,
@@ -281,6 +285,7 @@ class Persistent(ABC):
         query_filter: QueryFilter,
         replacement: Document,
         user_id: Optional[ObjectId],  # pylint: disable=unused-argument
+        disable_audit: bool = False,
     ) -> int:
         """
         Replace one record in collection. Note that when using this method inside a non BaseDocumentService,
@@ -316,6 +321,7 @@ class Persistent(ABC):
         collection_name: str,
         query_filter: QueryFilter,
         user_id: Optional[ObjectId],  # pylint: disable=unused-argument
+        disable_audit: bool = False,
     ) -> int:
         """
         Delete one record from collection. Note that when using this method inside a non BaseDocumentService,
@@ -343,6 +349,7 @@ class Persistent(ABC):
         collection_name: str,
         query_filter: QueryFilter,
         user_id: Optional[ObjectId],  # pylint: disable=unused-argument
+        disable_audit: bool = False,
     ) -> int:
         """
         Delete many records from collection. Note that when using this method inside a non BaseDocumentService,

--- a/featurebyte/persistent/base.py
+++ b/featurebyte/persistent/base.py
@@ -58,7 +58,7 @@ class Persistent(ABC):
         collection_name: str,
         document: Document,
         user_id: Optional[ObjectId],  # pylint: disable=unused-argument
-        disable_audit: bool = False,
+        disable_audit: bool = False,  # pylint: disable=unused-argument
     ) -> ObjectId:
         """
         Insert record into collection. Note that when using this method inside a non BaseDocumentService,
@@ -72,6 +72,8 @@ class Persistent(ABC):
             Document to insert
         user_id: Optional[ObjectId]
             ID of user who performed this operation
+        disable_audit: bool
+            Whether to disable creating an audit record for this operation
 
         Returns
         -------
@@ -87,7 +89,7 @@ class Persistent(ABC):
         collection_name: str,
         documents: Iterable[Document],
         user_id: Optional[ObjectId],  # pylint: disable=unused-argument
-        disable_audit: bool = False,
+        disable_audit: bool = False,  # pylint: disable=unused-argument
     ) -> List[ObjectId]:
         """
         Insert records into collection. Note that when using this method inside a non BaseDocumentService,
@@ -101,6 +103,8 @@ class Persistent(ABC):
             Documents to insert
         user_id: Optional[ObjectId]
             ID of user who performed this operation
+        disable_audit: bool
+            Whether to disable creating an audit record for this operation
 
         Returns
         -------
@@ -118,7 +122,7 @@ class Persistent(ABC):
         collection_name: str,
         query_filter: QueryFilter,
         user_id: Optional[ObjectId] = None,  # pylint: disable=unused-argument
-    ) -> Optional[Document]:
+    ) -> Optional[Document]:  # pylint: disable=unused-argument
         """
         Find one record from collection. Note that when using this method inside a non BaseDocumentService,
         please use with caution as it does not inject catalog_id into the query filter automatically.
@@ -191,7 +195,7 @@ class Persistent(ABC):
         query_filter: QueryFilter,
         update: DocumentUpdate,
         user_id: Optional[ObjectId],  # pylint: disable=unused-argument
-        disable_audit: bool = False,
+        disable_audit: bool = False,  # pylint: disable=unused-argument
     ) -> int:
         """
         Update one record in collection. Note that when using this method inside a non BaseDocumentService,
@@ -208,6 +212,8 @@ class Persistent(ABC):
             Conditions to filter on
         update: DocumentUpdate
             Values to update
+        disable_audit: bool
+            Whether to disable creating an audit record for this operation
 
         Returns
         -------
@@ -238,7 +244,7 @@ class Persistent(ABC):
         query_filter: QueryFilter,
         update: DocumentUpdate,
         user_id: Optional[ObjectId],  # pylint: disable=unused-argument
-        disable_audit: bool = False,
+        disable_audit: bool = False,  # pylint: disable=unused-argument
     ) -> int:
         """
         Update many records in collection. Note that when using this method inside a non BaseDocumentService,
@@ -255,6 +261,8 @@ class Persistent(ABC):
             Values to update
         user_id: Optional[ObjectId]
             ID of user who performed this operation
+        disable_audit: bool
+            Whether to disable creating an audit record for this operation
 
         Returns
         -------
@@ -285,7 +293,7 @@ class Persistent(ABC):
         query_filter: QueryFilter,
         replacement: Document,
         user_id: Optional[ObjectId],  # pylint: disable=unused-argument
-        disable_audit: bool = False,
+        disable_audit: bool = False,  # pylint: disable=unused-argument
     ) -> int:
         """
         Replace one record in collection. Note that when using this method inside a non BaseDocumentService,
@@ -302,6 +310,8 @@ class Persistent(ABC):
             New document to replace existing one
         user_id: Optional[ObjectId]
             ID of user who performed this operation
+        disable_audit: bool
+            Whether to disable creating an audit record for this operation
 
         Returns
         -------
@@ -321,7 +331,7 @@ class Persistent(ABC):
         collection_name: str,
         query_filter: QueryFilter,
         user_id: Optional[ObjectId],  # pylint: disable=unused-argument
-        disable_audit: bool = False,
+        disable_audit: bool = False,  # pylint: disable=unused-argument
     ) -> int:
         """
         Delete one record from collection. Note that when using this method inside a non BaseDocumentService,
@@ -335,6 +345,8 @@ class Persistent(ABC):
             Conditions to filter on
         user_id: Optional[ObjectId]
             ID of user who performed this operation
+        disable_audit: bool
+            Whether to disable creating an audit record for this operation
 
         Returns
         -------
@@ -349,7 +361,7 @@ class Persistent(ABC):
         collection_name: str,
         query_filter: QueryFilter,
         user_id: Optional[ObjectId],  # pylint: disable=unused-argument
-        disable_audit: bool = False,
+        disable_audit: bool = False,  # pylint: disable=unused-argument
     ) -> int:
         """
         Delete many records from collection. Note that when using this method inside a non BaseDocumentService,
@@ -363,6 +375,8 @@ class Persistent(ABC):
             Conditions to filter on
         user_id: Optional[ObjectId]
             ID of user who performed this operation
+        disable_audit: bool
+            Whether to disable creating an audit record for this operation
 
         Returns
         -------


### PR DESCRIPTION
## Description

This adds the option to disable audit logging for internally used documents. Audit logging incurs non-trivial runtime cost and can cause write conflict errors for concurrent operations so it should be disabled unless necessary. A few internally used collections are marked as non-auditable: `OnlineStoreTableVersion`, `OnlineStoreComputeQueryModel`, `TileModel`.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
