### PR TITLE
[DEV-2026] Filter EventTable by tile date range directly when possible

### DIFF
--- a/.changelog/DEV-2026-2.yaml
+++ b/.changelog/DEV-2026-2.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Apply event timestamp filter on EventTable directly in scheduled tile jobs when possible"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/models/user_defined_function.py
+++ b/featurebyte/models/user_defined_function.py
@@ -301,6 +301,7 @@ class UserDefinedFunctionModel(FeatureByteBaseDocumentModel):
                 sql_type=SQLType.MATERIALIZE,
                 source_type=source_type,
                 to_filter_scd_by_current_flag=False,
+                event_table_timestamp_filter=None,
             )
         )
         sql_tree = select(sql_node.sql)

--- a/featurebyte/query_graph/sql/ast/base.py
+++ b/featurebyte/query_graph/sql/ast/base.py
@@ -9,6 +9,7 @@ from abc import ABC, abstractmethod
 from copy import copy
 from dataclasses import dataclass, field
 
+from bson import ObjectId
 from sqlglot import expressions
 from sqlglot.expressions import Expression, Select, select
 
@@ -21,6 +22,21 @@ from featurebyte.query_graph.sql.common import SQLType
 
 SQLNodeT = TypeVar("SQLNodeT", bound="SQLNode")
 TableNodeT = TypeVar("TableNodeT", bound="TableNode")
+
+
+@dataclass
+class EventTableTimestampFilter:
+    """
+    Information about the timestamp filter to be applied when selecting from EventTable
+
+    timestamp_column_name: str
+        Name of the timestamp column
+    event_table_id: ObjectId
+        Id of the EventTable. Only EventTable matching this id should be filtered.
+    """
+
+    timestamp_column_name: str
+    event_table_id: ObjectId
 
 
 @dataclass
@@ -48,6 +64,7 @@ class SQLNodeContext:
     source_type: SourceType
     input_sql_nodes: list[SQLNode]
     to_filter_scd_by_current_flag: Optional[bool]
+    event_table_timestamp_filter: Optional[EventTableTimestampFilter]
 
     def __post_init__(self) -> None:
         self.parameters = self.query_node.parameters.dict()

--- a/featurebyte/query_graph/sql/ast/join_feature.py
+++ b/featurebyte/query_graph/sql/ast/join_feature.py
@@ -14,7 +14,11 @@ from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.model.graph import QueryGraphModel
 from featurebyte.query_graph.node import Node
 from featurebyte.query_graph.node.generic import ItemGroupbyParameters
-from featurebyte.query_graph.sql.ast.base import SQLNodeContext, TableNode
+from featurebyte.query_graph.sql.ast.base import (
+    EventTableTimestampFilter,
+    SQLNodeContext,
+    TableNode,
+)
 from featurebyte.query_graph.sql.common import (
     SQLType,
     get_qualified_column_identifier,
@@ -48,6 +52,7 @@ class JoinFeature(TableNode):
             view_node=view_node,
             view_entity_column=context.parameters["view_entity_column"],
             source_type=context.source_type,
+            event_table_timestamp_filter=context.event_table_timestamp_filter,
         )
 
         # Apply any post-processing (e.g. filling missing value with 0 for count features)
@@ -76,6 +81,7 @@ class JoinFeature(TableNode):
         view_node: TableNode,
         view_entity_column: str,
         source_type: SourceType,
+        event_table_timestamp_filter: Optional[EventTableTimestampFilter] = None,
     ) -> Select:
         """
         Join the intermediate aggregation result of item aggregation with the EventView
@@ -96,6 +102,8 @@ class JoinFeature(TableNode):
             intermediate aggregation result
         source_type: SourceType
             Source type information
+        event_table_timestamp_filter: Optional[EventTableTimestampFilter]
+            Event table timestamp filter to apply if applicable
 
         Returns
         -------
@@ -127,6 +135,7 @@ class JoinFeature(TableNode):
                 graph=graph,
                 source_type=source_type,
                 serving_names_mapping=serving_names_mapping,
+                event_table_timestamp_filter=event_table_timestamp_filter,
             )
             for agg_spec in agg_specs:
                 item_aggregator.update(agg_spec)

--- a/featurebyte/query_graph/sql/builder.py
+++ b/featurebyte/query_graph/sql/builder.py
@@ -3,7 +3,7 @@ Module for SQL syntax tree builder
 """
 from __future__ import annotations
 
