### PR TITLE
[chore] Fix spark connection for non-default catalog

### DIFF
--- a/featurebyte/session/hive.py
+++ b/featurebyte/session/hive.py
@@ -119,7 +119,7 @@ class HiveConnection(Connection):
             super().__init__(**params)
         except OperationalError:
             # retry using default database to create schema
-            params["database"] = "default"
+            params["database"] = f"{catalog}`.`default"
             super().__init__(**params)
             cursor = self.cursor()
             cursor.execute(f"CREATE SCHEMA `{catalog}`.`{database}`")


### PR DESCRIPTION
## Description

Make spark connection for non-default catalog work when featurebyte schema does not exist

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
