### PR TITLE
[DEV-2254] Support rprefix parameter when joining views

### DIFF
--- a/.changelog/DEV-2254.yaml
+++ b/.changelog/DEV-2254.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Support rprefix parameter in View's join method"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/item_table.py
+++ b/featurebyte/api/item_table.py
@@ -15,7 +15,7 @@ from featurebyte.api.api_object import ApiObjectT, get_api_object_cache_key
 from featurebyte.api.base_table import TableApiObject
 from featurebyte.api.event_table import EventTable
 from featurebyte.common.doc_util import FBAutoDoc
-from featurebyte.common.join_utils import append_rsuffix_to_columns
+from featurebyte.common.join_utils import apply_column_name_modifiers
 from featurebyte.common.validator import construct_data_model_root_validator
 from featurebyte.enum import DBVarType, TableDataType, ViewMode
 from featurebyte.exception import RecordRetrievalException
@@ -288,12 +288,14 @@ class ItemTable(TableApiObject):
                 event_table_id=event_table.id,
             ),
         )
-        timestamp_column = append_rsuffix_to_columns([event_view.timestamp_column], event_suffix)[0]
+        timestamp_column = apply_column_name_modifiers(
+            [event_view.timestamp_column], rsuffix=event_suffix, rprefix=None
+        )[0]
         if event_view.timestamp_timezone_offset_column is None:
             timestamp_timezone_offset_column = None
         else:
