### PR TITLE
[chore] tile/window: refactor to use adapter for groupby

### DIFF
--- a/featurebyte/query_graph/sql/adapter/base.py
+++ b/featurebyte/query_graph/sql/adapter/base.py
@@ -646,18 +646,21 @@ class BaseAdapter(ABC):  # pylint: disable=too-many-public-methods
         vector_aggregate_columns: Optional[List[VectorAggColumn]] = None,
     ) -> Select:
         """
-        Construct query to group by
+        Construct query to group by.
 
         Parameters
         ----------
         input_expr: Select
-            Input Select expression
+            Input Select expression. This will typically contain the base table data that we are querying from, and
+            will be performing the groupby over.
         select_keys: List[Expression]
-            List of select keys
+            List of select keys. These are keys that typically correspond to the group by keys, as we will often
+            perform joins with these keys at a later point with other tables.
         agg_exprs: List[Expression]
-            List of aggregation expressions
+            List of aggregation expressions. These are typically aggregation functions that have been applied on a
+            column already, and potentially with an alias. An input might be something like ["sum(col1) as sum_col_1"].
         keys: List[Expression]
-            List of keys
+            List of keys. These keys refer to the columns that we want to group by.
         vector_aggregate_columns: Optional[List[Expression]]
             List of vector aggregate expressions. This should only be used if special handling is required to join
             vector aggregate functions, and that they're not usable as a normal function. This param is a no-op

--- a/featurebyte/query_graph/sql/aggregator/window.py
+++ b/featurebyte/query_graph/sql/aggregator/window.py
@@ -525,8 +525,8 @@ class WindowAggregator(TileBasedAggregator):
 
         return agg_expr
 
-    @staticmethod
     def merge_tiles_order_independent(
+        self,
         req_joined_with_tiles: Select,
         inner_group_by_keys: list[Expression],
         merge_exprs: list[str],
@@ -552,14 +552,16 @@ class WindowAggregator(TileBasedAggregator):
         -------
         Select
         """
-        inner_agg_expr = req_joined_with_tiles.select(
-            *inner_group_by_keys,
-            *[
-                alias_(merge_expr, inner_agg_result_name, quoted=True)
-                for merge_expr, inner_agg_result_name in zip(merge_exprs, inner_agg_result_names)
-            ],
-        ).group_by(*inner_group_by_keys)
-        return inner_agg_expr
+        agg_exprs = [
+            alias_(merge_expr, inner_agg_result_name, quoted=True)
+            for merge_expr, inner_agg_result_name in zip(merge_exprs, inner_agg_result_names)
+        ]
+        return self.adapter.group_by(
+            req_joined_with_tiles,
+            select_keys=inner_group_by_keys,
+            agg_exprs=agg_exprs,
+            keys=inner_group_by_keys,
+        )
 
     @staticmethod
     def merge_tiles_order_dependent(

--- a/featurebyte/query_graph/sql/ast/tile.py
+++ b/featurebyte/query_graph/sql/ast/tile.py
@@ -286,6 +286,7 @@ class BuildTileNode(TableNode):  # pylint: disable=too-many-instance-attributes
             time_modulo_frequency=parameters["time_modulo_frequency"],
             is_on_demand=is_on_demand,
             is_order_dependent=aggregator.is_order_dependent,
+            adapter=context.adapter,
         )
         return sql_node
 

--- a/featurebyte/query_graph/sql/groupby_helper.py
+++ b/featurebyte/query_graph/sql/groupby_helper.py
@@ -158,7 +158,9 @@ def get_vector_agg_column_snowflake(
         )
         for k in groupby_keys
     ]
-    keys = [get_qualified_column_identifier(k.name, initial_data_table_name) for k in groupby_keys]
+    partition_by_keys = [
+        get_qualified_column_identifier(k.name, initial_data_table_name) for k in groupby_keys
+    ]
 
     agg_name = f"AGG_{index}"
     # The VECTOR_AGG_RESULT column value here, is a constant and is the name of the return value defined in the
