### PR TITLE
[chore] Track duration in tile job log collection

### DIFF
--- a/featurebyte/models/tile_job_log.py
+++ b/featurebyte/models/tile_job_log.py
@@ -26,6 +26,7 @@ class TileJobLogModel(FeatureByteCatalogBaseDocumentModel):
     status: StrictStr
     message: StrictStr
     traceback: Optional[StrictStr]
+    duration: Optional[float]
 
     class Settings(FeatureByteCatalogBaseDocumentModel.Settings):
         """

--- a/tests/integration/tile/test_schedule_generate_tile.py
+++ b/tests/integration/tile/test_schedule_generate_tile.py
@@ -4,6 +4,7 @@ This module contains integration tests for scheduled tile generation
 from datetime import datetime
 
 import dateutil.parser
+import pandas as pd
 import pytest
 from bson import ObjectId
 
@@ -98,9 +99,10 @@ async def test_schedule_generate_tile_online(
 
     session_id = result[0]["session_id"]
     assert "|" in session_id
-    assert result[1]["created_at"] > result[0]["created_at"]
-    assert result[2]["created_at"] > result[1]["created_at"]
-    assert result[3]["created_at"] > result[2]["created_at"]
+
+    df = pd.DataFrame(result)
+    assert (df["created_at"].diff().iloc[1:].dt.total_seconds() > 0).all()
+    assert (df["duration"].iloc[1:] > 0).all()
 
 
 @pytest.mark.usefixtures("enable_tile_monitoring")


### PR DESCRIPTION
## Description

This adds a new field `duration` to track the runtime of different steps that occur in scheduled tile tasks to facilitate troubleshooting and testing.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
