### PR TITLE
[DEV-2067] vector_aggregate: register new UDAF; pass parent_dtype around; update construct specs

### DIFF
--- a/.changelog/DEV-2067.yaml
+++ b/.changelog/DEV-2067.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: vector-aggregation
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Register vector aggregate max, and update parent dtype inference logic."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/query_graph/sql/adapter/databricks.py
+++ b/featurebyte/query_graph/sql/adapter/databricks.py
@@ -31,6 +31,7 @@ class DatabricksAdapter(BaseAdapter):
         TIMESTAMP = "TIMESTAMP"
         STRING = "STRING"
         MAP = "MAP<STRING, DOUBLE>"
+        ARRAY = "ARRAY<DOUBLE>"
 
     @classmethod
     def object_agg(cls, key_column: str | Expression, value_column: str | Expression) -> Expression:
@@ -119,6 +120,7 @@ class DatabricksAdapter(BaseAdapter):
             DBVarType.VARCHAR: cls.DataType.STRING,
             DBVarType.OBJECT: cls.DataType.MAP,
             DBVarType.TIMESTAMP: cls.DataType.TIMESTAMP,
+            DBVarType.ARRAY: cls.DataType.ARRAY,
         }
         if dtype in mapping:
             return mapping[dtype]

--- a/featurebyte/query_graph/sql/adapter/snowflake.py
+++ b/featurebyte/query_graph/sql/adapter/snowflake.py
@@ -40,6 +40,7 @@ class SnowflakeAdapter(BaseAdapter):  # pylint: disable=too-many-public-methods
         TIMESTAMP_TZ = "TIMESTAMP_TZ"
         VARCHAR = "VARCHAR"
         VARIANT = "VARIANT"
+        ARRAY = "ARRAY"
 
     @classmethod
     def to_epoch_seconds(cls, timestamp_expr: Expression) -> Expression:
@@ -102,6 +103,7 @@ class SnowflakeAdapter(BaseAdapter):  # pylint: disable=too-many-public-methods
             DBVarType.OBJECT: cls.SnowflakeDataType.OBJECT,
             DBVarType.TIMESTAMP: cls.SnowflakeDataType.TIMESTAMP_NTZ,
             DBVarType.TIMESTAMP_TZ: cls.SnowflakeDataType.TIMESTAMP_TZ,
+            DBVarType.ARRAY: cls.SnowflakeDataType.ARRAY,
         }
         if dtype in mapping:
             return mapping[dtype]

--- a/featurebyte/query_graph/sql/ast/aggregate.py
+++ b/featurebyte/query_graph/sql/ast/aggregate.py
@@ -137,6 +137,7 @@ class Lookup(Aggregate):
         columns_map = {}
         specs = LookupSpec.from_query_graph_node(
             context.query_node,
+            graph=context.graph,
             aggregation_source=Aggregate.get_aggregation_source_from_source_node(source_node),
         )
         for spec in specs:
@@ -160,6 +161,7 @@ class LookupTarget(Aggregate):
         columns_map = {}
         specs = LookupTargetSpec.from_query_graph_node(
             context.query_node,
+            graph=context.graph,
             aggregation_source=Aggregate.get_aggregation_source_from_source_node(source_node),
         )
         for spec in specs:
@@ -182,6 +184,7 @@ class AsAt(Aggregate):
         columns_map = {}
         spec = AggregateAsAtSpec.from_query_graph_node(
             context.query_node,
+            graph=context.graph,
             aggregation_source=Aggregate.get_aggregation_source_from_source_node(source_node),
         )[0]
         feature_name = cast(str, spec.parameters.name)
@@ -204,6 +207,7 @@ class Item(Aggregate):
         columns_map = {}
         spec = ItemAggregationSpec.from_query_graph_node(
             context.query_node,
+            graph=context.graph,
             aggregation_source=Aggregate.get_aggregation_source_from_source_node(source_node),
         )[0]
         feature_name = cast(str, spec.parameters.name)