-from typing import Any, Iterable, Type
+from typing import Any, Iterable, Optional, Type
 
 from collections import defaultdict
 
@@ -12,7 +12,12 @@ from featurebyte.enum import SourceType
 from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.model.graph import QueryGraphModel
 from featurebyte.query_graph.node import Node
-from featurebyte.query_graph.sql.ast.base import SQLNode, SQLNodeContext, TableNode
+from featurebyte.query_graph.sql.ast.base import (
+    EventTableTimestampFilter,
+    SQLNode,
+    SQLNodeContext,
+    TableNode,
+)
 from featurebyte.query_graph.sql.ast.generic import (
     handle_filter_node,
     make_assign_node,
@@ -111,12 +116,14 @@ class SQLOperationGraph:
         sql_type: SQLType,
         source_type: SourceType,
         to_filter_scd_by_current_flag: bool = False,
+        event_table_timestamp_filter: Optional[EventTableTimestampFilter] = None,
     ) -> None:
         self.sql_nodes: dict[str, SQLNode | TableNode] = {}
         self.query_graph = query_graph
         self.sql_type = sql_type
         self.source_type = source_type
         self.to_filter_scd_by_current_flag = to_filter_scd_by_current_flag
+        self.event_table_timestamp_filter = event_table_timestamp_filter
 
     def build(self, target_node: Node) -> Any:
         """Build the graph from a given query Node, working backwards
@@ -179,6 +186,7 @@ class SQLOperationGraph:
             source_type=self.source_type,
             input_sql_nodes=input_sql_nodes,
             to_filter_scd_by_current_flag=self.to_filter_scd_by_current_flag,
+            event_table_timestamp_filter=self.event_table_timestamp_filter,
         )
 
         # Construct an appropriate SQLNode based on the candidates defined in NodeRegistry

--- a/featurebyte/query_graph/sql/interpreter/tile.py
+++ b/featurebyte/query_graph/sql/interpreter/tile.py
@@ -13,7 +13,7 @@ from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.model.graph import QueryGraphModel
 from featurebyte.query_graph.node import Node
 from featurebyte.query_graph.node.generic import GroupByNode
-from featurebyte.query_graph.node.metadata.operation import ViewDataColumnType
+from featurebyte.query_graph.node.metadata.operation import SourceDataColumn
 from featurebyte.query_graph.sql.ast.base import EventTableTimestampFilter
 from featurebyte.query_graph.sql.builder import SQLOperationGraph
 from featurebyte.query_graph.sql.common import SQLType
@@ -143,9 +143,10 @@ class TileSQLGenerator:
         for column in op_struct.columns:
             if (
                 column.name == groupby_node.parameters.timestamp
-                and column.type == ViewDataColumnType.SOURCE
+                and isinstance(column, SourceDataColumn)
                 and column.table_id is not None
             ):
+                assert isinstance(column, SourceDataColumn)
                 return EventTableTimestampFilter(
                     timestamp_column_name=column.name,
                     event_table_id=column.table_id,

--- a/featurebyte/query_graph/sql/specs.py
+++ b/featurebyte/query_graph/sql/specs.py
@@ -33,6 +33,7 @@ from featurebyte.query_graph.node.generic import (
 )
 from featurebyte.query_graph.node.mixin import BaseGroupbyParameters
 from featurebyte.query_graph.sql.adapter import BaseAdapter
+from featurebyte.query_graph.sql.ast.base import EventTableTimestampFilter
 from featurebyte.query_graph.sql.common import apply_serving_names_mapping
 from featurebyte.query_graph.sql.tiling import InputColumn, get_aggregator
 from featurebyte.query_graph.transform.operation_structure import OperationStructureExtractor
@@ -314,6 +315,7 @@ class NonTileBasedAggregationSpec(AggregationSpec):
         node: Node,
         source_type: SourceType,
         to_filter_scd_by_current_flag: bool,
+        event_table_timestamp_filter: Optional[EventTableTimestampFilter],
     ) -> AggregationSource:
         """
         Get the expression of the input view to be aggregated
