### PR TITLE
[DEV-2216] Fix conversion of date type to double in spark

### DIFF
--- a/.changelog/DEV-2216.yaml
+++ b/.changelog/DEV-2216.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix conversion of date type to double in spark"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/query_graph/sql/adapter/spark.py
+++ b/featurebyte/query_graph/sql/adapter/spark.py
@@ -41,7 +41,8 @@ class SparkAdapter(DatabricksAdapter):
     ) -> Expression:
         def _to_microseconds(expr: Expression) -> Expression:
             return expressions.Mul(
-                this=expressions.Cast(this=expr, to=expressions.DataType.build("DOUBLE")),
+                # this=expressions.Cast(this=expr, to=expressions.DataType.build("DOUBLE")),
+                this=cls.to_seconds_double(expr),
                 expression=make_literal_value(1e6),
             )
 

--- a/tests/unit/query_graph/sql/adapter/test_spark.py
+++ b/tests/unit/query_graph/sql/adapter/test_spark.py
@@ -2,6 +2,8 @@
 Test spark adapter module
 """
 
+from sqlglot import expressions
+
 from featurebyte.query_graph.sql.adapter import SparkAdapter
 from tests.unit.query_graph.sql.adapter.base_adapter_test import BaseAdapterTest
 
@@ -12,3 +14,24 @@ class TestSparkAdapter(BaseAdapterTest):
     """
 
     adapter = SparkAdapter()
+
+    def test_dateadd_seconds(self):
+        """
+        Test dateadd_second method for spark adapter
+        """
+        out = self.adapter.dateadd_second(
+            expressions.Literal.number(100), expressions.Identifier(this="my_timestamp")
+        )
+        expected = "CAST(CAST(CAST(my_timestamp AS TIMESTAMP) AS DOUBLE) + 100 AS TIMESTAMP)"
+        assert out.sql() == expected
+
+    def test_datediff_microseond(self):
+        """
+        Test datediff_microsecond method for spark adapter
+        """
+        out = self.adapter.datediff_microsecond(
+            expressions.Identifier(this="t1"),
+            expressions.Identifier(this="t2"),
+        )
+        expected = "(CAST(CAST(t2 AS TIMESTAMP) AS DOUBLE) * 1000000.0 - CAST(CAST(t1 AS TIMESTAMP) AS DOUBLE) * 1000000.0)"
+        assert out.sql() == expected


### PR DESCRIPTION
## Description

This fixes the conversion of date type to double in spark. Previously, the conversion produced null value if the type is not timestamp.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
