### PR TITLE
[chore] aggregators: mv parent_dtype into GroupbyColumn

### DIFF
--- a/featurebyte/query_graph/sql/aggregator/asat.py
+++ b/featurebyte/query_graph/sql/aggregator/asat.py
@@ -157,6 +157,7 @@ class AsAtAggregator(NonTileBasedAggregator[AggregateAsAtSpec]):
                     else None
                 ),
                 result_name=s.agg_result_name,
+                parent_dtype=s.parent_dtype,
             )
             for s in specs
         ]
@@ -180,7 +181,6 @@ class AsAtAggregator(NonTileBasedAggregator[AggregateAsAtSpec]):
             groupby_columns=groupby_columns,
             value_by=value_by,
             adapter=self.adapter,
-            parent_dtype=spec.parent_dtype,
         )
         return LeftJoinableSubquery(
             expr=aggregate_asat_expr,

--- a/featurebyte/query_graph/sql/aggregator/forward.py
+++ b/featurebyte/query_graph/sql/aggregator/forward.py
@@ -116,6 +116,7 @@ class ForwardAggregator(NonTileBasedAggregator[ForwardAggregateSpec]):
                     else None
                 ),
                 result_name=s.agg_result_name,
+                parent_dtype=s.parent_dtype,
             )
             for s in specs
         ]
@@ -150,7 +151,6 @@ class ForwardAggregator(NonTileBasedAggregator[ForwardAggregateSpec]):
             groupby_columns=groupby_columns,
             value_by=value_by,
             adapter=self.adapter,
-            parent_dtype=spec.parent_dtype,
         )
         return LeftJoinableSubquery(
             expr=forward_agg_expr,

--- a/featurebyte/query_graph/sql/aggregator/item.py
+++ b/featurebyte/query_graph/sql/aggregator/item.py
@@ -117,6 +117,7 @@ class ItemAggregator(NonTileBasedAggregator[ItemAggregationSpec]):
                     else None
                 ),
                 result_name=s.agg_result_name,
+                parent_dtype=s.parent_dtype,
             )
             for s in agg_specs
         ]
@@ -134,7 +135,6 @@ class ItemAggregator(NonTileBasedAggregator[ItemAggregationSpec]):
             groupby_columns=groupby_columns,
             value_by=value_by,
             adapter=self.adapter,
-            parent_dtype=spec.parent_dtype,
         )
 
         return LeftJoinableSubquery(

--- a/featurebyte/query_graph/sql/ast/groupby.py
+++ b/featurebyte/query_graph/sql/ast/groupby.py
@@ -3,13 +3,12 @@ Module for groupby operation (non-time aware) sql generation
 """
 from __future__ import annotations
 
-from typing import Optional, cast
+from typing import cast
 
 from dataclasses import dataclass
 
 from sqlglot.expressions import Expression, select
 
-from featurebyte.enum import DBVarType
 from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.sql.ast.base import SQLNodeContext, TableNode
 from featurebyte.query_graph.sql.common import SQLType, quoted_identifier

--- a/featurebyte/query_graph/sql/groupby_helper.py
+++ b/featurebyte/query_graph/sql/groupby_helper.py
@@ -23,6 +23,7 @@ class GroupbyColumn:
 
     agg_func: AggFunc
     parent_expr: Optional[Expression]
+    parent_dtype: Optional[DBVarType]
     result_name: str
 
 
@@ -113,7 +114,6 @@ def get_groupby_expr(
     groupby_columns: list[GroupbyColumn],
     value_by: Optional[GroupbyKey],
     adapter: BaseAdapter,
-    parent_dtype: Optional[DBVarType],
 ) -> Select:
     """
     Construct a GROUP BY statement using the provided expression as input
@@ -131,8 +131,6 @@ def get_groupby_expr(
         Optional category parameter
     adapter: BaseAdapter
         Adapter for generating engine specific expressions
-    parent_dtype: Optional[DBVarType]
-        Parent column data type
 
     Returns
     -------
@@ -143,7 +141,7 @@ def get_groupby_expr(
             get_aggregation_expression(
                 agg_func=column.agg_func,
                 input_column=column.parent_expr,
-                parent_dtype=parent_dtype,
+                parent_dtype=column.parent_dtype,
             ),
             alias=column.result_name + ("_inner" if value_by is not None else ""),
             quoted=True,

--- a/tests/unit/query_graph/sql/test_groupby_helper.py
+++ b/tests/unit/query_graph/sql/test_groupby_helper.py
@@ -44,6 +44,7 @@ def test_get_groupby_expr(agg_func, parent_dtype, method):
         agg_func=agg_func,
         parent_expr=(get_qualified_column_identifier("parent", "TABLE")),
         result_name="result",
+        parent_dtype=parent_dtype,
     )
     groupby_expr = get_groupby_expr(
         input_expr=select_expr,
@@ -51,7 +52,6 @@ def test_get_groupby_expr(agg_func, parent_dtype, method):
         groupby_columns=[groupby_column],
         value_by=valueby_key,
         adapter=get_sql_adapter(SourceType.SNOWFLAKE),
-        parent_dtype=parent_dtype,
     )
     expected = textwrap.dedent(
         f"""


### PR DESCRIPTION
## Description
Small refactor to mv `parent_dtype` into `GroupbyColumn`. This removes the assumption that all the input columns have the same `parent_dtype` which was invalid.
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
