### PR TITLE
[DEV-1974] Drop online store table when no longer needed

### DIFF
--- a/.changelog/DEV-1974.yaml
+++ b/.changelog/DEV-1974.yaml
@@ -16,7 +16,7 @@ component: service
 issues: []
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Implement scheduled task to clean up stale versions in online store tables"
+note: "Implement scheduled task to clean up stale versions and drop online store tables when possible"
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/tests/integration/feature_manager/test_feature_manager.py
+++ b/tests/integration/feature_manager/test_feature_manager.py
@@ -222,7 +222,7 @@ async def test_online_enabled__without_snowflake_scheduling(
             assert len(tasks) == 0
 
         finally:
-            await feature_manager_service.online_disable(online_feature_spec)
+            await feature_manager_service.online_disable(None, online_feature_spec)
             await session.execute_query(
                 f"DELETE FROM {feature_store_table_name} WHERE {InternalName.ONLINE_STORE_RESULT_NAME_COLUMN} = 'sum_30h'"
             )
@@ -266,7 +266,7 @@ async def online_enabled_feature_spec_fixture(
 
         yield online_feature_spec, schedule_time
 
-        await feature_manager_service.online_disable(online_feature_spec)
+        await feature_manager_service.online_disable(session, online_feature_spec)
 
 
 @pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
@@ -434,7 +434,7 @@ async def test_online_enable__re_deploy_from_latest_tile_start(
     last_tile_start_ts = tile_model.last_run_metadata_offline.tile_end_date
 
     # disable/un-deploy
-    await feature_manager_service.online_disable(online_feature_spec)
+    await feature_manager_service.online_disable(session, online_feature_spec)
 
     # re-deploy and verify that the tile start ts is the same as the last tile start ts
     with patch(

--- a/tests/unit/feature_manager/test_unit_snowflake_feature.py
+++ b/tests/unit/feature_manager/test_unit_snowflake_feature.py
@@ -243,7 +243,7 @@ async def test_online_disable(
         with mock.patch(
             "featurebyte.service.online_store_compute_query_service.OnlineStoreComputeQueryService.delete_by_result_name"
         ) as mock_delete_by_result_name:
-            await feature_manager_service.online_disable(feature_spec)
+            await feature_manager_service.online_disable(mock_snowflake_session, feature_spec)
 
     mock_delete_by_result_name.assert_called_once()
 


### PR DESCRIPTION
## Description

This updates the logic when online disabling a feature to drop the associated online store table(s) when no longer needed.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