@@ -226,6 +230,7 @@ class Forward(Aggregate):
         columns_map = {}
         spec = ForwardAggregateSpec.from_query_graph_node(
             context.query_node,
+            graph=context.graph,
             aggregation_source=Aggregate.get_aggregation_source_from_source_node(source_node),
         )[0]
         columns_map[spec.parameters.name] = quoted_identifier(spec.agg_result_name)

--- a/featurebyte/query_graph/sql/ast/tile.py
+++ b/featurebyte/query_graph/sql/ast/tile.py
@@ -263,12 +263,15 @@ class BuildTileNode(TableNode):  # pylint: disable=too-many-instance-attributes
         parameters = context.parameters
         input_node = context.input_sql_nodes[0]
         assert isinstance(input_node, TableNode)
-        aggregator = get_aggregator(parameters["agg_func"], adapter=context.adapter)
         if parameters["parent"] is None:
             parent_column = None
+            parent_dtype = None
         else:
             parent_dtype = get_parent_dtype(parameters["parent"], context.graph, context.query_node)
             parent_column = InputColumn(name=parameters["parent"], dtype=parent_dtype)
+        aggregator = get_aggregator(
+            parameters["agg_func"], adapter=context.adapter, parent_dtype=parent_dtype
+        )
         tile_specs = aggregator.tile(parent_column, parameters["aggregation_id"])
         columns = (
             [InternalName.TILE_START_DATE.value]

--- a/featurebyte/query_graph/sql/ast/tile.py
+++ b/featurebyte/query_graph/sql/ast/tile.py
@@ -19,6 +19,7 @@ from featurebyte.query_graph.sql.common import (
     get_qualified_column_identifier,
     quoted_identifier,
 )
+from featurebyte.query_graph.sql.query_graph_util import get_parent_dtype
 from featurebyte.query_graph.sql.specs import TileBasedAggregationSpec
 from featurebyte.query_graph.sql.tiling import InputColumn, TileSpec, get_aggregator
 from featurebyte.query_graph.transform.operation_structure import OperationStructureExtractor
@@ -266,7 +267,7 @@ class BuildTileNode(TableNode):  # pylint: disable=too-many-instance-attributes
         if parameters["parent"] is None:
             parent_column = None
         else:
-            parent_dtype = cls._get_parent_dtype(parameters["parent"], context)
+            parent_dtype = get_parent_dtype(parameters["parent"], context.graph, context.query_node)
             parent_column = InputColumn(name=parameters["parent"], dtype=parent_dtype)
         tile_specs = aggregator.tile(parent_column, parameters["aggregation_id"])
         columns = (

--- a/featurebyte/query_graph/sql/ast/tile.py
+++ b/featurebyte/query_graph/sql/ast/tile.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from sqlglot import expressions
 from sqlglot.expressions import Expression, Select, alias_, select
 
-from featurebyte.enum import DBVarType, InternalName
+from featurebyte.enum import InternalName
 from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.sql.ast.base import SQLNodeContext, TableNode
 from featurebyte.query_graph.sql.ast.literal import make_literal_value
@@ -22,7 +22,6 @@ from featurebyte.query_graph.sql.common import (
 from featurebyte.query_graph.sql.query_graph_util import get_parent_dtype
 from featurebyte.query_graph.sql.specs import TileBasedAggregationSpec
 from featurebyte.query_graph.sql.tiling import InputColumn, TileSpec, get_aggregator
-from featurebyte.query_graph.transform.operation_structure import OperationStructureExtractor
 
 
 @dataclass
@@ -235,15 +234,6 @@ class BuildTileNode(TableNode):  # pylint: disable=too-many-instance-attributes
         elif context.sql_type == SQLType.BUILD_TILE_ON_DEMAND:
             sql_node = cls.make_build_tile_node(context, is_on_demand=True)
         return sql_node
-
-    @staticmethod
-    def _get_parent_dtype(parent_column_name: str, context: SQLNodeContext) -> DBVarType:
-        op_struct = (
-            OperationStructureExtractor(graph=context.graph)
-            .extract(node=context.query_node)
-            .operation_structure_map[context.query_node.name]
-        )
-        return next(col for col in op_struct.columns if col.name == parent_column_name).dtype
 
     @classmethod
     def make_build_tile_node(cls, context: SQLNodeContext, is_on_demand: bool) -> BuildTileNode:

--- a/featurebyte/query_graph/sql/query_graph_util.py
+++ b/featurebyte/query_graph/sql/query_graph_util.py
@@ -1,0 +1,34 @@
+"""
+Query graph util module
+"""
+from featurebyte.enum import DBVarType
+from featurebyte.query_graph.model.graph import QueryGraphModel
+from featurebyte.query_graph.node import Node
+from featurebyte.query_graph.transform.operation_structure import OperationStructureExtractor
+
+
+def get_parent_dtype(
+    parent_column_name: str, graph: QueryGraphModel, query_node: Node
+) -> DBVarType:
+    """
+    Get the dtype of the parent column given a graph and query node.
+
+    Parameters
+    ----------
+    parent_column_name: str
+        Name of the parent column
+    graph: QueryGraphModel
+        Query graph
+    query_node: Node
+        Query node
+
+    Returns
+    -------
+    DBVarType
+    """
+    op_struct = (
+        OperationStructureExtractor(graph=graph)
+        .extract(node=query_node)
+        .operation_structure_map[query_node.name]
+    )
+    return next(col for col in op_struct.columns if col.name == parent_column_name).dtype

--- a/featurebyte/query_graph/sql/specifications/lookup.py
+++ b/featurebyte/query_graph/sql/specifications/lookup.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from dataclasses import dataclass
 
+from featurebyte.query_graph.model.graph import QueryGraphModel
 from featurebyte.query_graph.node import Node
 from featurebyte.query_graph.node.generic import LookupNode
 from featurebyte.query_graph.sql.specifications.base_lookup import BaseLookupSpec
@@ -29,6 +30,7 @@ class LookupSpec(BaseLookupSpec):
         node: Node,
         aggregation_source: AggregationSource,
         serving_names_mapping: Optional[dict[str, str]],
+        graph: Optional[QueryGraphModel],
     ) -> list[LookupSpec]:
         assert isinstance(node, LookupNode)
         params = node.parameters

--- a/featurebyte/query_graph/sql/specifications/lookup_target.py
+++ b/featurebyte/query_graph/sql/specifications/lookup_target.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from dataclasses import dataclass
 
+from featurebyte.query_graph.model.graph import QueryGraphModel
 from featurebyte.query_graph.node import Node
 from featurebyte.query_graph.node.generic import LookupTargetNode
 from featurebyte.query_graph.sql.specifications.base_lookup import BaseLookupSpec
@@ -31,6 +32,7 @@ class LookupTargetSpec(BaseLookupSpec):
         node: Node,
         aggregation_source: AggregationSource,
         serving_names_mapping: Optional[dict[str, str]],
+        graph: Optional[QueryGraphModel],
     ) -> list[LookupTargetSpec]:
         assert isinstance(node, LookupTargetNode)
         params = node.parameters

--- a/featurebyte/query_graph/sql/specs.py
+++ b/featurebyte/query_graph/sql/specs.py
@@ -618,6 +618,7 @@ class AggregateAsAtSpec(NonTileBasedAggregationSpec):
     ) -> list[AggregateAsAtSpec]:
         assert isinstance(node, AggregateAsAtNode)
         assert graph is not None