@@ -328,6 +330,8 @@ class NonTileBasedAggregationSpec(AggregationSpec):
             Source type information
         to_filter_scd_by_current_flag: bool
             Whether to filter SCD by current flag
+        event_table_timestamp_filter: EventTableTimestampFilter
+            Event table timestamp filter to apply if applicable
 
         Returns
         -------
@@ -344,6 +348,7 @@ class NonTileBasedAggregationSpec(AggregationSpec):
             sql_type=SQLType.AGGREGATION,
             source_type=source_type,
             to_filter_scd_by_current_flag=to_filter_scd_by_current_flag,
+            event_table_timestamp_filter=event_table_timestamp_filter,
         ).build(node)
 
         sql_node = cast(Aggregate, sql_node)
@@ -462,6 +467,7 @@ class NonTileBasedAggregationSpec(AggregationSpec):
         source_type: Optional[SourceType] = None,
         serving_names_mapping: Optional[dict[str, str]] = None,
         is_online_serving: Optional[bool] = None,
+        event_table_timestamp_filter: Optional[EventTableTimestampFilter] = None,
     ) -> list[NonTileBasedAggregationSpecT]:
         """Construct NonTileBasedAggregationSpec objects given a query graph node
 
@@ -479,6 +485,8 @@ class NonTileBasedAggregationSpec(AggregationSpec):
             Serving names mapping
         is_online_serving: bool
             Whether the query is for online serving
+        event_table_timestamp_filter: Optional[EventTableTimestampFilter]
+            Event table timestamp filter to apply if applicable
 
         Returns
         -------
@@ -496,6 +504,7 @@ class NonTileBasedAggregationSpec(AggregationSpec):
                 node=node,
                 source_type=source_type,
                 to_filter_scd_by_current_flag=to_filter_scd_by_current_flag,
+                event_table_timestamp_filter=event_table_timestamp_filter,
             )
 
         return cls.construct_specs(

--- a/tests/fixtures/expected_tile_sql_complex_feature_push_down_eligible.sql
+++ b/tests/fixtures/expected_tile_sql_complex_feature_push_down_eligible.sql
@@ -1,0 +1,215 @@
+SELECT
+  index,
+  "cust_id",
+  SUM("added_feature") AS value_sum_ae7ea38511285eab9c15813aa9fe9c1b16f25fb4
+FROM (
+  SELECT
+    *,
+    F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "event_timestamp"), 300, 600, 30) AS index
+  FROM (
+    SELECT
+      *
+    FROM (
+      SELECT
+        "col_int" AS "col_int",
+        "col_float" AS "col_float",
+        "col_char" AS "col_char",
+        "col_text" AS "col_text",
+        "col_binary" AS "col_binary",
+        "col_boolean" AS "col_boolean",
+        "event_timestamp" AS "event_timestamp",
+        "cust_id" AS "cust_id",
+        "col_float_scd" AS "col_float_scd",
+        "col_binary_scd" AS "col_binary_scd",
+        "col_boolean_scd" AS "col_boolean_scd",
+        "created_at_scd" AS "created_at_scd",
+        "cust_id_scd" AS "cust_id_scd",
+        (
+          "_fb_internal_item_sum_item_amount_event_id_col_None_join_1" + "col_float_scd"
+        ) AS "added_feature"
+      FROM (
+        SELECT
+          REQ."col_int",
+          REQ."col_float",
+          REQ."col_char",
+          REQ."col_text",
+          REQ."col_binary",
+          REQ."col_boolean",
+          REQ."event_timestamp",
+          REQ."cust_id",
+          REQ."col_float_scd",
+          REQ."col_binary_scd",
+          REQ."col_boolean_scd",
+          REQ."created_at_scd",
+          REQ."cust_id_scd",
+          "T0"."_fb_internal_item_sum_item_amount_event_id_col_None_join_1" AS "_fb_internal_item_sum_item_amount_event_id_col_None_join_1"
+        FROM (
+          SELECT
+            L."col_int" AS "col_int",
+            L."col_float" AS "col_float",
+            L."col_char" AS "col_char",
+            L."col_text" AS "col_text",
+            L."col_binary" AS "col_binary",
+            L."col_boolean" AS "col_boolean",
+            L."event_timestamp" AS "event_timestamp",
+            L."cust_id" AS "cust_id",
+            R."col_float" AS "col_float_scd",
+            R."col_binary" AS "col_binary_scd",
+            R."col_boolean" AS "col_boolean_scd",
+            R."created_at" AS "created_at_scd",
+            R."cust_id" AS "cust_id_scd"
+          FROM (
+            SELECT
+              "__FB_KEY_COL_0",
+              "__FB_LAST_TS",
+              "col_int",
+              "col_float",
+              "col_char",
+              "col_text",
+              "col_binary",
+              "col_boolean",
+              "event_timestamp",
+              "cust_id"
+            FROM (
+              SELECT
+                "__FB_KEY_COL_0",
+                LAG("__FB_EFFECTIVE_TS_COL") IGNORE NULLS OVER (PARTITION BY "__FB_KEY_COL_0" ORDER BY "__FB_TS_COL", "__FB_TS_TIE_BREAKER_COL") AS "__FB_LAST_TS",
+                "col_int",
+                "col_float",
+                "col_char",
+                "col_text",
+                "col_binary",
+                "col_boolean",
+                "event_timestamp",
+                "cust_id",
+                "__FB_EFFECTIVE_TS_COL"
+              FROM (
+                SELECT
+                  CAST(CONVERT_TIMEZONE('UTC', "event_timestamp") AS TIMESTAMP) AS "__FB_TS_COL",
+                  "cust_id" AS "__FB_KEY_COL_0",
+                  NULL AS "__FB_EFFECTIVE_TS_COL",
+                  2 AS "__FB_TS_TIE_BREAKER_COL",
+                  "col_int" AS "col_int",
+                  "col_float" AS "col_float",
+                  "col_char" AS "col_char",
+                  "col_text" AS "col_text",
+                  "col_binary" AS "col_binary",
+                  "col_boolean" AS "col_boolean",
+                  "event_timestamp" AS "event_timestamp",
+                  "cust_id" AS "cust_id"
+                FROM (
+                  SELECT
+                    "col_int" AS "col_int",
+                    "col_float" AS "col_float",
+                    "col_char" AS "col_char",
+                    "col_text" AS "col_text",
+                    "col_binary" AS "col_binary",
+                    "col_boolean" AS "col_boolean",
+                    "event_timestamp" AS "event_timestamp",
+                    "cust_id" AS "cust_id"
+                  FROM "sf_database"."sf_schema"."sf_table"
+                  WHERE
+                    "event_timestamp" >= CAST(__FB_START_DATE AS TIMESTAMPNTZ)
+                    AND "event_timestamp" < CAST(__FB_END_DATE AS TIMESTAMPNTZ)
+                )
+                UNION ALL
+                SELECT
+                  CAST(CONVERT_TIMEZONE('UTC', "effective_timestamp") AS TIMESTAMP) AS "__FB_TS_COL",
+                  "col_text" AS "__FB_KEY_COL_0",
+                  "effective_timestamp" AS "__FB_EFFECTIVE_TS_COL",
+                  1 AS "__FB_TS_TIE_BREAKER_COL",
+                  NULL AS "col_int",
+                  NULL AS "col_float",
+                  NULL AS "col_char",
+                  NULL AS "col_text",
+                  NULL AS "col_binary",
+                  NULL AS "col_boolean",
+                  NULL AS "event_timestamp",
+                  NULL AS "cust_id"
+                FROM (
+                  SELECT
+                    "col_int" AS "col_int",
+                    "col_float" AS "col_float",
+                    "col_text" AS "col_text",
+                    "col_binary" AS "col_binary",
+                    "col_boolean" AS "col_boolean",
+                    "effective_timestamp" AS "effective_timestamp",
+                    "end_timestamp" AS "end_timestamp",
+                    "created_at" AS "created_at",
+                    "cust_id" AS "cust_id"
+                  FROM "sf_database"."sf_schema"."scd_table"
+                )
+              )
+            )
+            WHERE
+              "__FB_EFFECTIVE_TS_COL" IS NULL
+          ) AS L
+          LEFT JOIN (
+            SELECT
+              "col_int" AS "col_int",
+              "col_float" AS "col_float",
+              "col_text" AS "col_text",
+              "col_binary" AS "col_binary",
+              "col_boolean" AS "col_boolean",
+              "effective_timestamp" AS "effective_timestamp",
+              "end_timestamp" AS "end_timestamp",
+              "created_at" AS "created_at",
+              "cust_id" AS "cust_id"
+            FROM "sf_database"."sf_schema"."scd_table"
+          ) AS R
+            ON L."__FB_LAST_TS" = R."effective_timestamp" AND L."__FB_KEY_COL_0" = R."col_text"
+        ) AS REQ
+        LEFT JOIN (
+          SELECT
+            ITEM."event_id_col" AS "cust_id",
+            SUM(ITEM."item_amount") AS "_fb_internal_item_sum_item_amount_event_id_col_None_join_1"
+          FROM (
+            SELECT
+              L."event_id_col" AS "event_id_col",
+              L."item_id_col" AS "item_id_col",
+              L."item_type" AS "item_type",
+              L."item_amount" AS "item_amount",
+              L."created_at" AS "created_at",
+              L."event_timestamp" AS "event_timestamp",
+              R."event_timestamp" AS "event_timestamp_event_table"
+            FROM (
+              SELECT
+                "event_id_col" AS "event_id_col",
+                "item_id_col" AS "item_id_col",
+                "item_type" AS "item_type",
+                "item_amount" AS "item_amount",
+                "created_at" AS "created_at",
+                "event_timestamp" AS "event_timestamp"
+              FROM "sf_database"."sf_schema"."items_table"
+            ) AS L
+            INNER JOIN (
+              SELECT
+                "col_int" AS "col_int",
+                "col_float" AS "col_float",
+                "col_char" AS "col_char",
+                "col_text" AS "col_text",
+                "col_binary" AS "col_binary",
+                "col_boolean" AS "col_boolean",
+                "event_timestamp" AS "event_timestamp",
+                "cust_id" AS "cust_id"
+              FROM "sf_database"."sf_schema"."sf_table"
+              WHERE
+                "event_timestamp" >= CAST(__FB_START_DATE AS TIMESTAMPNTZ)
+                AND "event_timestamp" < CAST(__FB_END_DATE AS TIMESTAMPNTZ)
+            ) AS R
+              ON L."event_id_col" = R."col_int"
+          ) AS ITEM
+          GROUP BY
+            ITEM."event_id_col"
+        ) AS T0
+          ON REQ."cust_id" = T0."cust_id"
+      )
+    )
+    WHERE
+      "event_timestamp" >= CAST(__FB_START_DATE AS TIMESTAMPNTZ)
+      AND "event_timestamp" < CAST(__FB_END_DATE AS TIMESTAMPNTZ)
+  )
+)
+GROUP BY
+  index,
+  "cust_id"

--- a/tests/fixtures/expected_tile_sql_feature_with_lag.sql
+++ b/tests/fixtures/expected_tile_sql_feature_with_lag.sql
@@ -1,0 +1,32 @@
+SELECT
+  index,
+  "cust_id",
+  SUM("lag_col") AS value_sum_23fef7e510b53d16fcdcebb208add139a307f458
+FROM (
+  SELECT
+    *,
+    F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "event_timestamp"), 300, 600, 30) AS index
+  FROM (
+    SELECT
+      *
+    FROM (
+      SELECT
+        "col_int" AS "col_int",
+        "col_float" AS "col_float",
+        "col_char" AS "col_char",
+        "col_text" AS "col_text",
+        "col_binary" AS "col_binary",
+        "col_boolean" AS "col_boolean",
+        "event_timestamp" AS "event_timestamp",
+        "cust_id" AS "cust_id",
+        LAG("col_float", 1) OVER (PARTITION BY "cust_id" ORDER BY "event_timestamp") AS "lag_col"
+      FROM "sf_database"."sf_schema"."sf_table"
+    )
+    WHERE
+      "event_timestamp" >= CAST(__FB_START_DATE AS TIMESTAMPNTZ)
+      AND "event_timestamp" < CAST(__FB_END_DATE AS TIMESTAMPNTZ)
+  )
+)
+GROUP BY
+  index,
+  "cust_id"

--- a/tests/fixtures/expected_tile_sql_feature_without_lag.sql
+++ b/tests/fixtures/expected_tile_sql_feature_without_lag.sql
@@ -1,0 +1,34 @@
+SELECT
+  index,
+  "cust_id",
+  SUM("col_float") AS value_sum_aed233b0e8a6e1c1e0d5427b126b03c949609481
+FROM (
+  SELECT
+    *,
+    F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "event_timestamp"), 300, 600, 30) AS index
+  FROM (
+    SELECT
+      *
+    FROM (
+      SELECT
+        "col_int" AS "col_int",
+        "col_float" AS "col_float",
+        "col_char" AS "col_char",
+        "col_text" AS "col_text",
+        "col_binary" AS "col_binary",
+        "col_boolean" AS "col_boolean",
+        "event_timestamp" AS "event_timestamp",
+        "cust_id" AS "cust_id"
+      FROM "sf_database"."sf_schema"."sf_table"
+      WHERE
+        "event_timestamp" >= CAST(__FB_START_DATE AS TIMESTAMPNTZ)
+        AND "event_timestamp" < CAST(__FB_END_DATE AS TIMESTAMPNTZ)
+    )
+    WHERE
+      "event_timestamp" >= CAST(__FB_START_DATE AS TIMESTAMPNTZ)
+      AND "event_timestamp" < CAST(__FB_END_DATE AS TIMESTAMPNTZ)
+  )
+)
+GROUP BY
+  index,
+  "cust_id"

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -1110,6 +1110,16 @@ def test_add_feature(event_view, non_time_based_feature, scd_table, source_type)
         "transaction_count_sum_24h": 56,
     }
 
+    feature_list = FeatureList([transaction_counts], name="temp_list")
+    df_historical = feature_list.compute_historical_features(
+        pd.DataFrame([{"POINT_IN_TIME": timestamp_str, "PRODUCT_ACTION": "purchase"}]),
+    )
+    assert df_historical.iloc[0].to_dict() == {
+        "POINT_IN_TIME": pd.Timestamp(timestamp_str),
+        "PRODUCT_ACTION": "purchase",
+        "transaction_count_sum_24h": 56,
+    }
+
 
 @pytest.mark.parametrize("source_type", ["snowflake", "spark", "databricks"], indirect=True)
 def test_add_feature_on_view_with_join(event_view, scd_table, non_time_based_feature):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -843,6 +843,14 @@ def snowflake_event_view_entity_feature_job_fixture(
     yield event_view
 
 
+@pytest.fixture(name="snowflake_scd_view_with_entity")
+def snowflake_scd_view_with_entity_fixture(snowflake_scd_table_with_entity):
+    """
+    Fixture for an SCD view with entity
+    """
+    return snowflake_scd_table_with_entity.get_view()
+
+
 @pytest.fixture(name="patched_observation_table_service")
 def patched_observation_table_service_fixture():
     """

