### PR TITLE
[chore] Optimize `get_by_id` by using cache

### DIFF
--- a/tests/unit/api/test_event_table.py
+++ b/tests/unit/api/test_event_table.py
@@ -928,8 +928,10 @@ def test_list_feature_job_setting_analysis(mock_list, saved_event_table):
     assert output == mock_list.return_value
 
 
-def test_event_table__entity_relation_auto_tagging(saved_event_table):
+def test_event_table__entity_relation_auto_tagging(saved_event_table, mock_api_object_cache):
     """Test event table update: entity relation will be created automatically"""
+    _ = mock_api_object_cache
+
     transaction_entity = Entity(name="transaction", serving_names=["transaction_id"])
     transaction_entity.save()
 

--- a/tests/unit/api/test_scd_table.py
+++ b/tests/unit/api/test_scd_table.py
@@ -333,8 +333,10 @@ def test_info(saved_scd_table):
     assert_info_helper(info)
 
 
-def test_scd_table__entity_relation_auto_tagging(saved_scd_table):
+def test_scd_table__entity_relation_auto_tagging(saved_scd_table, mock_api_object_cache):
     """Test scd table update: entity relation will be created automatically"""
+    _ = mock_api_object_cache
+
     entity_a = Entity(name="a", serving_names=["a_id"])
     entity_a.save()
 


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

Current `get_by_id` operation does not use api cache. To reduce number of API calls, this PR updates `get_by_id` by using cached results.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
