### PR TITLE
[DEV-2026] User inner join when joining event and item tables

### DIFF
--- a/.changelog/DEV-2026.yaml
+++ b/.changelog/DEV-2026.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Change join type to inner when joining event and item tables"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/query_graph/model/table.py
+++ b/featurebyte/query_graph/model/table.py
@@ -191,7 +191,7 @@ class ItemTableData(BaseTableData):
             left_output_columns=left_output_columns,
             right_input_columns=columns_excluding_event_id,
             right_output_columns=right_output_columns,
-            join_type="left",
+            join_type="inner",
             metadata=JoinEventTableAttributesMetadata(
                 columns=columns_to_join,
                 event_suffix=event_suffix,

--- a/featurebyte/query_graph/node/generic.py
+++ b/featurebyte/query_graph/node/generic.py
@@ -1116,7 +1116,11 @@ class JoinNode(BasePrunableNode):
                         node_name=self.name,
                     )
 
-        if self.parameters.join_type == "left":
+        is_event_item_join = (
+            self.parameters.metadata is not None
+            and self.parameters.metadata.type == "join_event_table_attributes"
+        )
+        if self.parameters.join_type == "left" or is_event_item_join:
             row_index_lineage = inputs[0].row_index_lineage
         else:
             row_index_lineage = append_to_lineage(inputs[0].row_index_lineage, self.name)

--- a/tests/fixtures/sdk_code/complex_event_item_feature.py
+++ b/tests/fixtures/sdk_code/complex_event_item_feature.py
@@ -45,7 +45,9 @@ grouped = joined_view_1.groupby(
     skip_fill_na=True,
 )
 feat = grouped["count_a_24h_per_col_int"]
-feat_1 = (feat.cd.entropy()) * (feat.cd.most_frequent()).str.len()
+feat_1 = feat.cd.unique_count(include_missing=True)
+feat_2 = feat.cd.unique_count(include_missing=False)
+feat_3 = (feat.cd.entropy()) * (feat.cd.most_frequent()).str.len()
 grouped_1 = joined_view_1.groupby(
     by_keys=["cust_id"], category=None
 ).aggregate_over(
@@ -58,7 +60,5 @@ grouped_1 = joined_view_1.groupby(
     ),
     skip_fill_na=True,
 )
-feat_2 = grouped_1["sum_a_24h"]
-feat_3 = feat.cd.unique_count(include_missing=False)
-feat_4 = feat.cd.unique_count(include_missing=True)
-output = (feat_2 + feat_1) - (feat_3 / feat_4)
+feat_4 = grouped_1["sum_a_24h"]
+output = (feat_4 + feat_3) - (feat_2 / feat_1)

