### PR TITLE
[DEV-1849] Support conditionally updating a feature using a mask derived from other feature(s)

### DIFF
--- a/.changelog/DEV-1849.yaml
+++ b/.changelog/DEV-1849.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Support conditionally updating a feature using a mask derived from other feature(s)"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/feature.py
+++ b/featurebyte/api/feature.py
@@ -130,6 +130,10 @@ class Feature(
 
     @property
     def row_index_lineage(self) -> Tuple[str, ...]:
+        # Override the row_index_lineage property to return a constant value. This is so that the
+        # check for row_lineage_index alignment for Feature objects always passes. The check is not
+        # applicable to Feature objects because they can freely interact with each other regardless
+        # of their lineage.
         return tuple()
 
     @root_validator(pre=True)

--- a/featurebyte/api/feature.py
+++ b/featurebyte/api/feature.py
@@ -128,6 +128,10 @@ class Feature(
         tile_specs = ExtendedFeatureModel(**self.dict(by_alias=True)).tile_specs
         return [(str(self.name), tile_specs)] if tile_specs else []
 
+    @property
+    def row_index_lineage(self) -> Tuple[str, ...]:
+        return tuple()
+
     @root_validator(pre=True)
     @classmethod
     def _set_feature_store(cls, values: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Description

The `row_index_lineage` alignment check is applicable to Columns but not Features. Features are joined into a common table and can freely interact with each other regardless of the lineage.

This overrides the `row_index_lineage` property for Feature class as a way to bypass the alignment checks. By doing this, we can support things like conditionally updating a feature using a mask derived from other features.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
