### PR TITLE
[DEV-2140] Fix logic for determining timezone offset column in datetime accessor

### DIFF
--- a/.changelog/DEV-2140.yaml
+++ b/.changelog/DEV-2140.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: api
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix logic for determining timezone offset column in datetime accessor"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/core/accessor/datetime.py
+++ b/featurebyte/core/accessor/datetime.py
@@ -688,7 +688,7 @@ class DatetimeAccessor:
                 break
 
         if is_derived_from_timezone_offset_column:
-            allowed_node_types = {NodeType.INPUT, NodeType.GRAPH}
+            allowed_node_types = {NodeType.INPUT, NodeType.GRAPH, NodeType.JOIN}
             for node_name in opstruct_column.node_names:
                 is_node_type_allowed = any(
                     node_name.startswith(allowed_node_type)

--- a/featurebyte/core/accessor/datetime.py
+++ b/featurebyte/core/accessor/datetime.py
@@ -647,7 +647,7 @@ class DatetimeAccessor:
 
             elif isinstance(opstruct_column, DerivedDataColumn):
                 if cls._is_valid_timezone_offset_column_if_derived_column(
-                    opstruct_column, table_id, offset_column_name, frame
+                    opstruct_column, table_id, offset_column_name
                 ):
                     offset_column_name_in_frame = opstruct_column.name
                     break

--- a/featurebyte/core/accessor/datetime.py
+++ b/featurebyte/core/accessor/datetime.py
@@ -650,7 +650,7 @@ class DatetimeAccessor:
                     opstruct_column, table_id, offset_column_name, frame
                 ):
                     offset_column_name_in_frame = opstruct_column.name
-                    # break
+                    break
 
         if offset_column_name_in_frame is not None:
             return frame[offset_column_name_in_frame]  # type: ignore
@@ -663,7 +663,6 @@ class DatetimeAccessor:
         opstruct_column: DerivedDataColumn,
         table_id: PydanticObjectId,
         offset_column_name: str,
-        frame: Frame,
     ):
         """
         Check whether a DerivedDataColumn is a valid timezone offset column

--- a/featurebyte/core/accessor/datetime.py
+++ b/featurebyte/core/accessor/datetime.py
@@ -688,6 +688,9 @@ class DatetimeAccessor:
                 break
 
         if is_derived_from_timezone_offset_column:
+            # These node types are allowed as they don't change the nature of the timezone offset
+            # column. They arise from joins between tables (e.g. EventTable and ItemTable) as well
+            # as cleaning operations.
             allowed_node_types = {NodeType.INPUT, NodeType.GRAPH, NodeType.JOIN}
             for node_name in opstruct_column.node_names:
                 is_node_type_allowed = any(

--- a/featurebyte/core/accessor/datetime.py
+++ b/featurebyte/core/accessor/datetime.py
@@ -661,9 +661,9 @@ class DatetimeAccessor:
     def _is_valid_timezone_offset_column_if_derived_column(
         cls,
         opstruct_column: DerivedDataColumn,
-        table_id: PydanticObjectId,
+        table_id: Optional[PydanticObjectId],
         offset_column_name: str,
-    ):
+    ) -> bool:
         """
         Check whether a DerivedDataColumn is a valid timezone offset column
 
@@ -671,13 +671,15 @@ class DatetimeAccessor:
         ----------
         opstruct_column: DerivedDataColumn
             The DerivedDataColumn to check
-        table_id: PydanticObjectId
+        table_id: Optional[PydanticObjectId]
             Table identifier of the EventTable
         offset_column_name: str
             Name of the offset column as defined in the EventTable. The column might not necessarily
             have the same name in the frame (e.g. due to join suffix).
