### PR TITLE
[chore] docs: rm links from method names

### DIFF
--- a/featurebyte/common/documentation/autodoc_processor.py
+++ b/featurebyte/common/documentation/autodoc_processor.py
@@ -165,13 +165,6 @@ class FBAutoDocProcessor(AutoDocProcessor):
             qualifier_elem.text = "async "
 
         name_elem = etree.SubElement(signature_elem, "span")
-        if resource_details.type == "method":
-            # add reference link for methods
-            name_elem = etree.SubElement(name_elem, "a")
-            name_elem.set(
-                "href",
-                f'javascript:window.location=new URL("../{resource_details.path}.{resource_details.realname}/", window.location.href.split("#")[0]).href',
-            )
 
         main_name_elem = etree.SubElement(name_elem, "strong")
         main_name_elem.text = resource_details.name


### PR DESCRIPTION
## Description
There are currently some broken links in the documentation pages that will go to a 404.

Eg. https://docs.featurebyte.com/0.3/reference/featurebyte.Feature.cd.unique_count/ - clicking on the method name will go to a 404.

![Screenshot 2023-08-01 at 2 53 33 PM](https://github.com/featurebyte/featurebyte/assets/2313101/19216837-efa3-4156-9047-c74ce11ccfd0)

These links don't seem particularly useful since it should just point to the current page they're on. These were probably previously added when we had some main pages that displayed all the methods for a class. We don't have those pages anymore, so these links should not be needed.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
