### PR TITLE
[DEV-2173] Split online store compute and insert query into multiple statements

### DIFF
--- a/.changelog/DEV-2173.yaml
+++ b/.changelog/DEV-2173.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: online-serving
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Split online store compute and insert query to minimize table locking"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/sql/common.py
+++ b/featurebyte/sql/common.py
@@ -3,12 +3,14 @@ Common utilities for Spark SQL
 """
 from __future__ import annotations
 
-from typing import Optional
+from typing import AsyncIterator, Optional
 
 import asyncio
+from contextlib import asynccontextmanager
 from random import randint
 
 import pandas as pd
+from bson import ObjectId
 
 from featurebyte.logging import get_logger
 from featurebyte.session.base import BaseSession
@@ -109,3 +111,34 @@ async def retry_sql(
         await asyncio.sleep(random_interval)
 
     return None
+
+
+@asynccontextmanager
+async def register_temporary_physical_table(session: BaseSession, query: str) -> AsyncIterator[str]:
+    """
+    Register a temporary physical table using a Select query
+
+    Parameters
+    ----------
+    session : BaseSession
+        Session objectd
+    query : str
+        SQL query for the table
+
+    Yields
+    ------
+    str
+        The name of the temporary table
+    """
+    table_name = f"__SESSION_TEMP_TABLE_{ObjectId()}".upper()
+    create_sql = construct_create_table_query(table_name, query, session=session)
+    await session.execute_query_long_running(create_sql)
+    try:
+        yield table_name
+    finally:
+        await session.drop_table(
+            table_name,
+            schema_name=session.schema_name,
+            database_name=session.database_name,
+            if_exists=True,
+        )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -33,7 +33,7 @@ from featurebyte.api.feature_store import FeatureStore
 from featurebyte.api.groupby import GroupBy
 from featurebyte.api.item_table import ItemTable
 from featurebyte.app import User, app, get_celery
-from featurebyte.enum import AggFunc, InternalName
+from featurebyte.enum import AggFunc, InternalName, SourceType
 from featurebyte.exception import DuplicatedRecordException, ObjectHasBeenSavedError
 from featurebyte.models.credential import CredentialModel
 from featurebyte.models.feature_namespace import FeatureReadiness
@@ -46,6 +46,7 @@ from featurebyte.schema.task import TaskStatus
 from featurebyte.schema.worker.task.base import BaseTaskPayload
 from featurebyte.session.base import DEFAULT_EXECUTE_QUERY_TIMEOUT_SECONDS
 from featurebyte.session.manager import SessionManager, session_cache
+from featurebyte.session.snowflake import SnowflakeSession
 from featurebyte.storage import LocalTempStorage
 from featurebyte.storage.local import LocalStorage
 from featurebyte.worker import get_redis
@@ -1342,6 +1343,20 @@ def session_manager_fixture(credentials, snowflake_connector):
     _ = snowflake_connector
     session_cache.clear()
     yield SessionManager(credentials=credentials)
+
+
+@pytest.fixture(name="mock_snowflake_session")
+def mock_snowflake_session_fixture():
+    """
+    SnowflakeSession object fixture
+    """
+    return Mock(
+        name="mock_snowflake_session",
+        spec=SnowflakeSession,
+        source_type=SourceType.SNOWFLAKE,
+        database_name="sf_db",
+        schema_name="sf_schema",
+    )
 
 
 @pytest.fixture

--- a/tests/unit/feature_manager/test_unit_snowflake_feature.py
+++ b/tests/unit/feature_manager/test_unit_snowflake_feature.py
@@ -34,18 +34,6 @@ def feature_manager_service_fixture(app_container):
     return app_container.feature_manager_service
 
 
-@pytest.fixture(name="mock_snowflake_session")
-def mock_snowflake_session_fixture():
-    """
-    SnowflakeSession object fixture
-    """
-    return Mock(
-        name="mock_snowflake_session",
-        spec=SnowflakeSession,
-        source_type=SourceType.SNOWFLAKE,
-    )
-
-
 @pytest.fixture(name="feature_spec")
 def feature_spec_fixture(mock_snowflake_feature):
     """

--- a/tests/unit/feature_manager/test_unit_snowflake_feature.py
+++ b/tests/unit/feature_manager/test_unit_snowflake_feature.py
@@ -98,9 +98,10 @@ async def test_online_enable(
 
     # Expected execute_query calls are triggered by TileScheduleOnlineStore:
     # 1. Check if online store table exists (execute_query)
-    # 2. Insert into online store table (execute_query_long_running)
+    # 2. Compute online store values and store in a temporary table
+    # 3. Insert into online store table (execute_query_long_running)
     assert mock_snowflake_session.execute_query.call_count == 1
-    assert mock_snowflake_session.execute_query_long_running.call_count == 1
+    assert mock_snowflake_session.execute_query_long_running.call_count == 2
 
     # First call
     args, _ = mock_snowflake_session.execute_query.call_args_list[0]
@@ -110,6 +111,10 @@ async def test_online_enable(
 
     # Second call
     args, _ = mock_snowflake_session.execute_query_long_running.call_args_list[0]
+    assert args[0].strip().startswith("CREATE TABLE __SESSION_TEMP_TABLE_")
+
+    # Third call
+    args, _ = mock_snowflake_session.execute_query_long_running.call_args_list[1]
     assert args[0].strip().startswith("INSERT INTO online_store_")
 
 

--- a/tests/unit/sql/test_common.py
+++ b/tests/unit/sql/test_common.py
@@ -1,0 +1,30 @@
+"""
+Unit tests for featurebyte/sql/common.py
+"""
+from unittest.mock import call
+
+import pytest
+
+from featurebyte.sql.common import register_temporary_physical_table
+
+
+@pytest.mark.asyncio
+async def test_register_temporary_physical_table(mock_snowflake_session):
+    """
+    Test register_temporary_physical_table
+    """
+    query = "select a, b, c from my_table"
+    try:
+        async with register_temporary_physical_table(mock_snowflake_session, query) as temp_table:
+            assert mock_snowflake_session.execute_query_long_running.call_args == call(
+                f"CREATE TABLE {temp_table} AS (SELECT * FROM (select a, b, c from my_table))"
+            )
+            raise RuntimeError("Fail on purpose")
+    except RuntimeError:
+        pass
+    assert mock_snowflake_session.drop_table.call_args == call(
+        temp_table,
+        schema_name="sf_schema",
+        database_name="sf_db",
+        if_exists=True,
+    )


### PR DESCRIPTION
## Description

This splits the online store compute and insert query into multiple statements to minimise table locking. It the issue persists, this allows us to retry the insert without having to recompute the results.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
