### PR TITLE
[chore] groupby_helper: rm quotes around alias to keep consistent w/ tiles

### DIFF
--- a/featurebyte/query_graph/sql/groupby_helper.py
+++ b/featurebyte/query_graph/sql/groupby_helper.py
@@ -178,7 +178,7 @@ def get_vector_agg_column_snowflake(
     for key in groupby_keys:
         updated_groupby_keys.append(alias_(key.expr, alias=key.name, quoted=True))
     updated_groupby_keys.append(
-        alias_(groupby_column.parent_expr, alias=groupby_column_parent_expr.name, quoted=True)
+        alias_(groupby_column.parent_expr, alias=groupby_column_parent_expr.name)
     )
 
     updated_input_expr_with_select_keys = input_expr.select(*updated_groupby_keys)

--- a/tests/unit/query_graph/sql/adapter/test_snowflake.py
+++ b/tests/unit/query_graph/sql/adapter/test_snowflake.py
@@ -38,7 +38,7 @@ class TestSnowflakeAdapter(BaseAdapterTest):
                     SELECT
                       REQ."serving_name" AS "serving_name",
                       REQ."serving_name_2" AS "serving_name_2",
-                      TABLE."parent" AS "parent"
+                      TABLE."parent" AS parent
                   ) AS INITIAL_DATA, TABLE(
                     VECTOR_AGGREGATE_SUM(parent) OVER (PARTITION BY INITIAL_DATA."serving_name", INITIAL_DATA."serving_name_2")
                   ) AS "AGG_0"
@@ -52,7 +52,7 @@ class TestSnowflakeAdapter(BaseAdapterTest):
                     SELECT
                       REQ."serving_name" AS "serving_name",
                       REQ."serving_name_2" AS "serving_name_2",
-                      TABLE."parent2" AS "parent2"
+                      TABLE."parent2" AS parent2
                   ) AS INITIAL_DATA, TABLE(
                     VECTOR_AGGREGATE_SUM(parent2) OVER (PARTITION BY INITIAL_DATA."serving_name", INITIAL_DATA."serving_name_2")
                   ) AS "AGG_1"
@@ -68,7 +68,7 @@ class TestSnowflakeAdapter(BaseAdapterTest):
                     SELECT
                       REQ."serving_name" AS "serving_name",
                       REQ."serving_name_2" AS "serving_name_2",
-                      TABLE."parent3" AS "parent3"
+                      TABLE."parent3" AS parent3
                   ) AS INITIAL_DATA, TABLE(
                     VECTOR_AGGREGATE_SUM(parent3) OVER (PARTITION BY INITIAL_DATA."serving_name", INITIAL_DATA."serving_name_2")
                   ) AS "AGG_2"

--- a/tests/unit/query_graph/sql/fixtures/snowflake_double_vector_agg_only.py
+++ b/tests/unit/query_graph/sql/fixtures/snowflake_double_vector_agg_only.py
@@ -40,7 +40,7 @@ SNOWFLAKE_DOUBLE_VECTOR_AGG_ONLY_QUERY = textwrap.dedent(
               SELECT
                 REQ."serving_name" AS "serving_name",
                 REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
-                TABLE."parent" AS "parent"
+                TABLE."parent" AS parent
               FROM REQ
             ) AS INITIAL_DATA, TABLE(
               VECTOR_AGGREGATE_MAX(parent) OVER (PARTITION BY INITIAL_DATA."serving_name", INITIAL_DATA."POINT_IN_TIME")
@@ -55,7 +55,7 @@ SNOWFLAKE_DOUBLE_VECTOR_AGG_ONLY_QUERY = textwrap.dedent(
               SELECT
                 REQ."serving_name" AS "serving_name",
                 REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
-                TABLE."parent" AS "parent"
+                TABLE."parent" AS parent
               FROM REQ
             ) AS INITIAL_DATA, TABLE(
               VECTOR_AGGREGATE_MAX(parent) OVER (PARTITION BY INITIAL_DATA."serving_name", INITIAL_DATA."POINT_IN_TIME")

--- a/tests/unit/query_graph/sql/fixtures/snowflake_double_vector_agg_only_no_value_by.py
+++ b/tests/unit/query_graph/sql/fixtures/snowflake_double_vector_agg_only_no_value_by.py
@@ -19,7 +19,7 @@ SNOWFLAKE_DOUBLE_VECTOR_AGG_NO_VALUE_BY_QUERY = textwrap.dedent(
             SELECT
               REQ."serving_name" AS "serving_name",
               REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
-              TABLE."parent" AS "parent"
+              TABLE."parent" AS parent
             FROM REQ
           ) AS INITIAL_DATA, TABLE(
             VECTOR_AGGREGATE_MAX(parent) OVER (PARTITION BY INITIAL_DATA."serving_name", INITIAL_DATA."POINT_IN_TIME")
@@ -34,7 +34,7 @@ SNOWFLAKE_DOUBLE_VECTOR_AGG_NO_VALUE_BY_QUERY = textwrap.dedent(
             SELECT
               REQ."serving_name" AS "serving_name",
               REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
-              TABLE."parent" AS "parent"
+              TABLE."parent" AS parent
             FROM REQ
           ) AS INITIAL_DATA, TABLE(
             VECTOR_AGGREGATE_MAX(parent) OVER (PARTITION BY INITIAL_DATA."serving_name", INITIAL_DATA."POINT_IN_TIME")

--- a/tests/unit/query_graph/sql/fixtures/snowflake_vector_agg_with_normal_agg.py
+++ b/tests/unit/query_graph/sql/fixtures/snowflake_vector_agg_with_normal_agg.py
@@ -40,7 +40,7 @@ SNOWFLAKE_VECTOR_AGG_WITH_NORMAL_AGG_QUERY = textwrap.dedent(
               SELECT
                 REQ."serving_name" AS "serving_name",
                 REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
-                TABLE."parent" AS "parent"
+                TABLE."parent" AS parent
               FROM REQ
             ) AS INITIAL_DATA, TABLE(
               VECTOR_AGGREGATE_MAX(parent) OVER (PARTITION BY INITIAL_DATA."serving_name", INITIAL_DATA."POINT_IN_TIME")

--- a/tests/unit/query_graph/sql/test_groupby_helper.py
+++ b/tests/unit/query_graph/sql/test_groupby_helper.py
@@ -95,7 +95,7 @@ def test_get_vector_agg_column_snowflake(
             FROM (
               SELECT
                 REQ."serving_name" AS "serving_name",
-                TABLE."parent" AS "parent"
+                TABLE."parent" AS parent
               FROM REQ
             ) AS INITIAL_DATA, TABLE({expected_table_func}(parent) OVER (PARTITION BY INITIAL_DATA."serving_name")) AS "AGG_0"
         """


### PR DESCRIPTION
## Description
Make a small change here to remove quotes around the aggregated value alias. This is to keep the aliases consistent with table tile names.

Will be using this change as part of the work to get vector_aggs for tiling aggregates, but decided to split it out to make sure that there're no regressions w/ other aggregations that have already been implemented, and are covered by existing integration tests.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