+        assert node.parameters.parent is not None
         parent_dtype = get_parent_dtype(node.parameters.parent, graph, node)
         return [
             AggregateAsAtSpec(

--- a/featurebyte/query_graph/sql/specs.py
+++ b/featurebyte/query_graph/sql/specs.py
@@ -464,8 +464,8 @@ class NonTileBasedAggregationSpec(AggregationSpec):
     def from_query_graph_node(
         cls: Type[NonTileBasedAggregationSpecT],
         node: Node,
+        graph: QueryGraphModel,
         aggregation_source: Optional[AggregationSource] = None,
-        graph: Optional[QueryGraphModel] = None,
         source_type: Optional[SourceType] = None,
         serving_names_mapping: Optional[dict[str, str]] = None,
         is_online_serving: Optional[bool] = None,
@@ -477,10 +477,10 @@ class NonTileBasedAggregationSpec(AggregationSpec):
         ----------
         node : Node
             Query graph node
+        graph: QueryGraphModel
+            Query graph. Mandatory if aggregation_source is not provided
         aggregation_source: Optional[AggregationSource]
             Source of the aggregation
-        graph: Optional[QueryGraphModel]
-            Query graph. Mandatory if aggregation_source is not provided
         source_type: Optional[SourceType]
             Source type information. Mandatory if aggregation_source is not provided
         serving_names_mapping: Optional[dict[str, str]]
@@ -617,9 +617,10 @@ class AggregateAsAtSpec(NonTileBasedAggregationSpec):
         graph: Optional[QueryGraphModel],
     ) -> list[AggregateAsAtSpec]:
         assert isinstance(node, AggregateAsAtNode)
-        assert graph is not None
-        assert node.parameters.parent is not None
-        parent_dtype = get_parent_dtype(node.parameters.parent, graph, node)
+        parent_dtype = None
+        if node.parameters.parent is not None:
+            assert graph is not None
+            parent_dtype = get_parent_dtype(node.parameters.parent, graph, node)
         return [
             AggregateAsAtSpec(
                 parameters=node.parameters,

--- a/featurebyte/query_graph/sql/specs.py
+++ b/featurebyte/query_graph/sql/specs.py
@@ -197,9 +197,11 @@ class TileBasedAggregationSpec(AggregationSpec):
 
         serving_names = params["serving_names"]
         aggregation_specs = []
-        aggregator = get_aggregator(params["agg_func"], adapter=adapter)
+        aggregator = get_aggregator(
+            params["agg_func"], adapter=adapter, parent_dtype=params["parent_dtype"]
+        )
         if params["parent"]:
-            # Note: here, we only need to retrive tile column names. Ideally the dtype should be set
+            # Note: here, we only need to retrieve tile column names. Ideally the dtype should be set
             # as the parent column's dtype, but in this case a dummy dtype is passed since that
             # doesn't affect the tile column names.
             parent_column = InputColumn(name=params["parent"], dtype=DBVarType.FLOAT)

--- a/featurebyte/query_graph/sql/specs.py
+++ b/featurebyte/query_graph/sql/specs.py
@@ -188,6 +188,7 @@ class TileBasedAggregationSpec(AggregationSpec):
         list[TileBasedAggregationSpec]
             List of AggregationSpec
         """
+        # pylint: disable=too-many-locals
         assert isinstance(groupby_node, GroupByNode)
         tile_table_id = groupby_node.parameters.tile_id
         aggregation_id = groupby_node.parameters.aggregation_id
@@ -512,6 +513,7 @@ class NonTileBasedAggregationSpec(AggregationSpec):
             node=node,
             aggregation_source=aggregation_source,
             serving_names_mapping=serving_names_mapping,
+            graph=graph,
         )
 
 

--- a/featurebyte/query_graph/sql/tiling.py
+++ b/featurebyte/query_graph/sql/tiling.py
@@ -321,11 +321,11 @@ def get_aggregator(
     type[TilingAggregator]
     """
     if parent_dtype is not None and parent_dtype == DBVarType.ARRAY:
-        aggregator_mapping: dict[AggFunc, type[TilingAggregator]] = {
+        vector_aggregator_mapping: dict[AggFunc, type[TilingAggregator]] = {
             AggFunc.MAX: VectorMaxAggregator,
         }
-        assert agg_name in aggregator_mapping
-        return aggregator_mapping[agg_name](adapter=adapter)
+        assert agg_name in vector_aggregator_mapping
+        return vector_aggregator_mapping[agg_name](adapter=adapter)
 
     aggregator_mapping: dict[AggFunc, type[TilingAggregator]] = {
         AggFunc.SUM: SumAggregator,

--- a/featurebyte/session/base_spark.py
+++ b/featurebyte/session/base_spark.py
@@ -401,6 +401,8 @@ class BaseSparkSchemaInitializer(BaseSchemaInitializer):
         # and re-register the function with the new class
         udf_functions = [
             ("VECTOR_AGGREGATE_MAX", "com.featurebyte.hive.udf.VectorAggregateMax"),
+            ("VECTOR_AGGREGATE_SUM", "com.featurebyte.hive.udf.VectorAggregateSum"),
+            ("VECTOR_AGGREGATE_AVG", "com.featurebyte.hive.udf.VectorAggregateAverage"),
             ("OBJECT_AGG", "com.featurebyte.hive.udf.ObjectAggregate"),
             ("OBJECT_DELETE", "com.featurebyte.hive.udf.ObjectDelete"),
             ("F_TIMESTAMP_TO_INDEX", "com.featurebyte.hive.udf.TimestampToIndex"),

--- a/featurebyte/session/base_spark.py
+++ b/featurebyte/session/base_spark.py
@@ -310,7 +310,7 @@ class BaseSparkSchemaInitializer(BaseSchemaInitializer):
 
     @property
     def current_working_schema_version(self) -> int:
-        return 2
+        return 3
 
     @property
     def sql_directory_name(self) -> str:
@@ -400,6 +400,7 @@ class BaseSparkSchemaInitializer(BaseSchemaInitializer):
         # To ensure functionality is updated for a function we should create a new class
         # and re-register the function with the new class
         udf_functions = [
+            ("VECTOR_AGGREGATE_MAX", "com.featurebyte.hive.udf.VectorAggregateMax"),
             ("OBJECT_AGG", "com.featurebyte.hive.udf.ObjectAggregate"),
             ("OBJECT_DELETE", "com.featurebyte.hive.udf.ObjectDelete"),
             ("F_TIMESTAMP_TO_INDEX", "com.featurebyte.hive.udf.TimestampToIndex"),

--- a/tests/unit/query_graph/sql/test_query_graph_util.py
+++ b/tests/unit/query_graph/sql/test_query_graph_util.py
@@ -1,0 +1,14 @@
+"""
+Test query graph util module
+"""
+from featurebyte.enum import DBVarType
+from featurebyte.query_graph.sql.query_graph_util import get_parent_dtype
+
+
+def test_get_parent_dtype(query_graph_and_assign_node):
+    """
+    Test get_parent_dtype
+    """
+    graph, node = query_graph_and_assign_node
+    dtype = get_parent_dtype("c", graph, node)
+    assert dtype == DBVarType.FLOAT

--- a/tests/unit/query_graph/test_adapter.py
+++ b/tests/unit/query_graph/test_adapter.py
@@ -17,6 +17,7 @@ from featurebyte.query_graph.sql.adapter import SnowflakeAdapter, SparkAdapter, 
         (DBVarType.VARCHAR, "VARCHAR"),
         (DBVarType.OBJECT, "OBJECT"),
         (DBVarType.BINARY, "VARIANT"),
+        (DBVarType.ARRAY, "ARRAY"),
     ],
 )
 def test_get_online_store_type_from_dtype(dtype, expected):

--- a/tests/unit/query_graph/test_tiling.py
+++ b/tests/unit/query_graph/test_tiling.py
@@ -168,8 +168,8 @@ def make_expected_tile_spec(tile_expr, tile_column_name, tile_column_type=None):
             [
                 make_expected_tile_spec(
                     tile_expr='VECTOR_AGGREGATE_SUM("a_column")',
-                    tile_column_name="sum_value_1234beef",
-                    tile_column_type="FLOAT",
+                    tile_column_name="sum_list_value_1234beef",
+                    tile_column_type="ARRAY",
                 ),
                 make_expected_tile_spec(
                     tile_expr="COUNT(*)",
@@ -177,7 +177,7 @@ def make_expected_tile_spec(tile_expr, tile_column_name, tile_column_type=None):
                     tile_column_type="FLOAT",
                 ),
             ],
-            "VECTOR_AGGREGATE_AVG(sum_value_1234beef, count_value_1234beef)",
+            "VECTOR_AGGREGATE_AVG(sum_list_value_1234beef, count_value_1234beef)",
         ),
     ],
 )

--- a/tests/unit/query_graph/test_tiling.py
+++ b/tests/unit/query_graph/test_tiling.py
@@ -28,10 +28,11 @@ def make_expected_tile_spec(tile_expr, tile_column_name, tile_column_type=None):
 
 
 @pytest.mark.parametrize(
-    "agg_func,expected_tile_specs,expected_merge_expr",
+    "agg_func,parent_dtype,expected_tile_specs,expected_merge_expr",
     [
         (
             AggFunc.SUM,
+            None,
             [
                 make_expected_tile_spec(
                     tile_expr='SUM("a_column")', tile_column_name="value_1234beef"
@@ -41,6 +42,7 @@ def make_expected_tile_spec(tile_expr, tile_column_name, tile_column_type=None):
         ),
         (
             AggFunc.AVG,
+            None,
             [
                 make_expected_tile_spec(
                     tile_expr='SUM("a_column")', tile_column_name="sum_value_1234beef"
@@ -53,6 +55,7 @@ def make_expected_tile_spec(tile_expr, tile_column_name, tile_column_type=None):
         ),
         (
             AggFunc.MIN,
+            None,
             [
                 make_expected_tile_spec(
                     tile_expr='MIN("a_column")', tile_column_name="value_1234beef"
@@ -62,6 +65,17 @@ def make_expected_tile_spec(tile_expr, tile_column_name, tile_column_type=None):
         ),
         (
             AggFunc.MAX,
+            None,
+            [
+                make_expected_tile_spec(
+                    tile_expr='MAX("a_column")', tile_column_name="value_1234beef"
+                )
+            ],
+            "MAX(value_1234beef)",
+        ),
+        (
+            AggFunc.MAX,
+            DBVarType.FLOAT,
             [
                 make_expected_tile_spec(
                     tile_expr='MAX("a_column")', tile_column_name="value_1234beef"
@@ -71,11 +85,13 @@ def make_expected_tile_spec(tile_expr, tile_column_name, tile_column_type=None):
         ),
         (
             AggFunc.COUNT,
+            None,
             [make_expected_tile_spec(tile_expr="COUNT(*)", tile_column_name="value_1234beef")],
             "SUM(value_1234beef)",
         ),
         (
             AggFunc.NA_COUNT,
+            None,
             [
                 make_expected_tile_spec(
                     tile_expr='SUM(CAST("a_column" IS NULL AS INTEGER))',
@@ -86,6 +102,7 @@ def make_expected_tile_spec(tile_expr, tile_column_name, tile_column_type=None):
         ),
         (
             AggFunc.STD,
+            None,
             [
                 make_expected_tile_spec(
                     tile_expr='SUM("a_column" * "a_column")',
@@ -110,6 +127,7 @@ def make_expected_tile_spec(tile_expr, tile_column_name, tile_column_type=None):
         ),
         (
             AggFunc.LATEST,
+            None,
             [
                 make_expected_tile_spec(
                     tile_expr='FIRST_VALUE("a_column")',
@@ -119,12 +137,26 @@ def make_expected_tile_spec(tile_expr, tile_column_name, tile_column_type=None):
             ],
             "FIRST_VALUE(value_1234beef)",
         ),
+        (
+            AggFunc.MAX,
+            DBVarType.ARRAY,
+            [
+                make_expected_tile_spec(
+                    tile_expr='VECTOR_AGGREGATE_MAX("a_column")',
+                    tile_column_name="value_1234beef",
+                    tile_column_type="VARCHAR",
+                )
+            ],
+            "VECTOR_AGGREGATE_MAX(value_1234beef)",
+        ),
     ],
 )
-def test_tiling_aggregators(agg_func, expected_tile_specs, expected_merge_expr):
+def test_tiling_aggregators(agg_func, parent_dtype, expected_tile_specs, expected_merge_expr):
     """Test tiling aggregators produces expected expressions"""
     agg_id = "1234beef"
-    agg = get_aggregator(agg_func, adapter=get_sql_adapter(SourceType.SNOWFLAKE))
+    agg = get_aggregator(
+        agg_func, adapter=get_sql_adapter(SourceType.SNOWFLAKE), parent_dtype=parent_dtype
+    )
     input_column = InputColumn(name="a_column", dtype=DBVarType.VARCHAR)
     tile_specs = agg.tile(input_column, agg_id)
     merge_expr = agg.merge(agg_id)

--- a/tests/unit/query_graph/test_tiling.py
+++ b/tests/unit/query_graph/test_tiling.py
@@ -54,6 +54,19 @@ def make_expected_tile_spec(tile_expr, tile_column_name, tile_column_type=None):
             "SUM(sum_value_1234beef) / SUM(count_value_1234beef)",
         ),
         (
+            AggFunc.AVG,
+            DBVarType.FLOAT,  # adding a non-array parent type will use the normal average aggregator
+            [
+                make_expected_tile_spec(
+                    tile_expr='SUM("a_column")', tile_column_name="sum_value_1234beef"
+                ),
+                make_expected_tile_spec(
+                    tile_expr='COUNT("a_column")', tile_column_name="count_value_1234beef"
+                ),
+            ],
+            "SUM(sum_value_1234beef) / SUM(count_value_1234beef)",
+        ),
+        (
             AggFunc.MIN,
             None,
             [
@@ -75,7 +88,7 @@ def make_expected_tile_spec(tile_expr, tile_column_name, tile_column_type=None):
         ),
         (
             AggFunc.MAX,
-            DBVarType.FLOAT,
+            DBVarType.FLOAT,  # adding a non-array parent type will use the normal max aggregator
             [
                 make_expected_tile_spec(
                     tile_expr='MAX("a_column")', tile_column_name="value_1234beef"
@@ -148,6 +161,23 @@ def make_expected_tile_spec(tile_expr, tile_column_name, tile_column_type=None):
                 )
             ],
             "VECTOR_AGGREGATE_MAX(value_1234beef)",
+        ),
+        (
+            AggFunc.AVG,
+            DBVarType.ARRAY,
+            [
+                make_expected_tile_spec(
+                    tile_expr='VECTOR_AGGREGATE_SUM("a_column")',
+                    tile_column_name="sum_value_1234beef",
+                    tile_column_type="FLOAT",
+                ),
+                make_expected_tile_spec(
+                    tile_expr="COUNT(*)",
+                    tile_column_name="count_value_1234beef",
+                    tile_column_type="FLOAT",
+                ),
+            ],
+            "VECTOR_AGGREGATE_AVG(sum_value_1234beef, count_value_1234beef)",
         ),
     ],
 )


### PR DESCRIPTION
## Description
This PR makes a few changes
- registers the `VECTOR_AGGREGATE_MAX` and `VECTOR_AGGREGATE_AVG` udaf for spark
- passes `parent_dtype` into the `get_aggregator` function so that we can pick up the correct aggregator depending on the parents dtype
- updates `construct_specs` to take in a graph as a parameter too
- registers datatypes for arrays in snowflake and spark

This PR doesn't yet include the changes to the `groupby_helper`. That will be done in a follow-up.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-2067
https://featurebyte.atlassian.net/browse/DEV-2073
https://featurebyte.atlassian.net/browse/DEV-2080
https://featurebyte.atlassian.net/browse/DEV-2081

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
