### PR TITLE
[DEV-2137] Support case insensitive substring search on asset names

### DIFF
--- a/featurebyte/service/base_document.py
+++ b/featurebyte/service/base_document.py
@@ -414,7 +414,10 @@ class BaseDocumentService(
         if kwargs.get("version"):
             output["version"] = kwargs["version"]
         if kwargs.get("search"):
-            output["$text"] = {"$search": kwargs["search"]}
+            output["$or"] = [
+                {"$text": {"$search": kwargs["search"]}},
+                {"name": {"$regex": kwargs["search"], "$options": "i"}},
+            ]
         # inject catalog_id into filter if document is catalog specific
         if self.is_catalog_specific:
             output["catalog_id"] = self.catalog_id

--- a/tests/unit/service/test_base_document.py
+++ b/tests/unit/service/test_base_document.py
@@ -320,7 +320,13 @@ def test_get_filed_history__existing_field_removal(audit_docs, expected):
         ({"name": "some_name"}, {"name": "some_name", "catalog_id": "catalog_id"}),
         (
             {"search": "some_value"},
-            {"$text": {"$search": "some_value"}, "catalog_id": "catalog_id"},
+            {
+                "$or": [
+                    {"$text": {"$search": "some_value"}},
+                    {"name": {"$regex": "some_value", "$options": "i"}},
+                ],
+                "catalog_id": "catalog_id",
+            },
         ),
         (
             {"query_filter": {"field": {"$in": ["a", "b"]}}},
@@ -334,7 +340,10 @@ def test_get_filed_history__existing_field_removal(audit_docs, expected):
             },
             {
                 "name": "some_name",
-                "$text": {"$search": "some_value"},
+                "$or": [
+                    {"$text": {"$search": "some_value"}},
+                    {"name": {"$regex": "some_value", "$options": "i"}},
+                ],
                 "field": {"$in": ["a", "b"]},
                 "catalog_id": "catalog_id",
             },


### PR DESCRIPTION
## Description

Support case insensitive substring search on asset names

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-2137

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
