### PR TITLE
[chore] Allow task commands to be overridden

### DIFF
--- a/featurebyte/worker/task/base.py
+++ b/featurebyte/worker/task/base.py
@@ -9,6 +9,7 @@ from abc import abstractmethod
 from enum import Enum
 from uuid import UUID
 
+from featurebyte.logging import get_logger
 from featurebyte.models.base import User
 from featurebyte.models.task import Task
 from featurebyte.persistent import Persistent
@@ -18,6 +19,9 @@ from featurebyte.schema.worker.task.base import BaseTaskPayload
 from featurebyte.storage import Storage
 
 TASK_MAP: Dict[Enum, type[BaseTask]] = {}
+
+
+logger = get_logger(__name__)
 
 
 class BaseTask:  # pylint: disable=too-many-instance-attributes
@@ -53,7 +57,7 @@ class BaseTask:  # pylint: disable=too-many-instance-attributes
         assert isinstance(cls.payload_class.command, Enum)
         command = cls.payload_class.command
         if command in TASK_MAP:
-            raise ValueError(f'Command "{command}" has been implemented.')
+            logger.warning("Existing task command overridden.", extra={"command": command.value})
         TASK_MAP[command] = cls
 
     @property


### PR DESCRIPTION
## Description

Allow task commands to be overridden with a warning to make library more extensible 

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
