### PR TITLE
[DEV-2024] target: fix fill_value by also updating name

### DIFF
--- a/.changelog/DEV-2024.yaml
+++ b/.changelog/DEV-2024.yaml
@@ -16,7 +16,7 @@ component: target
 issues: []
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Add fill_value and skip_fill_na to forward_aggregate"
+note: "Add fill_value and skip_fill_na to forward_aggregate, and update name"
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/featurebyte/api/aggregator/base_aggregator.py
+++ b/featurebyte/api/aggregator/base_aggregator.py
@@ -3,7 +3,7 @@ This module contains base aggregator related class
 """
 from __future__ import annotations
 
-from typing import List, Optional, Type
+from typing import List, Optional, Type, Union
 
 from abc import ABC, abstractmethod
 
@@ -150,27 +150,27 @@ class BaseAggregator(ABC):
             feature_dtype=var_type,
         )
         if not skip_fill_na:
-            self._fill_feature(feature, method, feature_name, fill_value)
+            self._fill_feature_or_target(feature, method, feature_name, fill_value)
         return feature
 
-    def _fill_feature(
+    def _fill_feature_or_target(
         self,
-        feature: Feature,
+        feature_or_target: Union[Feature, Target],
         method: str,
-        feature_name: str,
+        feature_or_target_name: str,
         fill_value: OptionalScalar,
-    ) -> Feature:
+    ) -> Union[Feature, Target]:
         """
-        Fill feature values as needed.
+        Fill feature or target values as needed.
 
         Parameters
         ----------
-        feature: Feature
-            feature
+        feature_or_target: Union[Feature, Target]
+            feature or target
         method: str
             aggregation method
-        feature_name: str
-            feature name
+        feature_or_target_name: str
+            feature or target name
         fill_value: OptionalScalar
             value to fill
 
@@ -189,49 +189,10 @@ class BaseAggregator(ABC):
         if method in {AggFunc.COUNT, AggFunc.NA_COUNT} and self.category is None:
             # Count features should be 0 instead of NaN when there are no records
             value_to_fill = get_or_default(fill_value, 0)
-            feature.fillna(value_to_fill)
-            feature.name = feature_name
+            feature_or_target.fillna(value_to_fill)
+            feature_or_target.name = feature_or_target_name
         elif fill_value is not None:
-            feature.fillna(fill_value)
-            feature.name = feature_name
+            feature_or_target.fillna(fill_value)
+            feature_or_target.name = feature_or_target_name
 
-        return feature
-
-    def _fill_target(
-        self,
-        target: Target,
-        method: str,
-        fill_value: OptionalScalar,
-    ) -> Target:
-        """
-        Fill target values as needed.
-
-        Parameters
-        ----------
-        target: Target
-            target
-        method: str
-            aggregation method
-        fill_value: OptionalScalar
-            value to fill
-
-        Returns
-        -------
-        Target
-
-        Raises
-        ------
-        ValueError
-            If both fill_value and category parameters are specified
-        """
-        if fill_value is not None and self.category is not None:
-            raise ValueError("fill_value is not supported for aggregation per category")
-
-        if method in {AggFunc.COUNT, AggFunc.NA_COUNT} and self.category is None:
-            # Count features should be 0 instead of NaN when there are no records
-            value_to_fill = get_or_default(fill_value, 0)
-            target.fillna(value_to_fill)
-        elif fill_value is not None:
-            target.fillna(fill_value)
-
-        return target
+        return feature_or_target

--- a/featurebyte/api/aggregator/forward_aggregator.py
+++ b/featurebyte/api/aggregator/forward_aggregator.py
@@ -103,7 +103,7 @@ class ForwardAggregator(BaseAggregator):
             dtype=output_var_type,
         )
         if not skip_fill_na:
-            return self._fill_target(target, method, fill_value)
+            return self._fill_feature_or_target(target, method, target_name, fill_value)
         return target
 
     def _prepare_node_parameters(

--- a/featurebyte/api/aggregator/forward_aggregator.py
+++ b/featurebyte/api/aggregator/forward_aggregator.py
@@ -102,8 +102,9 @@ class ForwardAggregator(BaseAggregator):
             feature_store=self.view.feature_store,
             dtype=output_var_type,
         )
+        assert target_name is not None
         if not skip_fill_na:
