### PR TITLE
[chore] source_table: fix typo in create_scd_table docs

### DIFF
--- a/featurebyte/api/source_table.py
+++ b/featurebyte/api/source_table.py
@@ -692,7 +692,7 @@ class SourceTable(AbstractTableData):
         - Type 1: Overwrites old data with new data
         - Type 2: Maintains a history of changes by creating a new record for each change.
 
-        eatureByte only supports the use of Type 2 SCD Tables since Type 1 SCD Tables may cause data leaks during
+        FeatureByte only supports the use of Type 2 SCD Tables since Type 1 SCD Tables may cause data leaks during
         model training and poor performance during inference.
 
         To create an SCD Table, you need to identify columns for the natural key, effective timestamp, optionally


### PR DESCRIPTION
## Description
Fix a small typo in the docs.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
