### PR TITLE
[DEV-1970] Add redis lock to block concurrent deployment update

### DIFF
--- a/.changelog/DEV-1970.yaml
+++ b/.changelog/DEV-1970.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Block submitting multiple concurrent deployment enablement requests to the same deployment"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/routes/deployment/controller.py
+++ b/featurebyte/routes/deployment/controller.py
@@ -119,6 +119,12 @@ class DeploymentController(
         -------
         Optional[Task]
             Task to create deployment.
+
+        Raises
+        ------
+        DocumentUpdateError
+            If there is an existing task to update deployment that is conflicting with the current request.
+            If the task submission lock is not acquired.
         """
         # check if deployment exists
         deployment = await self.service.get_document(document_id=document_id)

--- a/featurebyte/service/task_manager.py
+++ b/featurebyte/service/task_manager.py
@@ -105,6 +105,7 @@ class TaskManager:
         page: int = 1,
         page_size: int = DEFAULT_PAGE_SIZE,
         ascending: bool = True,
+        query_filter: Optional[dict[str, Any]] = None,
     ) -> tuple[list[Task], int]:
         """
         List tasks.
@@ -117,6 +118,8 @@ class TaskManager:
             Page size
         ascending: bool
             Sort direction
+        query_filter: Optional[dict[str, Any]]
+            Query filter
 
         Returns
         -------
@@ -125,7 +128,7 @@ class TaskManager:
         # Perform the query
         results, total = await self.persistent.find(
             collection_name=TaskModel.collection_name(),
-            query_filter={},
+            query_filter=query_filter or {},
             page=page,
             page_size=page_size,
             sort_by="date_done",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -128,6 +128,13 @@ def mock_get_persistent_function(mongo_persistent):
         yield mock_persistent
 
 
+@pytest.fixture(name="mock_redis_lock", autouse=True)
+def mock_redis_lock_fixture():
+    """Mock redis lock"""
+    with patch("featurebyte.routes.deployment.controller.Lock") as mock_redis_lock:
+        yield mock_redis_lock
+
+
 @pytest.fixture(autouse=True)
 def mock_settings_env_vars(mock_config_path_env, mock_get_persistent):
     """Use these fixtures for all tests"""

--- a/tests/unit/routes/test_deployment.py
+++ b/tests/unit/routes/test_deployment.py
@@ -31,12 +31,6 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
         with patch("featurebyte.service.deploy.OnlineEnableService.update_data_warehouse"):
             yield
 
-    @pytest.fixture(name="mock_redis_lock")
-    def mock_redis_lock_fixture(self):
-        """Mock redis lock"""
-        with patch("featurebyte.routes.deployment.controller.Lock") as mock_redis_lock:
-            yield mock_redis_lock
-
     def setup_creation_route(self, api_client):
         """Setup for post route"""
         catalog_id = api_client.get("/catalog").json()["data"][0]["_id"]


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR prevents multiple deployment enable update requests applied to the same deployment.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