-        frame: Frame
-            The parent object of the datetime series
+
+        Returns
+        -------
+        bool
         """
         is_derived_from_timezone_offset_column = False
         for column in opstruct_column.columns:

--- a/tests/fixtures/expected_preview_sql_timezone_offset_item_view_joined_scd_view.sql
+++ b/tests/fixtures/expected_preview_sql_timezone_offset_item_view_joined_scd_view.sql
@@ -1,0 +1,164 @@
+SELECT
+  L."event_id_col" AS "event_id_col",
+  L."item_id_col" AS "item_id_col",
+  L."item_type" AS "item_type",
+  L."item_amount" AS "item_amount",
+  CAST(L."created_at" AS STRING) AS "created_at",
+  CAST(L."event_timestamp" AS STRING) AS "event_timestamp",
+  L."event_timestamp_event_table" AS "event_timestamp_event_table",
+  L."cust_id_event_table" AS "cust_id_event_table",
+  L."tz_offset_event_table" AS "tz_offset_event_table",
+  R."col_float" AS "col_float_joined",
+  R."col_binary" AS "col_binary_joined",
+  R."col_boolean" AS "col_boolean_joined",
+  R."date_of_birth" AS "date_of_birth_joined",
+  CAST(R."created_at" AS STRING) AS "created_at_joined",
+  R."cust_id" AS "cust_id_joined",
+  CASE
+    WHEN (
+      EXTRACT(month FROM DATEADD(
+        second,
+        F_TIMEZONE_OFFSET_TO_SECOND(L."tz_offset_event_table"),
+        L."event_timestamp_event_table"
+      )) < EXTRACT(month FROM R."date_of_birth")
+    )
+    THEN (
+      (
+        EXTRACT(year FROM DATEADD(
+          second,
+          F_TIMEZONE_OFFSET_TO_SECOND(L."tz_offset_event_table"),
+          L."event_timestamp_event_table"
+        )) - EXTRACT(year FROM R."date_of_birth")
+      ) - 1
+    )
+    ELSE (
+      EXTRACT(year FROM DATEADD(
+        second,
+        F_TIMEZONE_OFFSET_TO_SECOND(L."tz_offset_event_table"),
+        L."event_timestamp_event_table"
+      )) - EXTRACT(year FROM R."date_of_birth")
+    )
+  END AS "customer_age"
+FROM (
+  SELECT
+    "__FB_KEY_COL_0",
+    "__FB_LAST_TS",
+    "event_id_col",
+    "item_id_col",
+    "item_type",
+    "item_amount",
+    "created_at",
+    "event_timestamp",
+    "event_timestamp_event_table",
+    "cust_id_event_table",
+    "tz_offset_event_table"
+  FROM (
+    SELECT
+      "__FB_KEY_COL_0",
+      LAG("__FB_EFFECTIVE_TS_COL") IGNORE NULLS OVER (PARTITION BY "__FB_KEY_COL_0" ORDER BY "__FB_TS_COL", "__FB_TS_TIE_BREAKER_COL") AS "__FB_LAST_TS",
+      "event_id_col",
+      "item_id_col",
+      "item_type",
+      "item_amount",
+      "created_at",
+      "event_timestamp",
+      "event_timestamp_event_table",
+      "cust_id_event_table",
+      "tz_offset_event_table",
+      "__FB_EFFECTIVE_TS_COL"
+    FROM (
+      SELECT
+        CAST(CONVERT_TIMEZONE('UTC', "event_timestamp_event_table") AS TIMESTAMP) AS "__FB_TS_COL",
+        "cust_id_event_table" AS "__FB_KEY_COL_0",
+        NULL AS "__FB_EFFECTIVE_TS_COL",
+        2 AS "__FB_TS_TIE_BREAKER_COL",
+        "event_id_col" AS "event_id_col",
+        "item_id_col" AS "item_id_col",
+        "item_type" AS "item_type",
+        "item_amount" AS "item_amount",
+        "created_at" AS "created_at",
+        "event_timestamp" AS "event_timestamp",
+        "event_timestamp_event_table" AS "event_timestamp_event_table",
+        "cust_id_event_table" AS "cust_id_event_table",
+        "tz_offset_event_table" AS "tz_offset_event_table"
+      FROM (
+        SELECT
+          L."event_id_col" AS "event_id_col",
+          L."item_id_col" AS "item_id_col",
+          L."item_type" AS "item_type",
+          L."item_amount" AS "item_amount",
+          L."created_at" AS "created_at",
+          L."event_timestamp" AS "event_timestamp",
+          R."event_timestamp" AS "event_timestamp_event_table",
+          R."cust_id" AS "cust_id_event_table",
+          R."tz_offset" AS "tz_offset_event_table"
+        FROM (
+          SELECT
+            "event_id_col" AS "event_id_col",
+            "item_id_col" AS "item_id_col",
+            "item_type" AS "item_type",
+            "item_amount" AS "item_amount",
+            "created_at" AS "created_at",
+            "event_timestamp" AS "event_timestamp"
+          FROM "sf_database"."sf_schema"."items_table"
+        ) AS L
+        INNER JOIN (
+          SELECT
+            "event_timestamp" AS "event_timestamp",
+            "col_int" AS "col_int",
+            "cust_id" AS "cust_id",
+            "tz_offset" AS "tz_offset"
+          FROM "sf_database"."sf_schema"."sf_table_no_tz"
+        ) AS R
+          ON L."event_id_col" = R."col_int"
+      )
+      UNION ALL
+      SELECT
+        CAST(CONVERT_TIMEZONE('UTC', "effective_timestamp") AS TIMESTAMP) AS "__FB_TS_COL",
+        "col_text" AS "__FB_KEY_COL_0",
+        "effective_timestamp" AS "__FB_EFFECTIVE_TS_COL",
+        1 AS "__FB_TS_TIE_BREAKER_COL",
+        NULL AS "event_id_col",
+        NULL AS "item_id_col",
+        NULL AS "item_type",
+        NULL AS "item_amount",
+        NULL AS "created_at",
+        NULL AS "event_timestamp",
+        NULL AS "event_timestamp_event_table",
+        NULL AS "cust_id_event_table",
+        NULL AS "tz_offset_event_table"
+      FROM (
+        SELECT
+          "col_int" AS "col_int",
+          "col_float" AS "col_float",
+          "col_text" AS "col_text",
+          "col_binary" AS "col_binary",
+          "col_boolean" AS "col_boolean",
+          "effective_timestamp" AS "effective_timestamp",
+          "end_timestamp" AS "end_timestamp",
+          "date_of_birth" AS "date_of_birth",
+          "created_at" AS "created_at",
+          "cust_id" AS "cust_id"
+        FROM "sf_database"."sf_schema"."scd_table"
+      )
+    )
+  )
+  WHERE
+    "__FB_EFFECTIVE_TS_COL" IS NULL
+) AS L
+LEFT JOIN (
+  SELECT
+    "col_int" AS "col_int",
+    "col_float" AS "col_float",
+    "col_text" AS "col_text",
+    "col_binary" AS "col_binary",
+    "col_boolean" AS "col_boolean",
+    "effective_timestamp" AS "effective_timestamp",
+    "end_timestamp" AS "end_timestamp",
+    "date_of_birth" AS "date_of_birth",
+    "created_at" AS "created_at",
+    "cust_id" AS "cust_id"
+  FROM "sf_database"."sf_schema"."scd_table"
+) AS R
+  ON L."__FB_LAST_TS" = R."effective_timestamp" AND L."__FB_KEY_COL_0" = R."col_text"
+LIMIT 10

--- a/tests/fixtures/expected_tile_sql_complex_feature_push_down_eligible.sql
+++ b/tests/fixtures/expected_tile_sql_complex_feature_push_down_eligible.sql
@@ -1,7 +1,7 @@
 SELECT
   index,
   "cust_id",
-  SUM("added_feature") AS value_sum_ae7ea38511285eab9c15813aa9fe9c1b16f25fb4
+  SUM("added_feature") AS value_sum_135378d8fda24b22b1987e8f97c82334823c50c7
 FROM (
   SELECT
     *,
@@ -22,6 +22,7 @@ FROM (
         "col_float_scd" AS "col_float_scd",
         "col_binary_scd" AS "col_binary_scd",
         "col_boolean_scd" AS "col_boolean_scd",
+        "date_of_birth_scd" AS "date_of_birth_scd",
         "created_at_scd" AS "created_at_scd",
         "cust_id_scd" AS "cust_id_scd",
         (
@@ -40,6 +41,7 @@ FROM (
           REQ."col_float_scd",
           REQ."col_binary_scd",
           REQ."col_boolean_scd",
+          REQ."date_of_birth_scd",
           REQ."created_at_scd",
           REQ."cust_id_scd",
           "T0"."_fb_internal_item_sum_item_amount_event_id_col_None_join_1" AS "_fb_internal_item_sum_item_amount_event_id_col_None_join_1"
@@ -56,6 +58,7 @@ FROM (
             R."col_float" AS "col_float_scd",
             R."col_binary" AS "col_binary_scd",
             R."col_boolean" AS "col_boolean_scd",
+            R."date_of_birth" AS "date_of_birth_scd",
             R."created_at" AS "created_at_scd",
             R."cust_id" AS "cust_id_scd"
           FROM (
@@ -135,6 +138,7 @@ FROM (
                     "col_boolean" AS "col_boolean",
                     "effective_timestamp" AS "effective_timestamp",
                     "end_timestamp" AS "end_timestamp",
+                    "date_of_birth" AS "date_of_birth",
                     "created_at" AS "created_at",
                     "cust_id" AS "cust_id"
                   FROM "sf_database"."sf_schema"."scd_table"
@@ -153,6 +157,7 @@ FROM (
               "col_boolean" AS "col_boolean",
               "effective_timestamp" AS "effective_timestamp",
               "end_timestamp" AS "end_timestamp",
+              "date_of_birth" AS "date_of_birth",
               "created_at" AS "created_at",
               "cust_id" AS "cust_id"
             FROM "sf_database"."sf_schema"."scd_table"

--- a/tests/fixtures/sdk_code/scd_table.py
+++ b/tests/fixtures/sdk_code/scd_table.py
@@ -36,6 +36,7 @@ scd_table = SCDTable(
         ColumnInfo(name="col_boolean", dtype="BOOL"),
         ColumnInfo(name="effective_timestamp", dtype="TIMESTAMP_TZ"),
         ColumnInfo(name="end_timestamp", dtype="TIMESTAMP_TZ"),
+        ColumnInfo(name="date_of_birth", dtype="TIMESTAMP"),
         ColumnInfo(name="created_at", dtype="TIMESTAMP_TZ"),
         ColumnInfo(name="cust_id", dtype="INT"),
     ],

--- a/tests/unit/api/test_change_view.py
+++ b/tests/unit/api/test_change_view.py
@@ -407,7 +407,7 @@ def test_aggregate_over_feature_tile_sql(feature_from_change_view):
         SELECT
           index,
           "col_text",
-          COUNT(*) AS value_{expected_aggregation_id}
+          COUNT(*) AS value_count_4286197032f980d554bc6f6564ea53f42532d702
         FROM (
           SELECT
             *,
@@ -445,6 +445,7 @@ def test_aggregate_over_feature_tile_sql(feature_from_change_view):
                       "col_boolean" AS "col_boolean",
                       "effective_timestamp" AS "effective_timestamp",
                       "end_timestamp" AS "end_timestamp",
+                      "date_of_birth" AS "date_of_birth",
                       "created_at" AS "created_at",
                       "cust_id" AS "cust_id"
                     FROM "sf_database"."sf_schema"."scd_table"
@@ -509,6 +510,7 @@ def test_get_change_view__keep_record_creation_timestamp_column(
                 "col_boolean" AS "col_boolean",
                 "effective_timestamp" AS "effective_timestamp",
                 "end_timestamp" AS "end_timestamp",
+                "date_of_birth" AS "date_of_birth",
                 "created_at" AS "created_at",
                 "cust_id" AS "cust_id"
               FROM "sf_database"."sf_schema"."scd_table"
@@ -565,6 +567,7 @@ def test_get_change_view__keep_record_creation_timestamp_column(
                 "col_boolean" AS "col_boolean",
                 "effective_timestamp" AS "effective_timestamp",
                 "end_timestamp" AS "end_timestamp",
+                "date_of_birth" AS "date_of_birth",
                 CASE WHEN (
                   "created_at" IS NULL
                 ) THEN '2020-01-01' ELSE "created_at" END AS "created_at",
@@ -674,6 +677,7 @@ def test_filtered_view_output(saved_scd_table, cust_id_entity):
             "col_boolean" AS "col_boolean",
             "effective_timestamp" AS "effective_timestamp",
             "end_timestamp" AS "end_timestamp",
+            "date_of_birth" AS "date_of_birth",
             "created_at" AS "created_at",
             "cust_id" AS "cust_id"
           FROM "sf_database"."sf_schema"."scd_table"
@@ -734,6 +738,7 @@ def test_change_view_column_lag(snowflake_change_view):
                 "col_boolean" AS "col_boolean",
                 "effective_timestamp" AS "effective_timestamp",
                 "end_timestamp" AS "end_timestamp",
+                "date_of_birth" AS "date_of_birth",
                 "created_at" AS "created_at",
                 "cust_id" AS "cust_id"
               FROM "sf_database"."sf_schema"."scd_table"

--- a/tests/unit/api/test_scd_table.py
+++ b/tests/unit/api/test_scd_table.py
@@ -30,6 +30,7 @@ class TestSCDTableTestSuite(BaseTableTestSuite):
         "col_binary",
         "col_int",
         "cust_id",
+        "date_of_birth",
     }
     expected_table_sql = """
     SELECT
