### PR TITLE
[DEV-2051][DEV-2079] Fix item table default job setting not synchronized with event table

### DIFF
--- a/.changelog/DEV-2051.yaml
+++ b/.changelog/DEV-2051.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: api
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix item table default job settings not synchronized when job settings are updated in the event table"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/.changelog/DEV-2051.yaml
+++ b/.changelog/DEV-2051.yaml
@@ -16,7 +16,7 @@ component: api
 issues: []
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Fix item table default job settings not synchronized when job settings are updated in the event table"
+note: "Fix item table default job settings not synchronized when job settings are updated in the event table, fix historical feature table listing failure"
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/featurebyte/api/item_table.py
+++ b/featurebyte/api/item_table.py
@@ -3,11 +3,15 @@ ItemTable class
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, List, Literal, Optional, Type, cast
+from typing import TYPE_CHECKING, Any, ClassVar, List, Literal, Optional, Type, Union, cast
+
+import operator
 
 from bson import ObjectId
+from cachetools import cachedmethod
 from pydantic import Field, StrictStr, root_validator
 
+from featurebyte.api.api_object import ApiObjectT, get_api_object_cache_key
 from featurebyte.api.base_table import TableApiObject
 from featurebyte.api.event_table import EventTable
 from featurebyte.common.doc_util import FBAutoDoc
@@ -15,7 +19,7 @@ from featurebyte.common.join_utils import append_rsuffix_to_columns
 from featurebyte.common.validator import construct_data_model_root_validator
 from featurebyte.enum import DBVarType, TableDataType, ViewMode
 from featurebyte.exception import RecordRetrievalException
-from featurebyte.models.base import PydanticObjectId
+from featurebyte.models.base import FeatureByteBaseDocumentModel, PydanticObjectId
 from featurebyte.models.item_table import ItemTableModel
 from featurebyte.query_graph.graph import GlobalQueryGraph
 from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
@@ -27,6 +31,28 @@ from featurebyte.schema.item_table import ItemTableCreate, ItemTableUpdate
 
 if TYPE_CHECKING:
     from featurebyte.api.item_view import ItemView
+
+
+def get_default_job_setting_cache_key(
+    obj: Union[ApiObjectT, FeatureByteBaseDocumentModel], *args: Any, **kwargs: Any
+) -> Any:
+    """
+    Construct cache key for a given document model object
+
+    Parameters
+    ----------
+    obj: Union[ApiObjectT, FeatureByteBaseDocumentModel]
+        Api object or document model object
+    args: Any
+        Additional positional arguments
+    kwargs: Any
+        Additional keywords arguments
+
+    Returns
+    -------
+    Any
+    """
+    return get_api_object_cache_key(obj, *args, attribute="default_job_setting", **kwargs)
 
 
 class ItemTable(TableApiObject):
@@ -72,19 +98,6 @@ class ItemTable(TableApiObject):
     event_table_id: PydanticObjectId = Field(
         allow_mutation=False,
         description="Returns the ID of the event table that " "is associated with the item table.",
-    )
-    default_feature_job_setting: Optional[FeatureJobSetting] = Field(
-        exclude=True,
-        allow_mutation=False,
-        description="Returns the default feature job setting for the table.\n\n"
-        "The Default Feature Job Setting establishes the default "
-        "setting used by features that aggregate data in the table, "
-        "ensuring consistency of the Feature Job Setting across "
-        "features created by different team members. While it's "
-        "possible to override the setting during feature declaration, "
-        "using the Default Feature Job Setting simplifies the "
-        "process of setting up the Feature Job Setting for each "
-        "feature.",
     )
 
     # pydantic instance variable (internal use)
@@ -299,21 +312,28 @@ class ItemTable(TableApiObject):
             timestamp_timezone_offset_column_name=timestamp_timezone_offset_column,
         )
 
-    @root_validator(pre=True)
-    @classmethod
-    def _set_default_feature_job_setting(cls, values: dict[str, Any]) -> dict[str, Any]:
-        if "event_table_id" in values:
-            event_table_id = values["event_table_id"]
-            try:
-                default_feature_job_setting = EventTable.get_by_id(
-                    event_table_id
-                ).default_feature_job_setting
-            except RecordRetrievalException:
-                # Typically this shouldn't happen since event_table_id should be available if the
-                # ItemTable was instantiated correctly. Currently, this occurs only in tests.
-                return values
-            values["default_feature_job_setting"] = default_feature_job_setting
-        return values
+    @property
+    @cachedmethod(cache=operator.attrgetter("_cache"), key=get_default_job_setting_cache_key)
+    def default_feature_job_setting(self) -> Optional[FeatureJobSetting]:
+        """
+        Returns the default feature job setting for the table.
+
+        The Default Feature Job Setting establishes the default setting used by features that
+        aggregate data in the table, ensuring consistency of the Feature Job Setting across
+        features created by different team members. While it's possible to override the setting
+        during feature declaration, using the Default Feature Job Setting simplifies the process
+        of setting up the Feature Job Setting for each feature.
+
+        Returns
+        -------
+        Optional[FeatureJobSetting]
+        """
+        try:
+            return EventTable.get_by_id(self.event_table_id).default_feature_job_setting
+        except RecordRetrievalException:
+            # Typically this shouldn't happen since event_table_id should be available if the
+            # ItemTable was instantiated correctly. Currently, this occurs only in tests.
+            return None
 
     @property
     def event_id_column(self) -> str:

--- a/featurebyte/schema/historical_feature_table.py
+++ b/featurebyte/schema/historical_feature_table.py
@@ -3,7 +3,7 @@ HistoricalFeatureTable API payload schema
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from pydantic import root_validator
 
@@ -37,7 +37,7 @@ class HistoricalFeatureTableListRecord(BaseMaterializedTableListRecord):
     """
 
     feature_store_id: PydanticObjectId
-    observation_table_id: PydanticObjectId
+    observation_table_id: Optional[PydanticObjectId]
 
     @root_validator(pre=True)
     @classmethod


### PR DESCRIPTION
Make item table default job setting a property so it can be synchronized frequently from the event table.

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-2051

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