--- a/tests/unit/feature_manager/test_model.py
+++ b/tests/unit/feature_manager/test_model.py
@@ -36,6 +36,9 @@ def test_extended_feature_model__float_feature(float_feature, snowflake_feature_
                 "event_timestamp" AS "event_timestamp",
                 "cust_id" AS "cust_id"
               FROM "sf_database"."sf_schema"."sf_table"
+              WHERE
+                "event_timestamp" >= CAST(__FB_START_DATE AS TIMESTAMPNTZ)
+                AND "event_timestamp" < CAST(__FB_END_DATE AS TIMESTAMPNTZ)
             )
             WHERE
               "event_timestamp" >= CAST(__FB_START_DATE AS TIMESTAMPNTZ)
@@ -98,6 +101,9 @@ def test_extended_feature_model__agg_per_category_feature(
                 "event_timestamp" AS "event_timestamp",
                 "cust_id" AS "cust_id"
               FROM "sf_database"."sf_schema"."sf_table"
+              WHERE
+                "event_timestamp" >= CAST(__FB_START_DATE AS TIMESTAMPNTZ)
+                AND "event_timestamp" < CAST(__FB_END_DATE AS TIMESTAMPNTZ)
             )
             WHERE
               "event_timestamp" >= CAST(__FB_START_DATE AS TIMESTAMPNTZ)

