### PR TITLE
[DEV-2063][DEV-2064] hive/udf: add vector aggregate max and sum

### DIFF
--- a/.changelog/DEV-2063.yaml
+++ b/.changelog/DEV-2063.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: vector-aggregation
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add java UDAFs for sum and max for use in spark."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/hive-udf/lib/src/main/java/com/featurebyte/hive/udf/BaseVectorAggregate.java
+++ b/hive-udf/lib/src/main/java/com/featurebyte/hive/udf/BaseVectorAggregate.java
@@ -1,0 +1,155 @@
+package com.featurebyte.hive.udf;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.udf.generic.AbstractGenericUDAFResolver;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFParameterInfo;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.StandardListObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.LIST;
+
+@Description(name = "vector_aggregate_sum", value = "_FUNC_(x) - Aggregate vectors by summing them")
+@SuppressWarnings("deprecation")
+public abstract class BaseVectorAggregate extends AbstractGenericUDAFResolver {
+
+  public BaseVectorAggregate() {}
+
+  /**
+   * Return the evaluator that will be used.
+   *
+   * @return GenericUDAFEvaluator
+   */
+  protected abstract GenericUDAFEvaluator getEvaluator();
+
+  public GenericUDAFEvaluator getEvaluator(GenericUDAFParameterInfo info)
+    throws SemanticException {
+    ObjectInspector firstParameter = getObjectInspector(info);
+    StandardListObjectInspector listOI = (StandardListObjectInspector) firstParameter;
+    String listElementTypeName = listOI.getListElementObjectInspector().getTypeName();
+    PrimitiveObjectInspectorUtils.PrimitiveTypeEntry typeEntry =
+      PrimitiveObjectInspectorUtils.getTypeEntryFromTypeName(listElementTypeName);
+    switch (typeEntry.primitiveCategory) {
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+      case DECIMAL:
+        return getEvaluator();
+      default:
+        throw new UDFArgumentTypeException(0, "Only ints, longs, floats, doubles or decimals are accepted " +
+          "for parameter 1");
+    }
+  }
+
+  private static ObjectInspector getObjectInspector(GenericUDAFParameterInfo info) throws SemanticException {
+    // Taken from parent implementation
+    if (info.isAllColumns()) {
+      throw new SemanticException(
+        "The specified syntax for UDAF invocation is invalid.");
+    }
+
+    ObjectInspector[] parameters = info.getParameterObjectInspectors();
+
+    if (parameters.length != 1) {
+      throw new UDFArgumentTypeException(
+        parameters.length - 1, "Exactly one argument is expected.");
+    }
+
+    ObjectInspector firstParameter = parameters[0];
+
+    if (firstParameter.getCategory() != LIST) {
+      throw new UDFArgumentTypeException(0, "Parameter 1 must be a list");
+    }
+    return firstParameter;
+  }
+
+  static class ListAggregationBuffer extends GenericUDAFEvaluator.AbstractAggregationBuffer {
+
+    List<Object> container;
+
+    public ListAggregationBuffer() {
+      container = new ArrayList<>();
+    }
+  }
+
+  public static abstract class VectorAggregateListEvaluator extends GenericUDAFEvaluator {
+    private transient ObjectInspector inputValueOI;
+
+    public VectorAggregateListEvaluator() {}
+
+    @Override
+    public ObjectInspector init(Mode m, ObjectInspector[] parameters) throws HiveException {
+      super.init(m, parameters);
+      assert (parameters.length == 1);
+      ObjectInspector inputListOI = parameters[0];
+      StandardListObjectInspector internalValueOI = (StandardListObjectInspector) inputListOI;
+      inputValueOI = internalValueOI.getListElementObjectInspector();
+      return ObjectInspectorFactory.getStandardListObjectInspector(inputListOI);
+    }
+
+    protected ObjectInspector getInputValueOI() {
+      return inputValueOI;
+    }
+
+    @Override
+    public void reset(AggregationBuffer agg) {
+      ((ListAggregationBuffer) agg).container.clear();
+    }
+
+    @Override
+    public AggregationBuffer getNewAggregationBuffer() {
+      return new ListAggregationBuffer();
+    }
+
+    @Override
+    public void iterate(AggregationBuffer agg, Object[] parameters) {
+      assert (parameters.length == 1);
+      merge(agg, parameters[0]);
+    }
+
+    @Override
+    public Object terminatePartial(AggregationBuffer agg) {
+      ListAggregationBuffer myagg = (ListAggregationBuffer) agg;
+      return new ArrayList<>(myagg.container);
+    }
+
+    protected abstract void doMerge(List<Object> listA, List<Object> listB);
+
+    @Override
+    public void merge(AggregationBuffer agg, Object partial) {
+      // Don't do anything if partial is empty.
+      if (partial == null) {
+        return;
+      }
+
+      // Cast current aggregation buffer, and partial value.
+      ListAggregationBuffer myagg = (ListAggregationBuffer) agg;
+      List<Object> myList = (List<Object>) partial;
+      List<Object> container = myagg.container;
+
+      // If there's no current value in the buffer, just set the partial value into the buffer.
+      if (container == null || container.isEmpty()) {
+        myagg.container = myList;
+        return;
+      }
+
+      // If not, compare the two lists, and update to the max value.
+      assert (container.size() == myList.size());
+      doMerge(container, myList);
+    }
+
+    @Override
+    public Object terminate(AggregationBuffer agg) {
+      return this.terminatePartial(agg);
+    }
+  }
+}

--- a/hive-udf/lib/src/main/java/com/featurebyte/hive/udf/BaseVectorAggregate.java
+++ b/hive-udf/lib/src/main/java/com/featurebyte/hive/udf/BaseVectorAggregate.java
@@ -1,5 +1,9 @@
 package com.featurebyte.hive.udf;
 
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.LIST;
+
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.hadoop.hive.ql.exec.Description;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
@@ -11,11 +15,6 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.StandardListObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.LIST;
 
 @Description(name = "vector_aggregate_sum", value = "_FUNC_(x) - Aggregate vectors by summing them")
 @SuppressWarnings("deprecation")
