### PR TITLE
[chore] routes: refactor API routes into a BaseRouter

### DIFF
--- a/featurebyte/app.py
+++ b/featurebyte/app.py
@@ -143,6 +143,10 @@ def get_app() -> FastAPI:
         temp_data_api,
         catalog_api,
     ]
+    routers = [
+        credential_api.CredentialRouter(),
+    ]
+    resource_apis.extend(routers)
     dependencies = _get_api_deps()
     for resource_api in resource_apis:
         _app.include_router(

--- a/featurebyte/app.py
+++ b/featurebyte/app.py
@@ -10,7 +10,6 @@ from starlette.websockets import WebSocket
 
 import featurebyte.routes.batch_feature_table.api as batch_feature_table_api
 import featurebyte.routes.batch_request_table.api as batch_request_table_api
-import featurebyte.routes.context.api as context_api
 import featurebyte.routes.deployment.api as deployment_api
 import featurebyte.routes.dimension_table.api as dimension_table_api
 import featurebyte.routes.entity.api as entity_api
@@ -41,6 +40,7 @@ from featurebyte.logging import get_logger
 from featurebyte.middleware import ExceptionMiddleware
 from featurebyte.models.base import PydanticObjectId, User
 from featurebyte.routes.catalog.api import CatalogRouter
+from featurebyte.routes.context.api import ContextRouter
 from featurebyte.routes.credential.api import CredentialRouter
 from featurebyte.routes.lazy_app_container import LazyAppContainer
 from featurebyte.routes.registry import app_container_config
@@ -158,9 +158,9 @@ def get_app() -> FastAPI:
     routers = [
         TargetTableRouter(prefix="/target_table"),
         static_source_table_api.StaticSourceTableRouter(prefix="/static_source_table"),
+        ContextRouter(),
     ]
     resource_apis = [
-        context_api,
         deployment_api,
         dimension_table_api,
         event_table_api,

--- a/featurebyte/app.py
+++ b/featurebyte/app.py
@@ -145,7 +145,7 @@ def get_app() -> FastAPI:
         CredentialRouter(),
         CatalogRouter(),
     ]
-    resource_apis.extend(routers)
+    resource_apis.extend(routers)  # type: ignore[arg-type]
     dependencies = _get_api_deps()
     for resource_api in resource_apis:
         _app.include_router(

--- a/featurebyte/app.py
+++ b/featurebyte/app.py
@@ -10,9 +10,7 @@ from starlette.websockets import WebSocket
 
 import featurebyte.routes.batch_feature_table.api as batch_feature_table_api
 import featurebyte.routes.batch_request_table.api as batch_request_table_api
-import featurebyte.routes.catalog.api as catalog_api
 import featurebyte.routes.context.api as context_api
-import featurebyte.routes.credential.api as credential_api
 import featurebyte.routes.deployment.api as deployment_api
 import featurebyte.routes.dimension_table.api as dimension_table_api
 import featurebyte.routes.entity.api as entity_api
@@ -42,6 +40,8 @@ from featurebyte.common.utils import get_version
 from featurebyte.logging import get_logger
 from featurebyte.middleware import ExceptionMiddleware
 from featurebyte.models.base import PydanticObjectId, User
+from featurebyte.routes.catalog.api import CatalogRouter
+from featurebyte.routes.credential.api import CredentialRouter
 from featurebyte.routes.lazy_app_container import LazyAppContainer
 from featurebyte.routes.registry import app_container_config
 from featurebyte.routes.target_table.api import TargetTableRouter
@@ -136,15 +136,14 @@ def get_app() -> FastAPI:
 
     # register routes that are not catalog-specific
     resource_apis = [
-        credential_api,
         feature_store_api,
         semantic_api,
         task_api,
         temp_data_api,
-        catalog_api,
     ]
     routers = [
-        credential_api.CredentialRouter(),
+        CredentialRouter(),
+        CatalogRouter(),
     ]
     resource_apis.extend(routers)
     dependencies = _get_api_deps()

--- a/featurebyte/routes/base_router.py
+++ b/featurebyte/routes/base_router.py
@@ -128,7 +128,7 @@ class BaseApiRouter(
         Create object
         """
         controller = self.get_controller_for_request(request)
-        result: ObjectModelT = await controller.create(data=data)
+        result: ObjectModelT = await controller.service.create_document(data=data)
         return result
 
     async def list_objects(

--- a/featurebyte/routes/base_router.py
+++ b/featurebyte/routes/base_router.py
@@ -1,0 +1,195 @@
+"""
+Base router
+"""
+from typing import Generic, Optional, Type, TypeVar, Union, cast
+
+from http import HTTPStatus
+
+from fastapi import APIRouter, Request
+
+from featurebyte.models.base import PydanticObjectId
+from featurebyte.models.persistent import AuditDocumentList
+from featurebyte.routes.common.schema import (
+    AuditLogSortByQuery,
+    NameQuery,
+    PageQuery,
+    PageSizeQuery,
+    SearchQuery,
+    SortByQuery,
+    SortDirQuery,
+)
+from featurebyte.schema.common.base import DeleteResponse, DescriptionUpdate
+
+ObjectModelT = TypeVar("ObjectModelT")
+ListObjectModelT = TypeVar("ListObjectModelT")
+CreateObjectSchemaT = TypeVar("CreateObjectSchemaT")
+ControllerT = TypeVar("ControllerT")
+
+
+class BaseRouter:
+    """
+    BaseRouter class that just encapsulates the APIRouter object.
+    """
+
+    def __init__(self, router: APIRouter) -> None:
+        self.router = router
+
+
+class BaseApiRouter(
+    BaseRouter, Generic[ObjectModelT, ListObjectModelT, CreateObjectSchemaT, ControllerT]
+):
+    """
+    Base API router.
+
+    This class contains basic CRUD operations for a given model.
+    """
+
+    object_model: Type[ObjectModelT]
+    list_object_model: Type[ListObjectModelT]
+    create_object_schema: Type[CreateObjectSchemaT]
+    controller: Union[Type[ControllerT], str]
+
+    def __init__(self, prefix: str, skip_id_prefix: bool = False):
+        super().__init__(router=APIRouter(prefix=prefix))
+        base_name = prefix.lstrip("/")
+        api_id = f"{{{base_name}_id}}" if not skip_id_prefix else "{object_id}"
+
+        # Get object
+        self.router.add_api_route(
+            f"/{api_id}",
+            self.get_object,
+            methods=["GET"],
+            response_model=self.object_model,
+            status_code=HTTPStatus.OK,
+        )
+
+        # Create an object
+        self.router.add_api_route(
+            "",
+            self.create_object,
+            methods=["POST"],
+            response_model=self.object_model,
+            status_code=HTTPStatus.CREATED,
+        )
+
+        # List objects
+        self.router.add_api_route(
+            "",
+            self.list_objects,
+            methods=["GET"],
+            response_model=self.list_object_model,
+            status_code=HTTPStatus.OK,
+        )
+
+        # Delete objects
+        self.router.add_api_route(
+            f"/{api_id}",
+            self.delete_object,
+            methods=["DELETE"],
+            status_code=HTTPStatus.OK,
+        )
+
+        # List audit logs for object
+        self.router.add_api_route(
+            f"/audit/{api_id}",
+            self.list_audit_logs,
+            methods=["GET"],
+            response_model=AuditDocumentList,
+        )
+
+        # Update description for object
+        self.router.add_api_route(
+            f"/{api_id}/description",
+            self.update_description,
+            methods=["PATCH"],
+            response_model=self.object_model,
+        )
+
+    async def get_object(self, request: Request, object_id: PydanticObjectId) -> ObjectModelT:
+        """
+        Get table
+        """
+        controller = request.state.app_container.get(self.controller)
+        object_model: ObjectModelT = await controller.get(document_id=object_id)
+        return object_model
+
+    async def create_object(self, request: Request, data: CreateObjectSchemaT) -> ObjectModelT:
+        """
+        Create object
+        """
+        controller = request.state.app_container.get(self.controller)
+        result: ObjectModelT = await controller.service.create_document(
+            data=data,
+        )
+        return result
+
+    async def list_objects(
+        self,
+        request: Request,
+        page: int = PageQuery,
+        page_size: int = PageSizeQuery,
+        sort_by: Optional[str] = SortByQuery,
+        sort_dir: Optional[str] = SortDirQuery,
+        search: Optional[str] = SearchQuery,
+        name: Optional[str] = NameQuery,
+    ) -> ObjectModelT:
+        """
+        List objects
+        """
+        controller = request.state.app_container.get(self.controller)
+        return cast(
+            ObjectModelT,
+            await controller.list(
+                page=page,
+                page_size=page_size,
+                sort_by=sort_by,
+                sort_dir=sort_dir,
+                search=search,
+                name=name,
+            ),
+        )
+
+    async def delete_object(self, request: Request, object_id: PydanticObjectId) -> DeleteResponse:
+        """
+        Delete object
+        """
+        controller = request.state.app_container.get(self.controller)
+        await controller.delete(document_id=object_id)
+        return DeleteResponse()
+
+    async def list_audit_logs(
+        self,
+        request: Request,
+        object_id: PydanticObjectId,
+        page: int = PageQuery,
+        page_size: int = PageSizeQuery,
+        sort_by: Optional[str] = AuditLogSortByQuery,
+        sort_dir: Optional[str] = SortDirQuery,
+        search: Optional[str] = SearchQuery,
+    ) -> AuditDocumentList:
+        """
+        List audit logs
+        """
+        controller = request.state.app_container.get(self.controller)
+        audit_doc_list: AuditDocumentList = await controller.list_audit(
+            document_id=object_id,
+            page=page,
+            page_size=page_size,
+            sort_by=sort_by,
+            sort_dir=sort_dir,
+            search=search,
+        )
+        return audit_doc_list
+
+    async def update_description(
+        self, request: Request, object_id: PydanticObjectId, data: DescriptionUpdate
+    ) -> ObjectModelT:
+        """
+        Update description
+        """
+        controller = request.state.app_container.get(self.controller)
+        object_model: ObjectModelT = await controller.update_description(
+            document_id=object_id,
+            description=data.description,
+        )
+        return object_model

--- a/featurebyte/routes/base_router.py
+++ b/featurebyte/routes/base_router.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Request
 
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
+from featurebyte.routes.common.base import BaseDocumentController
 from featurebyte.routes.common.schema import (
     AuditLogSortByQuery,
     NameQuery,
@@ -24,7 +25,7 @@ from featurebyte.schema.common.base import DeleteResponse, DescriptionUpdate
 ObjectModelT = TypeVar("ObjectModelT")
 ListObjectModelT = TypeVar("ListObjectModelT")
 CreateObjectSchemaT = TypeVar("CreateObjectSchemaT")
-ControllerT = TypeVar("ControllerT")
+ControllerT = TypeVar("ControllerT", bound=BaseDocumentController)
 
 
 class BaseRouter:

--- a/featurebyte/routes/base_router.py
+++ b/featurebyte/routes/base_router.py
@@ -9,7 +9,6 @@ from fastapi import APIRouter, Request
 
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
-from featurebyte.routes.common.base import BaseDocumentController
 from featurebyte.routes.common.schema import (
     AuditLogSortByQuery,
     NameQuery,
@@ -25,7 +24,7 @@ from featurebyte.schema.common.base import DeleteResponse, DescriptionUpdate
 ObjectModelT = TypeVar("ObjectModelT")
 ListObjectModelT = TypeVar("ListObjectModelT")
 CreateObjectSchemaT = TypeVar("CreateObjectSchemaT")
-ControllerT = TypeVar("ControllerT", bound=BaseDocumentController)
+ControllerT = TypeVar("ControllerT")
 
 
 class BaseRouter:
@@ -140,18 +139,18 @@ class BaseApiRouter(
         sort_dir: Optional[str] = SortDirQuery,
         search: Optional[str] = SearchQuery,
         name: Optional[str] = NameQuery,
-    ) -> ObjectModelT:
+    ) -> ListObjectModelT:
         """
         List objects
         """
         controller = self.get_controller_for_request(request)
         return cast(
-            ObjectModelT,
+            ListObjectModelT,
             await controller.list(
                 page=page,
                 page_size=page_size,
                 sort_by=sort_by,
-                sort_dir=sort_dir,
+                sort_dir=sort_dir,  # type: ignore[arg-type]
                 search=search,
                 name=name,
             ),
@@ -184,7 +183,7 @@ class BaseApiRouter(
             page=page,
             page_size=page_size,
             sort_by=sort_by,
-            sort_dir=sort_dir,
+            sort_dir=sort_dir,  # type: ignore[arg-type]
             search=search,
         )
         return audit_doc_list

--- a/featurebyte/routes/base_router.py
+++ b/featurebyte/routes/base_router.py
@@ -25,7 +25,7 @@ from featurebyte.schema.common.base import DeleteResponse, DescriptionUpdate
 ObjectModelT = TypeVar("ObjectModelT")
 ListObjectModelT = TypeVar("ListObjectModelT")
 CreateObjectSchemaT = TypeVar("CreateObjectSchemaT")
-ControllerT = TypeVar("ControllerT", bound=BaseDocumentController)
+ControllerT = TypeVar("ControllerT", bound=BaseDocumentController)  # type: ignore[type-arg]
 
 
 class BaseRouter:

--- a/featurebyte/routes/base_router.py
+++ b/featurebyte/routes/base_router.py
@@ -127,9 +127,7 @@ class BaseApiRouter(
         Create object
         """
         controller = self.get_controller_for_request(request)
-        result: ObjectModelT = await controller.service.create_document(
-            data=data,
-        )
+        result: ObjectModelT = await controller.create(data=data)
         return result
 
     async def list_objects(

--- a/featurebyte/routes/catalog/api.py
+++ b/featurebyte/routes/catalog/api.py
@@ -7,170 +7,152 @@ from typing import List, Optional, cast
 
 from http import HTTPStatus
 
-from fastapi import APIRouter, Request
+from fastapi import Request
 
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.catalog import CatalogModel, CatalogNameHistoryEntry
 from featurebyte.models.persistent import AuditDocumentList
+from featurebyte.routes.base_router import BaseApiRouter
+from featurebyte.routes.catalog.controller import CatalogController
 from featurebyte.routes.common.schema import (
     AuditLogSortByQuery,
-    NameQuery,
     PageQuery,
     PageSizeQuery,
     SearchQuery,
-    SortByQuery,
     SortDirQuery,
     VerboseQuery,
 )
 from featurebyte.schema.catalog import CatalogCreate, CatalogList, CatalogUpdate
-from featurebyte.schema.common.base import DescriptionUpdate
+from featurebyte.schema.common.base import DeleteResponse, DescriptionUpdate
 from featurebyte.schema.info import CatalogInfo
 
-router = APIRouter(prefix="/catalog")
 
-
-@router.post("", response_model=CatalogModel, status_code=HTTPStatus.CREATED)
-async def create_catalog(request: Request, data: CatalogCreate) -> CatalogModel:
+class CatalogRouter(BaseApiRouter[CatalogModel, CatalogList, CatalogCreate, CatalogController]):
     """
-    Create Catalog
+    Credential API router
     """
-    controller = request.state.app_container.catalog_controller
-    catalog: CatalogModel = await controller.create_catalog(data=data)
-    return catalog
 
+    # pylint: disable=arguments-renamed
 
-@router.get("/{catalog_id}", response_model=CatalogModel)
-async def get_catalog(request: Request, catalog_id: PydanticObjectId) -> CatalogModel:
-    """
-    Get catalog
-    """
-    controller = request.state.app_container.catalog_controller
-    catalog: CatalogModel = await controller.get(document_id=catalog_id)
-    return catalog
+    object_model = CatalogModel
+    list_object_model = CatalogList
+    create_object_schema = CatalogCreate
+    controller = CatalogController
 
+    def __init__(self) -> None:
+        super().__init__("/catalog")
 
-@router.get("", response_model=CatalogList)
-async def list_catalogs(
-    request: Request,
-    page: int = PageQuery,
-    page_size: int = PageSizeQuery,
-    sort_by: Optional[str] = SortByQuery,
-    sort_dir: Optional[str] = SortDirQuery,
-    search: Optional[str] = SearchQuery,
-    name: Optional[str] = NameQuery,
-) -> CatalogList:
-    """
-    List catalog
-    """
-    controller = request.state.app_container.catalog_controller
-    catalog_list: CatalogList = await controller.list(
-        page=page,
-        page_size=page_size,
-        sort_by=sort_by,
-        sort_dir=sort_dir,
-        search=search,
-        name=name,
-    )
-    return catalog_list
-
-
-@router.patch("/{catalog_id}", response_model=CatalogModel)
-async def update_catalog(
-    request: Request,
-    catalog_id: PydanticObjectId,
-    data: CatalogUpdate,
-) -> CatalogModel:
-    """
-    Update catalog
-    """
-    controller = request.state.app_container.catalog_controller
-    catalog: CatalogModel = await controller.update_catalog(
-        catalog_id=catalog_id,
-        data=data,
-    )
-    return catalog
-
-
-@router.get("/audit/{catalog_id}", response_model=AuditDocumentList)
-async def list_catalog_audit_logs(
-    request: Request,
-    catalog_id: PydanticObjectId,
-    page: int = PageQuery,
-    page_size: int = PageSizeQuery,
-    sort_by: Optional[str] = AuditLogSortByQuery,
-    sort_dir: Optional[str] = SortDirQuery,
-    search: Optional[str] = SearchQuery,
-) -> AuditDocumentList:
-    """
-    List catalog audit logs
-    """
-    controller = request.state.app_container.catalog_controller
-    audit_doc_list: AuditDocumentList = await controller.list_audit(
-        document_id=catalog_id,
-        page=page,
-        page_size=page_size,
-        sort_by=sort_by,
-        sort_dir=sort_dir,
-        search=search,
-    )
-    return audit_doc_list
-
-
-@router.get(
-    "/history/name/{catalog_id}",
-    response_model=List[CatalogNameHistoryEntry],
-)
-async def list_name_history(
-    request: Request,
-    catalog_id: PydanticObjectId,
-) -> List[CatalogNameHistoryEntry]:
-    """
-    List catalog name history
-    """
-    controller = request.state.app_container.catalog_controller
-    history_values = await controller.list_field_history(
-        document_id=catalog_id,
-        field="name",
-    )
-
-    return [
-        CatalogNameHistoryEntry(
-            created_at=record.created_at,
-            name=record.value,
+        # # update route
+        self.router.add_api_route(
+            "/{catalog_id}",
+            self.update_catalog,
+            methods=["PATCH"],
+            response_model=CatalogModel,
+            status_code=HTTPStatus.OK,
         )
-        for record in history_values
-    ]
 
+        # info route
+        self.router.add_api_route(
+            "/{catalog_id}/info",
+            self.get_catalog_info,
+            methods=["GET"],
+            response_model=CatalogInfo,
+        )
 
-@router.get("/{catalog_id}/info", response_model=CatalogInfo)
-async def get_catalog_info(
-    request: Request,
-    catalog_id: PydanticObjectId,
-    verbose: bool = VerboseQuery,
-) -> CatalogInfo:
-    """
-    Retrieve catalog info
-    """
-    controller = request.state.app_container.catalog_controller
-    info = await controller.get_info(
-        document_id=catalog_id,
-        verbose=verbose,
-    )
-    return cast(CatalogInfo, info)
+        # history name route
+        self.router.add_api_route(
+            "/history/name/{catalog_id}",
+            self.list_name_history,
+            methods=["GET"],
+            response_model=List[CatalogNameHistoryEntry],
+        )
 
+    async def get_object(self, request: Request, catalog_id: PydanticObjectId) -> CatalogModel:
+        return await super().get_object(request, catalog_id)
 
-@router.patch("/{catalog_id}/description", response_model=CatalogModel)
-async def update_catalog_description(
-    request: Request,
-    catalog_id: PydanticObjectId,
-    data: DescriptionUpdate,
-) -> CatalogModel:
-    """
-    Update catalog description
-    """
-    controller = request.state.app_container.catalog_controller
-    catalog: CatalogModel = await controller.update_description(
-        document_id=catalog_id,
-        description=data.description,
-    )
-    return catalog
+    async def delete_object(self, request: Request, catalog_id: PydanticObjectId) -> DeleteResponse:
+        return await super().delete_object(request, catalog_id)
+
+    async def list_audit_logs(
+        self,
+        request: Request,
+        catalog_id: PydanticObjectId,
+        page: int = PageQuery,
+        page_size: int = PageSizeQuery,
+        sort_by: Optional[str] = AuditLogSortByQuery,
+        sort_dir: Optional[str] = SortDirQuery,
+        search: Optional[str] = SearchQuery,
+    ) -> AuditDocumentList:
+        return await super().list_audit_logs(
+            request, catalog_id, page, page_size, sort_by, sort_dir, search
+        )
+
+    async def update_description(
+        self, request: Request, catalog_id: PydanticObjectId, data: DescriptionUpdate
+    ) -> CatalogModel:
+        return await super().update_description(request, catalog_id, data)
+
+    async def create_object(
+        self,
+        request: Request,
+        data: CatalogCreate,
+    ) -> CatalogModel:
+        """
+        Create catalog
+        """
+        controller = self.get_controller_for_request(request)
+        return cast(CatalogModel, await controller.create_catalog(data=data))
+
+    async def get_catalog_info(
+        self,
+        request: Request,
+        catalog_id: PydanticObjectId,
+        verbose: bool = VerboseQuery,
+    ) -> CatalogInfo:
+        """
+        Retrieve catalog info
+        """
+        controller = self.get_controller_for_request(request)
+        info = await controller.get_info(
+            document_id=catalog_id,
+            verbose=verbose,
+        )
+        return cast(CatalogInfo, info)
+
+    async def update_catalog(
+        self,
+        request: Request,
+        catalog_id: PydanticObjectId,
+        data: CatalogUpdate,
+    ) -> CatalogModel:
+        """
+        Update catalog
+        """
+        controller = self.get_controller_for_request(request)
+        catalog: CatalogModel = await controller.update_catalog(
+            catalog_id=catalog_id,
+            data=data,
+        )
+        return catalog
+
+    async def list_name_history(
+        self,
+        request: Request,
+        catalog_id: PydanticObjectId,
+    ) -> List[CatalogNameHistoryEntry]:
+        """
+        List catalog name history
+        """
+        controller = self.get_controller_for_request(request)
+        history_values = await controller.list_field_history(
+            document_id=catalog_id,
+            field="name",
+        )
+
+        return [
+            CatalogNameHistoryEntry(
+                created_at=record.created_at,
+                name=record.value,
+            )
+            for record in history_values
+        ]

--- a/featurebyte/routes/catalog/api.py
+++ b/featurebyte/routes/catalog/api.py
@@ -29,7 +29,7 @@ from featurebyte.schema.info import CatalogInfo
 
 class CatalogRouter(BaseApiRouter[CatalogModel, CatalogList, CatalogCreate, CatalogController]):
     """
-    Credential API router
+    Catalog API router
     """
 
     # pylint: disable=arguments-renamed

--- a/featurebyte/routes/catalog/api.py
+++ b/featurebyte/routes/catalog/api.py
@@ -100,8 +100,7 @@ class CatalogRouter(BaseApiRouter[CatalogModel, CatalogList, CatalogCreate, Cata
         """
         Create catalog
         """
-        controller = self.get_controller_for_request(request)
-        return cast(CatalogModel, await controller.create_catalog(data=data))
+        return await super().create_object(request, data)
 
     async def get_catalog_info(
         self,

--- a/featurebyte/routes/catalog/api.py
+++ b/featurebyte/routes/catalog/api.py
@@ -3,7 +3,7 @@ Catalog API routes
 """
 from __future__ import annotations
 
-from typing import List, Optional, cast
+from typing import List, Optional
 
 from http import HTTPStatus
 

--- a/featurebyte/routes/catalog/api.py
+++ b/featurebyte/routes/catalog/api.py
@@ -116,7 +116,7 @@ class CatalogRouter(BaseApiRouter[CatalogModel, CatalogList, CatalogCreate, Cata
             document_id=catalog_id,
             verbose=verbose,
         )
-        return cast(CatalogInfo, info)
+        return info
 
     async def update_catalog(
         self,

--- a/featurebyte/routes/catalog/controller.py
+++ b/featurebyte/routes/catalog/controller.py
@@ -7,12 +7,7 @@ from bson.objectid import ObjectId
 
 from featurebyte.models.catalog import CatalogModel
 from featurebyte.routes.common.base import BaseDocumentController
-from featurebyte.schema.catalog import (
-    CatalogCreate,
-    CatalogList,
-    CatalogServiceUpdate,
-    CatalogUpdate,
-)
+from featurebyte.schema.catalog import CatalogList, CatalogServiceUpdate, CatalogUpdate
 from featurebyte.schema.info import CatalogInfo
 from featurebyte.service.catalog import CatalogService
 
@@ -25,25 +20,6 @@ class CatalogController(
     """
 
     paginated_document_class = CatalogList
-
-    async def create_catalog(
-        self,
-        data: CatalogCreate,
-    ) -> CatalogModel:
-        """
-        Create Catalog at persistent
-
-        Parameters
-        ----------
-        data: CatalogCreate
-            Catalog creation payload
-
-        Returns
-        -------
-        CatalogModel
-            Newly created Catalog object
-        """
-        return await self.service.create_document(data)
 
     async def update_catalog(
         self,

--- a/featurebyte/routes/common/base.py
+++ b/featurebyte/routes/common/base.py
@@ -28,7 +28,7 @@ from featurebyte.service.feature_namespace import FeatureNamespaceService
 from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.service.historical_feature_table import HistoricalFeatureTableService
 from featurebyte.service.item_table import ItemTableService
-from featurebyte.service.mixin import DEFAULT_PAGE_SIZE, Document
+from featurebyte.service.mixin import DEFAULT_PAGE_SIZE, Document, DocumentCreateSchema
 from featurebyte.service.observation_table import ObservationTableService
 from featurebyte.service.periodic_task import PeriodicTaskService
 from featurebyte.service.relationship import ParentT, RelationshipService
@@ -154,6 +154,17 @@ class BaseDocumentController(Generic[Document, DocumentServiceT, PaginatedDocume
             **kwargs,
         )
         return cast(PaginatedDocument, self.paginated_document_class(**document_data))
+
+    async def create(self, data: DocumentCreateSchema) -> Document:
+        """
+        Create document.
+
+        Parameters
+        ----------
+        data: DocumentCreateSchema
+            Document creation payload object
+        """
+        return await self.service.create_document(data)
 
     async def delete(self, document_id: ObjectId) -> None:
         """

--- a/featurebyte/routes/common/base.py
+++ b/featurebyte/routes/common/base.py
@@ -155,6 +155,17 @@ class BaseDocumentController(Generic[Document, DocumentServiceT, PaginatedDocume
         )
         return cast(PaginatedDocument, self.paginated_document_class(**document_data))
 
+    async def delete(self, document_id: ObjectId) -> None:
+        """
+        Delete document.
+
+        Parameters
+        ----------
+        document_id: ObjectId
+            ID of document to delete
+        """
+        await self.service.delete_document(document_id=document_id)
+
     async def list_audit(
         self,
         document_id: ObjectId,

--- a/featurebyte/routes/common/base.py
+++ b/featurebyte/routes/common/base.py
@@ -28,7 +28,7 @@ from featurebyte.service.feature_namespace import FeatureNamespaceService
 from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.service.historical_feature_table import HistoricalFeatureTableService
 from featurebyte.service.item_table import ItemTableService
-from featurebyte.service.mixin import DEFAULT_PAGE_SIZE, Document, DocumentCreateSchema
+from featurebyte.service.mixin import DEFAULT_PAGE_SIZE, Document
 from featurebyte.service.observation_table import ObservationTableService
 from featurebyte.service.periodic_task import PeriodicTaskService
 from featurebyte.service.relationship import ParentT, RelationshipService
@@ -154,17 +154,6 @@ class BaseDocumentController(Generic[Document, DocumentServiceT, PaginatedDocume
             **kwargs,
         )
         return cast(PaginatedDocument, self.paginated_document_class(**document_data))
-
-    async def create(self, data: DocumentCreateSchema) -> Document:
-        """
-        Create document.
-
-        Parameters
-        ----------
-        data: DocumentCreateSchema
-            Document creation payload object
-        """
-        return await self.service.create_document(data)
 
     async def delete(self, document_id: ObjectId) -> None:
         """

--- a/featurebyte/routes/context/api.py
+++ b/featurebyte/routes/context/api.py
@@ -3,144 +3,118 @@ Context API routes
 """
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, cast
 
 from http import HTTPStatus
 
-from fastapi import APIRouter, Request
+from fastapi import Request
 
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.context import ContextModel
 from featurebyte.models.persistent import AuditDocumentList
+from featurebyte.routes.base_router import BaseApiRouter
 from featurebyte.routes.common.schema import (
     AuditLogSortByQuery,
-    NameQuery,
     PageQuery,
     PageSizeQuery,
     SearchQuery,
-    SortByQuery,
     SortDirQuery,
 )
+from featurebyte.routes.context.controller import ContextController
 from featurebyte.schema.common.base import DescriptionUpdate
 from featurebyte.schema.context import ContextCreate, ContextList, ContextUpdate
 from featurebyte.schema.observation_table import ObservationTableList
 
-router = APIRouter(prefix="/context")
 
+class ContextRouter(BaseApiRouter[ContextModel, ContextList, ContextCreate, ContextController]):
+    """
+    Credential API router
+    """
 
-@router.post("", response_model=ContextModel, status_code=HTTPStatus.CREATED)
-async def create_context(request: Request, data: ContextCreate) -> ContextModel:
-    """
-    Create Context
-    """
-    controller = request.state.app_container.context_controller
-    context: ContextModel = await controller.create_context(data=data)
-    return context
+    # pylint: disable=arguments-renamed
 
+    object_model = ContextModel
+    list_object_model = ContextList
+    create_object_schema = ContextCreate
+    controller = ContextController
 
-@router.get("/{context_id}", response_model=ContextModel)
-async def get_context(request: Request, context_id: PydanticObjectId) -> ContextModel:
-    """
-    Get Context
-    """
-    controller = request.state.app_container.context_controller
-    context: ContextModel = await controller.get(document_id=context_id)
-    return context
+    def __init__(self) -> None:
+        super().__init__("/context")
 
+        # update route
+        self.router.add_api_route(
+            "/{context_id}",
+            self.update_context,
+            methods=["PATCH"],
+            response_model=ContextModel,
+            status_code=HTTPStatus.OK,
+        )
 
-@router.get("/{context_id}/observation_tables", response_model=ObservationTableList)
-async def list_context_observation_tables(
-    request: Request,
-    context_id: PydanticObjectId,
-    page: int = PageQuery,
-    page_size: int = PageSizeQuery,
-) -> ObservationTableList:
-    """
-    List Observation Tables associated with the Use Case
-    """
-    observation_table_controller = request.state.app_container.observation_table_controller
-    observation_table_list: ObservationTableList = await observation_table_controller.list(
-        query_filter={"context_id": context_id},
-        page=page,
-        page_size=page_size,
-    )
-    return observation_table_list
+        # list observation tables
+        self.router.add_api_route(
+            "/{context_id}/observation_tables",
+            self.list_context_observation_tables,
+            methods=["GET"],
+            response_model=ObservationTableList,
+        )
 
+    async def get_object(self, request: Request, context_id: PydanticObjectId) -> ContextModel:
+        return await super().get_object(request, context_id)
 
-@router.get("", response_model=ContextList)
-async def list_contexts(
-    request: Request,
-    page: int = PageQuery,
-    page_size: int = PageSizeQuery,
-    sort_by: Optional[str] = SortByQuery,
-    sort_dir: Optional[str] = SortDirQuery,
-    search: Optional[str] = SearchQuery,
-    name: Optional[str] = NameQuery,
-) -> ContextList:
-    """
-    List Context
-    """
-    controller = request.state.app_container.context_controller
-    context_list: ContextList = await controller.list(
-        page=page,
-        page_size=page_size,
-        sort_by=sort_by,
-        sort_dir=sort_dir,
-        search=search,
-        name=name,
-    )
-    return context_list
+    async def list_audit_logs(
+        self,
+        request: Request,
+        context_id: PydanticObjectId,
+        page: int = PageQuery,
+        page_size: int = PageSizeQuery,
+        sort_by: Optional[str] = AuditLogSortByQuery,
+        sort_dir: Optional[str] = SortDirQuery,
+        search: Optional[str] = SearchQuery,
+    ) -> AuditDocumentList:
+        return await super().list_audit_logs(
+            request, context_id, page, page_size, sort_by, sort_dir, search
+        )
 
+    async def update_description(
+        self, request: Request, context_id: PydanticObjectId, data: DescriptionUpdate
+    ) -> ContextModel:
+        return await super().update_description(request, context_id, data)
 
-@router.patch("/{context_id}", response_model=ContextModel)
-async def update_context(
-    request: Request, context_id: PydanticObjectId, data: ContextUpdate
-) -> ContextModel:
-    """
-    Update Context
-    """
-    controller = request.state.app_container.context_controller
-    context: ContextModel = await controller.update_context(context_id=context_id, data=data)
-    return context
+    async def create_object(
+        self,
+        request: Request,
+        data: ContextCreate,
+    ) -> ContextModel:
+        """
+        Create credential
+        """
+        controller = self.get_controller_for_request(request)
+        return cast(ContextModel, await controller.create_context(data=data))
 
+    async def update_context(
+        self, request: Request, context_id: PydanticObjectId, data: ContextUpdate
+    ) -> ContextModel:
+        """
+        Update Context
+        """
+        controller = self.get_controller_for_request(request)
+        context: ContextModel = await controller.update_context(context_id=context_id, data=data)
+        return context
 
-@router.get("/audit/{context_id}", response_model=AuditDocumentList)
-async def list_context_audit_logs(
-    request: Request,
-    context_id: PydanticObjectId,
-    page: int = PageQuery,
-    page_size: int = PageSizeQuery,
-    sort_by: Optional[str] = AuditLogSortByQuery,
-    sort_dir: Optional[str] = SortDirQuery,
-    search: Optional[str] = SearchQuery,
-) -> AuditDocumentList:
-    """
-    List Context audit logs
-    """
-    controller = request.state.app_container.context_controller
-    audit_doc_list: AuditDocumentList = await controller.list_audit(
-        document_id=context_id,
-        page=page,
-        page_size=page_size,
-        sort_by=sort_by,
-        sort_dir=sort_dir,
-        search=search,
-    )
-    return audit_doc_list
-
-
-@router.patch("/{context_id}/description", response_model=ContextModel)
-async def update_context_description(
-    request: Request,
-    context_id: PydanticObjectId,
-    data: DescriptionUpdate,
-) -> ContextModel:
-    """
-    Update context description
-    """
-    controller = request.state.app_container.context_controller
-    context: ContextModel = await controller.update_description(
-        document_id=context_id,
-        description=data.description,
-    )
-    return context
+    @staticmethod
+    async def list_context_observation_tables(
+        request: Request,
+        context_id: PydanticObjectId,
+        page: int = PageQuery,
+        page_size: int = PageSizeQuery,
+    ) -> ObservationTableList:
+        """
+        List Observation Tables associated with the Use Case
+        """
+        observation_table_controller = request.state.app_container.observation_table_controller
+        observation_table_list: ObservationTableList = await observation_table_controller.list(
+            query_filter={"context_id": context_id},
+            page=page,
+            page_size=page_size,
+        )
+        return observation_table_list

--- a/featurebyte/routes/context/api.py
+++ b/featurebyte/routes/context/api.py
@@ -3,7 +3,7 @@ Context API routes
 """
 from __future__ import annotations
 
-from typing import Optional, cast
+from typing import Optional
 
 from http import HTTPStatus
 
@@ -88,8 +88,7 @@ class ContextRouter(BaseApiRouter[ContextModel, ContextList, ContextCreate, Cont
         """
         Create credential
         """
-        controller = self.get_controller_for_request(request)
-        return cast(ContextModel, await controller.create_context(data=data))
+        return await super().create_object(request, data)
 
     async def update_context(
         self, request: Request, context_id: PydanticObjectId, data: ContextUpdate

--- a/featurebyte/routes/context/api.py
+++ b/featurebyte/routes/context/api.py
@@ -28,7 +28,7 @@ from featurebyte.schema.observation_table import ObservationTableList
 
 class ContextRouter(BaseApiRouter[ContextModel, ContextList, ContextCreate, ContextController]):
     """
-    Credential API router
+    Context API router
     """
 
     # pylint: disable=arguments-renamed

--- a/featurebyte/routes/context/controller.py
+++ b/featurebyte/routes/context/controller.py
@@ -7,7 +7,7 @@ from bson import ObjectId
 
 from featurebyte.models.context import ContextModel
 from featurebyte.routes.common.base import BaseDocumentController
-from featurebyte.schema.context import ContextCreate, ContextList, ContextUpdate
+from featurebyte.schema.context import ContextList, ContextUpdate
 from featurebyte.schema.observation_table import ObservationTableUpdate
 from featurebyte.service.context import ContextService
 from featurebyte.service.observation_table import ObservationTableService
@@ -29,22 +29,6 @@ class ContextController(BaseDocumentController[ContextModel, ContextService, Con
         super().__init__(service=context_service)
         self.observation_table_service = observation_table_service
         self.context_service = context_service
-
-    async def create_context(self, data: ContextCreate) -> ContextModel:
-        """
-        Create context at persistent
-
-        Parameters
-        ----------
-        data: ContextCreate
-            Context creation payload
-
-        Returns
-        -------
-        ContextModel
-            Newly created context object
-        """
-        return await self.service.create_document(data)
 
     async def update_context(self, context_id: ObjectId, data: ContextUpdate) -> ContextModel:
         """

--- a/featurebyte/routes/credential/api.py
+++ b/featurebyte/routes/credential/api.py
@@ -154,8 +154,7 @@ class CredentialRouter(
         Retrieve catalog info
         """
         controller = self.get_controller_for_request(request)
-        info = await controller.get_info(
+        return await controller.get_info(
             credential_id=credential_id,
             verbose=verbose,
         )
-        return cast(CredentialInfo, info)

--- a/featurebyte/routes/credential/api.py
+++ b/featurebyte/routes/credential/api.py
@@ -109,19 +109,14 @@ class CredentialRouter(
         List credentials
         """
         controller = self.get_controller_for_request(request)
-        return cast(
-            CredentialList,
-            await controller.list(
-                page=page,
-                page_size=page_size,
-                sort_by=sort_by,
-                sort_dir=sort_dir,
-                search=search,
-                name=name,
-                query_filter={}
-                if feature_store_id is None
-                else {"feature_store_id": feature_store_id},
-            ),
+        return await controller.list(
+            page=page,
+            page_size=page_size,
+            sort_by=sort_by,
+            sort_dir=sort_dir,
+            search=search,
+            name=name,
+            query_filter={} if feature_store_id is None else {"feature_store_id": feature_store_id},
         )
 
     async def create_object(
@@ -144,12 +139,9 @@ class CredentialRouter(
         Update credential
         """
         controller = self.get_controller_for_request(request)
-        return cast(
-            CredentialRead,
-            await controller.update_credential(
-                credential_id=credential_id,
-                data=data,
-            ),
+        return await controller.update_credential(
+            credential_id=credential_id,
+            data=data,
         )
 
     async def get_credential_info(

--- a/featurebyte/routes/credential/api.py
+++ b/featurebyte/routes/credential/api.py
@@ -32,8 +32,6 @@ from featurebyte.schema.credential import (
 )
 from featurebyte.schema.info import CredentialInfo
 
-router = APIRouter(prefix="/credential")
-
 
 class CredentialRouter(
     BaseApiRouter[CredentialRead, CredentialList, CredentialCreate, CredentialController]

--- a/featurebyte/routes/credential/api.py
+++ b/featurebyte/routes/credential/api.py
@@ -132,11 +132,10 @@ class CredentialRouter(
         """
         Create credential
         """
-        controller = self.get_controller_for_request(request)
-        return cast(CredentialRead, await controller.create_credential(data=data))
+        return await super().create_object(request, data)
 
-    @staticmethod
     async def update_credential(
+        self,
         request: Request,
         credential_id: PydanticObjectId,
         data: CredentialUpdate,
@@ -153,8 +152,8 @@ class CredentialRouter(
             ),
         )
 
-    @staticmethod
     async def get_credential_info(
+        self,
         request: Request,
         credential_id: PydanticObjectId,
         verbose: bool = VerboseQuery,

--- a/featurebyte/routes/credential/api.py
+++ b/featurebyte/routes/credential/api.py
@@ -7,7 +7,7 @@ from typing import Optional, cast
 
 from http import HTTPStatus
 
-from fastapi import APIRouter, Request
+from fastapi import Request
 
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
@@ -108,7 +108,7 @@ class CredentialRouter(
         """
         List credentials
         """
-        controller = request.state.app_container.credential_controller
+        controller = self.get_controller_for_request(request)
         return cast(
             CredentialList,
             await controller.list(
@@ -132,7 +132,7 @@ class CredentialRouter(
         """
         Create credential
         """
-        controller = request.state.app_container.credential_controller
+        controller = self.get_controller_for_request(request)
         return cast(CredentialRead, await controller.create_credential(data=data))
 
     @staticmethod
@@ -144,7 +144,7 @@ class CredentialRouter(
         """
         Update credential
         """
-        controller = request.state.app_container.credential_controller
+        controller = self.get_controller_for_request(request)
         return cast(
             CredentialRead,
             await controller.update_credential(
@@ -162,7 +162,7 @@ class CredentialRouter(
         """
         Retrieve catalog info
         """
-        controller = request.state.app_container.credential_controller
+        controller = self.get_controller_for_request(request)
         info = await controller.get_info(
             credential_id=credential_id,
             verbose=verbose,

--- a/featurebyte/routes/credential/api.py
+++ b/featurebyte/routes/credential/api.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Request
 
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
+from featurebyte.routes.base_router import BaseApiRouter
 from featurebyte.routes.common.schema import (
     AuditLogSortByQuery,
     NameQuery,
@@ -21,6 +22,7 @@ from featurebyte.routes.common.schema import (
     SortDirQuery,
     VerboseQuery,
 )
+from featurebyte.routes.credential.controller import CredentialController
 from featurebyte.schema.common.base import DeleteResponse, DescriptionUpdate
 from featurebyte.schema.credential import (
     CredentialCreate,
@@ -33,160 +35,138 @@ from featurebyte.schema.info import CredentialInfo
 router = APIRouter(prefix="/credential")
 
 
-@router.post("", response_model=CredentialRead, status_code=HTTPStatus.CREATED)
-async def create_credential(
-    request: Request,
-    data: CredentialCreate,
-) -> CredentialRead:
+class CredentialRouter(
+    BaseApiRouter[CredentialRead, CredentialList, CredentialCreate, CredentialController]
+):
     """
-    Create credential
+    Credential API router
     """
-    controller = request.state.app_container.credential_controller
-    return cast(CredentialRead, await controller.create_credential(data=data))
 
+    # pylint: disable=arguments-renamed
 
-@router.get(
-    "/{credential_id}",
-    response_model=CredentialRead,
-    status_code=HTTPStatus.OK,
-)
-async def retrieve_credential(
-    request: Request,
-    credential_id: PydanticObjectId,
-) -> CredentialRead:
-    """
-    Retrieve credential
-    """
-    controller = request.state.app_container.credential_controller
-    return cast(
-        CredentialRead,
-        await controller.get(
-            document_id=credential_id,
-        ),
-    )
+    object_model = CredentialRead
+    list_object_model = CredentialList
+    create_object_schema = CredentialCreate
+    controller = CredentialController
 
+    def __init__(self) -> None:
+        super().__init__("/credential")
 
-@router.get("", response_model=CredentialList, status_code=HTTPStatus.OK)
-async def list_credential(
-    request: Request,
-    page: int = PageQuery,
-    page_size: int = PageSizeQuery,
-    sort_by: Optional[str] = SortByQuery,
-    sort_dir: Optional[str] = SortDirQuery,
-    search: Optional[str] = SearchQuery,
-    name: Optional[str] = NameQuery,
-    feature_store_id: Optional[PydanticObjectId] = None,
-) -> CredentialList:
-    """
-    List credentials
-    """
-    controller = request.state.app_container.credential_controller
-    return cast(
-        CredentialList,
-        await controller.list(
-            page=page,
-            page_size=page_size,
-            sort_by=sort_by,
-            sort_dir=sort_dir,
-            search=search,
-            name=name,
-            query_filter={} if feature_store_id is None else {"feature_store_id": feature_store_id},
-        ),
-    )
+        # update route
+        self.router.add_api_route(
+            "/{credential_id}",
+            self.update_credential,
+            methods=["PATCH"],
+            response_model=CredentialRead,
+            status_code=HTTPStatus.OK,
+        )
 
+        # info route
+        self.router.add_api_route(
+            "/{credential_id}/info",
+            self.get_credential_info,
+            methods=["GET"],
+            response_model=CredentialInfo,
+        )
 
-@router.patch(
-    "/{credential_id}",
-    response_model=CredentialRead,
-    status_code=HTTPStatus.OK,
-)
-async def update_credential(
-    request: Request,
-    credential_id: PydanticObjectId,
-    data: CredentialUpdate,
-) -> CredentialRead:
-    """
-    Update credential
-    """
-    controller = request.state.app_container.credential_controller
-    return cast(
-        CredentialRead,
-        await controller.update_credential(
+    async def get_object(self, request: Request, credential_id: PydanticObjectId) -> CredentialRead:
+        return await super().get_object(request, credential_id)
+
+    async def delete_object(
+        self, request: Request, credential_id: PydanticObjectId
+    ) -> DeleteResponse:
+        return await super().delete_object(request, credential_id)
+
+    async def list_audit_logs(
+        self,
+        request: Request,
+        credential_id: PydanticObjectId,
+        page: int = PageQuery,
+        page_size: int = PageSizeQuery,
+        sort_by: Optional[str] = AuditLogSortByQuery,
+        sort_dir: Optional[str] = SortDirQuery,
+        search: Optional[str] = SearchQuery,
+    ) -> AuditDocumentList:
+        return await super().list_audit_logs(
+            request, credential_id, page, page_size, sort_by, sort_dir, search
+        )
+
+    async def update_description(
+        self, request: Request, credential_id: PydanticObjectId, data: DescriptionUpdate
+    ) -> CredentialRead:
+        return await super().update_description(request, credential_id, data)
+
+    async def list_objects(
+        self,
+        request: Request,
+        page: int = PageQuery,
+        page_size: int = PageSizeQuery,
+        sort_by: Optional[str] = SortByQuery,
+        sort_dir: Optional[str] = SortDirQuery,
+        search: Optional[str] = SearchQuery,
+        name: Optional[str] = NameQuery,
+        feature_store_id: Optional[PydanticObjectId] = None,
+    ) -> CredentialList:
+        """
+        List credentials
+        """
+        controller = request.state.app_container.credential_controller
+        return cast(
+            CredentialList,
+            await controller.list(
+                page=page,
+                page_size=page_size,
+                sort_by=sort_by,
+                sort_dir=sort_dir,
+                search=search,
+                name=name,
+                query_filter={}
+                if feature_store_id is None
+                else {"feature_store_id": feature_store_id},
+            ),
+        )
+
+    async def create_object(
+        self,
+        request: Request,
+        data: CredentialCreate,
+    ) -> CredentialRead:
+        """
+        Create credential
+        """
+        controller = request.state.app_container.credential_controller
+        return cast(CredentialRead, await controller.create_credential(data=data))
+
+    @staticmethod
+    async def update_credential(
+        request: Request,
+        credential_id: PydanticObjectId,
+        data: CredentialUpdate,
+    ) -> CredentialRead:
+        """
+        Update credential
+        """
+        controller = request.state.app_container.credential_controller
+        return cast(
+            CredentialRead,
+            await controller.update_credential(
+                credential_id=credential_id,
+                data=data,
+            ),
+        )
+
+    @staticmethod
+    async def get_credential_info(
+        request: Request,
+        credential_id: PydanticObjectId,
+        verbose: bool = VerboseQuery,
+    ) -> CredentialInfo:
+        """
+        Retrieve catalog info
+        """
+        controller = request.state.app_container.credential_controller
+        info = await controller.get_info(
             credential_id=credential_id,
-            data=data,
-        ),
-    )
-
-
-@router.get("/{credential_id}/info", response_model=CredentialInfo)
-async def get_credential_info(
-    request: Request,
-    credential_id: PydanticObjectId,
-    verbose: bool = VerboseQuery,
-) -> CredentialInfo:
-    """
-    Retrieve catalog info
-    """
-    controller = request.state.app_container.credential_controller
-    info = await controller.get_info(
-        credential_id=credential_id,
-        verbose=verbose,
-    )
-    return cast(CredentialInfo, info)
-
-
-@router.get("/audit/{credential_id}", response_model=AuditDocumentList)
-async def list_credential_audit_logs(
-    request: Request,
-    credential_id: PydanticObjectId,
-    page: int = PageQuery,
-    page_size: int = PageSizeQuery,
-    sort_by: Optional[str] = AuditLogSortByQuery,
-    sort_dir: Optional[str] = SortDirQuery,
-    search: Optional[str] = SearchQuery,
-) -> AuditDocumentList:
-    """
-    List credential audit logs
-    """
-    controller = request.state.app_container.credential_controller
-    audit_doc_list: AuditDocumentList = await controller.list_audit(
-        document_id=credential_id,
-        page=page,
-        page_size=page_size,
-        sort_by=sort_by,
-        sort_dir=sort_dir,
-        search=search,
-    )
-    return audit_doc_list
-
-
-@router.delete("/{credential_id}", status_code=HTTPStatus.OK)
-async def delete_credential(
-    request: Request,
-    credential_id: PydanticObjectId,
-) -> DeleteResponse:
-    """
-    Delete credential
-    """
-    controller = request.state.app_container.credential_controller
-    await controller.delete_credential(
-        credential_id=credential_id,
-    )
-    return DeleteResponse()
-
-
-@router.patch("/{credential_id}/description", response_model=CredentialRead)
-async def update_credential_description(
-    request: Request,
-    credential_id: PydanticObjectId,
-    data: DescriptionUpdate,
-) -> CredentialRead:
-    """
-    Update credential description
-    """
-    controller = request.state.app_container.credential_controller
-    credential: CredentialRead = await controller.update_description(
-        document_id=credential_id,
-        description=data.description,
-    )
-    return credential
+            verbose=verbose,
+        )
+        return cast(CredentialInfo, info)

--- a/featurebyte/routes/credential/api.py
+++ b/featurebyte/routes/credential/api.py
@@ -3,7 +3,7 @@ Credential API routes
 """
 from __future__ import annotations
 
-from typing import Optional, cast
+from typing import Optional
 
 from http import HTTPStatus
 

--- a/featurebyte/routes/credential/api.py
+++ b/featurebyte/routes/credential/api.py
@@ -113,7 +113,7 @@ class CredentialRouter(
             page=page,
             page_size=page_size,
             sort_by=sort_by,
-            sort_dir=sort_dir,
+            sort_dir=sort_dir,  # type: ignore[arg-type]
             search=search,
             name=name,
             query_filter={} if feature_store_id is None else {"feature_store_id": feature_store_id},

--- a/featurebyte/routes/credential/controller.py
+++ b/featurebyte/routes/credential/controller.py
@@ -82,20 +82,6 @@ class CredentialController(
         assert document is not None
         return CredentialRead(**document.dict(by_alias=True))
 
-    async def delete_credential(
-        self,
-        credential_id: PydanticObjectId,
-    ) -> None:
-        """
-        Delete credential
-
-        Parameters
-        ----------
-        credential_id: PydanticObjectId
-            ID of credential to update
-        """
-        await self.service.delete_document(document_id=credential_id)
-
     async def get_info(
         self,
         credential_id: ObjectId,

--- a/featurebyte/routes/credential/controller.py
+++ b/featurebyte/routes/credential/controller.py
@@ -9,7 +9,6 @@ from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.credential import CredentialModel
 from featurebyte.routes.common.base import BaseDocumentController
 from featurebyte.schema.credential import (
-    CredentialCreate,
     CredentialList,
     CredentialRead,
     CredentialServiceUpdate,
@@ -34,26 +33,6 @@ class CredentialController(
     ):
         super().__init__(credential_service)
         self.feature_store_service = feature_store_service
-
-    async def create_credential(
-        self,
-        data: CredentialCreate,
-    ) -> CredentialRead:
-        """
-        Create credential
-
-        Parameters
-        ----------
-        data: CredentialCreate
-            CredentialCreate object
-
-        Returns
-        -------
-        CredentialRead
-            CredentialRead object
-        """
-        document = await self.service.create_document(data=data)
-        return CredentialRead(**document.dict(by_alias=True))
 
     async def update_credential(
         self,


### PR DESCRIPTION
## Description
Refactor the common CRUD operations into a `BaseApiRouter` so that in the future, we can easily create a whole suite of basic API routes without having too many overrides, and duplicated code.

Similar to this PR in featurebyte-app - https://github.com/featurebyte/featurebyte-app/pull/627

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