-            return self._fill_feature_or_target(target, method, target_name, fill_value)
+            return self._fill_feature_or_target(target, method, target_name, fill_value)  # type: ignore[return-value]
         return target
 
     def _prepare_node_parameters(

--- a/featurebyte/api/feature.py
+++ b/featurebyte/api/feature.py
@@ -456,59 +456,6 @@ class Feature(
         """
         self._delete()
 
-    @typechecked
-    def __setattr__(self, key: str, value: Any) -> Any:
-        """
-        Custom __setattr__ to handle setting of special attributes such as name
-
-        Parameters
-        ----------
-        key : str
-            Key
-        value : Any
-            Value
-
-        Raises
-        ------
-        ValueError
-            if the name parameter is invalid
-
-        Returns
-        -------
-        Any
-        """
-        if key != "name":
-            return super().__setattr__(key, value)
-
-        if value is None:
-            raise ValueError("None is not a valid feature name")
-
-        # For now, only allow updating name if the feature is unnamed (i.e. created on-the-fly by
-        # combining different features)
-        name = value
-        node = self.node
-        if node.type in {NodeType.PROJECT, NodeType.ALIAS}:
-            if isinstance(node, ProjectNode):
-                existing_name = node.parameters.columns[0]
-            else:
-                assert isinstance(node, AliasNode)
-                existing_name = node.parameters.name  # type: ignore
-            if name != existing_name:
-                raise ValueError(f'Feature "{existing_name}" cannot be renamed to "{name}"')
-            # FeatureGroup sets name unconditionally, so we allow this here
-            return super().__setattr__(key, value)
-
-        # Here, node could be any node resulting from series operations, e.g. DIV. This
-        # validation was triggered by setting the name attribute of a Feature object
-        new_node = self.graph.add_operation(
-            node_type=NodeType.ALIAS,
-            node_params={"name": name},
-            node_output_type=NodeOutputType.SERIES,
-            input_nodes=[node],
-        )
-        self.node_name = new_node.name
-        return super().__setattr__(key, value)
-
     @property
     def feature_namespace(self) -> FeatureNamespace:
         """

--- a/featurebyte/api/feature.py
+++ b/featurebyte/api/feature.py
@@ -53,12 +53,10 @@ from featurebyte.models.feature import FeatureModel
 from featurebyte.models.feature_namespace import DefaultVersionMode, FeatureReadiness
 from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.models.tile import TileSpec
-from featurebyte.query_graph.enum import NodeOutputType, NodeType
 from featurebyte.query_graph.graph import GlobalQueryGraph
 from featurebyte.query_graph.model.common_table import TabularSource
 from featurebyte.query_graph.model.feature_job_setting import TableFeatureJobSetting
 from featurebyte.query_graph.node.cleaning_operation import TableCleaningOperation
-from featurebyte.query_graph.node.generic import AliasNode, ProjectNode
 from featurebyte.schema.feature import (
     BatchFeatureCreatePayload,
     BatchFeatureItem,

--- a/featurebyte/api/feature_or_target_mixin.py
+++ b/featurebyte/api/feature_or_target_mixin.py
@@ -1,7 +1,7 @@
 """
 Mixin class containing common methods for feature or target classes
 """
-from typing import List, Sequence, cast
+from typing import Any, List, Sequence, cast
 
 import time
 from http import HTTPStatus
@@ -9,6 +9,7 @@ from http import HTTPStatus
 import pandas as pd
 from bson import ObjectId
 from pydantic import Field
+from typeguard import typechecked
 
 from featurebyte.api.api_object import ApiObject
 from featurebyte.api.entity import Entity
@@ -21,6 +22,8 @@ from featurebyte.logging import get_logger
 from featurebyte.models.base import PydanticObjectId, get_active_catalog_id
 from featurebyte.models.feature import BaseFeatureModel
 from featurebyte.models.relationship_analysis import derive_primary_entity
+from featurebyte.query_graph.enum import NodeOutputType, NodeType
+from featurebyte.query_graph.node.generic import AliasNode, ProjectNode
 from featurebyte.schema.preview import FeatureOrTargetPreview
 
 logger = get_logger(__name__)
@@ -109,3 +112,56 @@ class FeatureOrTargetMixin(QueryObject, ApiObject):
             entities.append(Entity.get_by_id(entity_id))
         primary_entity = derive_primary_entity(entities)  # type: ignore
         return primary_entity
+
+    @typechecked
+    def __setattr__(self, key: str, value: Any) -> Any:
+        """
+        Custom __setattr__ to handle setting of special attributes such as name
+
+        Parameters
+        ----------
+        key : str
+            Key
+        value : Any
+            Value
+
+        Raises
+        ------
+        ValueError
+            if the name parameter is invalid
+
+        Returns
+        -------
+        Any
+        """
+        if key != "name":
+            return super().__setattr__(key, value)
+
+        if value is None:
+            raise ValueError("None is not a valid feature name")
+
+        # For now, only allow updating name if the feature is unnamed (i.e. created on-the-fly by
+        # combining different features)
+        name = value
+        node = self.node
+        if node.type in {NodeType.PROJECT, NodeType.ALIAS}:
+            if isinstance(node, ProjectNode):
+                existing_name = node.parameters.columns[0]
+            else:
+                assert isinstance(node, AliasNode)
+                existing_name = node.parameters.name  # type: ignore
+            if name != existing_name:
+                raise ValueError(f'Feature "{existing_name}" cannot be renamed to "{name}"')
+            # FeatureGroup sets name unconditionally, so we allow this here
+            return super().__setattr__(key, value)
+
+        # Here, node could be any node resulting from series operations, e.g. DIV. This
+        # validation was triggered by setting the name attribute of a Feature object
+        new_node = self.graph.add_operation(
+            node_type=NodeType.ALIAS,
+            node_params={"name": name},
+            node_output_type=NodeOutputType.SERIES,
+            input_nodes=[node],
+        )
+        self.node_name = new_node.name
+        return super().__setattr__(key, value)

--- a/tests/unit/api/aggregator/test_forward_aggregator.py
+++ b/tests/unit/api/aggregator/test_forward_aggregator.py
@@ -43,10 +43,24 @@ def test_forward_aggregate_fill_na(forward_aggregator):
         "col_float", AggFunc.SUM, "7d", "target", fill_value
     )
     target_node = target.node
-    assert target_node.type == NodeType.CONDITIONAL
+
+    # Check that we have the fill value
+    conditional_nodes = [
+        node
+        for node in forward_aggregator.view.graph.iterate_nodes(target_node, NodeType.CONDITIONAL)
+    ]
+    assert len(conditional_nodes) == 1
+    conditional_node = conditional_nodes[0]
+    assert conditional_node.type == NodeType.CONDITIONAL
+    assert conditional_node.parameters.dict() == {
+        "value": 1,
+    }
+
+    # Check that the final node is the alias node, and that it has the target name
+    assert target_node.type == NodeType.ALIAS
     assert target_node.output_type == NodeOutputType.SERIES
     assert target_node.parameters.dict() == {
-        "value": fill_value,
+        "name": "target",
     }
 
 

--- a/tests/unit/api/test_groupby.py
+++ b/tests/unit/api/test_groupby.py
@@ -438,15 +438,15 @@ def get_test_aggregator_and_feature_fixture(snowflake_event_view_with_entity_and
     )
 
 
-def test__fill_feature_noop(test_aggregator_and_sum_feature):
+def test__fill_feature_or_target_noop(test_aggregator_and_sum_feature):
     """
-    Test _fill_feature
+    Test _fill_feature_or_target
     """
     aggregator, feature = test_aggregator_and_sum_feature
 
     # Passing in None as fill value, and sum count type should result in a no-op
     original_edges = get_graph_edges_from_feature(feature)
-    filled_feature = aggregator._fill_feature(
+    filled_feature = aggregator._fill_feature_or_target(
         feature,
         "sum",
         feature.name,
@@ -480,13 +480,13 @@ def get_test_aggregator_and_count_feature_fixture(snowflake_event_view_with_enti
     )
 
 
-def test__fill_feature_count_fill_with_0(test_aggregator_and_count_feature):
+def test__fill_feature_or_target_count_fill_with_0(test_aggregator_and_count_feature):
     """
-    Test _fill_feature
+    Test _fill_feature_or_target
     """
     aggregator, feature = test_aggregator_and_count_feature
     original_edges = get_graph_edges_from_feature(feature)
-    filled_feature = aggregator._fill_feature(
+    filled_feature = aggregator._fill_feature_or_target(
         feature,
         "count",
         feature.name,
@@ -509,14 +509,14 @@ def get_node_from_feature(feature, node_name):
     return nodes[node_name]
 
 
-def test__fill_feature_update_value_count_feature(test_aggregator_and_count_feature):
+def test__fill_feature_or_target_update_value_count_feature(test_aggregator_and_count_feature):
     """
-    Test _fill_feature
+    Test _fill_feature_or_target
     """
     aggregator, feature = test_aggregator_and_count_feature
     original_edges = get_graph_edges_from_feature(feature)
     value_to_update = 2
-    filled_feature = aggregator._fill_feature(
+    filled_feature = aggregator._fill_feature_or_target(
         feature,
         "count",
         feature.name,
@@ -543,14 +543,14 @@ def assert_edges_updated_with_conditional(original_edges, updated_edges):
     assert expected_filled_edges == updated_edges
 
 
-def test__fill_feature_update_value_non_count_features(test_aggregator_and_count_feature):
+def test__fill_feature_or_target_update_value_non_count_features(test_aggregator_and_count_feature):
     """
-    Test _fill_feature
+    Test _fill_feature_or_target
     """
     aggregator, feature = test_aggregator_and_count_feature
     original_edges = get_graph_edges_from_feature(feature)
     value_to_update = 2
-    filled_feature = aggregator._fill_feature(
+    filled_feature = aggregator._fill_feature_or_target(
         feature,
         "sum",
         feature.name,


### PR DESCRIPTION
## Description
Currently, if you fill_value on a forward_aggregate, the target name is lost. I wrongly assumed that we didn't need to also update the name, but have come to realize that the last node needs to be a project or alias for the computation to pick up the name correctly.

We can reuse the logic w/ feature to keep this consistent.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