@@ -30,13 +29,12 @@ public abstract class BaseVectorAggregate extends AbstractGenericUDAFResolver {
    */
   protected abstract GenericUDAFEvaluator getEvaluator();
 
-  public GenericUDAFEvaluator getEvaluator(GenericUDAFParameterInfo info)
-    throws SemanticException {
+  public GenericUDAFEvaluator getEvaluator(GenericUDAFParameterInfo info) throws SemanticException {
     ObjectInspector firstParameter = getObjectInspector(info);
     StandardListObjectInspector listOI = (StandardListObjectInspector) firstParameter;
     String listElementTypeName = listOI.getListElementObjectInspector().getTypeName();
     PrimitiveObjectInspectorUtils.PrimitiveTypeEntry typeEntry =
-      PrimitiveObjectInspectorUtils.getTypeEntryFromTypeName(listElementTypeName);
+        PrimitiveObjectInspectorUtils.getTypeEntryFromTypeName(listElementTypeName);
     switch (typeEntry.primitiveCategory) {
       case INT:
       case LONG:
@@ -45,23 +43,23 @@ public abstract class BaseVectorAggregate extends AbstractGenericUDAFResolver {
       case DECIMAL:
         return getEvaluator();
       default:
-        throw new UDFArgumentTypeException(0, "Only ints, longs, floats, doubles or decimals are accepted " +
-          "for parameter 1");
+        throw new UDFArgumentTypeException(
+            0, "Only ints, longs, floats, doubles or decimals are accepted " + "for parameter 1");
     }
   }
 
-  private static ObjectInspector getObjectInspector(GenericUDAFParameterInfo info) throws SemanticException {
+  private static ObjectInspector getObjectInspector(GenericUDAFParameterInfo info)
+      throws SemanticException {
     // Taken from parent implementation
     if (info.isAllColumns()) {
-      throw new SemanticException(
-        "The specified syntax for UDAF invocation is invalid.");
+      throw new SemanticException("The specified syntax for UDAF invocation is invalid.");
     }
 
     ObjectInspector[] parameters = info.getParameterObjectInspectors();
 
     if (parameters.length != 1) {
       throw new UDFArgumentTypeException(
-        parameters.length - 1, "Exactly one argument is expected.");
+          parameters.length - 1, "Exactly one argument is expected.");
     }
 
     ObjectInspector firstParameter = parameters[0];
@@ -81,7 +79,7 @@ public abstract class BaseVectorAggregate extends AbstractGenericUDAFResolver {
     }
   }
 
-  public static abstract class VectorAggregateListEvaluator extends GenericUDAFEvaluator {
+  public abstract static class VectorAggregateListEvaluator extends GenericUDAFEvaluator {
     private transient ObjectInspector inputValueOI;
 
     public VectorAggregateListEvaluator() {}

--- a/hive-udf/lib/src/main/java/com/featurebyte/hive/udf/VectorAggregateMax.java
+++ b/hive-udf/lib/src/main/java/com/featurebyte/hive/udf/VectorAggregateMax.java
@@ -1,0 +1,151 @@
+package com.featurebyte.hive.udf;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.udf.generic.AbstractGenericUDAFResolver;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFParameterInfo;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
+import org.apache.hadoop.hive.serde2.objectinspector.StandardListObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.LIST;
+
+@Description(name = "vector_aggregate_max", value = "_FUNC_(x) - Aggregate vectors by selecting the maximum value")
+@SuppressWarnings("deprecation")
+public class VectorAggregateMax extends AbstractGenericUDAFResolver {
+
+    public VectorAggregateMax() {}
+
+    public GenericUDAFEvaluator getEvaluator(GenericUDAFParameterInfo info)
+            throws SemanticException {
+        ObjectInspector firstParameter = getObjectInspector(info);
+        StandardListObjectInspector listOI = (StandardListObjectInspector) firstParameter;
+        String listElementTypeName = listOI.getListElementObjectInspector().getTypeName();
+        PrimitiveObjectInspectorUtils.PrimitiveTypeEntry typeEntry =
+                PrimitiveObjectInspectorUtils.getTypeEntryFromTypeName(listElementTypeName);
+        switch (typeEntry.primitiveCategory) {
+            case INT:
+            case LONG:
+            case FLOAT:
+            case DOUBLE:
+            case DECIMAL:
+                return new VectorAggregateMaxEvaluator();
+            default:
+                throw new UDFArgumentTypeException(0, "Only ints, longs, floats, doubles or decimals are accepted " +
+                        "for parameter 1");
+        }
+    }
+
+    private static ObjectInspector getObjectInspector(GenericUDAFParameterInfo info) throws SemanticException {
+        // Taken from parent implementation
+        if (info.isAllColumns()) {
+            throw new SemanticException(
+                    "The specified syntax for UDAF invocation is invalid.");
+        }
+
+        ObjectInspector[] parameters = info.getParameterObjectInspectors();
+
+        if (parameters.length != 1) {
+            throw new UDFArgumentTypeException(
+                    parameters.length - 1, "Exactly one argument is expected.");
+        }
+
+        ObjectInspector firstParameter = parameters[0];
+
+        if (firstParameter.getCategory() != LIST) {
+            throw new UDFArgumentTypeException(0, "Parameter 1 must be a list");
+        }
+        return firstParameter;
+    }
+
+    static class MaxAggregationBuffer extends GenericUDAFEvaluator.AbstractAggregationBuffer {
+
+        List<Object> container;
+
+        public MaxAggregationBuffer() {
+            container = new ArrayList<>();
+        }
+    }
+
+    public static class VectorAggregateMaxEvaluator extends GenericUDAFEvaluator {
+        private transient ObjectInspector inputValueOI;
+
+        public VectorAggregateMaxEvaluator() {}
+
+        @Override
+        public ObjectInspector init(Mode m, ObjectInspector[] parameters) throws HiveException {
+            super.init(m, parameters);
+            assert (parameters.length == 1);
+            ObjectInspector inputListOI = parameters[0];
+            StandardListObjectInspector internalValueOI = (StandardListObjectInspector) inputListOI;
+            inputValueOI = internalValueOI.getListElementObjectInspector();
+            return ObjectInspectorFactory.getStandardListObjectInspector(inputListOI);
+        }
+
+        @Override
+        public void reset(AggregationBuffer agg) {
+            ((MaxAggregationBuffer) agg).container.clear();
+        }
+
+        @Override
+        public AggregationBuffer getNewAggregationBuffer() {
+            return new MaxAggregationBuffer();
+        }
+
+        @Override
+        public void iterate(AggregationBuffer agg, Object[] parameters) {
+            assert (parameters.length == 1);
+            merge(agg, parameters[0]);
+        }
+
+        @Override
+        public Object terminatePartial(AggregationBuffer agg) {
+            MaxAggregationBuffer myagg = (MaxAggregationBuffer) agg;
+            return new ArrayList<>(myagg.container);
+        }
+
+        @Override
+        public void merge(AggregationBuffer agg, Object partial) {
+            // Don't do anything if partial is empty.
+            if (partial == null) {
+                return;
+            }
+
+            // Cast current aggregation buffer, and partial value.
+            MaxAggregationBuffer myagg = (MaxAggregationBuffer) agg;
+            List<Object> myList = (List<Object>) partial;
+            List<Object> container = myagg.container;
+
+            // If there's no current value in the buffer, just set the partial value into the buffer.
+            if (container == null || container.isEmpty()) {
+                myagg.container = myList;
+                return;
+            }
+
+            // If not, compare the two lists, and update to the max value.
+            assert (container.size() == myList.size());
+
+            for (int i = 0; i < container.size(); i++) {
+                Object containerCurrentValue = container.get(i);
+                Object inputCurrentValue = myList.get(i);
+                int r = ObjectInspectorUtils.compare(containerCurrentValue, inputValueOI, inputCurrentValue, inputValueOI);
+                if (r < 0) {
+                    container.set(i, inputCurrentValue);
+                }
+            }
+        }
+
+        @Override
+        public Object terminate(AggregationBuffer agg) {
+            return this.terminatePartial(agg);
+        }
+    }
+}

--- a/hive-udf/lib/src/main/java/com/featurebyte/hive/udf/VectorAggregateMax.java
+++ b/hive-udf/lib/src/main/java/com/featurebyte/hive/udf/VectorAggregateMax.java
@@ -1,151 +1,36 @@
 package com.featurebyte.hive.udf;
 
 import org.apache.hadoop.hive.ql.exec.Description;
-import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
-import org.apache.hadoop.hive.ql.metadata.HiveException;
-import org.apache.hadoop.hive.ql.parse.SemanticException;
-import org.apache.hadoop.hive.ql.udf.generic.AbstractGenericUDAFResolver;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFParameterInfo;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
-import org.apache.hadoop.hive.serde2.objectinspector.StandardListObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.LIST;
-
 @Description(name = "vector_aggregate_max", value = "_FUNC_(x) - Aggregate vectors by selecting the maximum value")
-@SuppressWarnings("deprecation")
-public class VectorAggregateMax extends AbstractGenericUDAFResolver {
+public class VectorAggregateMax extends BaseVectorAggregate {
 
     public VectorAggregateMax() {}
 
-    public GenericUDAFEvaluator getEvaluator(GenericUDAFParameterInfo info)
-            throws SemanticException {
-        ObjectInspector firstParameter = getObjectInspector(info);
-        StandardListObjectInspector listOI = (StandardListObjectInspector) firstParameter;
-        String listElementTypeName = listOI.getListElementObjectInspector().getTypeName();
-        PrimitiveObjectInspectorUtils.PrimitiveTypeEntry typeEntry =
-                PrimitiveObjectInspectorUtils.getTypeEntryFromTypeName(listElementTypeName);
-        switch (typeEntry.primitiveCategory) {
-            case INT:
-            case LONG:
-            case FLOAT:
-            case DOUBLE:
-            case DECIMAL:
-                return new VectorAggregateMaxEvaluator();
-            default:
-                throw new UDFArgumentTypeException(0, "Only ints, longs, floats, doubles or decimals are accepted " +
-                        "for parameter 1");
-        }
+    protected GenericUDAFEvaluator getEvaluator() {
+      return new VectorAggregateMaxEvaluator();
     }
 
-    private static ObjectInspector getObjectInspector(GenericUDAFParameterInfo info) throws SemanticException {
-        // Taken from parent implementation
-        if (info.isAllColumns()) {
-            throw new SemanticException(
-                    "The specified syntax for UDAF invocation is invalid.");
-        }
-
-        ObjectInspector[] parameters = info.getParameterObjectInspectors();
-
-        if (parameters.length != 1) {
-            throw new UDFArgumentTypeException(
-                    parameters.length - 1, "Exactly one argument is expected.");
-        }
-
-        ObjectInspector firstParameter = parameters[0];
-
-        if (firstParameter.getCategory() != LIST) {
-            throw new UDFArgumentTypeException(0, "Parameter 1 must be a list");
-        }
-        return firstParameter;
-    }
-
-    static class MaxAggregationBuffer extends GenericUDAFEvaluator.AbstractAggregationBuffer {
-
-        List<Object> container;
-
-        public MaxAggregationBuffer() {
-            container = new ArrayList<>();
-        }
-    }
-
-    public static class VectorAggregateMaxEvaluator extends GenericUDAFEvaluator {
-        private transient ObjectInspector inputValueOI;
+    public static class VectorAggregateMaxEvaluator extends VectorAggregateListEvaluator {
 
         public VectorAggregateMaxEvaluator() {}
 
         @Override
-        public ObjectInspector init(Mode m, ObjectInspector[] parameters) throws HiveException {
-            super.init(m, parameters);
-            assert (parameters.length == 1);
-            ObjectInspector inputListOI = parameters[0];
-            StandardListObjectInspector internalValueOI = (StandardListObjectInspector) inputListOI;
-            inputValueOI = internalValueOI.getListElementObjectInspector();
-            return ObjectInspectorFactory.getStandardListObjectInspector(inputListOI);
-        }
-
-        @Override
-        public void reset(AggregationBuffer agg) {
-            ((MaxAggregationBuffer) agg).container.clear();
-        }
-
-        @Override
-        public AggregationBuffer getNewAggregationBuffer() {
-            return new MaxAggregationBuffer();
-        }
-
-        @Override
-        public void iterate(AggregationBuffer agg, Object[] parameters) {
-            assert (parameters.length == 1);
-            merge(agg, parameters[0]);
-        }
-
-        @Override
-        public Object terminatePartial(AggregationBuffer agg) {
-            MaxAggregationBuffer myagg = (MaxAggregationBuffer) agg;
-            return new ArrayList<>(myagg.container);
-        }
-
-        @Override
-        public void merge(AggregationBuffer agg, Object partial) {
-            // Don't do anything if partial is empty.
-            if (partial == null) {
-                return;
-            }
-
-            // Cast current aggregation buffer, and partial value.
-            MaxAggregationBuffer myagg = (MaxAggregationBuffer) agg;
-            List<Object> myList = (List<Object>) partial;
-            List<Object> container = myagg.container;
-
-            // If there's no current value in the buffer, just set the partial value into the buffer.
-            if (container == null || container.isEmpty()) {
-                myagg.container = myList;
-                return;
-            }
-
-            // If not, compare the two lists, and update to the max value.
-            assert (container.size() == myList.size());
-
-            for (int i = 0; i < container.size(); i++) {
-                Object containerCurrentValue = container.get(i);
-                Object inputCurrentValue = myList.get(i);
-                int r = ObjectInspectorUtils.compare(containerCurrentValue, inputValueOI, inputCurrentValue, inputValueOI);
+        public void doMerge(List<Object> listA, List<Object> listB) {
+            ObjectInspector inputOI = getInputValueOI();
+            for (int i = 0; i < listA.size(); i++) {
+                Object containerCurrentValue = listA.get(i);
+                Object inputCurrentValue = listB.get(i);
+                int r = ObjectInspectorUtils.compare(containerCurrentValue, inputOI, inputCurrentValue, inputOI);
                 if (r < 0) {
-                    container.set(i, inputCurrentValue);
+                    listA.set(i, inputCurrentValue);
                 }
             }
-        }
-
-        @Override
-        public Object terminate(AggregationBuffer agg) {
-            return this.terminatePartial(agg);
         }
     }
 }

--- a/hive-udf/lib/src/main/java/com/featurebyte/hive/udf/VectorAggregateMax.java
+++ b/hive-udf/lib/src/main/java/com/featurebyte/hive/udf/VectorAggregateMax.java
@@ -1,36 +1,39 @@
 package com.featurebyte.hive.udf;
 
+import java.util.List;
 import org.apache.hadoop.hive.ql.exec.Description;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
 
-import java.util.List;
-
-@Description(name = "vector_aggregate_max", value = "_FUNC_(x) - Aggregate vectors by selecting the maximum value")
+@Description(
+    name = "vector_aggregate_max",
+    value = "_FUNC_(x) - Aggregate vectors by selecting the maximum value")
 public class VectorAggregateMax extends BaseVectorAggregate {
 
-    public VectorAggregateMax() {}
+  public VectorAggregateMax() {}
 
-    protected GenericUDAFEvaluator getEvaluator() {
-      return new VectorAggregateMaxEvaluator();
-    }
+  protected GenericUDAFEvaluator getEvaluator() {
+    return new VectorAggregateMaxEvaluator();
+  }
 
-    public static class VectorAggregateMaxEvaluator extends VectorAggregateListEvaluator {
+  public static class VectorAggregateMaxEvaluator extends VectorAggregateListEvaluator {
 
-        public VectorAggregateMaxEvaluator() {}
+    public VectorAggregateMaxEvaluator() {}
 
-        @Override
-        public void doMerge(List<Object> listA, List<Object> listB) {
-            ObjectInspector inputOI = getInputValueOI();
-            for (int i = 0; i < listA.size(); i++) {
-                Object containerCurrentValue = listA.get(i);
-                Object inputCurrentValue = listB.get(i);
-                int r = ObjectInspectorUtils.compare(containerCurrentValue, inputOI, inputCurrentValue, inputOI);
-                if (r < 0) {
-                    listA.set(i, inputCurrentValue);
-                }
-            }
+    @Override
+    public void doMerge(List<Object> listA, List<Object> listB) {
+      ObjectInspector inputOI = getInputValueOI();
+      for (int i = 0; i < listA.size(); i++) {
+        Object containerCurrentValue = listA.get(i);
+        Object inputCurrentValue = listB.get(i);
+        int r =
+            ObjectInspectorUtils.compare(
+                containerCurrentValue, inputOI, inputCurrentValue, inputOI);
+        if (r < 0) {
+          listA.set(i, inputCurrentValue);
         }
+      }
     }
+  }
 }

--- a/hive-udf/lib/src/main/java/com/featurebyte/hive/udf/VectorAggregateSum.java
+++ b/hive-udf/lib/src/main/java/com/featurebyte/hive/udf/VectorAggregateSum.java
@@ -1,9 +1,8 @@
 package com.featurebyte.hive.udf;
 
+import java.util.List;
 import org.apache.hadoop.hive.ql.exec.Description;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
-
-import java.util.List;
 
 @Description(name = "vector_aggregate_sum", value = "_FUNC_(x) - Aggregate vectors by summing them")
 public class VectorAggregateSum extends BaseVectorAggregate {

--- a/hive-udf/lib/src/main/java/com/featurebyte/hive/udf/VectorAggregateSum.java
+++ b/hive-udf/lib/src/main/java/com/featurebyte/hive/udf/VectorAggregateSum.java
@@ -1,150 +1,30 @@
 package com.featurebyte.hive.udf;
 
 import org.apache.hadoop.hive.ql.exec.Description;
-import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
-import org.apache.hadoop.hive.ql.metadata.HiveException;
-import org.apache.hadoop.hive.ql.parse.SemanticException;
-import org.apache.hadoop.hive.ql.udf.generic.AbstractGenericUDAFResolver;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFParameterInfo;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
-import org.apache.hadoop.hive.serde2.objectinspector.StandardListObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.LIST;
-
 @Description(name = "vector_aggregate_sum", value = "_FUNC_(x) - Aggregate vectors by summing them")
-@SuppressWarnings("deprecation")
-public class VectorAggregateSum extends AbstractGenericUDAFResolver {
+public class VectorAggregateSum extends BaseVectorAggregate {
 
   public VectorAggregateSum() {}
 
-  public GenericUDAFEvaluator getEvaluator(GenericUDAFParameterInfo info)
-    throws SemanticException {
-    ObjectInspector firstParameter = getObjectInspector(info);
-    StandardListObjectInspector listOI = (StandardListObjectInspector) firstParameter;
-    String listElementTypeName = listOI.getListElementObjectInspector().getTypeName();
-    PrimitiveObjectInspectorUtils.PrimitiveTypeEntry typeEntry =
-      PrimitiveObjectInspectorUtils.getTypeEntryFromTypeName(listElementTypeName);
-    switch (typeEntry.primitiveCategory) {
-      case INT:
-      case LONG:
-      case FLOAT:
-      case DOUBLE:
-      case DECIMAL:
-        return new VectorAggregateSumEvaluator();
-      default:
-        throw new UDFArgumentTypeException(0, "Only ints, longs, floats, doubles or decimals are accepted " +
-          "for parameter 1");
-    }
+  public GenericUDAFEvaluator getEvaluator() {
+    return new VectorAggregateSumEvaluator();
   }
 
-  private static ObjectInspector getObjectInspector(GenericUDAFParameterInfo info) throws SemanticException {
-    // Taken from parent implementation
-    if (info.isAllColumns()) {
-      throw new SemanticException(
-        "The specified syntax for UDAF invocation is invalid.");
-    }
-
-    ObjectInspector[] parameters = info.getParameterObjectInspectors();
-
-    if (parameters.length != 1) {
-      throw new UDFArgumentTypeException(
-        parameters.length - 1, "Exactly one argument is expected.");
-    }
-
-    ObjectInspector firstParameter = parameters[0];
-
-    if (firstParameter.getCategory() != LIST) {
-      throw new UDFArgumentTypeException(0, "Parameter 1 must be a list");
-    }
-    return firstParameter;
-  }
-
-  static class SumAggregationBuffer extends GenericUDAFEvaluator.AbstractAggregationBuffer {
-
-    List<Object> container;
-
-    public SumAggregationBuffer() {
-      container = new ArrayList<>();
-    }
-  }
-
-  public static class VectorAggregateSumEvaluator extends GenericUDAFEvaluator {
-    private transient ObjectInspector inputValueOI;
-
-    public VectorAggregateSumEvaluator() {}
+  public static class VectorAggregateSumEvaluator extends VectorAggregateListEvaluator {
 
     @Override
-    public ObjectInspector init(Mode m, ObjectInspector[] parameters) throws HiveException {
-      super.init(m, parameters);
-      assert (parameters.length == 1);
-      ObjectInspector inputListOI = parameters[0];
-      StandardListObjectInspector internalValueOI = (StandardListObjectInspector) inputListOI;
-      inputValueOI = internalValueOI.getListElementObjectInspector();
-      return ObjectInspectorFactory.getStandardListObjectInspector(inputListOI);
-    }
-
-    @Override
-    public void reset(AggregationBuffer agg) {
-      ((SumAggregationBuffer) agg).container.clear();
-    }
-
-    @Override
-    public AggregationBuffer getNewAggregationBuffer() {
-      return new SumAggregationBuffer();
-    }
-
-    @Override
-    public void iterate(AggregationBuffer agg, Object[] parameters) {
-      assert (parameters.length == 1);
-      merge(agg, parameters[0]);
-    }
-
-    @Override
-    public Object terminatePartial(AggregationBuffer agg) {
-      SumAggregationBuffer myagg = (SumAggregationBuffer) agg;
-      return new ArrayList<>(myagg.container);
-    }
-
-    @Override
-    public void merge(AggregationBuffer agg, Object partial) {
-      // Don't do anything if partial is empty.
-      if (partial == null) {
-        return;
-      }
-
-      // Cast current aggregation buffer, and partial value.
-      SumAggregationBuffer myagg = (SumAggregationBuffer) agg;
-      List<Object> myList = (List<Object>) partial;
-      List<Object> container = myagg.container;
-
-      // If there's no current value in the buffer, just set the partial value into the buffer.
-      if (container == null || container.isEmpty()) {
-        myagg.container = myList;
-        return;
-      }
-
-      // If not, compare the two lists, and update to the sum value.
-      assert (container.size() == myList.size());
-
-      for (int i = 0; i < container.size(); i++) {
-        Object containerCurrentValue = container.get(i);
-        Object inputCurrentValue = myList.get(i);
+    public void doMerge(List<Object> listA, List<Object> listB) {
+      for (int i = 0; i < listA.size(); i++) {
+        Object containerCurrentValue = listA.get(i);
+        Object inputCurrentValue = listB.get(i);
         double currentValue = Double.parseDouble(containerCurrentValue.toString());
         double inputValue = Double.parseDouble(inputCurrentValue.toString());
-        container.set(i, currentValue + inputValue);
+        listA.set(i, currentValue + inputValue);
       }
-    }
-
-    @Override
-    public Object terminate(AggregationBuffer agg) {
-      return this.terminatePartial(agg);
     }
   }
 }

--- a/hive-udf/lib/src/main/java/com/featurebyte/hive/udf/VectorAggregateSum.java
+++ b/hive-udf/lib/src/main/java/com/featurebyte/hive/udf/VectorAggregateSum.java
@@ -1,0 +1,150 @@
+package com.featurebyte.hive.udf;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.udf.generic.AbstractGenericUDAFResolver;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFParameterInfo;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
+import org.apache.hadoop.hive.serde2.objectinspector.StandardListObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category.LIST;
+
+@Description(name = "vector_aggregate_sum", value = "_FUNC_(x) - Aggregate vectors by summing them")
+@SuppressWarnings("deprecation")
+public class VectorAggregateSum extends AbstractGenericUDAFResolver {
+
+  public VectorAggregateSum() {}
+
+  public GenericUDAFEvaluator getEvaluator(GenericUDAFParameterInfo info)
+    throws SemanticException {
+    ObjectInspector firstParameter = getObjectInspector(info);
+    StandardListObjectInspector listOI = (StandardListObjectInspector) firstParameter;
+    String listElementTypeName = listOI.getListElementObjectInspector().getTypeName();
+    PrimitiveObjectInspectorUtils.PrimitiveTypeEntry typeEntry =
+      PrimitiveObjectInspectorUtils.getTypeEntryFromTypeName(listElementTypeName);
+    switch (typeEntry.primitiveCategory) {
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+      case DECIMAL:
+        return new VectorAggregateSumEvaluator();
+      default:
+        throw new UDFArgumentTypeException(0, "Only ints, longs, floats, doubles or decimals are accepted " +
+          "for parameter 1");
+    }
+  }
+
+  private static ObjectInspector getObjectInspector(GenericUDAFParameterInfo info) throws SemanticException {
+    // Taken from parent implementation
+    if (info.isAllColumns()) {
+      throw new SemanticException(
+        "The specified syntax for UDAF invocation is invalid.");
+    }
+
+    ObjectInspector[] parameters = info.getParameterObjectInspectors();
+
+    if (parameters.length != 1) {
+      throw new UDFArgumentTypeException(
+        parameters.length - 1, "Exactly one argument is expected.");
+    }
+
+    ObjectInspector firstParameter = parameters[0];
+
+    if (firstParameter.getCategory() != LIST) {
+      throw new UDFArgumentTypeException(0, "Parameter 1 must be a list");
+    }
+    return firstParameter;
+  }
+
+  static class SumAggregationBuffer extends GenericUDAFEvaluator.AbstractAggregationBuffer {
+
+    List<Object> container;
+
+    public SumAggregationBuffer() {
+      container = new ArrayList<>();
+    }
+  }
+
+  public static class VectorAggregateSumEvaluator extends GenericUDAFEvaluator {
+    private transient ObjectInspector inputValueOI;
+
+    public VectorAggregateSumEvaluator() {}
+
+    @Override
+    public ObjectInspector init(Mode m, ObjectInspector[] parameters) throws HiveException {
+      super.init(m, parameters);
+      assert (parameters.length == 1);
+      ObjectInspector inputListOI = parameters[0];
+      StandardListObjectInspector internalValueOI = (StandardListObjectInspector) inputListOI;
+      inputValueOI = internalValueOI.getListElementObjectInspector();
+      return ObjectInspectorFactory.getStandardListObjectInspector(inputListOI);
+    }
+
+    @Override
+    public void reset(AggregationBuffer agg) {
+      ((SumAggregationBuffer) agg).container.clear();
+    }
+
+    @Override
+    public AggregationBuffer getNewAggregationBuffer() {
+      return new SumAggregationBuffer();
+    }
+
+    @Override
+    public void iterate(AggregationBuffer agg, Object[] parameters) {
+      assert (parameters.length == 1);
+      merge(agg, parameters[0]);
+    }
+
+    @Override
+    public Object terminatePartial(AggregationBuffer agg) {
+      SumAggregationBuffer myagg = (SumAggregationBuffer) agg;
+      return new ArrayList<>(myagg.container);
+    }
+
+    @Override
+    public void merge(AggregationBuffer agg, Object partial) {
+      // Don't do anything if partial is empty.
+      if (partial == null) {
+        return;
+      }
+
+      // Cast current aggregation buffer, and partial value.
+      SumAggregationBuffer myagg = (SumAggregationBuffer) agg;
+      List<Object> myList = (List<Object>) partial;
+      List<Object> container = myagg.container;
+
+      // If there's no current value in the buffer, just set the partial value into the buffer.
+      if (container == null || container.isEmpty()) {
+        myagg.container = myList;
+        return;
+      }
+
+      // If not, compare the two lists, and update to the sum value.
+      assert (container.size() == myList.size());
+
+      for (int i = 0; i < container.size(); i++) {
+        Object containerCurrentValue = container.get(i);
+        Object inputCurrentValue = myList.get(i);
+        double currentValue = Double.parseDouble(containerCurrentValue.toString());
+        double inputValue = Double.parseDouble(inputCurrentValue.toString());
+        container.set(i, currentValue + inputValue);
+      }
+    }
+
+    @Override
+    public Object terminate(AggregationBuffer agg) {
+      return this.terminatePartial(agg);
+    }
+  }
+}

--- a/hive-udf/lib/src/test/java/com/featurebyte/hive/udf/BaseVectorAggregateListTest.java
+++ b/hive-udf/lib/src/test/java/com/featurebyte/hive/udf/BaseVectorAggregateListTest.java
@@ -1,0 +1,64 @@
+package com.featurebyte.hive.udf;
+
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
+import org.apache.hadoop.hive.ql.udf.generic.SimpleGenericUDAFParameterInfo;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings("deprecation")
+public abstract class BaseVectorAggregateListTest {
+
+  protected abstract BaseVectorAggregate getAggregator();
+
+  /**
+   * getResults should return the final aggregated result.
+   * Input is hardcoded into the test, so refer to those values to calculate your final result.
+   */
+  protected abstract List<Double> getResults();
+
+  @Test
+  public void testVectorAggregate() throws HiveException {
+    ObjectInspector[] doubleOI = new ObjectInspector[] {
+      ObjectInspectorFactory.getStandardListObjectInspector(
+        PrimitiveObjectInspectorFactory.javaDoubleObjectInspector
+      ),
+    };
+    BaseVectorAggregate udaf = getAggregator();
+    SimpleGenericUDAFParameterInfo info = new SimpleGenericUDAFParameterInfo(doubleOI, false, false, false);
+    GenericUDAFEvaluator eval1 = udaf.getEvaluator(info);
+    GenericUDAFEvaluator eval2 = udaf.getEvaluator(info);
+
+    eval1.init(GenericUDAFEvaluator.Mode.PARTIAL1, doubleOI);
+    eval2.init(GenericUDAFEvaluator.Mode.PARTIAL1, doubleOI);
+
+    GenericUDAFEvaluator.AggregationBuffer buffer1 = eval1.getNewAggregationBuffer();
+    eval1.iterate(buffer1, new Object[] {Arrays.asList(1d, 2d, 3d)});
+    eval1.iterate(buffer1, new Object[] {Arrays.asList(4d, 5d, 6d)});
+    eval1.iterate(buffer1, new Object[] {Arrays.asList(7d, 8d, 9d)});
+    Object object1 = eval1.terminatePartial(buffer1);
+
+    GenericUDAFEvaluator.AggregationBuffer buffer2 = eval2.getNewAggregationBuffer();
+    eval2.iterate(buffer2, new Object[] {Arrays.asList(10d, 11d, 12d)});
+    eval2.iterate(buffer2, new Object[] {Arrays.asList(4d, 5d, 6d)});
+    eval2.iterate(buffer2, new Object[] {Arrays.asList(14d, 15d, 16d)});
+    eval2.iterate(buffer2, new Object[] {Arrays.asList(100d, 101d, 102d)});
+    Object object2 = eval2.terminatePartial(buffer2);
+
+    eval2.init(GenericUDAFEvaluator.Mode.FINAL, doubleOI);
+    GenericUDAFEvaluator.AggregationBuffer buffer3 = eval2.getNewAggregationBuffer();
+    eval2.merge(buffer3, object1);
+    eval2.merge(buffer3, object2);
+
+    Object result = eval2.terminate(buffer3);
+    List<Double> expected = getResults();
+    assertEquals(expected, result);
+  }
+}

--- a/hive-udf/lib/src/test/java/com/featurebyte/hive/udf/BaseVectorAggregateListTest.java
+++ b/hive-udf/lib/src/test/java/com/featurebyte/hive/udf/BaseVectorAggregateListTest.java
@@ -1,9 +1,9 @@
 package com.featurebyte.hive.udf;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.Arrays;
 import java.util.List;
-
-import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
 import org.apache.hadoop.hive.ql.udf.generic.SimpleGenericUDAFParameterInfo;
@@ -11,8 +11,6 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("deprecation")
 public abstract class BaseVectorAggregateListTest {
@@ -28,20 +26,21 @@ public abstract class BaseVectorAggregateListTest {
   @Test
   public void testErrorThrownIfColumnHasArrayOfDifferentLengths() throws HiveException {
     ObjectInspector[] doubleOI =
-      new ObjectInspector[] {
-        ObjectInspectorFactory.getStandardListObjectInspector(
-          PrimitiveObjectInspectorFactory.javaDoubleObjectInspector),
-      };
+        new ObjectInspector[] {
+          ObjectInspectorFactory.getStandardListObjectInspector(
+              PrimitiveObjectInspectorFactory.javaDoubleObjectInspector),
+        };
     BaseVectorAggregate udaf = getAggregator();
     SimpleGenericUDAFParameterInfo info =
-      new SimpleGenericUDAFParameterInfo(doubleOI, false, false, false);
+        new SimpleGenericUDAFParameterInfo(doubleOI, false, false, false);
     GenericUDAFEvaluator eval1 = udaf.getEvaluator(info);
     GenericUDAFEvaluator.AggregationBuffer buffer1 = eval1.getNewAggregationBuffer();
     eval1.iterate(buffer1, new Object[] {Arrays.asList(1d, 2d, 3d)});
     try {
       eval1.iterate(buffer1, new Object[] {Arrays.asList(4d, 5d, 6d, 7d)});
-      throw new RuntimeException("iterate should throw an assertion error as the size of the array passed in is " +
-        "different");
+      throw new RuntimeException(
+          "iterate should throw an assertion error as the size of the array passed in is "
+              + "different");
     } catch (AssertionError ignored) {
     }
   }

--- a/hive-udf/lib/src/test/java/com/featurebyte/hive/udf/BaseVectorAggregateListTest.java
+++ b/hive-udf/lib/src/test/java/com/featurebyte/hive/udf/BaseVectorAggregateListTest.java
@@ -1,9 +1,9 @@
 package com.featurebyte.hive.udf;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import java.util.Arrays;
 import java.util.List;
+
+import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
 import org.apache.hadoop.hive.ql.udf.generic.SimpleGenericUDAFParameterInfo;
@@ -11,6 +11,8 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("deprecation")
 public abstract class BaseVectorAggregateListTest {
@@ -22,6 +24,27 @@ public abstract class BaseVectorAggregateListTest {
    * refer to those values to calculate your final result.
    */
   protected abstract List<Double> getResults();
+
+  @Test
+  public void testErrorThrownIfColumnHasArrayOfDifferentLengths() throws HiveException {
+    ObjectInspector[] doubleOI =
+      new ObjectInspector[] {
+        ObjectInspectorFactory.getStandardListObjectInspector(
+          PrimitiveObjectInspectorFactory.javaDoubleObjectInspector),
+      };
+    BaseVectorAggregate udaf = getAggregator();
+    SimpleGenericUDAFParameterInfo info =
+      new SimpleGenericUDAFParameterInfo(doubleOI, false, false, false);
+    GenericUDAFEvaluator eval1 = udaf.getEvaluator(info);
+    GenericUDAFEvaluator.AggregationBuffer buffer1 = eval1.getNewAggregationBuffer();
+    eval1.iterate(buffer1, new Object[] {Arrays.asList(1d, 2d, 3d)});
+    try {
+      eval1.iterate(buffer1, new Object[] {Arrays.asList(4d, 5d, 6d, 7d)});
+      throw new RuntimeException("iterate should throw an assertion error as the size of the array passed in is " +
+        "different");
+    } catch (AssertionError ignored) {
+    }
+  }
 
   @Test
   public void testVectorAggregate() throws HiveException {

--- a/hive-udf/lib/src/test/java/com/featurebyte/hive/udf/BaseVectorAggregateListTest.java
+++ b/hive-udf/lib/src/test/java/com/featurebyte/hive/udf/BaseVectorAggregateListTest.java
@@ -1,5 +1,9 @@
 package com.featurebyte.hive.udf;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
 import org.apache.hadoop.hive.ql.udf.generic.SimpleGenericUDAFParameterInfo;
@@ -8,31 +12,27 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 @SuppressWarnings("deprecation")
 public abstract class BaseVectorAggregateListTest {
 
   protected abstract BaseVectorAggregate getAggregator();
 
   /**
-   * getResults should return the final aggregated result.
-   * Input is hardcoded into the test, so refer to those values to calculate your final result.
+   * getResults should return the final aggregated result. Input is hardcoded into the test, so
+   * refer to those values to calculate your final result.
    */
   protected abstract List<Double> getResults();
 
   @Test
   public void testVectorAggregate() throws HiveException {
-    ObjectInspector[] doubleOI = new ObjectInspector[] {
-      ObjectInspectorFactory.getStandardListObjectInspector(
-        PrimitiveObjectInspectorFactory.javaDoubleObjectInspector
-      ),
-    };
+    ObjectInspector[] doubleOI =
+        new ObjectInspector[] {
+          ObjectInspectorFactory.getStandardListObjectInspector(
+              PrimitiveObjectInspectorFactory.javaDoubleObjectInspector),
+        };
     BaseVectorAggregate udaf = getAggregator();
-    SimpleGenericUDAFParameterInfo info = new SimpleGenericUDAFParameterInfo(doubleOI, false, false, false);
+    SimpleGenericUDAFParameterInfo info =
+        new SimpleGenericUDAFParameterInfo(doubleOI, false, false, false);
     GenericUDAFEvaluator eval1 = udaf.getEvaluator(info);
     GenericUDAFEvaluator eval2 = udaf.getEvaluator(info);
 

--- a/hive-udf/lib/src/test/java/com/featurebyte/hive/udf/VectorAggregateMaxTest.java
+++ b/hive-udf/lib/src/test/java/com/featurebyte/hive/udf/VectorAggregateMaxTest.java
@@ -12,5 +12,4 @@ public class VectorAggregateMaxTest extends BaseVectorAggregateListTest {
   protected List<Double> getResults() {
     return Arrays.asList(100d, 101d, 102d);
   }
-
 }

--- a/hive-udf/lib/src/test/java/com/featurebyte/hive/udf/VectorAggregateMaxTest.java
+++ b/hive-udf/lib/src/test/java/com/featurebyte/hive/udf/VectorAggregateMaxTest.java
@@ -1,0 +1,56 @@
+package com.featurebyte.hive.udf;
+
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
+import org.apache.hadoop.hive.ql.udf.generic.SimpleGenericUDAFParameterInfo;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings("deprecation")
+public class VectorAggregateMaxTest {
+    VectorAggregateMax udaf = new VectorAggregateMax();
+
+    @Test
+    public void testVectorAggregateMax() throws HiveException {
+        ObjectInspector[] doubleOI = new ObjectInspector[] {
+                ObjectInspectorFactory.getStandardListObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaDoubleObjectInspector
+                ),
+        };
+        SimpleGenericUDAFParameterInfo info = new SimpleGenericUDAFParameterInfo(doubleOI, false, false, false);
+        GenericUDAFEvaluator eval1 = udaf.getEvaluator(info);
+        GenericUDAFEvaluator eval2 = udaf.getEvaluator(info);
+
+        eval1.init(GenericUDAFEvaluator.Mode.PARTIAL1, doubleOI);
+        eval2.init(GenericUDAFEvaluator.Mode.PARTIAL1, doubleOI);
+
+        GenericUDAFEvaluator.AggregationBuffer buffer1 = eval1.getNewAggregationBuffer();
+        eval1.iterate(buffer1, new Object[] {Arrays.asList(1d, 2d, 3d)});
+        eval1.iterate(buffer1, new Object[] {Arrays.asList(4d, 5d, 6d)});
+        eval1.iterate(buffer1, new Object[] {Arrays.asList(7d, 8d, 9d)});
+        Object object1 = eval1.terminatePartial(buffer1);
+
+        GenericUDAFEvaluator.AggregationBuffer buffer2 = eval2.getNewAggregationBuffer();
+        eval2.iterate(buffer2, new Object[] {Arrays.asList(10d, 11d, 12d)});
+        eval2.iterate(buffer2, new Object[] {Arrays.asList(4d, 5d, 6d)});
+        eval2.iterate(buffer2, new Object[] {Arrays.asList(14d, 15d, 16d)});
+        eval2.iterate(buffer2, new Object[] {Arrays.asList(100d, 101d, 102d)});
+        Object object2 = eval2.terminatePartial(buffer2);
+
+        eval2.init(GenericUDAFEvaluator.Mode.FINAL, doubleOI);
+        GenericUDAFEvaluator.AggregationBuffer buffer3 = eval2.getNewAggregationBuffer();
+        eval2.merge(buffer3, object1);
+        eval2.merge(buffer3, object2);
+
+        Object result = eval2.terminate(buffer3);
+        List<Double> expected = Arrays.asList(100d, 101d, 102d);
+        assertEquals(expected, result);
+    }
+}

--- a/hive-udf/lib/src/test/java/com/featurebyte/hive/udf/VectorAggregateMaxTest.java
+++ b/hive-udf/lib/src/test/java/com/featurebyte/hive/udf/VectorAggregateMaxTest.java
@@ -1,56 +1,16 @@
 package com.featurebyte.hive.udf;
 
-import org.apache.hadoop.hive.ql.metadata.HiveException;
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
-import org.apache.hadoop.hive.ql.udf.generic.SimpleGenericUDAFParameterInfo;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
-import org.junit.jupiter.api.Test;
-
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+public class VectorAggregateMaxTest extends BaseVectorAggregateListTest {
 
-@SuppressWarnings("deprecation")
-public class VectorAggregateMaxTest {
-    VectorAggregateMax udaf = new VectorAggregateMax();
+  protected BaseVectorAggregate getAggregator() {
+    return new VectorAggregateMax();
+  }
 
-    @Test
-    public void testVectorAggregateMax() throws HiveException {
-        ObjectInspector[] doubleOI = new ObjectInspector[] {
-                ObjectInspectorFactory.getStandardListObjectInspector(
-                        PrimitiveObjectInspectorFactory.javaDoubleObjectInspector
-                ),
-        };
-        SimpleGenericUDAFParameterInfo info = new SimpleGenericUDAFParameterInfo(doubleOI, false, false, false);
-        GenericUDAFEvaluator eval1 = udaf.getEvaluator(info);
-        GenericUDAFEvaluator eval2 = udaf.getEvaluator(info);
+  protected List<Double> getResults() {
+    return Arrays.asList(100d, 101d, 102d);
+  }
 
-        eval1.init(GenericUDAFEvaluator.Mode.PARTIAL1, doubleOI);
-        eval2.init(GenericUDAFEvaluator.Mode.PARTIAL1, doubleOI);
-
-        GenericUDAFEvaluator.AggregationBuffer buffer1 = eval1.getNewAggregationBuffer();
-        eval1.iterate(buffer1, new Object[] {Arrays.asList(1d, 2d, 3d)});
-        eval1.iterate(buffer1, new Object[] {Arrays.asList(4d, 5d, 6d)});
-        eval1.iterate(buffer1, new Object[] {Arrays.asList(7d, 8d, 9d)});
-        Object object1 = eval1.terminatePartial(buffer1);
-
-        GenericUDAFEvaluator.AggregationBuffer buffer2 = eval2.getNewAggregationBuffer();
-        eval2.iterate(buffer2, new Object[] {Arrays.asList(10d, 11d, 12d)});
-        eval2.iterate(buffer2, new Object[] {Arrays.asList(4d, 5d, 6d)});
-        eval2.iterate(buffer2, new Object[] {Arrays.asList(14d, 15d, 16d)});
-        eval2.iterate(buffer2, new Object[] {Arrays.asList(100d, 101d, 102d)});
-        Object object2 = eval2.terminatePartial(buffer2);
-
-        eval2.init(GenericUDAFEvaluator.Mode.FINAL, doubleOI);
-        GenericUDAFEvaluator.AggregationBuffer buffer3 = eval2.getNewAggregationBuffer();
-        eval2.merge(buffer3, object1);
-        eval2.merge(buffer3, object2);
-
-        Object result = eval2.terminate(buffer3);
-        List<Double> expected = Arrays.asList(100d, 101d, 102d);
-        assertEquals(expected, result);
-    }
 }

--- a/hive-udf/lib/src/test/java/com/featurebyte/hive/udf/VectorAggregateSumTest.java
+++ b/hive-udf/lib/src/test/java/com/featurebyte/hive/udf/VectorAggregateSumTest.java
@@ -1,56 +1,15 @@
 package com.featurebyte.hive.udf;
 
-import org.apache.hadoop.hive.ql.metadata.HiveException;
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
-import org.apache.hadoop.hive.ql.udf.generic.SimpleGenericUDAFParameterInfo;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
-import org.junit.jupiter.api.Test;
-
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-@SuppressWarnings("deprecation")
-public class VectorAggregateSumTest {
-  VectorAggregateSum udaf = new VectorAggregateSum();
-
-  @Test
-  public void testVectorAggregateSum() throws HiveException {
-    ObjectInspector[] doubleOI = new ObjectInspector[] {
-      ObjectInspectorFactory.getStandardListObjectInspector(
-        PrimitiveObjectInspectorFactory.javaDoubleObjectInspector
-      ),
-    };
-    SimpleGenericUDAFParameterInfo info = new SimpleGenericUDAFParameterInfo(doubleOI, false, false, false);
-    GenericUDAFEvaluator eval1 = udaf.getEvaluator(info);
-    GenericUDAFEvaluator eval2 = udaf.getEvaluator(info);
-
-    eval1.init(GenericUDAFEvaluator.Mode.PARTIAL1, doubleOI);
-    eval2.init(GenericUDAFEvaluator.Mode.PARTIAL1, doubleOI);
-
-    GenericUDAFEvaluator.AggregationBuffer buffer1 = eval1.getNewAggregationBuffer();
-    eval1.iterate(buffer1, new Object[] {Arrays.asList(1d, 2d, 5d)});
-    eval1.iterate(buffer1, new Object[] {Arrays.asList(4d, 5d, 6d)});
-    eval1.iterate(buffer1, new Object[] {Arrays.asList(5d, 8d, 9d)});
-    Object object1 = eval1.terminatePartial(buffer1);
-
-    GenericUDAFEvaluator.AggregationBuffer buffer2 = eval2.getNewAggregationBuffer();
-    eval2.iterate(buffer2, new Object[] {Arrays.asList(10d, 19d, 16d)});
-    eval2.iterate(buffer2, new Object[] {Arrays.asList(6d, 5d, 6d)});
-    eval2.iterate(buffer2, new Object[] {Arrays.asList(14d, 15d, 16d)});
-    eval2.iterate(buffer2, new Object[] {Arrays.asList(100d, 101d, 102d)});
-    Object object2 = eval2.terminatePartial(buffer2);
-
-    eval2.init(GenericUDAFEvaluator.Mode.FINAL, doubleOI);
-    GenericUDAFEvaluator.AggregationBuffer buffer3 = eval2.getNewAggregationBuffer();
-    eval2.merge(buffer3, object1);
-    eval2.merge(buffer3, object2);
-
-    Object result = eval2.terminate(buffer3);
-    List<Double> expected = Arrays.asList(140d, 155d, 160d);
-    assertEquals(expected, result);
+public class VectorAggregateSumTest extends BaseVectorAggregateListTest {
+  protected BaseVectorAggregate getAggregator() {
+    return new VectorAggregateSum();
   }
+
+  protected List<Double> getResults() {
+    return Arrays.asList(140d, 147d, 154d);
+  }
+
 }

--- a/hive-udf/lib/src/test/java/com/featurebyte/hive/udf/VectorAggregateSumTest.java
+++ b/hive-udf/lib/src/test/java/com/featurebyte/hive/udf/VectorAggregateSumTest.java
@@ -11,5 +11,4 @@ public class VectorAggregateSumTest extends BaseVectorAggregateListTest {
   protected List<Double> getResults() {
     return Arrays.asList(140d, 147d, 154d);
   }
-
 }

--- a/hive-udf/lib/src/test/java/com/featurebyte/hive/udf/VectorAggregateSumTest.java
+++ b/hive-udf/lib/src/test/java/com/featurebyte/hive/udf/VectorAggregateSumTest.java
@@ -1,0 +1,56 @@
+package com.featurebyte.hive.udf;
+
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
+import org.apache.hadoop.hive.ql.udf.generic.SimpleGenericUDAFParameterInfo;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings("deprecation")
+public class VectorAggregateSumTest {
+  VectorAggregateSum udaf = new VectorAggregateSum();
+
+  @Test
+  public void testVectorAggregateSum() throws HiveException {
+    ObjectInspector[] doubleOI = new ObjectInspector[] {
+      ObjectInspectorFactory.getStandardListObjectInspector(
+        PrimitiveObjectInspectorFactory.javaDoubleObjectInspector
+      ),
+    };
+    SimpleGenericUDAFParameterInfo info = new SimpleGenericUDAFParameterInfo(doubleOI, false, false, false);
+    GenericUDAFEvaluator eval1 = udaf.getEvaluator(info);
+    GenericUDAFEvaluator eval2 = udaf.getEvaluator(info);
+
+    eval1.init(GenericUDAFEvaluator.Mode.PARTIAL1, doubleOI);
+    eval2.init(GenericUDAFEvaluator.Mode.PARTIAL1, doubleOI);
+
+    GenericUDAFEvaluator.AggregationBuffer buffer1 = eval1.getNewAggregationBuffer();
+    eval1.iterate(buffer1, new Object[] {Arrays.asList(1d, 2d, 5d)});
+    eval1.iterate(buffer1, new Object[] {Arrays.asList(4d, 5d, 6d)});
+    eval1.iterate(buffer1, new Object[] {Arrays.asList(5d, 8d, 9d)});
+    Object object1 = eval1.terminatePartial(buffer1);
+
+    GenericUDAFEvaluator.AggregationBuffer buffer2 = eval2.getNewAggregationBuffer();
+    eval2.iterate(buffer2, new Object[] {Arrays.asList(10d, 19d, 16d)});
+    eval2.iterate(buffer2, new Object[] {Arrays.asList(6d, 5d, 6d)});
+    eval2.iterate(buffer2, new Object[] {Arrays.asList(14d, 15d, 16d)});
+    eval2.iterate(buffer2, new Object[] {Arrays.asList(100d, 101d, 102d)});
+    Object object2 = eval2.terminatePartial(buffer2);
+
+    eval2.init(GenericUDAFEvaluator.Mode.FINAL, doubleOI);
+    GenericUDAFEvaluator.AggregationBuffer buffer3 = eval2.getNewAggregationBuffer();
+    eval2.merge(buffer3, object1);
+    eval2.merge(buffer3, object2);
+
+    Object result = eval2.terminate(buffer3);
+    List<Double> expected = Arrays.asList(140d, 155d, 160d);
+    assertEquals(expected, result);
+  }
+}


### PR DESCRIPTION
## Description
Add two UDAFs - max and sum - for use in the vector aggregation. We will add the UDAF for average in a follow-up PR.

We will also register these UDAFs for use with the SDK in a separate PR.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-2063
https://featurebyte.atlassian.net/browse/DEV-2064

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
