### PR TITLE
[chore] observation_table: change TargetInput to return None for no-op

### DIFF
--- a/featurebyte/models/observation_table.py
+++ b/featurebyte/models/observation_table.py
@@ -63,13 +63,7 @@ class TargetInput(FeatureByteBaseModel):
             The destination table to materialize the target input to
         sample_rows: Optional[int]
             The number of rows to sample from the target input
-
-        Raises
-        ------
-        NotImplementedError
-            If this method is called
         """
-        raise NotImplementedError
 
 
 ObservationInput = Annotated[


### PR DESCRIPTION
## Description
Change to return none instead of throwing an error so that this is truly no-op.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