@@ -173,7 +175,7 @@ def get_vector_agg_column_snowflake(
     agg_func_expr = expressions.Anonymous(
         this=_get_vector_sql_func(agg_func), expressions=[groupby_column_parent_expr.name]
     )
-    window_expr = expressions.Window(this=agg_func_expr, partition_by=keys)
+    window_expr = expressions.Window(this=agg_func_expr, partition_by=partition_by_keys)
     table_expr = expressions.Anonymous(this="TABLE", expressions=[window_expr])
     aliased_table_expr = alias_(table_expr, alias=agg_name, quoted=True)
 

--- a/featurebyte/query_graph/sql/groupby_helper.py
+++ b/featurebyte/query_graph/sql/groupby_helper.py
@@ -48,6 +48,29 @@ class GroupbyKey:
         return cast(Expression, alias_(self.expr, self.name, quoted=True))
 
 
+def _get_vector_sql_func(agg_func: AggFunc) -> str:
+    """
+    Helper function to get the SQL function name for an aggregate function.
+
+    Parameters
+    ----------
+    agg_func : AggFunc
+        Aggregate function
+
+    Returns
+    -------
+    str
+        This is the name of the aggregate function in SQL.
+    """
+    array_parent_agg_func_sql_mapping = {
+        AggFunc.MAX: "VECTOR_AGGREGATE_MAX",
+        AggFunc.AVG: "VECTOR_AGGREGATE_SIMPLE_AVERAGE",
+        AggFunc.SUM: "VECTOR_AGGREGATE_SUM",
+    }
+    assert agg_func in array_parent_agg_func_sql_mapping
+    return array_parent_agg_func_sql_mapping[agg_func]
+
+
 def get_aggregation_expression(
     agg_func: AggFunc, input_column: Optional[str | Expression], parent_dtype: Optional[DBVarType]
 ) -> Expression:
@@ -67,14 +90,17 @@ def get_aggregation_expression(
     -------
     Expression
     """
-    if input_column is not None:
-        if isinstance(input_column, str):
-            input_column_expr = quoted_identifier(input_column)
-        else:
-            input_column_expr = input_column
-    else:
-        input_column_expr = None
+    # Check if it's a count function
+    if agg_func == AggFunc.COUNT:
+        return expressions.Count(this="*")
 
+    # Get input_column_expr from input_column
+    assert input_column is not None
+    input_column_expr = input_column
+    if isinstance(input_column, str):
+        input_column_expr = quoted_identifier(input_column)
+
+    # Try to get a built-in SQL aggregate function
     agg_func_sql_mapping = {
         AggFunc.SUM: "SUM",
         AggFunc.AVG: "AVG",
@@ -82,31 +108,16 @@ def get_aggregation_expression(
         AggFunc.MAX: "MAX",
         AggFunc.STD: "STDDEV",
     }
-    array_parent_agg_func_sql_mapping = {
-        AggFunc.MAX: "VECTOR_AGGREGATE_MAX",
-        AggFunc.AVG: "VECTOR_AGGREGATE_SIMPLE_AVERAGE",
-        AggFunc.SUM: "VECTOR_AGGREGATE_SUM",
-    }
-    expr: Expression
     if agg_func in agg_func_sql_mapping:
-        assert input_column_expr is not None
         sql_func = agg_func_sql_mapping[agg_func]
         if parent_dtype is not None and parent_dtype == DBVarType.ARRAY:
-            assert agg_func in array_parent_agg_func_sql_mapping
-            sql_func = array_parent_agg_func_sql_mapping[agg_func]
-        expr = expressions.Anonymous(this=sql_func, expressions=[input_column_expr])
-    else:
-        if agg_func == AggFunc.COUNT:
-            expr = cast(Expression, parse_one("COUNT(*)"))
-        else:
-            # Must be NA_COUNT
-            assert agg_func == AggFunc.NA_COUNT
-            assert input_column_expr is not None
-            expr_is_null = expressions.Is(this=input_column_expr, expression=expressions.NULL)
-            expr = expressions.Sum(
-                this=expressions.Cast(this=expr_is_null, to=parse_one("INTEGER"))
-            )
-    return expr
+            sql_func = _get_vector_sql_func(agg_func)
+        return expressions.Anonymous(this=sql_func, expressions=[input_column_expr])
+
+    # Must be NA_COUNT
+    assert agg_func == AggFunc.NA_COUNT
+    expr_is_null = expressions.Is(this=input_column_expr, expression=expressions.NULL)
+    return expressions.Sum(this=expressions.Cast(this=expr_is_null, to=parse_one("INTEGER")))
 
 
 def get_vector_agg_column_snowflake(
@@ -138,14 +149,6 @@ def get_vector_agg_column_snowflake(
     VectorAggColumn
     """
     # pylint: disable=too-many-locals
-    array_parent_agg_func_sql_mapping = {
-        AggFunc.MAX: "VECTOR_AGGREGATE_MAX",
-        AggFunc.AVG: "VECTOR_AGGREGATE_SIMPLE_AVERAGE",
-        AggFunc.SUM: "VECTOR_AGGREGATE_SUM",
-    }
-    assert agg_func in array_parent_agg_func_sql_mapping
-    snowflake_agg_func = array_parent_agg_func_sql_mapping[agg_func]
-
     initial_data_table_name = "INITIAL_DATA"
     select_keys = [
         alias_(
@@ -168,7 +171,7 @@ def get_vector_agg_column_snowflake(
     groupby_column_parent_expr = groupby_column.parent_expr
     assert groupby_column_parent_expr is not None
     agg_func_expr = expressions.Anonymous(
-        this=snowflake_agg_func, expressions=[groupby_column_parent_expr.name]
+        this=_get_vector_sql_func(agg_func), expressions=[groupby_column_parent_expr.name]
     )
     window_expr = expressions.Window(this=agg_func_expr, partition_by=keys)
     table_expr = expressions.Anonymous(this="TABLE", expressions=[window_expr])


### PR DESCRIPTION
## Description
Small refactor to use adapter for groupby queries in tile and window operations. Making a bunch of small changes in this final stretch to make sure I don't break anything.

Also make a small refactor to retrieving the sql_func for vector aggregations as we'll be adding some logic there in a subsequent PR.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-2167

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
