### PR TITLE
[ISSUES-1598] Update is_notebook to support Google Colab and Databricks

### DIFF
--- a/.changelog/ISSUES-1598.yaml
+++ b/.changelog/ISSUES-1598.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: utils
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: ["https://github.com/featurebyte/featurebyte/issues/1598"]
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix is_notebook check to support Google Colab"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/common/env_util.py
+++ b/featurebyte/common/env_util.py
@@ -18,8 +18,7 @@ def is_notebook() -> bool:
     """
     try:
         shell = get_ipython().__class__.__name__  # type: ignore
-        if shell == "ZMQInteractiveShell" or shell == "Shell":
-            return True
+        return bool(shell in ["ZMQInteractiveShell", "Shell"])
     except NameError:
         return False
 

--- a/featurebyte/common/env_util.py
+++ b/featurebyte/common/env_util.py
@@ -18,7 +18,7 @@ def is_notebook() -> bool:
     """
     try:
         shell = get_ipython().__class__.__name__  # type: ignore
-        return bool(shell in ["ZMQInteractiveShell", "Shell"])
+        return bool(shell in ["ZMQInteractiveShell", "Shell", "DatabricksShell"])
     except NameError:
         return False
 

--- a/featurebyte/common/env_util.py
+++ b/featurebyte/common/env_util.py
@@ -18,7 +18,8 @@ def is_notebook() -> bool:
     """
     try:
         shell = get_ipython().__class__.__name__  # type: ignore
-        return bool(shell == "ZMQInteractiveShell")
+        if shell == "ZMQInteractiveShell" or shell == "Shell":
+            return True
     except NameError:
         return False
 


### PR DESCRIPTION
In Colab get_ipython().__class__.__name__ returns just "Shell" instead of "ZMQInteractiveShell" like other Notebook evnironments do. So handle both cases since we are already guarded against not being in a notebook with the name exception.

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [x] I have labeled my Pull Request correctly
