### PR TITLE
[DEV-2285] Support value counts and customised statistics in PreviewService

### DIFF
--- a/.changelog/DEV-2285.yaml
+++ b/.changelog/DEV-2285.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Support extracting value counts and customised statistics in PreviewService"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/query_graph/sql/interpreter/preview.py
+++ b/featurebyte/query_graph/sql/interpreter/preview.py
@@ -589,12 +589,12 @@ class PreviewMixin(BaseGraphInterpreter):
         # get subquery with columns casted to string to compute value counts
         casted_columns = []
         for col_expr in sql_tree.expressions:
-            alias_or_name = col_expr.alias or col_expr.name
+            col_name = col_expr.alias_or_name
             # add casted columns
             casted_columns.append(
                 expressions.alias_(
-                    expressions.Cast(this=quoted_identifier(alias_or_name), to=parse_one("STRING")),
-                    alias_or_name,
+                    expressions.Cast(this=quoted_identifier(col_name), to=parse_one("STRING")),
+                    col_name,
                     quoted=True,
                 )
             )
@@ -824,14 +824,14 @@ class PreviewMixin(BaseGraphInterpreter):
         # It's expected that this function is called on a node that is associated with a column and
         # not a frame, so here we simply take the first column.
         col_expr = sql_tree.expressions[0]
