### PR TITLE
[DEV-2129] Remove mongodb index on periodic task name 

### DIFF
--- a/.changelog/DEV-2129.yaml
+++ b/.changelog/DEV-2129.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: model
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Mongodb index on periodic task name conflicts with scheduler engine"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/models/periodic_task.py
+++ b/featurebyte/models/periodic_task.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 import pymongo
 from pydantic import BaseModel, Field
+from pymongo.operations import IndexModel
 
 from featurebyte.models.base import (
     FeatureByteCatalogBaseDocumentModel,
@@ -91,8 +92,12 @@ class PeriodicTask(FeatureByteCatalogBaseDocumentModel):
             ),
         ]
 
-        indexes = FeatureByteCatalogBaseDocumentModel.Settings.indexes + [
-            pymongo.operations.IndexModel("task"),
+        # NOTE: Index on name is created by scheduler package, DO NOT INCLUDE HERE
+        indexes = [
+            IndexModel("user_id"),
+            IndexModel("created_at"),
+            IndexModel("updated_at"),
+            IndexModel("task"),
             [
                 ("name", pymongo.TEXT),
                 ("description", pymongo.TEXT),

--- a/featurebyte/models/periodic_task.py
+++ b/featurebyte/models/periodic_task.py
@@ -97,6 +97,7 @@ class PeriodicTask(FeatureByteCatalogBaseDocumentModel):
             IndexModel("user_id"),
             IndexModel("created_at"),
             IndexModel("updated_at"),
+            IndexModel("catalog_id"),
             IndexModel("task"),
             [
                 ("name", pymongo.TEXT),

--- a/tests/unit/models/test_periodic_task.py
+++ b/tests/unit/models/test_periodic_task.py
@@ -1,0 +1,16 @@
+"""
+Test periodic task model
+"""
+from pymongo.operations import IndexModel
+
+from featurebyte.models.periodic_task import PeriodicTask
+
+
+def test_name_not_in_indexes():
+    """
+    Test name is not in indexes
+    """
+    # name is indexed by celerybeatmongo package and should be excluded to avoid conflict
+    for index in PeriodicTask.Settings.indexes:
+        if isinstance(index, IndexModel):
+            assert "name" not in index.document["name"]


### PR DESCRIPTION
## Description

The celery beat scheduler already indexes this column.
Remove redundant mongodb index on periodic task name to avoid conflict.

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-2129

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
