### PR TITLE
[DEV-2165] Cast online store columns to expected types when creating tables

### DIFF
--- a/.changelog/DEV-2165.yaml
+++ b/.changelog/DEV-2165.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: online-serving
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix incompatible column types when inserting to online store tables"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/sql/tile_schedule_online_store.py
+++ b/featurebyte/sql/tile_schedule_online_store.py
@@ -70,10 +70,6 @@ class TileScheduleOnlineStore(BaseSqlModel):
             quoted_entity_columns = (
                 [self.quote_column(col) for col in f_entity_columns] if f_entity_columns else []
             )
-            column_names = ", ".join(
-                quoted_entity_columns + [quoted_result_name_column, quoted_value_column]
-            )
-
             current_ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
             # get current version
@@ -101,7 +97,7 @@ class TileScheduleOnlineStore(BaseSqlModel):
                       to_timestamp('{current_ts}') AS UPDATED_AT
                     FROM ({f_sql})
                     """
-                ).strip()
+                )
                 create_sql = construct_create_table_query(
                     fs_table,
                     query,
@@ -112,7 +108,9 @@ class TileScheduleOnlineStore(BaseSqlModel):
 
             else:
                 # feature store table already exists, insert records with the input feature sql
-
+                column_names = ", ".join(
+                    quoted_entity_columns + [quoted_result_name_column, quoted_value_column]
+                )
                 insert_query = textwrap.dedent(
                     f"""
                     INSERT INTO {fs_table} ({column_names}, {quoted_version_column}, UPDATED_AT)


### PR DESCRIPTION
## Description

This ensures that columns are casted to the expected type when creating online store tables. This is to prevent the default type being too restrictive and causing subsequent insert statements to fail when they produce data that doesn't fit within the initial schema.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
