### PR TITLE
[chore] Fx hive connection for service where spark is not default catalog

### DIFF
--- a/featurebyte/session/hive.py
+++ b/featurebyte/session/hive.py
@@ -106,7 +106,7 @@ class HiveConnection(Connection):
             "port": port,
             "scheme": scheme,
             "username": username,
-            "database": database,
+            "database": f"{catalog}`.`{database}",
             "auth": auth,
             "configuration": configuration,
             "kerberos_service_name": kerberos_service_name,


### PR DESCRIPTION
## Description

Hive connection not provided correct database parameter. 
It works well when spark_catalog is the default catalog but breaks otherwise.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
