### PR TITLE
[chore] prebuilt_catalogs: use get_table instead of get_source_table

### DIFF
--- a/notebooks/prebuilt_catalogs.py
+++ b/notebooks/prebuilt_catalogs.py
@@ -190,11 +190,13 @@ class TableCreator:
         self.data_source = fb.FeatureStore.get("playground").get_data_source()
         catalog = fb.Catalog.get_active()
         self.catalog = catalog
-        self.current_tables = catalog.list_tables().name.str
         self.schema_name = schema_name
 
+    def _does_table_exist(self, table_name: str) -> bool:
+        return self.catalog.list_tables().name.str.contains(table_name).any()
+
     def get_or_create_scd_table(self, table_name: str, **kwargs) -> SCDTable:
-        if not self.current_tables.contains(table_name).any():
+        if not self._does_table_exist(table_name):
             return self.data_source.get_source_table(
                 database_name="spark_catalog", schema_name=self.schema_name, table_name=table_name
             ).create_scd_table(
@@ -205,7 +207,7 @@ class TableCreator:
             return self.catalog.get_table(table_name)
 
     def get_or_create_event_table(self, table_name: str, **kwargs) -> EventTable:
-        if not self.current_tables.contains(table_name).any():
+        if not self._does_table_exist(table_name):
             return self.data_source.get_source_table(
                 database_name="spark_catalog", schema_name=self.schema_name, table_name=table_name
             ).create_event_table(
@@ -216,7 +218,7 @@ class TableCreator:
             return self.catalog.get_table(table_name)
 
     def get_or_create_item_table(self, table_name: str, **kwargs) -> ItemTable:
-        if not self.current_tables.contains(table_name).any():
+        if not self._does_table_exist(table_name):
             return self.data_source.get_source_table(
                 database_name="spark_catalog", schema_name=self.schema_name, table_name=table_name
             ).create_item_table(
@@ -227,7 +229,7 @@ class TableCreator:
             return self.catalog.get_table(table_name)
 
     def get_or_create_dimension_table(self, table_name: str, **kwargs) -> DimensionTable:
-        if not self.current_tables.contains(table_name).any():
+        if not self._does_table_exist(table_name):
             return self.data_source.get_source_table(
                 database_name="spark_catalog", schema_name=self.schema_name, table_name=table_name
             ).create_dimension_table(

--- a/notebooks/prebuilt_catalogs.py
+++ b/notebooks/prebuilt_catalogs.py
@@ -202,7 +202,7 @@ class TableCreator:
                 **kwargs,
             )
         else:
-            return self.catalog.get_source_table(table_name)
+            return self.catalog.get_table(table_name)
 
     def get_or_create_event_table(self, table_name: str, **kwargs) -> EventTable:
         if not self.current_tables.contains(table_name).any():
@@ -213,7 +213,7 @@ class TableCreator:
                 **kwargs,
             )
         else:
-            return self.catalog.get_source_table(table_name)
+            return self.catalog.get_table(table_name)
 
     def get_or_create_item_table(self, table_name: str, **kwargs) -> ItemTable:
         if not self.current_tables.contains(table_name).any():
@@ -224,7 +224,7 @@ class TableCreator:
                 **kwargs,
             )
         else:
-            return self.catalog.get_source_table(table_name)
+            return self.catalog.get_table(table_name)
 
     def get_or_create_dimension_table(self, table_name: str, **kwargs) -> DimensionTable:
         if not self.current_tables.contains(table_name).any():
@@ -235,7 +235,7 @@ class TableCreator:
                 **kwargs,
             )
         else:
-            return self.catalog.get_source_table(table_name)
+            return self.catalog.get_table(table_name)
 
 
 def register_grocery_tables():


### PR DESCRIPTION
## Description
Use the right method on the catalog to retrieve a table if it already exists.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