--- a/tests/unit/query_graph/sql/test_tile.py
+++ b/tests/unit/query_graph/sql/test_tile.py
@@ -66,7 +66,7 @@ def test_scheduled_tile_sql__can_push_down_date_filter(float_feature, update_fix
     """
     tile_sql = get_tile_sql_used_in_scheduled_tasks(float_feature)
     assert_equal_with_expected_fixture(
-        tile_sql, "fixtures/expected_tile_sql_feature_without_lag.sql", update_fixtures
+        tile_sql, "tests/fixtures/expected_tile_sql_feature_without_lag.sql", update_fixtures
     )
 
 
@@ -76,7 +76,7 @@ def test_scheduled_tile_sql__cannot_push_down_date_filter(feature_with_lag, upda
     """
     tile_sql = get_tile_sql_used_in_scheduled_tasks(feature_with_lag)
     assert_equal_with_expected_fixture(
-        tile_sql, "fixtures/expected_tile_sql_feature_with_lag.sql", update_fixtures
+        tile_sql, "tests/fixtures/expected_tile_sql_feature_with_lag.sql", update_fixtures
     )
 
 
@@ -88,6 +88,6 @@ def test_scheduled_tile_sql__complex(complex_feature_but_push_down_eligible, upd
     tile_sql = get_tile_sql_used_in_scheduled_tasks(complex_feature_but_push_down_eligible)
     assert_equal_with_expected_fixture(
         tile_sql,
-        "fixtures/expected_tile_sql_complex_feature_push_down_eligible.sql",
+        "tests/fixtures/expected_tile_sql_complex_feature_push_down_eligible.sql",
         update_fixtures,
     )

--- a/tests/unit/query_graph/sql/test_tile.py
+++ b/tests/unit/query_graph/sql/test_tile.py
@@ -1,0 +1,93 @@
+"""
+Tests for tile related SQL generation using high level API fixtures
+"""
+import pytest
+
+from featurebyte.feature_manager.model import ExtendedFeatureModel
+from tests.util.helper import assert_equal_with_expected_fixture
+
+
+@pytest.fixture
+def feature_with_lag(snowflake_event_view_with_entity, feature_group_feature_job_setting):
+    """
+    Fixture for a feature with lag
+    """
+    view = snowflake_event_view_with_entity
+    view["lag_col"] = view["col_float"].lag("cust_id")
+    feature = view.groupby("cust_id").aggregate_over(
+        value_column="lag_col",
+        method="sum",
+        windows=["30m"],
+        feature_job_setting=feature_group_feature_job_setting,
+        feature_names=["my_feature"],
+    )["my_feature"]
+    return feature
+
+
+@pytest.fixture
+def complex_feature_but_push_down_eligible(
+    non_time_based_features,
+    snowflake_event_view_with_entity,
+    snowflake_scd_view_with_entity,
+    feature_group_feature_job_setting,
+):
+    """
+    Fixture for a complex feature that can still benefit from pushing down the date filter
+    """
+    joined_view = snowflake_event_view_with_entity.join(
+        snowflake_scd_view_with_entity,
+        on="cust_id",
+        rsuffix="_scd",
+    )
+    joined_view = joined_view.add_feature("added_feature", non_time_based_features[0], "cust_id")
+    joined_view["added_feature"] = joined_view["added_feature"] + joined_view["col_float_scd"]
+    feature = joined_view.groupby("cust_id").aggregate_over(
+        value_column="added_feature",
+        method="sum",
+        windows=["30m"],
+        feature_job_setting=feature_group_feature_job_setting,
+        feature_names=["my_feature"],
+    )["my_feature"]
+    return feature
+
+
+def get_tile_sql_used_in_scheduled_tasks(feature):
+    """
+    Helper function to get the tile SQL used in scheduled tasks
+    """
+    tile_specs = ExtendedFeatureModel(**feature.dict(by_alias=True)).tile_specs
+    assert len(tile_specs) == 1
+    return tile_specs[0].tile_sql
+
+
+def test_scheduled_tile_sql__can_push_down_date_filter(float_feature, update_fixtures):
+    """
+    Test date filters are applied for simple features
+    """
+    tile_sql = get_tile_sql_used_in_scheduled_tasks(float_feature)
+    assert_equal_with_expected_fixture(
+        tile_sql, "fixtures/expected_tile_sql_feature_without_lag.sql", update_fixtures
+    )
+
+
+def test_scheduled_tile_sql__cannot_push_down_date_filter(feature_with_lag, update_fixtures):
+    """
+    Test date filters are not applied if feature has lag
+    """
+    tile_sql = get_tile_sql_used_in_scheduled_tasks(feature_with_lag)
+    assert_equal_with_expected_fixture(
+        tile_sql, "fixtures/expected_tile_sql_feature_with_lag.sql", update_fixtures
+    )
+
+
+def test_scheduled_tile_sql__complex(complex_feature_but_push_down_eligible, update_fixtures):
+    """
+    Test date filters are applied even for a complex feature as long as the feature does not contain
+    any lag operations
+    """
+    tile_sql = get_tile_sql_used_in_scheduled_tasks(complex_feature_but_push_down_eligible)
+    assert_equal_with_expected_fixture(
+        tile_sql,
+        "fixtures/expected_tile_sql_complex_feature_push_down_eligible.sql",
+        update_fixtures,
+    )

--- a/tests/unit/query_graph/test_sql.py
+++ b/tests/unit/query_graph/test_sql.py
@@ -58,6 +58,7 @@ def make_context(node_type=None, parameters=None, input_sql_nodes=None, sql_type
         sql_type=sql_type,
         source_type=SourceType.SNOWFLAKE,
         to_filter_scd_by_current_flag=False,
+        event_table_timestamp_filter=None,
     )
     return context
 


### PR DESCRIPTION
## Description

This adds a filter on EventTable directly based on tile date range when possible. This is safe to do when there is no lag operations in the applied transforms. This mainly benefits the cases where a feature involves complex joins and the existing top level filter cannot be pushed down automatically. 

In testing, the speedup for the tile building query ranges from 1x (simple features based on EventTable only that won't benefit from this change) to more than 6x (features involving Event-Item-SCD joins + double aggregation; 2m 14s before vs 21s after).

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
