### PR TITLE
[chore] adapter/snowflake: respect quotes from identifer passed in

### DIFF
--- a/featurebyte/query_graph/sql/adapter/snowflake.py
+++ b/featurebyte/query_graph/sql/adapter/snowflake.py
@@ -405,11 +405,15 @@ class SnowflakeAdapter(BaseAdapter):  # pylint: disable=too-many-public-methods
         # Rename the TABLE that we're selecting the keys from to be the aggregated table, aliased by the subquery above.
         renamed_table_select_keys = []
         for select_key in select_keys:
+            # Keep quoting with the original select key that is passed in
+            should_quote_alias = quote_vector_agg_aliases
+            if isinstance(select_key, Identifier):
+                should_quote_alias = select_key.quoted
             renamed_table_select_keys.append(
                 alias_(
                     get_qualified_column_identifier(select_key.alias_or_name, table_alias),
                     alias=select_key.alias_or_name,
-                    quoted=quote_vector_agg_aliases,
+                    quoted=should_quote_alias,
                 )
             )
         left_expression = select(

--- a/tests/unit/query_graph/sql/adapter/base_adapter_test.py
+++ b/tests/unit/query_graph/sql/adapter/base_adapter_test.py
@@ -8,12 +8,12 @@ import textwrap
 from select import select
 
 from sqlglot import select
-from sqlglot.expressions import Select, alias_
+from sqlglot.expressions import Identifier, Select, alias_
 
 from featurebyte import AggFunc
 from featurebyte.enum import DBVarType
 from featurebyte.query_graph.sql.adapter import BaseAdapter
-from featurebyte.query_graph.sql.common import get_qualified_column_identifier
+from featurebyte.query_graph.sql.common import get_qualified_column_identifier, quoted_identifier
 from featurebyte.query_graph.sql.groupby_helper import (
     GroupbyColumn,
     GroupbyKey,
@@ -41,6 +41,8 @@ class BaseAdapterTest:
                   b,
                   REQ."serving_name" AS "serving_name",
                   REQ."serving_name_2" AS "serving_name_2",
+                  entity_column,
+                  "entity_column_2",
                   SUM("parent") AS "sum_result",
                   AVG("parent_avg") AS "avg_result"
                 GROUP BY
@@ -66,6 +68,8 @@ class BaseAdapterTest:
             ),
         ]
         select_keys = [k.get_alias() for k in groupby_keys]
+        select_keys.append(Identifier(this="entity_column"))
+        select_keys.append(quoted_identifier("entity_column_2"))
         keys = [k.expr for k in groupby_keys]
         agg_exprs = [
             alias_(

--- a/tests/unit/query_graph/sql/adapter/test_snowflake.py
+++ b/tests/unit/query_graph/sql/adapter/test_snowflake.py
@@ -24,6 +24,8 @@ class TestSnowflakeAdapter(BaseAdapterTest):
                 SELECT
                   VECTOR_T0."serving_name" AS "serving_name",
                   VECTOR_T0."serving_name_2" AS "serving_name_2",
+                  VECTOR_T0."entity_column" AS entity_column,
+                  VECTOR_T0."entity_column_2" AS "entity_column_2",
                   GROUP_BY_RESULT."sum_result" AS "sum_result",
                   GROUP_BY_RESULT."avg_result" AS "avg_result",
                   VECTOR_T0."result" AS "result",
@@ -59,6 +61,8 @@ class TestSnowflakeAdapter(BaseAdapterTest):
                 ) AS VECTOR_T1
                   ON VECTOR_T0."serving_name" = VECTOR_T1."serving_name"
                   AND VECTOR_T0."serving_name_2" = VECTOR_T1."serving_name_2"
+                  AND VECTOR_T0."entity_column" = VECTOR_T1."entity_column"
+                  AND VECTOR_T0."entity_column_2" = VECTOR_T1."entity_column_2"
                 INNER JOIN (
                   SELECT
                     INITIAL_DATA."serving_name" AS "serving_name",
@@ -75,12 +79,16 @@ class TestSnowflakeAdapter(BaseAdapterTest):
                 ) AS VECTOR_T2
                   ON VECTOR_T1."serving_name" = VECTOR_T2."serving_name"
                   AND VECTOR_T1."serving_name_2" = VECTOR_T2."serving_name_2"
+                  AND VECTOR_T1."entity_column" = VECTOR_T2."entity_column"
+                  AND VECTOR_T1."entity_column_2" = VECTOR_T2."entity_column_2"
                 INNER JOIN (
                   SELECT
                     a,
                     b,
                     REQ."serving_name" AS "serving_name",
                     REQ."serving_name_2" AS "serving_name_2",
+                    entity_column,
+                    "entity_column_2",
                     SUM("parent") AS "sum_result",
                     AVG("parent_avg") AS "avg_result"
                   GROUP BY
@@ -89,5 +97,7 @@ class TestSnowflakeAdapter(BaseAdapterTest):
                 ) AS GROUP_BY_RESULT
                   ON GROUP_BY_RESULT."serving_name" = VECTOR_T2."serving_name"
                   AND GROUP_BY_RESULT."serving_name_2" = VECTOR_T2."serving_name_2"
+                  AND GROUP_BY_RESULT.entity_column = VECTOR_T2."entity_column"
+                  AND GROUP_BY_RESULT."entity_column_2" = VECTOR_T2."entity_column_2"
             """
         ).strip()


### PR DESCRIPTION
## Description
In scenarios where the keys passed in are just identifiers, and not expressions, we can use the `identifiers.quoted` parameter to determine if we should quote the aliases. This will allow us to be more consistent with the callers. 

This was reported by viktor where we had this query

```
merge into TILE_F86400_M79811_B600_88B38744550A87992403BB95438F70F83CBB3064 a using (
            select
                index,
                "EmployeeId", value_max_b261e7ab1fdf1754f7bfcbd9584c6490b13b8077,
                current_timestamp() as created_at
            from (SELECT
  VECTOR_T0."index" AS index,
  VECTOR_T0."EmployeeId" AS EmployeeId,
  VECTOR_T0."value_max_b261e7ab1fdf1754f7bfcbd9584c6490b13b8077" AS value_max_b261e7ab1fdf1754f7bfcbd9584c6490b13b8077
FROM (
  SELECT
    INITIAL_DATA."index" AS "index",
    INITIAL_DATA."EmployeeId" AS "EmployeeId",
    AGG_0."VECTOR_AGG_RESULT" AS "value_max_b261e7ab1fdf1754f7bfcbd9584c6490b13b8077"
```

in which the calling "merge into" block had `"EmployeeId"` quoted, while our `group_by` logic removed the quotes on the aliased `EmployeeId`. This change should help fix that problem.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