@@ -41,6 +42,7 @@ class TestSCDTableTestSuite(BaseTableTestSuite):
       "col_boolean" AS "col_boolean",
       CAST("effective_timestamp" AS STRING) AS "effective_timestamp",
       CAST("end_timestamp" AS STRING) AS "end_timestamp",
+      "date_of_birth" AS "date_of_birth",
       CAST("created_at" AS STRING) AS "created_at",
       "cust_id" AS "cust_id"
     FROM "sf_database"."sf_schema"."scd_table"
@@ -64,6 +66,7 @@ class TestSCDTableTestSuite(BaseTableTestSuite):
       "col_boolean" AS "col_boolean",
       CAST("effective_timestamp" AS STRING) AS "effective_timestamp",
       CAST("end_timestamp" AS STRING) AS "end_timestamp",
+      "date_of_birth" AS "date_of_birth",
       CAST("created_at" AS STRING) AS "created_at",
       "cust_id" AS "cust_id"
     FROM "sf_database"."sf_schema"."scd_table"
@@ -160,6 +163,14 @@ def scd_table_dict_fixture(snowflake_database_table_scd_table):
                 "description": None,
             },
             {
+                "critical_data_info": None,
+                "description": None,
+                "dtype": "TIMESTAMP",
+                "entity_id": None,
+                "name": "date_of_birth",
+                "semantic_id": None,
+            },
+            {
                 "entity_id": None,
                 "name": "created_at",
                 "dtype": "TIMESTAMP_TZ",
@@ -219,7 +230,7 @@ def test_create_scd_table(snowflake_database_table_scd_table, scd_table_dict, ca
     scd_table_dict["updated_at"] = scd_table.updated_at
     scd_table_dict["description"] = None
     scd_table_dict["block_modification_by"] = []
-    for column_idx in [0, 2, 3, 6, 7, 8]:
+    for column_idx in [0, 2, 3, 6, 7, 9]:
         scd_table_dict["columns_info"][column_idx]["semantic_id"] = scd_table.columns_info[
             column_idx
         ].semantic_id

--- a/tests/unit/api/test_scd_view.py
+++ b/tests/unit/api/test_scd_view.py
@@ -28,6 +28,7 @@ class TestSCDView(BaseViewTestSuite):
       "col_boolean" AS "col_boolean",
       CAST("effective_timestamp" AS STRING) AS "effective_timestamp",
       CAST("end_timestamp" AS STRING) AS "end_timestamp",
+      "date_of_birth" AS "date_of_birth",
       CAST("created_at" AS STRING) AS "created_at",
       "cust_id" AS "cust_id",
       (
@@ -109,11 +110,19 @@ def test_event_view_join_scd_view(
             "event_timestamp",
             "cust_id",
         ],
-        "right_input_columns": ["col_float", "col_binary", "col_boolean", "created_at", "cust_id"],
+        "right_input_columns": [
+            "col_float",
+            "col_binary",
+            "col_boolean",
+            "date_of_birth",
+            "created_at",
+            "cust_id",
+        ],
         "right_output_columns": [
             "col_float_scd",
             "col_binary_scd",
             "col_boolean_scd",
+            "date_of_birth_scd",
             "created_at_scd",
             "cust_id_scd",
         ],

--- a/tests/unit/api/test_timezone_offset.py
+++ b/tests/unit/api/test_timezone_offset.py
@@ -247,6 +247,190 @@ def test_datetime_property_extraction__event_timestamp_in_item_view(
     assert view.preview_sql() == expected
 
 
+def test_datetime_property_extraction__event_timestamp_in_item_view_joined_scd_view(
+    snowflake_item_table_with_timezone_offset_column, snowflake_scd_view
+):
+    """
+    Test datetime property extraction from an ItemView with event timestamp timezone offset column
+    """
+    view = snowflake_item_table_with_timezone_offset_column.get_view(event_suffix="_event_table")
+    view = view.join(snowflake_scd_view, on="cust_id_event_table", rsuffix="_joined")
+    view["customer_age"] = (
+        view["event_timestamp_event_table"].dt.year - view["date_of_birth_joined"].dt.year
+    )
+    cond = view["event_timestamp_event_table"].dt.month < view["date_of_birth_joined"].dt.month
+    view["customer_age"][cond] = view["customer_age"][cond] - 1
+    expected = textwrap.dedent(
+        """
+        SELECT
+          L."event_id_col" AS "event_id_col",
+          L."item_id_col" AS "item_id_col",
+          L."item_type" AS "item_type",
+          L."item_amount" AS "item_amount",
+          CAST(L."created_at" AS STRING) AS "created_at",
+          CAST(L."event_timestamp" AS STRING) AS "event_timestamp",
+          L."event_timestamp_event_table" AS "event_timestamp_event_table",
+          L."cust_id_event_table" AS "cust_id_event_table",
+          L."tz_offset_event_table" AS "tz_offset_event_table",
+          R."col_float" AS "col_float_joined",
+          R."col_binary" AS "col_binary_joined",
+          R."col_boolean" AS "col_boolean_joined",
+          R."date_of_birth" AS "date_of_birth_joined",
+          CAST(R."created_at" AS STRING) AS "created_at_joined",
+          R."cust_id" AS "cust_id_joined",
+          CASE
+            WHEN (
+              EXTRACT(month FROM DATEADD(
+                second,
+                F_TIMEZONE_OFFSET_TO_SECOND(L."tz_offset_event_table"),
+                L."event_timestamp_event_table"
+              )) < EXTRACT(month FROM R."date_of_birth")
+            )
+            THEN (
+              (
+                EXTRACT(year FROM DATEADD(
+                  second,
+                  F_TIMEZONE_OFFSET_TO_SECOND(L."tz_offset_event_table"),
+                  L."event_timestamp_event_table"
+                )) - EXTRACT(year FROM R."date_of_birth")
+              ) - 1
+            )
+            ELSE (
+              EXTRACT(year FROM DATEADD(
+                second,
+                F_TIMEZONE_OFFSET_TO_SECOND(L."tz_offset_event_table"),
+                L."event_timestamp_event_table"
+              )) - EXTRACT(year FROM R."date_of_birth")
+            )
+          END AS "customer_age"
+        FROM (
+          SELECT
+            "__FB_KEY_COL_0",
+            "__FB_LAST_TS",
+            "event_id_col",
+            "item_id_col",
+            "item_type",
+            "item_amount",
+            "created_at",
+            "event_timestamp",
+            "event_timestamp_event_table",
+            "cust_id_event_table",
+            "tz_offset_event_table"
+          FROM (
+            SELECT
+              "__FB_KEY_COL_0",
+              LAG("__FB_EFFECTIVE_TS_COL") IGNORE NULLS OVER (PARTITION BY "__FB_KEY_COL_0" ORDER BY "__FB_TS_COL", "__FB_TS_TIE_BREAKER_COL") AS "__FB_LAST_TS",
+              "event_id_col",
+              "item_id_col",
+              "item_type",
+              "item_amount",
+              "created_at",
+              "event_timestamp",
+              "event_timestamp_event_table",
+              "cust_id_event_table",
+              "tz_offset_event_table",
+              "__FB_EFFECTIVE_TS_COL"
+            FROM (
+              SELECT
+                CAST(CONVERT_TIMEZONE('UTC', "event_timestamp_event_table") AS TIMESTAMP) AS "__FB_TS_COL",
+                "cust_id_event_table" AS "__FB_KEY_COL_0",
+                NULL AS "__FB_EFFECTIVE_TS_COL",
+                2 AS "__FB_TS_TIE_BREAKER_COL",
+                "event_id_col" AS "event_id_col",
+                "item_id_col" AS "item_id_col",
+                "item_type" AS "item_type",
+                "item_amount" AS "item_amount",
+                "created_at" AS "created_at",
+                "event_timestamp" AS "event_timestamp",
+                "event_timestamp_event_table" AS "event_timestamp_event_table",
+                "cust_id_event_table" AS "cust_id_event_table",
+                "tz_offset_event_table" AS "tz_offset_event_table"
+              FROM (
+                SELECT
+                  L."event_id_col" AS "event_id_col",
+                  L."item_id_col" AS "item_id_col",
+                  L."item_type" AS "item_type",
+                  L."item_amount" AS "item_amount",
+                  L."created_at" AS "created_at",
+                  L."event_timestamp" AS "event_timestamp",
+                  R."event_timestamp" AS "event_timestamp_event_table",
+                  R."cust_id" AS "cust_id_event_table",
+                  R."tz_offset" AS "tz_offset_event_table"
+                FROM (
+                  SELECT
+                    "event_id_col" AS "event_id_col",
+                    "item_id_col" AS "item_id_col",
+                    "item_type" AS "item_type",
+                    "item_amount" AS "item_amount",
+                    "created_at" AS "created_at",
+                    "event_timestamp" AS "event_timestamp"
+                  FROM "sf_database"."sf_schema"."items_table"
+                ) AS L
+                INNER JOIN (
+                  SELECT
+                    "event_timestamp" AS "event_timestamp",
+                    "col_int" AS "col_int",
+                    "cust_id" AS "cust_id",
+                    "tz_offset" AS "tz_offset"
+                  FROM "sf_database"."sf_schema"."sf_table_no_tz"
+                ) AS R
+                  ON L."event_id_col" = R."col_int"
+              )
+              UNION ALL
+              SELECT
+                CAST(CONVERT_TIMEZONE('UTC', "effective_timestamp") AS TIMESTAMP) AS "__FB_TS_COL",
+                "col_text" AS "__FB_KEY_COL_0",
+                "effective_timestamp" AS "__FB_EFFECTIVE_TS_COL",
+                1 AS "__FB_TS_TIE_BREAKER_COL",
+                NULL AS "event_id_col",
+                NULL AS "item_id_col",
+                NULL AS "item_type",
+                NULL AS "item_amount",
+                NULL AS "created_at",
+                NULL AS "event_timestamp",
+                NULL AS "event_timestamp_event_table",
+                NULL AS "cust_id_event_table",
+                NULL AS "tz_offset_event_table"
+              FROM (
+                SELECT
+                  "col_int" AS "col_int",
+                  "col_float" AS "col_float",
+                  "col_text" AS "col_text",
+                  "col_binary" AS "col_binary",
+                  "col_boolean" AS "col_boolean",
+                  "effective_timestamp" AS "effective_timestamp",
+                  "end_timestamp" AS "end_timestamp",
+                  "date_of_birth" AS "date_of_birth",
+                  "created_at" AS "created_at",
+                  "cust_id" AS "cust_id"
+                FROM "sf_database"."sf_schema"."scd_table"
+              )
+            )
+          )
+          WHERE
+            "__FB_EFFECTIVE_TS_COL" IS NULL
+        ) AS L
+        LEFT JOIN (
+          SELECT
+            "col_int" AS "col_int",
+            "col_float" AS "col_float",
+            "col_text" AS "col_text",
+            "col_binary" AS "col_binary",
+            "col_boolean" AS "col_boolean",
+            "effective_timestamp" AS "effective_timestamp",
+            "end_timestamp" AS "end_timestamp",
+            "date_of_birth" AS "date_of_birth",
+            "created_at" AS "created_at",
+            "cust_id" AS "cust_id"
+          FROM "sf_database"."sf_schema"."scd_table"
+        ) AS R
+          ON L."__FB_LAST_TS" = R."effective_timestamp" AND L."__FB_KEY_COL_0" = R."col_text"
+        LIMIT 10
+        """
+    ).strip()
+    assert view.preview_sql() == expected
+
+
 def test_feature_using_timezone_offset_with_cleaning_operations(
     snowflake_event_table_with_tz_offset_column, update_fixtures
 ):

--- a/tests/unit/api/test_timezone_offset.py
+++ b/tests/unit/api/test_timezone_offset.py
@@ -5,7 +5,7 @@ import textwrap
 
 from featurebyte import FeatureJobSetting, MissingValueImputation
 from featurebyte.api.feature import Feature
-from tests.util.helper import check_sdk_code_generation
+from tests.util.helper import assert_equal_with_expected_fixture, check_sdk_code_generation
 
 
 def test_protected_attributes__event_view(
@@ -248,7 +248,7 @@ def test_datetime_property_extraction__event_timestamp_in_item_view(
 
 
 def test_datetime_property_extraction__event_timestamp_in_item_view_joined_scd_view(
-    snowflake_item_table_with_timezone_offset_column, snowflake_scd_view
+    snowflake_item_table_with_timezone_offset_column, snowflake_scd_view, update_fixtures
 ):
     """
     Test datetime property extraction from an ItemView with event timestamp timezone offset column
@@ -260,175 +260,11 @@ def test_datetime_property_extraction__event_timestamp_in_item_view_joined_scd_v
     )
     cond = view["event_timestamp_event_table"].dt.month < view["date_of_birth_joined"].dt.month
     view["customer_age"][cond] = view["customer_age"][cond] - 1
-    expected = textwrap.dedent(
-        """
-        SELECT
-          L."event_id_col" AS "event_id_col",
-          L."item_id_col" AS "item_id_col",
-          L."item_type" AS "item_type",
-          L."item_amount" AS "item_amount",
-          CAST(L."created_at" AS STRING) AS "created_at",
-          CAST(L."event_timestamp" AS STRING) AS "event_timestamp",
-          L."event_timestamp_event_table" AS "event_timestamp_event_table",
-          L."cust_id_event_table" AS "cust_id_event_table",
-          L."tz_offset_event_table" AS "tz_offset_event_table",
-          R."col_float" AS "col_float_joined",
-          R."col_binary" AS "col_binary_joined",
-          R."col_boolean" AS "col_boolean_joined",
-          R."date_of_birth" AS "date_of_birth_joined",
-          CAST(R."created_at" AS STRING) AS "created_at_joined",
-          R."cust_id" AS "cust_id_joined",
-          CASE
-            WHEN (
-              EXTRACT(month FROM DATEADD(
-                second,
-                F_TIMEZONE_OFFSET_TO_SECOND(L."tz_offset_event_table"),
-                L."event_timestamp_event_table"
-              )) < EXTRACT(month FROM R."date_of_birth")
-            )
-            THEN (
-              (
-                EXTRACT(year FROM DATEADD(
-                  second,
-                  F_TIMEZONE_OFFSET_TO_SECOND(L."tz_offset_event_table"),
-                  L."event_timestamp_event_table"
-                )) - EXTRACT(year FROM R."date_of_birth")
-              ) - 1
-            )
-            ELSE (
-              EXTRACT(year FROM DATEADD(
-                second,
-                F_TIMEZONE_OFFSET_TO_SECOND(L."tz_offset_event_table"),
-                L."event_timestamp_event_table"
-              )) - EXTRACT(year FROM R."date_of_birth")
-            )
-          END AS "customer_age"
-        FROM (
-          SELECT
-            "__FB_KEY_COL_0",
-            "__FB_LAST_TS",
-            "event_id_col",
-            "item_id_col",
-            "item_type",
-            "item_amount",
-            "created_at",
-            "event_timestamp",
-            "event_timestamp_event_table",
-            "cust_id_event_table",
-            "tz_offset_event_table"
-          FROM (
-            SELECT
-              "__FB_KEY_COL_0",
-              LAG("__FB_EFFECTIVE_TS_COL") IGNORE NULLS OVER (PARTITION BY "__FB_KEY_COL_0" ORDER BY "__FB_TS_COL", "__FB_TS_TIE_BREAKER_COL") AS "__FB_LAST_TS",
-              "event_id_col",
-              "item_id_col",
-              "item_type",
-              "item_amount",
-              "created_at",
-              "event_timestamp",
-              "event_timestamp_event_table",
-              "cust_id_event_table",
-              "tz_offset_event_table",
-              "__FB_EFFECTIVE_TS_COL"
-            FROM (
-              SELECT
-                CAST(CONVERT_TIMEZONE('UTC', "event_timestamp_event_table") AS TIMESTAMP) AS "__FB_TS_COL",
-                "cust_id_event_table" AS "__FB_KEY_COL_0",
-                NULL AS "__FB_EFFECTIVE_TS_COL",
-                2 AS "__FB_TS_TIE_BREAKER_COL",
-                "event_id_col" AS "event_id_col",
-                "item_id_col" AS "item_id_col",
-                "item_type" AS "item_type",
-                "item_amount" AS "item_amount",
-                "created_at" AS "created_at",
-                "event_timestamp" AS "event_timestamp",
-                "event_timestamp_event_table" AS "event_timestamp_event_table",
-                "cust_id_event_table" AS "cust_id_event_table",
-                "tz_offset_event_table" AS "tz_offset_event_table"
-              FROM (
-                SELECT
-                  L."event_id_col" AS "event_id_col",
-                  L."item_id_col" AS "item_id_col",
-                  L."item_type" AS "item_type",
-                  L."item_amount" AS "item_amount",
-                  L."created_at" AS "created_at",
-                  L."event_timestamp" AS "event_timestamp",
-                  R."event_timestamp" AS "event_timestamp_event_table",
-                  R."cust_id" AS "cust_id_event_table",
-                  R."tz_offset" AS "tz_offset_event_table"
-                FROM (
-                  SELECT
-                    "event_id_col" AS "event_id_col",
-                    "item_id_col" AS "item_id_col",
-                    "item_type" AS "item_type",
-                    "item_amount" AS "item_amount",
-                    "created_at" AS "created_at",
-                    "event_timestamp" AS "event_timestamp"
-                  FROM "sf_database"."sf_schema"."items_table"
-                ) AS L
-                INNER JOIN (
-                  SELECT
-                    "event_timestamp" AS "event_timestamp",
-                    "col_int" AS "col_int",
-                    "cust_id" AS "cust_id",
-                    "tz_offset" AS "tz_offset"
-                  FROM "sf_database"."sf_schema"."sf_table_no_tz"
-                ) AS R
-                  ON L."event_id_col" = R."col_int"
-              )
-              UNION ALL
-              SELECT
-                CAST(CONVERT_TIMEZONE('UTC', "effective_timestamp") AS TIMESTAMP) AS "__FB_TS_COL",
-                "col_text" AS "__FB_KEY_COL_0",
-                "effective_timestamp" AS "__FB_EFFECTIVE_TS_COL",
-                1 AS "__FB_TS_TIE_BREAKER_COL",
-                NULL AS "event_id_col",
-                NULL AS "item_id_col",
-                NULL AS "item_type",
-                NULL AS "item_amount",
-                NULL AS "created_at",
-                NULL AS "event_timestamp",
-                NULL AS "event_timestamp_event_table",
-                NULL AS "cust_id_event_table",
-                NULL AS "tz_offset_event_table"
-              FROM (
-                SELECT
-                  "col_int" AS "col_int",
-                  "col_float" AS "col_float",
-                  "col_text" AS "col_text",
-                  "col_binary" AS "col_binary",
-                  "col_boolean" AS "col_boolean",
-                  "effective_timestamp" AS "effective_timestamp",
-                  "end_timestamp" AS "end_timestamp",
-                  "date_of_birth" AS "date_of_birth",
-                  "created_at" AS "created_at",
-                  "cust_id" AS "cust_id"
-                FROM "sf_database"."sf_schema"."scd_table"
-              )
-            )
-          )
-          WHERE
-            "__FB_EFFECTIVE_TS_COL" IS NULL
-        ) AS L
-        LEFT JOIN (
-          SELECT
-            "col_int" AS "col_int",
-            "col_float" AS "col_float",
-            "col_text" AS "col_text",
-            "col_binary" AS "col_binary",
-            "col_boolean" AS "col_boolean",
-            "effective_timestamp" AS "effective_timestamp",
-            "end_timestamp" AS "end_timestamp",
-            "date_of_birth" AS "date_of_birth",
-            "created_at" AS "created_at",
-            "cust_id" AS "cust_id"
-          FROM "sf_database"."sf_schema"."scd_table"
-        ) AS R
-          ON L."__FB_LAST_TS" = R."effective_timestamp" AND L."__FB_KEY_COL_0" = R."col_text"
-        LIMIT 10
-        """
-    ).strip()
-    assert view.preview_sql() == expected
+    assert_equal_with_expected_fixture(
+        view.preview_sql(),
+        "tests/fixtures/expected_preview_sql_timezone_offset_item_view_joined_scd_view.sql",
+        update_fixtures,
+    )
 
 
 def test_feature_using_timezone_offset_with_cleaning_operations(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -288,6 +288,10 @@ def snowflake_query_map_fixture():
                 "column_name": "end_timestamp",
                 "data_type": json.dumps({"type": "TIMESTAMP_TZ"}),
             },
+            {
+                "column_name": "date_of_birth",
+                "data_type": json.dumps({"type": "TIMESTAMP_NTZ"}),
+            },
             {"column_name": "created_at", "data_type": json.dumps({"type": "TIMESTAMP_TZ"})},
             {"column_name": "cust_id", "data_type": json.dumps({"type": "FIXED", "scale": 0})},
         ],


### PR DESCRIPTION
## Description

This fixes a bug where timezone offset column was incorrectly identified in the datetime accessor.

Fixes errors such as :

> RecordRetrievalException: 100132 (P0000): JavaScript execution error: Uncaught Error: Invalid timezone offset format: 36 in F_TIMEZONE_OFFSET_TO_SECOND at '    throw new Error("Invalid timezone offset format: " + OFFSET_STRING);' position 4
stackstrace: 
F_TIMEZONE_OFFSET_TO_SECOND line: 10


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
