### PR TITLE
[DEV-2174][chore] docs: add list_deployment docs

### DIFF
--- a/featurebyte/__init__.py
+++ b/featurebyte/__init__.py
@@ -57,7 +57,7 @@ from featurebyte.exception import (
     InvalidSettingsError,
     RecordRetrievalException,
 )
-from featurebyte.feature_utility import list_unsaved_features
+from featurebyte.list_utility import list_deployments, list_unsaved_features
 from featurebyte.logging import get_logger
 from featurebyte.models.credential import (
     AccessTokenCredential,
@@ -401,51 +401,6 @@ def playground(
     )
 
 
-def list_deployments(
-    include_id: Optional[bool] = True,
-) -> pd.DataFrame:
-    """
-    List all deployments across all catalogs.
-    Deployed features are updated regularly based on their job settings and consume recurring compute resources
-    in the data warehouse.
-    It is recommended to delete deployments when they are no longer needed to avoid unnecessary costs.
-
-    Parameters
-    ----------
-    include_id: Optional[bool]
-        Whether to include id in the list
-
-    Returns
-    -------
-    pd.DataFrame
-        List of deployments
-
-    Examples
-    --------
-    >>> fb.list_deployments()
-    Empty DataFrame
-    Columns: [id, name, catalog_name, feature_list_name, feature_list_version, num_feature]
-    Index: []
-
-    See Also
-    --------
-    - [FeatureList.deploy](/reference/featurebyte.api.feature_list.FeatureList.deploy/) Deploy / Undeploy a feature list
-    """
-    output = []
-    for item_dict in iterate_api_object_using_paginated_routes(
-        route="/deployment/all/", params={"enabled": True}
-    ):
-        output.append(item_dict)
-    columns = ["name", "catalog_name", "feature_list_name", "feature_list_version", "num_feature"]
-    output_df = pd.DataFrame(
-        output,
-        columns=["_id"] + columns,
-    ).rename(columns={"_id": "id"})
-    if include_id:
-        return output_df
-    return output_df.drop(columns=["id"])
-
-
 __all__ = [
     # API objects
     "BatchFeatureTable",
@@ -515,6 +470,7 @@ __all__ = [
     "stop",
     "playground",
     # utility
+    "list_deployments",
     "list_unsaved_features",
     "UDF",
 ]

--- a/featurebyte/common/documentation/documentation_layout.py
+++ b/featurebyte/common/documentation/documentation_layout.py
@@ -743,7 +743,12 @@ def _get_utility_methods_layout() -> List[DocLayoutItem]:
         ),
         DocLayoutItem(
             [UTILITY_METHODS, LIST, "list_unsaved_features"],
-            doc_path_override="feature_utility.list_unsaved_features.md",
+            doc_path_override="list_utility.list_unsaved_features.md",
+            is_pure_method=True,
+        ),
+        DocLayoutItem(
+            [UTILITY_METHODS, LIST, "list_deployments"],
+            doc_path_override="list_utility.list_deployments.md",
             is_pure_method=True,
         ),
     ]

--- a/featurebyte/common/documentation/gen_ref_pages_docs_builder.py
+++ b/featurebyte/common/documentation/gen_ref_pages_docs_builder.py
@@ -551,7 +551,8 @@ def _add_pure_methods_to_doc_groups(
     """
     methods = [
         ("featurebyte.core.timedelta", "to_timedelta"),
-        ("featurebyte.feature_utility", "list_unsaved_features"),
+        ("featurebyte.list_utility", "list_unsaved_features"),
+        ("featurebyte.list_utility", "list_deployments"),
     ]
     for method in methods:
         doc_groups[

--- a/featurebyte/list_utility.py
+++ b/featurebyte/list_utility.py
@@ -8,7 +8,7 @@ from http import HTTPStatus
 
 import pandas as pd
 
-from featurebyte import iterate_api_object_using_paginated_routes
+from featurebyte.api.api_object_util import iterate_api_object_using_paginated_routes
 from featurebyte.api.catalog import Catalog
 from featurebyte.api.feature import Feature
 from featurebyte.api.feature_group import BaseFeatureGroup


### PR DESCRIPTION
## Description
Add the `fb.list_deployments` function into docs. We move the method out of the `__init__.py` file as it's not possible for our docs scraper to pick up docstrings from that file. 

![Screenshot 2023-08-28 at 10 54 47 AM](https://github.com/featurebyte/featurebyte/assets/2313101/6f42103f-0f66-483f-b848-b2dd5f665fb3)


<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-2174

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
