### PR TITLE
[DEV-1987] Fix online serving output row ordering

### DIFF
--- a/.changelog/DEV-1987.yaml
+++ b/.changelog/DEV-1987.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Ensure row ordering of online serving output DataFrame matches input request data"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/tests/integration/query_graph/test_online_serving.py
+++ b/tests/integration/query_graph/test_online_serving.py
@@ -208,7 +208,7 @@ def check_online_features_route(deployment, config, df_historical, columns):
     """
     client = config.get_client()
 
-    user_ids = [5, -999]
+    user_ids = [-999, 5]
     entity_serving_names = [{"üser id": user_id} for user_id in user_ids]
     data = OnlineFeaturesRequestPayload(entity_serving_names=entity_serving_names)
 
@@ -223,11 +223,17 @@ def check_online_features_route(deployment, config, df_historical, columns):
     elapsed = time.time() - tic
     print(f"online_features elapsed: {elapsed:.6f}s")
 
+    assert df["üser id"].tolist() == user_ids
     assert df.columns.tolist() == columns
     df_expected = df_historical[df_historical["üser id"].isin(user_ids)][columns].reset_index(
         drop=True
     )
-    fb_assert_frame_equal(df_expected, df, dict_like_columns=["EVENT_COUNT_BY_ACTION_24h"])
+    fb_assert_frame_equal(
+        df_expected,
+        df,
+        dict_like_columns=["EVENT_COUNT_BY_ACTION_24h"],
+        sort_by_columns=["üser id"],
+    )
 
 
 def check_get_batch_features(deployment, batch_request_table, df_historical, columns):

--- a/tests/unit/routes/test_deployment.py
+++ b/tests/unit/routes/test_deployment.py
@@ -310,7 +310,7 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
 
         async def mock_execute_query(query):
             _ = query
-            return pd.DataFrame([{"cust_id": 1, "feature_value": 123.0}])
+            return pd.DataFrame([{"cust_id": 1, "feature_value": 123.0, "__FB_ROW_INDEX": 0}])
 
         mock_session = mock_get_session.return_value
         mock_session.execute_query = mock_execute_query
@@ -401,7 +401,9 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
 
         async def mock_execute_query(query):
             _ = query
-            return pd.DataFrame([{"cust_id": 1, "feature_value": missing_value}])
+            return pd.DataFrame(
+                [{"cust_id": 1, "feature_value": missing_value, "__FB_ROW_INDEX": 0}]
+            )
 
         mock_session = mock_get_session.return_value
         mock_session.execute_query = mock_execute_query


### PR DESCRIPTION
## Description

This ensures that the row ordering of online serving output DataFrame is the same as the input data.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
