### PR TITLE
[0.4][DEV-2044] Fix error when retrieving feature info for some features

### DIFF
--- a/.changelog/DEV-2044.yaml
+++ b/.changelog/DEV-2044.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix error when generating info for features in some edge cases"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/models/feature.py
+++ b/featurebyte/models/feature.py
@@ -146,10 +146,17 @@ class BaseFeatureModel(FeatureByteCatalogBaseDocumentModel):
         mapped_node = pruned_graph.get_node_by_name(node_name_map[self.node.name])
         return pruned_graph, mapped_node
 
-    def extract_operation_structure(self) -> GroupOperationStructure:
+    def extract_operation_structure(
+        self, keep_all_source_columns: bool = False
+    ) -> GroupOperationStructure:
         """
         Extract feature or target operation structure based on query graph. This method is mainly
         used for deriving feature or target metadata used in feature/target info.
+
+        Parameters
+        ----------
+        keep_all_source_columns: bool
+            Whether to keep all source columns in the operation structure
 
         Returns
         -------
@@ -157,7 +164,7 @@ class BaseFeatureModel(FeatureByteCatalogBaseDocumentModel):
         """
         # group the view columns by source columns & derived columns
         operation_structure = self.graph.extract_operation_structure(
-            self.node, keep_all_source_columns=False
+            self.node, keep_all_source_columns=keep_all_source_columns
         )
         return operation_structure.to_group_operation_structure()
 

--- a/featurebyte/routes/feature/controller.py
+++ b/featurebyte/routes/feature/controller.py
@@ -520,8 +520,7 @@ class FeatureController(
                 )
             )
 
-        op_struct = feature.extract_operation_structure()
-        metadata = await self.feature_or_target_metadata_extractor.extract(op_struct=op_struct)
+        metadata = await self.feature_or_target_metadata_extractor.extract_from_object(feature)
 
         namespace_info_dict = namespace_info.dict()
         # use feature list description instead of namespace description

--- a/featurebyte/routes/target/controller.py
+++ b/featurebyte/routes/target/controller.py
@@ -140,9 +140,8 @@ class TargetController(BaseDocumentController[TargetModel, TargetService, Target
         )
 
         # Get metadata
-        group_op_structure = target_doc.extract_operation_structure()
-        target_metadata = await self.feature_or_target_metadata_extractor.extract(
-            group_op_structure
+        target_metadata = await self.feature_or_target_metadata_extractor.extract_from_object(
+            target_doc
         )
 
         return TargetInfo(

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -291,6 +291,16 @@ def snowflake_scd_view_fixture(snowflake_scd_table):
     yield scd_view
 
 
+@pytest.fixture(name="snowflake_scd_view_with_entity")
+def snowflake_scd_view_with_entity_fixture(snowflake_scd_table, cust_id_entity, transaction_entity):
+    """
+    SCDView fixture with entity
+    """
+    snowflake_scd_table["cust_id"].as_entity(cust_id_entity.name)
+    snowflake_scd_table["col_text"].as_entity(transaction_entity.name)
+    return snowflake_scd_table.get_view()
+
+
 @pytest.fixture(name="snowflake_change_view")
 def snowflake_change_view(snowflake_scd_table):
     """

--- a/tests/unit/api/test_scd_view.py
+++ b/tests/unit/api/test_scd_view.py
@@ -293,3 +293,34 @@ def test_feature_derived_from_multiple_scd_joins(multiple_scd_joined_feature):
     feat_info = feat.info()
     table_names = [table["name"] for table in feat_info["tables"]]
     assert table_names == ["scd_table_state_map", "sf_scd_table", "sf_event_table"]
+
+
+def test_event_view_join_scd_view__feature_info(
+    snowflake_event_view, snowflake_scd_view_with_entity
+):
+    """
+    Test joining event view with SCD view and creating a feature
+    """
+    joined_view = snowflake_event_view.join(snowflake_scd_view_with_entity, rsuffix="_scd")
+    joined_view["new_col"] = joined_view["col_float"].lag("cust_id_scd")
+    feature = joined_view.groupby("cust_id_scd").aggregate_over(
+        value_column="new_col", method="max", feature_names=["new_col_max_feature"], windows=["3d"]
+    )["new_col_max_feature"]
+    feature.save()
+    info = feature.info()
+    assert info["name"] == "new_col_max_feature"
+    assert info["metadata"]["input_columns"] == {
+        "Input0": {
+            "data": "sf_event_table",
+            "column_name": "event_timestamp",
+            "semantic": "event_timestamp",
+        },
+        "Input1": {"data": "sf_event_table", "column_name": "col_text", "semantic": None},
+        "Input2": {
+            "data": "sf_scd_table",
+            "column_name": "col_text",
+            "semantic": "scd_natural_key_id",
+        },
+        "Input3": {"data": "sf_scd_table", "column_name": "cust_id", "semantic": None},
+        "Input4": {"data": "sf_event_table", "column_name": "col_float", "semantic": None},
+    }


### PR DESCRIPTION
Backport #1630 to release/0.4.

This fixes an error when generating info for features in some edge cases caused by the behaviour of the keep_all_source_columns flag. This is a workaround that prevents the error and will be cleaned up later.

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
