### PR TITLE
[DEV-2031] Speed up operation structure extraction by caching the result of _extract()

### DIFF
--- a/.changelog/DEV-2031.yaml
+++ b/.changelog/DEV-2031.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Speed up operation structure extraction by caching the result of _extract() in BaseGraphExtractor"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/query_graph/transform/base.py
+++ b/featurebyte/query_graph/transform/base.py
@@ -19,7 +19,7 @@ class BaseGraphExtractor(Generic[OutputT, BranchStateT, GlobalStateT]):
 
     def __init__(self, graph: QueryGraphT):
         self.graph = graph
-        self._input_node_map_cache = {}
+        self._input_node_map_cache: Dict[str, OutputT] = {}
 
     @abstractmethod
     def _pre_compute(

--- a/featurebyte/query_graph/transform/base.py
+++ b/featurebyte/query_graph/transform/base.py
@@ -19,6 +19,7 @@ class BaseGraphExtractor(Generic[OutputT, BranchStateT, GlobalStateT]):
 
     def __init__(self, graph: QueryGraphT):
         self.graph = graph
+        self._input_node_map_cache = {}
 
     @abstractmethod
     def _pre_compute(
@@ -124,12 +125,14 @@ class BaseGraphExtractor(Generic[OutputT, BranchStateT, GlobalStateT]):
                 node=node,
                 input_node=input_node,
             )
-            input_node_map[input_node_name] = self._extract(
-                node=input_node,
-                branch_state=branch_state,
-                global_state=global_state,
-                topological_order_map=topological_order_map,
-            )
+            if input_node_name not in self._input_node_map_cache:
+                self._input_node_map_cache[input_node_name] = self._extract(
+                    node=input_node,
+                    branch_state=branch_state,
+                    global_state=global_state,
+                    topological_order_map=topological_order_map,
+                )
+            input_node_map[input_node_name] = self._input_node_map_cache[input_node_name]
 
         return self._post_compute(
             branch_state=branch_state,

--- a/featurebyte/query_graph/transform/base.py
+++ b/featurebyte/query_graph/transform/base.py
@@ -118,14 +118,14 @@ class BaseGraphExtractor(Generic[OutputT, BranchStateT, GlobalStateT]):
         for input_node_name in sorted(
             input_node_names, key=lambda x: topological_order_map[x], reverse=True
         ):
-            input_node = self.graph.nodes_map[input_node_name]
-            branch_state = self._in_compute(
-                branch_state=branch_state,
-                global_state=global_state,
-                node=node,
-                input_node=input_node,
-            )
             if input_node_name not in self._input_node_map_cache:
+                input_node = self.graph.nodes_map[input_node_name]
+                branch_state = self._in_compute(
+                    branch_state=branch_state,
+                    global_state=global_state,
+                    node=node,
+                    input_node=input_node,
+                )
                 self._input_node_map_cache[input_node_name] = self._extract(
                     node=input_node,
                     branch_state=branch_state,


### PR DESCRIPTION
## Description

Speed up operation structure extraction by caching the result of `_extract()` in `BaseGraphExtractor`.

Timing comparison using the problematic SDK code: 1m 27s (before) vs 2s (after).

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
