### PR TITLE
[DEV-2293] Fix race condition when accessing cache in ApiObject's get_by_id()

### DIFF
--- a/.changelog/DEV-2293.yaml
+++ b/.changelog/DEV-2293.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix race condition when accessing cached values in ApiObject's get_by_id()"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/api_object.py
+++ b/featurebyte/api/api_object.py
@@ -38,6 +38,8 @@ from featurebyte.models.base import FeatureByteBaseDocumentModel, FeatureByteBas
 ApiObjectT = TypeVar("ApiObjectT", bound="ApiObject")
 ModelT = TypeVar("ModelT", bound=FeatureByteBaseDocumentModel)
 
+CacheKeyNotFound = object()
+
 logger = get_logger(__name__)
 
 
@@ -292,8 +294,9 @@ class ApiObject(FeatureByteBaseDocumentModel, AsyncMixin):
         if use_cache:
             collection_name = _get_cache_collection_name(cls)
             key = hashkey(collection_name, id)
-            if key in cls._cache:
-                return cls.from_persistent_object_dict(cls._cache[key].dict(by_alias=True))
+            cached_value = cls._cache.get(key, CacheKeyNotFound)
+            if cached_value is not CacheKeyNotFound:
+                return cls.from_persistent_object_dict(cached_value.dict(by_alias=True))
         return cls.from_persistent_object_dict(cls._get_object_dict_by_id(id_value=id))
 
     @classmethod


### PR DESCRIPTION
## Description

This fixes a race condition that arises when accessing cached values in ApiObject's `get_by_id()`.

Example error:
```
  File "/opt/venv/lib/python3.8/site-packages/featurebyte/api/api_object.py", line 347, in get_by_id
    return cls._get_by_id(id)
  File "/opt/venv/lib/python3.8/site-packages/featurebyte/api/api_object.py", line 296, in _get_by_id
    return cls.from_persistent_object_dict(cls._cache[key].dict(by_alias=True))
  File "/opt/venv/lib/python3.8/site-packages/cachetools/__init__.py", line 416, in __getitem__
    return self.__missing__(key)
  File "/opt/venv/lib/python3.8/site-packages/cachetools/__init__.py", line 97, in __missing__
    raise KeyError(key)
KeyError: ('entity', ObjectId('6507f3bea4e7c32abee8659b'))
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