-        alias_or_name = col_expr.alias or col_expr.name
+        col_name = col_expr.alias_or_name
         cat_counts = self._get_cat_counts(
-            quoted_identifier(alias_or_name), num_categories_limit=num_categories_limit
+            quoted_identifier(col_name), num_categories_limit=num_categories_limit
         )
         output_expr = (
             construct_cte_sql(cte_statements)
             .select(
-                expressions.alias_(quoted_identifier(alias_or_name), "key", quoted=True),
+                expressions.alias_(quoted_identifier(col_name), "key", quoted=True),
                 expressions.alias_(
                     quoted_identifier(CATEGORY_COUNT_COLUMN_NAME), "count", quoted=True
                 ),

--- a/featurebyte/query_graph/sql/interpreter/preview.py
+++ b/featurebyte/query_graph/sql/interpreter/preview.py
@@ -826,7 +826,7 @@ class PreviewMixin(BaseGraphInterpreter):
         output_expr = (
             construct_cte_sql(cte_statements)
             .select(
-                expressions.alias_(quoted_identifier(col_name), col_name, quoted=True),
+                expressions.alias_(quoted_identifier(col_name), "key", quoted=True),
                 expressions.alias_(
                     quoted_identifier(CATEGORY_COUNT_COLUMN_NAME), "count", quoted=True
                 ),

--- a/featurebyte/schema/feature_store.py
+++ b/featurebyte/schema/feature_store.py
@@ -57,6 +57,7 @@ class FeatureStoreSample(FeatureStorePreview):
     from_timestamp: Optional[datetime] = Field(default=None)
     to_timestamp: Optional[datetime] = Field(default=None)
     timestamp_column: Optional[str] = Field(default=None)
+    stats_names: Optional[List[str]] = Field(default=None)
 
     @root_validator()
     @classmethod

--- a/featurebyte/service/preview.py
+++ b/featurebyte/service/preview.py
@@ -221,6 +221,7 @@ class PreviewService:
             from_timestamp=sample.from_timestamp,
             to_timestamp=sample.to_timestamp,
             timestamp_column=sample.timestamp_column,
+            stats_names=sample.stats_names,
         )
         logger.debug("Execute describe SQL", extra={"describe_sql": describe_sql})
         result = await session.execute_query(describe_sql)

--- a/featurebyte/service/preview.py
+++ b/featurebyte/service/preview.py
@@ -277,8 +277,8 @@ class PreviewService:
             seed=seed,
         )
         df_result = await session.execute_query(value_counts_sql)
-        assert df_result.columns.tolist() == ["key", "count"]
-        return df_result.set_index("key")["count"].to_dict()
+        assert df_result.columns.tolist() == ["key", "count"]  # type: ignore
+        return df_result.set_index("key")["count"].to_dict()  # type: ignore
 
     async def download_table(
         self,

--- a/tests/fixtures/expected_describe_request.sql
+++ b/tests/fixtures/expected_describe_request.sql
@@ -21,7 +21,7 @@ WITH data AS (
     FROM (
       SELECT
         "col_float",
-        COUNT('*') AS "__FB_COUNTS"
+        COUNT(*) AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "col_float"
@@ -41,7 +41,7 @@ WITH data AS (
     FROM (
       SELECT
         "col_text",
-        COUNT('*') AS "__FB_COUNTS"
+        COUNT(*) AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "col_text"

--- a/tests/fixtures/expected_describe_request.sql
+++ b/tests/fixtures/expected_describe_request.sql
@@ -17,16 +17,16 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__0"
   FROM (
     SELECT
-      OBJECT_AGG("col_float", "COUNTS") AS "COUNT_DICT"
+      OBJECT_AGG("col_float", "__FB_COUNTS") AS "COUNT_DICT"
     FROM (
       SELECT
         "col_float",
-        COUNT('*') AS "COUNTS"
+        COUNT('*') AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "col_float"
       ORDER BY
-        COUNTS DESC NULLS LAST
+        "__FB_COUNTS" DESC NULLS LAST
       LIMIT 500
     ) AS cat_counts
   ) AS count_dict
@@ -37,16 +37,16 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__1"
   FROM (
     SELECT
-      OBJECT_AGG("col_text", "COUNTS") AS "COUNT_DICT"
+      OBJECT_AGG("col_text", "__FB_COUNTS") AS "COUNT_DICT"
     FROM (
       SELECT
         "col_text",
-        COUNT('*') AS "COUNTS"
+        COUNT('*') AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "col_text"
       ORDER BY
-        COUNTS DESC NULLS LAST
+        "__FB_COUNTS" DESC NULLS LAST
       LIMIT 500
     ) AS cat_counts
   ) AS count_dict

--- a/tests/fixtures/query_graph/expected_describe_snowflake.sql
+++ b/tests/fixtures/query_graph/expected_describe_snowflake.sql
@@ -23,16 +23,16 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__0"
   FROM (
     SELECT
-      OBJECT_AGG("ts", "COUNTS") AS "COUNT_DICT"
+      OBJECT_AGG("ts", "__FB_COUNTS") AS "COUNT_DICT"
     FROM (
       SELECT
         "ts",
-        COUNT('*') AS "COUNTS"
+        COUNT('*') AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "ts"
       ORDER BY
-        COUNTS DESC NULLS LAST
+        "__FB_COUNTS" DESC NULLS LAST
       LIMIT 500
     ) AS cat_counts
   ) AS count_dict
@@ -43,16 +43,16 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__1"
   FROM (
     SELECT
-      OBJECT_AGG("cust_id", "COUNTS") AS "COUNT_DICT"
+      OBJECT_AGG("cust_id", "__FB_COUNTS") AS "COUNT_DICT"
     FROM (
       SELECT
         "cust_id",
-        COUNT('*') AS "COUNTS"
+        COUNT('*') AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "cust_id"
       ORDER BY
-        COUNTS DESC NULLS LAST
+        "__FB_COUNTS" DESC NULLS LAST
       LIMIT 500
     ) AS cat_counts
   ) AS count_dict
@@ -62,16 +62,16 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__2"
   FROM (
     SELECT
-      OBJECT_AGG("a", "COUNTS") AS "COUNT_DICT"
+      OBJECT_AGG("a", "__FB_COUNTS") AS "COUNT_DICT"
     FROM (
       SELECT
         "a",
-        COUNT('*') AS "COUNTS"
+        COUNT('*') AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "a"
       ORDER BY
-        COUNTS DESC NULLS LAST
+        "__FB_COUNTS" DESC NULLS LAST
       LIMIT 500
     ) AS cat_counts
   ) AS count_dict
@@ -81,16 +81,16 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__3"
   FROM (
     SELECT
-      OBJECT_AGG("b", "COUNTS") AS "COUNT_DICT"
+      OBJECT_AGG("b", "__FB_COUNTS") AS "COUNT_DICT"
     FROM (
       SELECT
         "b",
-        COUNT('*') AS "COUNTS"
+        COUNT('*') AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "b"
       ORDER BY
-        COUNTS DESC NULLS LAST
+        "__FB_COUNTS" DESC NULLS LAST
       LIMIT 500
     ) AS cat_counts
   ) AS count_dict
@@ -100,16 +100,16 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__4"
   FROM (
     SELECT
-      OBJECT_AGG("a_copy", "COUNTS") AS "COUNT_DICT"
+      OBJECT_AGG("a_copy", "__FB_COUNTS") AS "COUNT_DICT"
     FROM (
       SELECT
         "a_copy",
-        COUNT('*') AS "COUNTS"
+        COUNT('*') AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "a_copy"
       ORDER BY
-        COUNTS DESC NULLS LAST
+        "__FB_COUNTS" DESC NULLS LAST
       LIMIT 500
     ) AS cat_counts
   ) AS count_dict

--- a/tests/fixtures/query_graph/expected_describe_snowflake.sql
+++ b/tests/fixtures/query_graph/expected_describe_snowflake.sql
@@ -27,7 +27,7 @@ WITH data AS (
     FROM (
       SELECT
         "ts",
-        COUNT('*') AS "__FB_COUNTS"
+        COUNT(*) AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "ts"
@@ -47,7 +47,7 @@ WITH data AS (
     FROM (
       SELECT
         "cust_id",
-        COUNT('*') AS "__FB_COUNTS"
+        COUNT(*) AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "cust_id"
@@ -66,7 +66,7 @@ WITH data AS (
     FROM (
       SELECT
         "a",
-        COUNT('*') AS "__FB_COUNTS"
+        COUNT(*) AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "a"
@@ -85,7 +85,7 @@ WITH data AS (
     FROM (
       SELECT
         "b",
-        COUNT('*') AS "__FB_COUNTS"
+        COUNT(*) AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "b"
@@ -104,7 +104,7 @@ WITH data AS (
     FROM (
       SELECT
         "a_copy",
-        COUNT('*') AS "__FB_COUNTS"
+        COUNT(*) AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "a_copy"

--- a/tests/fixtures/query_graph/expected_describe_spark.sql
+++ b/tests/fixtures/query_graph/expected_describe_spark.sql
@@ -23,16 +23,16 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict.`COUNT_DICT`) AS `freq__0`
   FROM (
     SELECT
-      OBJECT_AGG(`ts`, `COUNTS`) AS `COUNT_DICT`
+      OBJECT_AGG(`ts`, `__FB_COUNTS`) AS `COUNT_DICT`
     FROM (
       SELECT
         `ts`,
-        COUNT('*') AS `COUNTS`
+        COUNT('*') AS `__FB_COUNTS`
       FROM casted_data
       GROUP BY
         `ts`
       ORDER BY
-        COUNTS DESC
+        `__FB_COUNTS` DESC
       LIMIT 500
     ) AS cat_counts
   ) AS count_dict
@@ -43,16 +43,16 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict.`COUNT_DICT`) AS `freq__1`
   FROM (
     SELECT
-      OBJECT_AGG(`cust_id`, `COUNTS`) AS `COUNT_DICT`
+      OBJECT_AGG(`cust_id`, `__FB_COUNTS`) AS `COUNT_DICT`
     FROM (
       SELECT
         `cust_id`,
-        COUNT('*') AS `COUNTS`
+        COUNT('*') AS `__FB_COUNTS`
       FROM casted_data
       GROUP BY
         `cust_id`
       ORDER BY
-        COUNTS DESC
+        `__FB_COUNTS` DESC
       LIMIT 500
     ) AS cat_counts
   ) AS count_dict
@@ -62,16 +62,16 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict.`COUNT_DICT`) AS `freq__2`
   FROM (
     SELECT
-      OBJECT_AGG(`a`, `COUNTS`) AS `COUNT_DICT`
+      OBJECT_AGG(`a`, `__FB_COUNTS`) AS `COUNT_DICT`
     FROM (
       SELECT
         `a`,
-        COUNT('*') AS `COUNTS`
+        COUNT('*') AS `__FB_COUNTS`
       FROM casted_data
       GROUP BY
         `a`
       ORDER BY
-        COUNTS DESC
+        `__FB_COUNTS` DESC
       LIMIT 500
     ) AS cat_counts
   ) AS count_dict
@@ -81,16 +81,16 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict.`COUNT_DICT`) AS `freq__3`
   FROM (
     SELECT
-      OBJECT_AGG(`b`, `COUNTS`) AS `COUNT_DICT`
+      OBJECT_AGG(`b`, `__FB_COUNTS`) AS `COUNT_DICT`
     FROM (
       SELECT
         `b`,
-        COUNT('*') AS `COUNTS`
+        COUNT('*') AS `__FB_COUNTS`
       FROM casted_data
       GROUP BY
         `b`
       ORDER BY
-        COUNTS DESC
+        `__FB_COUNTS` DESC
       LIMIT 500
     ) AS cat_counts
   ) AS count_dict
@@ -100,16 +100,16 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict.`COUNT_DICT`) AS `freq__4`
   FROM (
     SELECT
-      OBJECT_AGG(`a_copy`, `COUNTS`) AS `COUNT_DICT`
+      OBJECT_AGG(`a_copy`, `__FB_COUNTS`) AS `COUNT_DICT`
     FROM (
       SELECT
         `a_copy`,
-        COUNT('*') AS `COUNTS`
+        COUNT('*') AS `__FB_COUNTS`
       FROM casted_data
       GROUP BY
         `a_copy`
       ORDER BY
-        COUNTS DESC
+        `__FB_COUNTS` DESC
       LIMIT 500
     ) AS cat_counts
   ) AS count_dict

--- a/tests/fixtures/query_graph/expected_describe_spark.sql
+++ b/tests/fixtures/query_graph/expected_describe_spark.sql
@@ -27,7 +27,7 @@ WITH data AS (
     FROM (
       SELECT
         `ts`,
-        COUNT('*') AS `__FB_COUNTS`
+        COUNT(*) AS `__FB_COUNTS`
       FROM casted_data
       GROUP BY
         `ts`
@@ -47,7 +47,7 @@ WITH data AS (
     FROM (
       SELECT
         `cust_id`,
-        COUNT('*') AS `__FB_COUNTS`
+        COUNT(*) AS `__FB_COUNTS`
       FROM casted_data
       GROUP BY
         `cust_id`
@@ -66,7 +66,7 @@ WITH data AS (
     FROM (
       SELECT
         `a`,
-        COUNT('*') AS `__FB_COUNTS`
+        COUNT(*) AS `__FB_COUNTS`
       FROM casted_data
       GROUP BY
         `a`
@@ -85,7 +85,7 @@ WITH data AS (
     FROM (
       SELECT
         `b`,
-        COUNT('*') AS `__FB_COUNTS`
+        COUNT(*) AS `__FB_COUNTS`
       FROM casted_data
       GROUP BY
         `b`
@@ -104,7 +104,7 @@ WITH data AS (
     FROM (
       SELECT
         `a_copy`,
-        COUNT('*') AS `__FB_COUNTS`
+        COUNT(*) AS `__FB_COUNTS`
       FROM casted_data
       GROUP BY
         `a_copy`

--- a/tests/fixtures/query_graph/expected_describe_stats_names.sql
+++ b/tests/fixtures/query_graph/expected_describe_stats_names.sql
@@ -1,0 +1,151 @@
+WITH data AS (
+  SELECT
+    "ts" AS "ts",
+    "cust_id" AS "cust_id",
+    "a" AS "a",
+    "b" AS "b",
+    "a" AS "a_copy"
+  FROM "db"."public"."event_table"
+  ORDER BY
+    RANDOM(1234)
+  LIMIT 10
+), casted_data AS (
+  SELECT
+    CAST("ts" AS STRING) AS "ts",
+    CAST("cust_id" AS STRING) AS "cust_id",
+    CAST("a" AS STRING) AS "a",
+    CAST("b" AS STRING) AS "b",
+    CAST("a_copy" AS STRING) AS "a_copy"
+  FROM data
+), counts__0 AS (
+  SELECT
+    F_COUNT_DICT_MOST_FREQUENT(count_dict."COUNT_DICT") AS "top__0",
+    F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__0"
+  FROM (
+    SELECT
+      OBJECT_AGG("ts", "COUNTS") AS "COUNT_DICT"
+    FROM (
+      SELECT
+        "ts",
+        COUNT('*') AS "COUNTS"
+      FROM casted_data
+      GROUP BY
+        "ts"
+      ORDER BY
+        COUNTS DESC NULLS LAST
+      LIMIT 500
+    ) AS cat_counts
+  ) AS count_dict
+), counts__1 AS (
+  SELECT
+    F_COUNT_DICT_ENTROPY(count_dict."COUNT_DICT") AS "entropy__1",
+    F_COUNT_DICT_MOST_FREQUENT(count_dict."COUNT_DICT") AS "top__1",
+    F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__1"
+  FROM (
+    SELECT
+      OBJECT_AGG("cust_id", "COUNTS") AS "COUNT_DICT"
+    FROM (
+      SELECT
+        "cust_id",
+        COUNT('*') AS "COUNTS"
+      FROM casted_data
+      GROUP BY
+        "cust_id"
+      ORDER BY
+        COUNTS DESC NULLS LAST
+      LIMIT 500
+    ) AS cat_counts
+  ) AS count_dict
+), counts__2 AS (
+  SELECT
+    F_COUNT_DICT_MOST_FREQUENT(count_dict."COUNT_DICT") AS "top__2",
+    F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__2"
+  FROM (
+    SELECT
+      OBJECT_AGG("a", "COUNTS") AS "COUNT_DICT"
+    FROM (
+      SELECT
+        "a",
+        COUNT('*') AS "COUNTS"
+      FROM casted_data
+      GROUP BY
+        "a"
+      ORDER BY
+        COUNTS DESC NULLS LAST
+      LIMIT 500
+    ) AS cat_counts
+  ) AS count_dict
+), counts__3 AS (
+  SELECT
+    F_COUNT_DICT_MOST_FREQUENT(count_dict."COUNT_DICT") AS "top__3",
+    F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__3"
+  FROM (
+    SELECT
+      OBJECT_AGG("b", "COUNTS") AS "COUNT_DICT"
+    FROM (
+      SELECT
+        "b",
+        COUNT('*') AS "COUNTS"
+      FROM casted_data
+      GROUP BY
+        "b"
+      ORDER BY
+        COUNTS DESC NULLS LAST
+      LIMIT 500
+    ) AS cat_counts
+  ) AS count_dict
+), counts__4 AS (
+  SELECT
+    F_COUNT_DICT_MOST_FREQUENT(count_dict."COUNT_DICT") AS "top__4",
+    F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__4"
+  FROM (
+    SELECT
+      OBJECT_AGG("a_copy", "COUNTS") AS "COUNT_DICT"
+    FROM (
+      SELECT
+        "a_copy",
+        COUNT('*') AS "COUNTS"
+      FROM casted_data
+      GROUP BY
+        "a_copy"
+      ORDER BY
+        COUNTS DESC NULLS LAST
+      LIMIT 500
+    ) AS cat_counts
+  ) AS count_dict
+), stats AS (
+  SELECT
+    MIN("ts") AS "min__0",
+    MAX("ts") AS "max__0",
+    NULL AS "min__1",
+    NULL AS "max__1",
+    MIN("a") AS "min__2",
+    MAX("a") AS "max__2",
+    MIN("b") AS "min__3",
+    MAX("b") AS "max__3",
+    MIN("a_copy") AS "min__4",
+    MAX("a_copy") AS "max__4"
+  FROM data
+)
+SELECT
+  'TIMESTAMP' AS "dtype__0",
+  stats."min__0",
+  stats."max__0",
+  'VARCHAR' AS "dtype__1",
+  stats."min__1",
+  stats."max__1",
+  'FLOAT' AS "dtype__2",
+  stats."min__2",
+  stats."max__2",
+  'INT' AS "dtype__3",
+  stats."min__3",
+  stats."max__3",
+  'FLOAT' AS "dtype__4",
+  stats."min__4",
+  stats."max__4"
+FROM stats
+LEFT JOIN counts__0
+LEFT JOIN counts__1
+LEFT JOIN counts__2
+LEFT JOIN counts__3
+LEFT JOIN counts__4

--- a/tests/fixtures/query_graph/expected_describe_stats_names.sql
+++ b/tests/fixtures/query_graph/expected_describe_stats_names.sql
@@ -23,16 +23,16 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__0"
   FROM (
     SELECT
-      OBJECT_AGG("ts", "COUNTS") AS "COUNT_DICT"
+      OBJECT_AGG("ts", "__FB_COUNTS") AS "COUNT_DICT"
     FROM (
       SELECT
         "ts",
-        COUNT('*') AS "COUNTS"
+        COUNT('*') AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "ts"
       ORDER BY
-        COUNTS DESC NULLS LAST
+        "__FB_COUNTS" DESC NULLS LAST
       LIMIT 500
     ) AS cat_counts
   ) AS count_dict
@@ -43,16 +43,16 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__1"
   FROM (
     SELECT
-      OBJECT_AGG("cust_id", "COUNTS") AS "COUNT_DICT"
+      OBJECT_AGG("cust_id", "__FB_COUNTS") AS "COUNT_DICT"
     FROM (
       SELECT
         "cust_id",
-        COUNT('*') AS "COUNTS"
+        COUNT('*') AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "cust_id"
       ORDER BY
-        COUNTS DESC NULLS LAST
+        "__FB_COUNTS" DESC NULLS LAST
       LIMIT 500
     ) AS cat_counts
   ) AS count_dict
@@ -62,16 +62,16 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__2"
   FROM (
     SELECT
-      OBJECT_AGG("a", "COUNTS") AS "COUNT_DICT"
+      OBJECT_AGG("a", "__FB_COUNTS") AS "COUNT_DICT"
     FROM (
       SELECT
         "a",
-        COUNT('*') AS "COUNTS"
+        COUNT('*') AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "a"
       ORDER BY
-        COUNTS DESC NULLS LAST
+        "__FB_COUNTS" DESC NULLS LAST
       LIMIT 500
     ) AS cat_counts
   ) AS count_dict
@@ -81,16 +81,16 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__3"
   FROM (
     SELECT
-      OBJECT_AGG("b", "COUNTS") AS "COUNT_DICT"
+      OBJECT_AGG("b", "__FB_COUNTS") AS "COUNT_DICT"
     FROM (
       SELECT
         "b",
-        COUNT('*') AS "COUNTS"
+        COUNT('*') AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "b"
       ORDER BY
-        COUNTS DESC NULLS LAST
+        "__FB_COUNTS" DESC NULLS LAST
       LIMIT 500
     ) AS cat_counts
   ) AS count_dict
@@ -100,16 +100,16 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__4"
   FROM (
     SELECT
-      OBJECT_AGG("a_copy", "COUNTS") AS "COUNT_DICT"
+      OBJECT_AGG("a_copy", "__FB_COUNTS") AS "COUNT_DICT"
     FROM (
       SELECT
         "a_copy",
-        COUNT('*') AS "COUNTS"
+        COUNT('*') AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "a_copy"
       ORDER BY
-        COUNTS DESC NULLS LAST
+        "__FB_COUNTS" DESC NULLS LAST
       LIMIT 500
     ) AS cat_counts
   ) AS count_dict

--- a/tests/fixtures/query_graph/expected_describe_stats_names.sql
+++ b/tests/fixtures/query_graph/expected_describe_stats_names.sql
@@ -27,7 +27,7 @@ WITH data AS (
     FROM (
       SELECT
         "ts",
-        COUNT('*') AS "__FB_COUNTS"
+        COUNT(*) AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "ts"
@@ -47,7 +47,7 @@ WITH data AS (
     FROM (
       SELECT
         "cust_id",
-        COUNT('*') AS "__FB_COUNTS"
+        COUNT(*) AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "cust_id"
@@ -66,7 +66,7 @@ WITH data AS (
     FROM (
       SELECT
         "a",
-        COUNT('*') AS "__FB_COUNTS"
+        COUNT(*) AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "a"
@@ -85,7 +85,7 @@ WITH data AS (
     FROM (
       SELECT
         "b",
-        COUNT('*') AS "__FB_COUNTS"
+        COUNT(*) AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "b"
@@ -104,7 +104,7 @@ WITH data AS (
     FROM (
       SELECT
         "a_copy",
-        COUNT('*') AS "__FB_COUNTS"
+        COUNT(*) AS "__FB_COUNTS"
       FROM casted_data
       GROUP BY
         "a_copy"

--- a/tests/fixtures/query_graph/expected_value_counts.sql
+++ b/tests/fixtures/query_graph/expected_value_counts.sql
@@ -1,0 +1,26 @@
+WITH data AS (
+  SELECT
+    "a" AS "a"
+  FROM "db"."public"."event_table"
+  ORDER BY
+    RANDOM(1234)
+  LIMIT 50000
+), casted_data AS (
+  SELECT
+    CAST("a" AS STRING) AS "a"
+  FROM data
+)
+SELECT
+  "a" AS "a",
+  COUNTS AS "count"
+FROM (
+  SELECT
+    "a",
+    COUNT('*') AS "COUNTS"
+  FROM casted_data
+  GROUP BY
+    "a"
+  ORDER BY
+    COUNTS DESC NULLS LAST
+  LIMIT 1000
+)

--- a/tests/fixtures/query_graph/expected_value_counts.sql
+++ b/tests/fixtures/query_graph/expected_value_counts.sql
@@ -16,7 +16,7 @@ SELECT
 FROM (
   SELECT
     "a",
-    COUNT('*') AS "__FB_COUNTS"
+    COUNT(*) AS "__FB_COUNTS"
   FROM casted_data
   GROUP BY
     "a"

--- a/tests/fixtures/query_graph/expected_value_counts.sql
+++ b/tests/fixtures/query_graph/expected_value_counts.sql
@@ -12,15 +12,15 @@ WITH data AS (
 )
 SELECT
   "a" AS "a",
-  COUNTS AS "count"
+  "__FB_COUNTS" AS "count"
 FROM (
   SELECT
     "a",
-    COUNT('*') AS "COUNTS"
+    COUNT('*') AS "__FB_COUNTS"
   FROM casted_data
   GROUP BY
     "a"
   ORDER BY
-    COUNTS DESC NULLS LAST
+    "__FB_COUNTS" DESC NULLS LAST
   LIMIT 1000
 )

--- a/tests/fixtures/query_graph/expected_value_counts.sql
+++ b/tests/fixtures/query_graph/expected_value_counts.sql
@@ -11,7 +11,7 @@ WITH data AS (
   FROM data
 )
 SELECT
-  "a" AS "a",
+  "a" AS "key",
   "__FB_COUNTS" AS "count"
 FROM (
   SELECT

--- a/tests/unit/query_graph/interpreter/conftest.py
+++ b/tests/unit/query_graph/interpreter/conftest.py
@@ -64,3 +64,15 @@ def simple_graph_fixture(graph, node_input):
         input_nodes=[node_input, proj_a],
     )
     return graph, assign
+
+
+@pytest.fixture(name="project_from_simple_graph", scope="function")
+def project_from_simple_graph_fixture(graph, node_input):
+    """Simple graph with a project node"""
+    proj_a = graph.add_operation(
+        node_type=NodeType.PROJECT,
+        node_params={"columns": ["a"]},
+        node_output_type=NodeOutputType.SERIES,
+        input_nodes=[node_input],
+    )
+    return graph, proj_a

--- a/tests/unit/query_graph/interpreter/test_preview.py
+++ b/tests/unit/query_graph/interpreter/test_preview.py
@@ -29,3 +29,16 @@ def test_describe_specify_stats_names(simple_graph, update_fixtures):
     )[0]
     expected_filename = f"tests/fixtures/query_graph/expected_describe_stats_names.sql"
     assert_equal_with_expected_fixture(sql_code, expected_filename, update_fixtures)
+
+
+def test_value_counts_sql(project_from_simple_graph, update_fixtures):
+    """Test value counts sql"""
+    graph, node = project_from_simple_graph
+    interpreter = GraphInterpreter(graph, SourceType.SNOWFLAKE)
+    sql_code = interpreter.construct_value_counts_sql(
+        node.name,
+        num_rows=50000,
+        num_categories_limit=1000,
+    )
+    expected_filename = f"tests/fixtures/query_graph/expected_value_counts.sql"
+    assert_equal_with_expected_fixture(sql_code, expected_filename, update_fixtures)

--- a/tests/unit/query_graph/interpreter/test_preview.py
+++ b/tests/unit/query_graph/interpreter/test_preview.py
@@ -17,3 +17,15 @@ def test_graph_interpreter_describe(simple_graph, source_type, update_fixtures):
     sql_code = interpreter.construct_describe_sql(node.name, num_rows=10, seed=1234)[0]
     expected_filename = f"tests/fixtures/query_graph/expected_describe_{source_type.lower()}.sql"
     assert_equal_with_expected_fixture(sql_code, expected_filename, update_fixtures)
+
+
+def test_describe_specify_stats_names(simple_graph, update_fixtures):
+    """Test describe sql with only required stats names"""
+    graph, node = simple_graph
+    interpreter = GraphInterpreter(graph, SourceType.SNOWFLAKE)
+
+    sql_code = interpreter.construct_describe_sql(
+        node.name, num_rows=10, seed=1234, stats_names=["min", "max"]
+    )[0]
+    expected_filename = f"tests/fixtures/query_graph/expected_describe_stats_names.sql"
+    assert_equal_with_expected_fixture(sql_code, expected_filename, update_fixtures)

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -203,9 +203,11 @@ def online_enable_service_fixture(app_container):
 
 
 @pytest.fixture(name="preview_service")
-def preview_service_fixture(app_container):
+def preview_service_fixture(app_container, feature_store, mock_snowflake_session):
     """PreviewService fixture"""
-    return app_container.preview_service
+    with patch("featurebyte.service.preview.PreviewService._get_feature_store_session") as mocked:
+        mocked.return_value = feature_store, mock_snowflake_session
+        yield app_container.preview_service
 
 
 @pytest.fixture(name="feature_preview_service")

--- a/tests/unit/service/test_preview.py
+++ b/tests/unit/service/test_preview.py
@@ -12,7 +12,7 @@ from featurebyte.exception import MissingPointInTimeColumnError, RequiredEntityN
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.feature_list import FeatureCluster
 from featurebyte.schema.feature_list import FeatureListPreview
-from featurebyte.schema.feature_store import FeatureStorePreview, FeatureStoreSample
+from featurebyte.schema.feature_store import FeatureStorePreview
 from featurebyte.schema.preview import FeatureOrTargetPreview
 
 


### PR DESCRIPTION
## Description

This adds support for extracting value counts and customised statistics (a subset of the supported stats to reduce unneeded work) in PreviewService. This is mainly to support feature ideation work but it can also be exposed in the SDK later.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
