### PR TITLE
[DEV-1985] make table update service backward compatible to earlier clients

### DIFF
--- a/featurebyte/routes/common/base_table.py
+++ b/featurebyte/routes/common/base_table.py
@@ -136,6 +136,9 @@ class BaseTableDocumentController(
         TableDocumentT
             Table object with updated attribute(s)
         """
+
+        # Update of columns info is deprecated and will be removed in release 0.5.0
+        # See https://featurebyte.atlassian.net/browse/DEV-2000
         if data.columns_info:
             await self.table_column_info_service.update_columns_info(
                 service=self.service,

--- a/featurebyte/routes/common/base_table.py
+++ b/featurebyte/routes/common/base_table.py
@@ -136,6 +136,13 @@ class BaseTableDocumentController(
         TableDocumentT
             Table object with updated attribute(s)
         """
+        if data.columns_info:
+            await self.table_column_info_service.update_columns_info(
+                service=self.service,
+                document_id=document_id,
+                columns_info=data.columns_info,
+            )
+
         if data.status:
             await self.table_status_service.update_status(
                 service=self.service,

--- a/featurebyte/schema/table.py
+++ b/featurebyte/schema/table.py
@@ -40,6 +40,9 @@ class TableUpdate(FeatureByteBaseModel):
 
     status: Optional[TableStatus]
     record_creation_timestamp_column: Optional[StrictStr]
+
+    # Update of columns info is deprecated and will be removed in release 0.5.0
+    # See https://featurebyte.atlassian.net/browse/DEV-2000
     columns_info: Optional[List[ColumnInfo]]
 
 

--- a/featurebyte/schema/table.py
+++ b/featurebyte/schema/table.py
@@ -40,6 +40,7 @@ class TableUpdate(FeatureByteBaseModel):
 
     status: Optional[TableStatus]
     record_creation_timestamp_column: Optional[StrictStr]
+    columns_info: Optional[List[ColumnInfo]]
 
 
 class TableServiceUpdate(TableUpdate, BaseDocumentServiceUpdateSchema):

--- a/tests/unit/routes/base.py
+++ b/tests/unit/routes/base.py
@@ -1037,7 +1037,12 @@ class BaseTableApiTestSuite(BaseCatalogApiTestSuite):  # pylint: disable=too-man
     def test_update_column_critical_data_info_old(
         self, test_api_client_persistent, data_response, columns_info
     ):
-        """Test update columns info using update route"""
+        """
+        Test update columns info using column update route (DEPRECATED).
+
+        Update of columns info is deprecated and will be removed in release 0.5.0
+        See https://featurebyte.atlassian.net/browse/DEV-2000
+        """
 
         test_api_client, _ = test_api_client_persistent
         response_dict = data_response.json()
@@ -1051,7 +1056,6 @@ class BaseTableApiTestSuite(BaseCatalogApiTestSuite):  # pylint: disable=too-man
         columns_info[-2] = current_value_info
 
         # update critical data info
-        # update description
         update_response = test_api_client.patch(
             f"{self.base_route}/{response_dict['_id']}",
             json={"columns_info": columns_info},

--- a/tests/unit/routes/base.py
+++ b/tests/unit/routes/base.py
@@ -1034,6 +1034,34 @@ class BaseTableApiTestSuite(BaseCatalogApiTestSuite):  # pylint: disable=too-man
         assert update_response_dict.items() > expected_response.items()
         assert update_response_dict["updated_at"] is not None
 
+    def test_update_column_critical_data_info_old(
+        self, test_api_client_persistent, data_response, columns_info
+    ):
+        """Test update columns info using update route"""
+
+        test_api_client, _ = test_api_client_persistent
+        response_dict = data_response.json()
+
+        # modify current_value's critical data info
+        current_value_info = columns_info[-2]
+        assert current_value_info["name"] == "current_value"
+        current_value_info["critical_data_info"] = {
+            "cleaning_operations": [{"type": "missing", "imputed_value": 0}]
+        }
+        columns_info[-2] = current_value_info
+
+        # update critical data info
+        # update description
+        update_response = test_api_client.patch(
+            f"{self.base_route}/{response_dict['_id']}",
+            json={"columns_info": columns_info},
+        )
+        assert update_response.status_code == HTTPStatus.OK, update_response.json()
+        output_dict = update_response.json()
+        assert output_dict["columns_info"][-2].get("critical_data_info") == {
+            "cleaning_operations": [{"type": "missing", "imputed_value": 0}]
+        }
+
     def test_update_column_critical_data_info(
         self, test_api_client_persistent, data_response, columns_info
     ):


### PR DESCRIPTION
## Description

Fix the change in https://github.com/featurebyte/featurebyte/pull/1586 that breaks backward compatibility with older python clients.

The option to update column info from the column update route is deprecated and will be removed in the next major release (0.5.0)

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-1985
https://featurebyte.atlassian.net/browse/DEV-2000

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
