### PR TITLE
[DEV-2134] Some mongdb URI does not work well with scheduler

### DIFF
--- a/.changelog/DEV-2134.yaml
+++ b/.changelog/DEV-2134.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: worker
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fixes a bug where scheduler does not work with certain mongodb uris."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/tests/unit/worker/test_worker.py
+++ b/tests/unit/worker/test_worker.py
@@ -1,0 +1,31 @@
+"""
+Test worker module
+"""
+from featurebyte.worker import format_mongo_uri_for_scheduler
+
+
+def test_format_mongo_uri():
+    """
+    Test format_mongo_uri
+    """
+    assert (
+        format_mongo_uri_for_scheduler("mongodb://localhost:27017/") == "mongodb://localhost:27017/"
+    )
+    assert (
+        format_mongo_uri_for_scheduler("mongodb://localhost:27017/featurebyte")
+        == "mongodb://localhost:27017/featurebyte"
+    )
+    assert (
+        format_mongo_uri_for_scheduler("mongodb://localhost:27017/admin")
+        == "mongodb://localhost:27017/?authSource=admin"
+    )
+    assert (
+        format_mongo_uri_for_scheduler("mongodb://localhost:27017/admin?")
+        == "mongodb://localhost:27017/?authSource=admin"
+    )
+    assert (
+        format_mongo_uri_for_scheduler(
+            "mongodb://localhost:27017,localhost:27018/admin?replicaSet=rs&ssl=false"
+        )
+        == "mongodb://localhost:27017,localhost:27018/?authSource=admin&replicaSet=rs&ssl=false"
+    )


### PR DESCRIPTION
## Description

Ensure mongo uri is compatible with celery beat scheduler

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-2134

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