-            timestamp_timezone_offset_column = append_rsuffix_to_columns(
-                [event_view.timestamp_timezone_offset_column], event_suffix
+            timestamp_timezone_offset_column = apply_column_name_modifiers(
+                [event_view.timestamp_timezone_offset_column], rsuffix=event_suffix, rprefix=None
             )[0]
         inserted_graph_node = GlobalQueryGraph().add_node(
             view_graph_node, input_nodes=[data_node, event_view.node]

--- a/featurebyte/api/view.py
+++ b/featurebyte/api/view.py
@@ -1310,11 +1310,11 @@ class View(ProtectedColumnsQueryObject, Frame, ABC):
             will have the same number of rows as the left view. If ‘inner’ is selected, the resulting view will only
             contain rows where there is a match between the columns in both tables.
         rsuffix: str
-            The argument is used if the two views have overlapping column names and disambiguates such column
-            names after join. The default rsuffix is an empty string - ''.
+            The argument is used to disambiguate overalapping column names after join by adding the
+            suffix to the right view's column names. The default rsuffix is an empty string.
         rprefix: str
-            The argument is used if the two views have overlapping column names and disambiguates such column
-            names after join. The default rprefix is an empty string - ''.
+            The argument is used to disambiguate overalapping column names after join by adding the
+            prefix to the right view's column names. The default rprefix is an empty string.
 
         Returns
         -------

--- a/featurebyte/api/view.py
+++ b/featurebyte/api/view.py
@@ -1374,7 +1374,7 @@ class View(ProtectedColumnsQueryObject, Frame, ABC):
             "right_input_columns": right_input_columns,
             "right_output_columns": right_output_columns,
             "join_type": how,
-            "metadata": JoinMetadata(rsuffix=rsuffix),
+            "metadata": JoinMetadata(rsuffix=rsuffix, rprefix=rprefix),
         }
         node_params.update(
             other_view._get_join_parameters(self)  # pylint: disable=protected-access

--- a/featurebyte/api/view.py
+++ b/featurebyte/api/view.py
@@ -1314,7 +1314,7 @@ class View(ProtectedColumnsQueryObject, Frame, ABC):
             names after join. The default rsuffix is an empty string - ''.
         rprefix: str
             The argument is used if the two views have overlapping column names and disambiguates such column
-            names after join. The default rsuffix is an empty string - ''.
+            names after join. The default rprefix is an empty string - ''.
 
         Returns
         -------

--- a/featurebyte/common/join_utils.py
+++ b/featurebyte/common/join_utils.py
@@ -8,8 +8,33 @@ import copy
 from featurebyte.query_graph.model.column_info import ColumnInfo
 
 
-def append_rsuffix_to_column_info(
-    column_infos: List[ColumnInfo], rsuffix: Optional[str]
+def apply_modifiers_to_column_name(
+    column_name: str,
+    rsuffix: Optional[str],
+    rprefix: Optional[str],
+) -> str:
+    """
+    Updates the column name by including rsuffix and rprefix when provided
+
+    Parameters
+    ----------
+    column_name: str
+        column to update
+    rsuffix: Optional[str]
+        the suffix to attach on
+    rprefix: Optional[str]
+        the prefix to attach on
+
+    Returns
+    -------
+    str
+        Updated column name
+    """
+    return f"{rprefix if rprefix else ''}{column_name}{rsuffix if rsuffix else ''}"
+
+
+def apply_column_name_modifiers_columns_info(
+    column_infos: List[ColumnInfo], rsuffix: Optional[str], rprefix: Optional[str]
 ) -> List[ColumnInfo]:
     """
     Updates the column infos by appending the rsuffix to the column names.
@@ -20,17 +45,21 @@ def append_rsuffix_to_column_info(
         column infos to update
     rsuffix: Optional[str]
         the suffix to attach on
+    rprefix: Optional[str]
+        the prefix to attach on
 
     Returns
     -------
     List[ColumnInfo]
     """
-    if not rsuffix:
+    if rsuffix is None and rprefix is None:
         return column_infos
     updated_column_info = []
     for col_info in column_infos:
         new_col_info = col_info.copy()
-        new_col_info.name = f"{col_info.name}{rsuffix}"
+        new_col_info.name = apply_modifiers_to_column_name(
+            col_info.name, rsuffix=rsuffix, rprefix=rprefix
+        )
         updated_column_info.append(new_col_info)
     return updated_column_info
 
@@ -56,7 +85,9 @@ def filter_columns(columns: List[str], exclude_columns: List[str]) -> List[str]:
     return [col for col in columns if col not in exclude_columns_set]
 
 
-def append_rsuffix_to_columns(columns: List[str], rsuffix: Optional[str]) -> List[str]:
+def apply_column_name_modifiers(
+    columns: List[str], rsuffix: Optional[str], rprefix: Optional[str]
+) -> List[str]:
     """
     Appends the rsuffix to columns if a rsuffix is provided.
 
@@ -66,15 +97,19 @@ def append_rsuffix_to_columns(columns: List[str], rsuffix: Optional[str]) -> Lis
         columns to update
     rsuffix: Optional[str]
         the suffix to attach on
+    rprefix: Optional[str]
+        the prefix to attach on
 
     Returns
     -------
     List[str]
         updated columns with rsuffix, or original columns if none were provided
     """
-    if not rsuffix:
+    if not rsuffix and not rprefix:
         return columns
-    return [f"{col}{rsuffix}" for col in columns]
+    return [
+        apply_modifiers_to_column_name(col, rsuffix=rsuffix, rprefix=rprefix) for col in columns
+    ]
 
 
 def filter_columns_info(col_info: List[ColumnInfo], exclude_columns: List[str]) -> List[ColumnInfo]:

--- a/featurebyte/query_graph/model/table.py
+++ b/featurebyte/query_graph/model/table.py
@@ -10,8 +10,8 @@ from bson import ObjectId
 from pydantic import Field, StrictStr, parse_obj_as
 
 from featurebyte.common.join_utils import (
-    append_rsuffix_to_column_info,
-    append_rsuffix_to_columns,
+    apply_column_name_modifiers,
+    apply_column_name_modifiers_columns_info,
     combine_column_info_of_views,
     filter_columns,
 )
@@ -171,8 +171,8 @@ class ItemTableData(BaseTableData):
         # ItemView's event_id_column. There is no need to specify event_suffix if the
         # event_id_column is the only common column name between EventTable and ItemView.
         columns_excluding_event_id = filter_columns(columns_to_join, [right_on])
-        renamed_event_view_columns = append_rsuffix_to_columns(
-            columns_excluding_event_id, event_suffix
+        renamed_event_view_columns = apply_column_name_modifiers(
+            columns_excluding_event_id, rsuffix=event_suffix, rprefix=None
         )
         right_output_columns = renamed_event_view_columns
 
@@ -257,7 +257,9 @@ class ItemTableData(BaseTableData):
         renamed_event_view_columns = join_parameters.right_output_columns
         joined_columns_info = combine_column_info_of_views(
             item_view_columns_info,
-            append_rsuffix_to_column_info(event_view_columns_info, rsuffix=event_suffix),
+            apply_column_name_modifiers_columns_info(
+                event_view_columns_info, rsuffix=event_suffix, rprefix=None
+            ),
             filter_set=set(renamed_event_view_columns),
         )
         return node, joined_columns_info, join_parameters

--- a/featurebyte/query_graph/node/generic.py
+++ b/featurebyte/query_graph/node/generic.py
@@ -953,6 +953,14 @@ class JoinMetadata(BaseModel):
 
     type: str = Field("join", const=True)
     rsuffix: str
+    rprefix: str
+
+    @root_validator(pre=True)
+    @classmethod
+    def _backward_compat_fill_rprefix(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        if values.get("rprefix") is None:
+            values["rprefix"] = ""
+        return values
 
 
 class JoinEventTableAttributesMetadata(BaseModel):
@@ -1173,7 +1181,8 @@ class JoinNode(BasePrunableNode):
                 f"{var_name}.join({other_var_name}, "
                 f"on={ValueStr.create(self.parameters.left_on)}, "
                 f"how={ValueStr.create(self.parameters.join_type)}, "
-                f"rsuffix={ValueStr.create(self.parameters.metadata.rsuffix)})"
+                f"rsuffix={ValueStr.create(self.parameters.metadata.rsuffix)}, "
+                f"rprefix={ValueStr.create(self.parameters.metadata.rprefix)})"
             )
         else:
             expression = ExpressionStr(

--- a/tests/fixtures/expected_tile_sql_complex_feature_push_down_eligible.sql
+++ b/tests/fixtures/expected_tile_sql_complex_feature_push_down_eligible.sql
@@ -1,7 +1,7 @@
 SELECT
   index,
   "cust_id",
-  SUM("added_feature") AS value_sum_135378d8fda24b22b1987e8f97c82334823c50c7
+  SUM("added_feature") AS value_sum_71d3b2ce9e4497e987580c14c572df2f82fb1d2a
 FROM (
   SELECT
     *,

--- a/tests/fixtures/sdk_code/event_view_with_tz_offset_column.py
+++ b/tests/fixtures/sdk_code/event_view_with_tz_offset_column.py
@@ -16,9 +16,11 @@ event_view = event_table.get_view(
     drop_column_names=["created_at"],
     column_cleaning_operations=[],
 )
-joined_view = event_view.join(view, on="col_int", how="left", rsuffix="")
-col = joined_view["tz_offset"]
-col_1 = joined_view["event_timestamp"]
+joined_view = event_view.join(
+    view, on="col_int", how="left", rsuffix="", rprefix=""
+)
+col = joined_view["event_timestamp"]
+col_1 = joined_view["tz_offset"]
 view_1 = joined_view.copy()
-view_1["event_timestamp_hour"] = col_1.dt.tz_offset(col).hour
+view_1["event_timestamp_hour"] = col.dt.tz_offset(col_1).hour
 output = view_1

--- a/tests/unit/api/test_join_utils.py
+++ b/tests/unit/api/test_join_utils.py
@@ -4,8 +4,8 @@ Test join utils class
 from bson import ObjectId
 
 from featurebyte.common.join_utils import (
-    append_rsuffix_to_column_info,
-    append_rsuffix_to_columns,
+    apply_column_name_modifiers,
+    apply_column_name_modifiers_columns_info,
     combine_column_info_of_views,
     filter_columns,
     filter_columns_info,
@@ -52,7 +52,7 @@ def test_filter_join_key_from_column_info():
 
 def test_append_rsuffix_to_column_info():
     """
-    Test append_rsuffix_to_column_info
+    Test apply_column_name_modifiers_columns_info
     """
     col_a_string = "colA"
     col_b_string = "colB"
@@ -63,7 +63,7 @@ def test_append_rsuffix_to_column_info():
 
     # Append w/ suffix
     suffix = "hello"
-    output = append_rsuffix_to_column_info([col_info_a, col_info_b], suffix)
+    output = apply_column_name_modifiers_columns_info([col_info_a, col_info_b], suffix, None)
     assert len(output) == 2
     assert output[0].name == f"{col_a_string}{suffix}"
     assert output[1].name == f"{col_b_string}{suffix}"
@@ -73,28 +73,60 @@ def test_append_rsuffix_to_column_info():
 
     # Append w/ suffix as empty string
     suffix = ""
-    output = append_rsuffix_to_column_info([col_info_a, col_info_b], suffix)
+    output = apply_column_name_modifiers_columns_info([col_info_a, col_info_b], suffix, None)
     assert len(output) == 2
     assert output[0].name == col_a_string
     assert output[1].name == col_b_string
 
     # Append w/ suffix as None
-    output = append_rsuffix_to_column_info([col_info_a, col_info_b], None)
+    output = apply_column_name_modifiers_columns_info([col_info_a, col_info_b], None, None)
     assert len(output) == 2
     assert output[0].name == col_a_string
     assert output[1].name == col_b_string
 
 
-def test_append_rsuffix_to_columns():
+def test_prepend_rprefix_to_column_info():
     """
-    Test _append_rsuffix_to_columns
+    Test apply_column_name_modifiers_columns_info
+    """
+    col_a_string = "colA"
+    col_b_string = "colB"
+    col_info_a, col_info_b = (
+        ColumnInfo(name=col_a_string, dtype=DBVarType.INT),
+        ColumnInfo(name=col_b_string, dtype=DBVarType.INT),
+    )
+
+    # Append w/ suffix
+    prefix = "hello"
+    output = apply_column_name_modifiers_columns_info([col_info_a, col_info_b], None, prefix)
+    assert len(output) == 2
+    assert output[0].name == f"{prefix}{col_a_string}"
+    assert output[1].name == f"{prefix}{col_b_string}"
+    # Assert that original col_info's aren't changed
+    col_info_a.name = col_a_string
+    col_info_b.name = col_b_string
+
+    # Append w/ suffix as empty string
+    prefix = ""
+    output = apply_column_name_modifiers_columns_info([col_info_a, col_info_b], prefix, None)
+    assert len(output) == 2
+    assert output[0].name == col_a_string
+    assert output[1].name == col_b_string
+
+
+def test_apply_column_name_modifiers():
+    """
+    Test apply_column_name_modifiers
     """
     columns = ["col_a", "col_b", "col_c"]
-    results = append_rsuffix_to_columns(columns, "")
+    results = apply_column_name_modifiers(columns, "", None)
     assert columns == results
 
-    results = append_rsuffix_to_columns(columns, "r")
+    results = apply_column_name_modifiers(columns, "r", None)
     assert results == ["col_ar", "col_br", "col_cr"]
+
+    results = apply_column_name_modifiers(columns, "_r", "l_")
+    assert results == ["l_col_a_r", "l_col_b_r", "l_col_c_r"]
 
 
 def get_pydantic_object_id(id_str: str) -> PydanticObjectId:

--- a/tests/unit/api/test_join_utils.py
+++ b/tests/unit/api/test_join_utils.py
@@ -96,7 +96,7 @@ def test_prepend_rprefix_to_column_info():
         ColumnInfo(name=col_b_string, dtype=DBVarType.INT),
     )
 
-    # Append w/ suffix
+    # Add prefix
     prefix = "hello"
     output = apply_column_name_modifiers_columns_info([col_info_a, col_info_b], None, prefix)
     assert len(output) == 2
@@ -106,9 +106,9 @@ def test_prepend_rprefix_to_column_info():
     col_info_a.name = col_a_string
     col_info_b.name = col_b_string
 
-    # Append w/ suffix as empty string
+    # Add prefix as empty string
     prefix = ""
-    output = apply_column_name_modifiers_columns_info([col_info_a, col_info_b], prefix, None)
+    output = apply_column_name_modifiers_columns_info([col_info_a, col_info_b], None, prefix)
     assert len(output) == 2
     assert output[0].name == col_a_string
     assert output[1].name == col_b_string

--- a/tests/unit/api/test_scd_view.py
+++ b/tests/unit/api/test_scd_view.py
@@ -134,7 +134,7 @@ def test_event_view_join_scd_view(
             "end_timestamp_column": "end_timestamp",
             "left_timestamp_column": "event_timestamp",
         },
-        "metadata": {"type": "join", "rsuffix": "_scd"},
+        "metadata": {"type": "join", "rsuffix": "_scd", "rprefix": ""},
     }
 
     # check SDK code generation

--- a/tests/unit/api/test_view.py
+++ b/tests/unit/api/test_view.py
@@ -343,15 +343,15 @@ def test_join__left_join(generic_input_node_params, join_type_param):
 
     # do the join
     joined_view = current_view.join(
-        other_view, on=col_info_a.name, how=join_type_param, rsuffix="suffix"
+        other_view, on=col_info_a.name, how=join_type_param, rsuffix="suffix", rprefix="_"
     )
 
     # assert updated view params
     assert joined_view.columns_info == [
         col_info_a,
         col_info_b,
-        ColumnInfo(name="colDsuffix", dtype=DBVarType.INT),
-        ColumnInfo(name="colEsuffix", dtype=DBVarType.INT),
+        ColumnInfo(name="_colDsuffix", dtype=DBVarType.INT),
+        ColumnInfo(name="_colEsuffix", dtype=DBVarType.INT),
     ]
     assert joined_view.node_name == "join_1"
 
@@ -368,9 +368,9 @@ def test_join__left_join(generic_input_node_params, join_type_param):
             "left_output_columns": ["colA", "colB"],
             "right_input_columns": ["colD", "colE"],
             "right_on": "colC",
-            "right_output_columns": ["colDsuffix", "colEsuffix"],
+            "right_output_columns": ["_colDsuffix", "_colEsuffix"],
             "scd_parameters": None,
-            "metadata": {"type": "join", "rsuffix": "suffix"},
+            "metadata": {"type": "join", "rsuffix": "suffix", "rprefix": "_"},
         },
         "type": "join",
     }

--- a/tests/unit/api/test_view.py
+++ b/tests/unit/api/test_view.py
@@ -454,6 +454,9 @@ def test_validate_join__multiple_overlapping_columns():
     # multiple overlapping column names should not throw an error if suffix is provided
     base_view._validate_join(view_with_multiple_overlapping, rsuffix="suffix")
 
+    # also ok if prefix is provided
+    base_view._validate_join(view_with_multiple_overlapping, rprefix="prefix")
+
 
 def test_validate_join__check_on_column():
     """

--- a/tests/unit/query_graph/test_graph_pruning.py
+++ b/tests/unit/query_graph/test_graph_pruning.py
@@ -202,7 +202,7 @@ def test_join_with_assign_node__join_node_parameters_pruning(
         "right_output_columns": ["item_type", "item_name"],
         "join_type": "inner",
         "scd_parameters": None,
-        "metadata": {"type": "join", "rsuffix": ""},
+        "metadata": {"type": "join", "rsuffix": "", "rprefix": ""},
     }
     join_node = global_graph.add_operation(
         node_type=NodeType.JOIN,


### PR DESCRIPTION
## Description

This adds a `rprefix` parameter to the `join()` method for views. It behaves similarly as `rsuffix` but modifies the right columns by adding a prefix.

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-2254

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
