### PR TITLE
[0.4][DEV-2048] Fix feature materialisation error due to ambiguous internal column names

### DIFF
--- a/.changelog/DEV-2048.yaml
+++ b/.changelog/DEV-2048.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix feature materialization error due to ambiguous internal column names"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/query_graph/sql/ast/aggregate.py
+++ b/featurebyte/query_graph/sql/ast/aggregate.py
@@ -116,7 +116,7 @@ class Aggregate(TableNode):
         """
         return AggregationSource(
             expr=cast(Select, source_node.sql),
-            query_node_name=source_node.context.query_node.name,
+            query_node_name=source_node.context.current_query_node.name,
             is_scd_filtered_by_current_flag=source_node.context.to_filter_scd_by_current_flag,
         )
 

--- a/featurebyte/query_graph/sql/ast/generic.py
+++ b/featurebyte/query_graph/sql/ast/generic.py
@@ -150,7 +150,7 @@ def make_project_node(context: SQLNodeContext) -> Project | TableNode:
     if context.query_node.output_type == NodeOutputType.SERIES:
         sql_node = Project(context=context, table_node=table_node, column_name=columns[0])
     else:
-        sql_node = table_node.subset_columns(columns)
+        sql_node = table_node.subset_columns(context, columns)
     return sql_node
 
 
@@ -179,6 +179,7 @@ def make_assign_node(context: SQLNodeContext) -> TableNode:
         )
     assert isinstance(expr_node, ExpressionNode)
     sql_node = input_table_node.copy()
+    sql_node.context.current_query_node = context.query_node
     sql_node.assign_column(parameters["name"], expr_node)
     return sql_node
 
@@ -226,10 +227,10 @@ def handle_filter_node(context: SQLNodeContext) -> TableNode | ExpressionNode:
     sql_node: TableNode | ExpressionNode
     if context.query_node.output_type == NodeOutputType.FRAME:
         assert isinstance(item, TableNode)
-        sql_node = item.subset_rows(mask.sql)
+        sql_node = item.subset_rows(context, mask.sql)
     else:
         assert isinstance(item, ExpressionNode)
         assert isinstance(item.table_node, TableNode)
-        input_table_copy = item.table_node.subset_rows(mask.sql)
+        input_table_copy = item.table_node.subset_rows(context, mask.sql)
         sql_node = ParsedExpressionNode(context, input_table_copy, item.sql)
     return sql_node

--- a/tests/unit/api/test_dimension_view.py
+++ b/tests/unit/api/test_dimension_view.py
@@ -378,18 +378,18 @@ def test_multiple_as_feature__same_join(snowflake_dimension_view_with_entity):
             """
         WITH _FB_AGGREGATED AS (
           SELECT
-            "T0"."_fb_internal_lookup_col_float_input_1" AS "_fb_internal_lookup_col_float_input_1",
-            "T0"."_fb_internal_lookup_col_char_input_1" AS "_fb_internal_lookup_col_char_input_1",
-            "T0"."_fb_internal_lookup_col_binary_input_1" AS "_fb_internal_lookup_col_binary_input_1",
-            "T0"."_fb_internal_lookup_col_boolean_input_1" AS "_fb_internal_lookup_col_boolean_input_1"
+            "T0"."_fb_internal_lookup_col_float_project_1" AS "_fb_internal_lookup_col_float_project_1",
+            "T0"."_fb_internal_lookup_col_char_project_1" AS "_fb_internal_lookup_col_char_project_1",
+            "T0"."_fb_internal_lookup_col_binary_project_1" AS "_fb_internal_lookup_col_binary_project_1",
+            "T0"."_fb_internal_lookup_col_boolean_project_1" AS "_fb_internal_lookup_col_boolean_project_1"
           FROM REQUEST_TABLE AS REQ
           LEFT JOIN (
             SELECT
               "col_int" AS "cust_id",
-              "col_float" AS "_fb_internal_lookup_col_float_input_1",
-              "col_char" AS "_fb_internal_lookup_col_char_input_1",
-              "col_binary" AS "_fb_internal_lookup_col_binary_input_1",
-              "col_boolean" AS "_fb_internal_lookup_col_boolean_input_1"
+              "col_float" AS "_fb_internal_lookup_col_float_project_1",
+              "col_char" AS "_fb_internal_lookup_col_char_project_1",
+              "col_binary" AS "_fb_internal_lookup_col_binary_project_1",
+              "col_boolean" AS "_fb_internal_lookup_col_boolean_project_1"
             FROM (
               SELECT
                 "col_int" AS "col_int",
@@ -406,10 +406,10 @@ def test_multiple_as_feature__same_join(snowflake_dimension_view_with_entity):
             ON REQ."cust_id" = T0."cust_id"
         )
         SELECT
-          "_fb_internal_lookup_col_float_input_1" AS "FloatFeature",
-          "_fb_internal_lookup_col_char_input_1" AS "CharFeature",
-          "_fb_internal_lookup_col_binary_input_1" AS "BinaryFeature",
-          "_fb_internal_lookup_col_boolean_input_1" AS "BoolFeature"
+          "_fb_internal_lookup_col_float_project_1" AS "FloatFeature",
+          "_fb_internal_lookup_col_char_project_1" AS "CharFeature",
+          "_fb_internal_lookup_col_binary_project_1" AS "BinaryFeature",
+          "_fb_internal_lookup_col_boolean_project_1" AS "BoolFeature"
         FROM _FB_AGGREGATED AS AGG
         """
         ).strip()

--- a/tests/unit/query_graph/sql/ast/test_special_operations.py
+++ b/tests/unit/query_graph/sql/ast/test_special_operations.py
@@ -1,0 +1,55 @@
+"""
+Test for special operations that do not have a specific SQLNode implementation: filter, project, assign
+"""
+from featurebyte import SourceType
+from featurebyte.query_graph.sql.builder import SQLOperationGraph
+from featurebyte.query_graph.sql.common import SQLType
+from featurebyte.query_graph.sql.interpreter.base import BaseGraphInterpreter
+
+
+def test_handle_filter_node(snowflake_event_view_with_entity):
+    """
+    Test handling for filter query node
+    """
+    view = snowflake_event_view_with_entity
+    filtered_view = view[view["col_float"] > 1.5]
+    graph, node = BaseGraphInterpreter(view.graph, SourceType.SNOWFLAKE).flatten_graph(
+        filtered_view.node.name
+    )
+    sql_node = SQLOperationGraph(
+        query_graph=graph, sql_type=SQLType.AGGREGATION, source_type=SourceType.SNOWFLAKE
+    ).build(node)
+    assert sql_node.context.query_node.name.startswith("input")
+    assert sql_node.context.current_query_node.name == node.name
+
+
+def test_handle_assign_node(snowflake_event_view_with_entity):
+    """
+    Test handling for assign query node
+    """
+    view = snowflake_event_view_with_entity
+    view["col_float"] = view["col_float"] + 1.5
+    graph, node = BaseGraphInterpreter(view.graph, SourceType.SNOWFLAKE).flatten_graph(
+        view.node.name
+    )
+    sql_node = SQLOperationGraph(
+        query_graph=graph, sql_type=SQLType.AGGREGATION, source_type=SourceType.SNOWFLAKE
+    ).build(node)
+    assert sql_node.context.query_node.name.startswith("input")
+    assert sql_node.context.current_query_node.name == node.name
+
+
+def test_handle_project_node(snowflake_event_view_with_entity):
+    """
+    Test handling for project query node
+    """
+    view = snowflake_event_view_with_entity
+    view = view[["col_int", "col_float"]]
+    graph, node = BaseGraphInterpreter(view.graph, SourceType.SNOWFLAKE).flatten_graph(
+        view.node.name
+    )
+    sql_node = SQLOperationGraph(
+        query_graph=graph, sql_type=SQLType.AGGREGATION, source_type=SourceType.SNOWFLAKE
+    ).build(node)
+    assert sql_node.context.query_node.name.startswith("input")
+    assert sql_node.context.current_query_node.name == node.name

--- a/tests/unit/query_graph/test_sql.py
+++ b/tests/unit/query_graph/test_sql.py
@@ -105,7 +105,7 @@ def test_input_node__subset_columns(input_node):
     input_node.assign_column("col_new_2", expr_node_2)
 
     # check subset node
-    subset_node = input_node.subset_columns(["col_1", "col_new_1"])
+    subset_node = input_node.subset_columns(make_context(), ["col_1", "col_new_1"])
     assert subset_node.columns_map == {"col_1": parse_one("col_1"), "col_new_1": parse_one("a + 1")}
     assert subset_node.columns_node == {"col_new_1": expr_node_1}
     assert subset_node.get_column_expr("col_1") == parse_one("col_1")


### PR DESCRIPTION
Cherry pick #1635 to release/0.4.

This fixes an error in feature materialisation due to ambiguous internal column names. Previously, the internal column names generated were not sufficiently unique as operations such as filtering were not accounted for.

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
