### PR TITLE
[0.4][DEV-1976] Fix incorrect entity_id for columns derived from add_feature() (#1562)

### DIFF
--- a/.changelog/DEV-1976.yaml
+++ b/.changelog/DEV-1976.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix a bug in add_feature() where entity_id was incorrectly attached to the derived column"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/event_view.py
+++ b/featurebyte/api/event_view.py
@@ -436,7 +436,6 @@ class EventView(View, GroupByMixin, RawMixin):
             ColumnInfo(
                 name=new_column_name,
                 dtype=feature.dtype,
-                entity_id=EventView._get_feature_entity_id(feature),
             )
         )
 

--- a/tests/unit/api/test_event_view.py
+++ b/tests/unit/api/test_event_view.py
@@ -594,7 +594,6 @@ def test_add_feature(
         ColumnInfo(
             name="new_col",
             dtype=DBVarType.FLOAT,
-            entity_id=non_time_based_feature.entity_ids[0],
         ),
     ]
 
@@ -646,6 +645,35 @@ def test_add_feature(
             },
         },
     )
+
+
+def test_add_feature__inferred_entity_multiple_times(
+    snowflake_event_table,
+    snowflake_item_table,
+    non_time_based_features,
+    transaction_entity,
+):
+    """
+    Test calling add_feature() multiple times without specifying entity columns
+    """
+    snowflake_event_table[snowflake_event_table.event_id_column].as_entity(transaction_entity.name)
+    event_view = snowflake_event_table.get_view()
+    original_column_info = copy.deepcopy(event_view.columns_info)
+
+    event_view = event_view.add_feature("new_col", non_time_based_features[0])
+    event_view = event_view.add_feature("new_col_1", non_time_based_features[1])
+
+    assert event_view.columns_info == [
+        *original_column_info,
+        ColumnInfo(
+            name="new_col",
+            dtype=DBVarType.FLOAT,
+        ),
+        ColumnInfo(
+            name="new_col_1",
+            dtype=DBVarType.FLOAT,
+        ),
+    ]
 
 
 def test_add_feature__wrong_type(snowflake_event_view):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1122,8 +1122,8 @@ def feature_with_cleaning_operations_fixture(
     yield feature_group["sum_30m"]
 
 
-@pytest.fixture(name="non_time_based_feature")
-def get_non_time_based_feature_fixture(snowflake_item_table, transaction_entity):
+@pytest.fixture(name="non_time_based_features")
+def get_non_time_based_features_fixture(snowflake_item_table, transaction_entity):
     """
     Get a non-time-based feature.
 
@@ -1132,11 +1132,25 @@ def get_non_time_based_feature_fixture(snowflake_item_table, transaction_entity)
     snowflake_item_table.event_id_col.as_entity(transaction_entity.name)
     item_table = ItemTable(**{**snowflake_item_table.json_dict(), "item_id_column": "item_id_col"})
     item_view = item_table.get_view(event_suffix="_event_table")
-    return item_view.groupby("event_id_col").aggregate(
+    feature_1 = item_view.groupby("event_id_col").aggregate(
         value_column="item_amount",
         method=AggFunc.SUM,
         feature_name="non_time_time_sum_amount_feature",
     )
+    feature_2 = item_view.groupby("event_id_col").aggregate(
+        value_column="item_amount",
+        method=AggFunc.MAX,
+        feature_name="non_time_time_max_amount_feature",
+    )
+    return [feature_1, feature_2]
+
+
+@pytest.fixture(name="non_time_based_feature")
+def get_non_time_based_feature_fixture(non_time_based_features):
+    """
+    Get a non-time-based feature.
+    """
+    return non_time_based_features[0]
 
 
 @pytest.fixture(name="float_feature")


### PR DESCRIPTION
Cherry pick #1562 to release/0.4.

This fixes a bug in add_feature() where entity_id was incorrectly attached to the derived column. One consequence of the bug was that add_feature() errored the second time it's called on the same view when entity column is not specified.

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