--- a/tests/fixtures/sdk_code/feature_fraction.py
+++ b/tests/fixtures/sdk_code/feature_fraction.py
@@ -31,21 +31,7 @@ event_view = event_table.get_view(
 joined_view = event_view.add_feature(
     new_column_name="sum_item_amt", feature=col_1, entity_column="cust_id"
 )
-col_2 = joined_view["sum_item_amt"]
-view = joined_view.copy()
-view["sum_item_amt_plus_one"] = col_2 + 1
-grouped = view.groupby(by_keys=["cust_id"], category=None).aggregate_over(
-    value_column="sum_item_amt_plus_one",
-    method="sum",
-    windows=["30d"],
-    feature_names=["sum_item_amt_plus_one_over_30d"],
-    feature_job_setting=FeatureJobSetting(
-        blind_spot="90s", frequency="360s", time_modulo_frequency="180s"
-    ),
-    skip_fill_na=True,
-)
-feat = grouped["sum_item_amt_plus_one_over_30d"]
-grouped_1 = joined_view.groupby(
+grouped = joined_view.groupby(
     by_keys=["cust_id"], category=None
 ).aggregate_over(
     value_column="sum_item_amt",
@@ -57,7 +43,21 @@ grouped_1 = joined_view.groupby(
     ),
     skip_fill_na=True,
 )
-feat_1 = grouped_1["sum_item_amt_over_30d"]
-feat_2 = feat_1 / feat
+feat = grouped["sum_item_amt_over_30d"]
+col_2 = joined_view["sum_item_amt"]
+view = joined_view.copy()
+view["sum_item_amt_plus_one"] = col_2 + 1
+grouped_1 = view.groupby(by_keys=["cust_id"], category=None).aggregate_over(
+    value_column="sum_item_amt_plus_one",
+    method="sum",
+    windows=["30d"],
+    feature_names=["sum_item_amt_plus_one_over_30d"],
+    feature_job_setting=FeatureJobSetting(
+        blind_spot="90s", frequency="360s", time_modulo_frequency="180s"
+    ),
+    skip_fill_na=True,
+)
+feat_1 = grouped_1["sum_item_amt_plus_one_over_30d"]
+feat_2 = feat / feat_1
 feat_2.name = "fraction"
 output = feat_2

--- a/tests/fixtures/sdk_code/feature_item_cosine_similarity.py
+++ b/tests/fixtures/sdk_code/feature_item_cosine_similarity.py
@@ -18,19 +18,6 @@ grouped = item_view.groupby(
 ).aggregate_over(
     value_column="item_amount",
     method="sum",
-    windows=["30d"],
-    feature_names=["sum_item_amount_over_30d"],
-    feature_job_setting=FeatureJobSetting(
-        blind_spot="90s", frequency="360s", time_modulo_frequency="180s"
-    ),
-    skip_fill_na=True,
-)
-feat = grouped["sum_item_amount_over_30d"]
-grouped_1 = item_view.groupby(
-    by_keys=["cust_id_event_table"], category="item_id_col"
-).aggregate_over(
-    value_column="item_amount",
-    method="sum",
     windows=["90d"],
     feature_names=["sum_item_amount_over_90d"],
     feature_job_setting=FeatureJobSetting(
@@ -38,8 +25,21 @@ grouped_1 = item_view.groupby(
     ),
     skip_fill_na=True,
 )
-feat_1 = grouped_1["sum_item_amount_over_90d"]
-feat_2 = feat.cd.cosine_similarity(other=feat_1)
+feat = grouped["sum_item_amount_over_90d"]
+grouped_1 = item_view.groupby(
+    by_keys=["cust_id_event_table"], category="item_id_col"
+).aggregate_over(
+    value_column="item_amount",
+    method="sum",
+    windows=["30d"],
+    feature_names=["sum_item_amount_over_30d"],
+    feature_job_setting=FeatureJobSetting(
+        blind_spot="90s", frequency="360s", time_modulo_frequency="180s"
+    ),
+    skip_fill_na=True,
+)
+feat_1 = grouped_1["sum_item_amount_over_30d"]
+feat_2 = feat_1.cd.cosine_similarity(other=feat)
 feat_2.name = (
     "sum_item_amount_over_30d_cosine_similarity_sum_item_amount_over_90d"
 )

--- a/tests/unit/api/test_item_view.py
+++ b/tests/unit/api/test_item_view.py
@@ -60,7 +60,7 @@ class TestItemView(BaseViewTestSuite):
         "event_timestamp" AS "event_timestamp"
       FROM "sf_database"."sf_schema"."items_table"
     ) AS L
-    LEFT JOIN (
+    INNER JOIN (
       SELECT
         "col_int" AS "col_int",
         "col_float" AS "col_float",
@@ -158,7 +158,7 @@ def test_get_view__auto_join_columns(
                         "name": "join_1",
                         "output_type": "frame",
                         "parameters": {
-                            "join_type": "left",
+                            "join_type": "inner",
                             "left_input_columns": [
                                 "event_id_col",
                                 "item_id_col",
@@ -255,7 +255,7 @@ def test_get_view__auto_join_columns(
             "event_timestamp" AS "event_timestamp"
           FROM "sf_database"."sf_schema"."items_table"
         ) AS L
-        LEFT JOIN (
+        INNER JOIN (
           SELECT
             "col_int" AS "col_int",
             "col_float" AS "col_float",
@@ -353,7 +353,7 @@ def test_join_event_table_attributes__more_columns(
             "right_on": "col_int",
             "right_input_columns": ["col_float"],
             "right_output_columns": ["col_float"],
-            "join_type": "left",
+            "join_type": "inner",
             "scd_parameters": None,
             "metadata": {
                 "type": "join_event_table_attributes",
@@ -421,7 +421,7 @@ def test_join_event_table_attributes__more_columns(
               "event_timestamp" AS "event_timestamp"
             FROM "sf_database"."sf_schema"."items_table"
           ) AS L
-          LEFT JOIN (
+          INNER JOIN (
             SELECT
               "col_int" AS "col_int",
               "col_float" AS "col_float",
@@ -435,7 +435,7 @@ def test_join_event_table_attributes__more_columns(
           ) AS R
             ON L."event_id_col" = R."col_int"
         ) AS L
-        LEFT JOIN (
+        INNER JOIN (
           SELECT
             "col_int" AS "col_int",
             "col_float" AS "col_float",
@@ -525,7 +525,7 @@ def test_item_view__item_table_same_event_id_column_as_event_table(
                             "right_on": "col_int",
                             "right_input_columns": ["event_timestamp", "cust_id"],
                             "right_output_columns": ["event_timestamp", "cust_id"],
-                            "join_type": "left",
+                            "join_type": "inner",
                             "scd_parameters": None,
                             "metadata": {
                                 "type": "join_event_table_attributes",

--- a/tests/unit/api/test_timezone_offset.py
+++ b/tests/unit/api/test_timezone_offset.py
@@ -232,7 +232,7 @@ def test_datetime_property_extraction__event_timestamp_in_item_view(
             "event_timestamp" AS "event_timestamp"
           FROM "sf_database"."sf_schema"."items_table"
         ) AS L
-        LEFT JOIN (
+        INNER JOIN (
           SELECT
             "event_timestamp" AS "event_timestamp",
             "col_int" AS "col_int",


### PR DESCRIPTION
## Description

This changes the join type to "inner" when joining event and item tables. The result is equivalent since the join key should always match between such tables. This allows an upcoming change to apply date range filter on event table at the lowest level in scheduled tile job.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
