### PR TITLE
[chore] deployment: rm unused get_credential param

### DIFF
--- a/featurebyte/routes/deployment/api.py
+++ b/featurebyte/routes/deployment/api.py
@@ -161,7 +161,6 @@ async def compute_online_features(
     result = await controller.compute_online_features(
         deployment_id=deployment_id,
         data=data,
-        get_credential=request.state.get_credential,
     )
     return cast(OnlineFeaturesResponseModel, result)
 

--- a/featurebyte/routes/deployment/controller.py
+++ b/featurebyte/routes/deployment/controller.py
@@ -3,7 +3,7 @@ Deployment API route controller
 """
 from __future__ import annotations
 
-from typing import Any, Literal, Optional
+from typing import Literal, Optional
 
 from http import HTTPStatus
 

--- a/featurebyte/routes/deployment/controller.py
+++ b/featurebyte/routes/deployment/controller.py
@@ -180,7 +180,6 @@ class DeploymentController(
         self,
         deployment_id: ObjectId,
         data: OnlineFeaturesRequestPayload,
-        get_credential: Any,
     ) -> OnlineFeaturesResponseModel:
         """
         Compute online features for a given deployment ID.
@@ -191,8 +190,6 @@ class DeploymentController(
             ID of deployment to compute online features
         data: OnlineFeaturesRequestPayload
             Online features request payload
-        get_credential: Any
-            Get credential handler function
 
         Returns
         -------
@@ -209,7 +206,6 @@ class DeploymentController(
             result = await self.online_serving_service.get_online_features_from_feature_list(
                 feature_list=feature_list,
                 request_data=data.entity_serving_names,
-                get_credential=get_credential,
             )
         except (FeatureListNotOnlineEnabledError, RuntimeError) as exc:
             raise HTTPException(

--- a/featurebyte/service/deploy.py
+++ b/featurebyte/service/deploy.py
@@ -178,7 +178,6 @@ class DeployService(OpsServiceMixin):
         feature_list_id: ObjectId,
         deployed: bool,
         feature_online_enabled_map: dict[PydanticObjectId, bool],
-        get_credential: Any,
     ) -> None:
         # revert feature list deploy status
         feature_list = await self.feature_list_service.update_document(
@@ -198,7 +197,6 @@ class DeployService(OpsServiceMixin):
             await self.online_enable_service.update_data_warehouse(
                 updated_feature=document,
                 online_enabled_before_update=online_enabled,
-                get_credential=get_credential,
             )
 
         # update feature list namespace again
@@ -211,7 +209,6 @@ class DeployService(OpsServiceMixin):
     async def _update_feature_list(
         self,
         feature_list_id: ObjectId,
-        get_credential: Any,
         update_progress: Optional[Callable[[int, str | None], Coroutine[Any, Any, None]]] = None,
     ) -> FeatureListModel:
         """
@@ -221,8 +218,6 @@ class DeployService(OpsServiceMixin):
         ----------
         feature_list_id: ObjectId
             Target feature list ID
-        get_credential: Any
-            Get credential handler function
         update_progress: Callable[[int, str | None], Coroutine[Any, Any, None]]
             Update progress handler function
 
@@ -278,7 +273,6 @@ class DeployService(OpsServiceMixin):
                         await self.online_enable_service.update_data_warehouse(
                             updated_feature=updated_feature,
                             online_enabled_before_update=feature.online_enabled,
-                            get_credential=get_credential,
                         )
 
                     if update_progress:
@@ -303,7 +297,6 @@ class DeployService(OpsServiceMixin):
                         feature_list_id=feature_list_id,
                         deployed=original_deployed,
                         feature_online_enabled_map=feature_online_enabled_map,
-                        get_credential=get_credential,
                     )
                 except Exception as revert_exc:
                     raise revert_exc from exc
@@ -317,7 +310,6 @@ class DeployService(OpsServiceMixin):
         deployment_id: ObjectId,
         deployment_name: Optional[str],
         to_enable_deployment: bool,
-        get_credential: Any,
         update_progress: Optional[Callable[[int, str | None], Coroutine[Any, Any, None]]] = None,
         use_case_id: Optional[ObjectId] = None,
         context_id: Optional[ObjectId] = None,
@@ -335,8 +327,6 @@ class DeployService(OpsServiceMixin):
             Deployment name
         to_enable_deployment: bool
             Whether to enable deployment
-        get_credential: Any
-            Get credential handler function
         update_progress: Callable[[int, str | None], Coroutine[Any, Any, None]]
             Update progress handler function
         use_case_id: ObjectId
@@ -366,7 +356,6 @@ class DeployService(OpsServiceMixin):
             )
             await self._update_feature_list(
                 feature_list_id=feature_list_id,
-                get_credential=get_credential,
                 update_progress=update_progress,
             )
         except Exception as exc:
@@ -382,7 +371,6 @@ class DeployService(OpsServiceMixin):
         self,
         deployment_id: ObjectId,
         enabled: bool,
-        get_credential: Any,
         update_progress: Optional[Callable[[int, str | None], Coroutine[Any, Any, None]]] = None,
     ) -> None:
         """
@@ -394,8 +382,6 @@ class DeployService(OpsServiceMixin):
             Deployment ID
         enabled: bool
             Enabled status
-        get_credential: Any
-            Get credential handler function
         update_progress: Callable[[int, str | None], Coroutine[Any, Any, None]]
             Update progress handler function
 
@@ -414,7 +400,6 @@ class DeployService(OpsServiceMixin):
                 )
                 await self._update_feature_list(
                     feature_list_id=deployment.feature_list_id,
-                    get_credential=get_credential,
                     update_progress=update_progress,
                 )
             except Exception as exc:

--- a/featurebyte/service/online_enable.py
+++ b/featurebyte/service/online_enable.py
@@ -3,7 +3,7 @@ OnlineEnableService class
 """
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Optional
 
 from bson.objectid import ObjectId
 

--- a/featurebyte/service/online_enable.py
+++ b/featurebyte/service/online_enable.py
@@ -168,7 +168,7 @@ class OnlineEnableService(OpsServiceMixin):
             await feature_manager_service.online_disable(session, online_feature_spec)
 
     async def update_data_warehouse(
-        self, updated_feature: FeatureModel, online_enabled_before_update: bool, get_credential: Any
+        self, updated_feature: FeatureModel, online_enabled_before_update: bool
     ) -> None:
         """
         Update data warehouse registry upon changes to online enable status, such as enabling or
@@ -180,8 +180,6 @@ class OnlineEnableService(OpsServiceMixin):
             Updated Feature
         online_enabled_before_update: bool
             Online enabled status
-        get_credential: Any
-            Get credential handler function
 
         Raises
         ------
@@ -198,7 +196,7 @@ class OnlineEnableService(OpsServiceMixin):
         )
         try:
             session = await self.session_manager_service.get_feature_store_session(
-                feature_store_model, get_credential
+                feature_store_model
             )
         except CredentialsError as exc:
             if updated_feature.online_enabled:

--- a/featurebyte/service/online_serving.py
+++ b/featurebyte/service/online_serving.py
@@ -40,7 +40,6 @@ class OnlineServingService:
         self,
         feature_list: FeatureListModel,
         request_data: Union[List[Dict[str, Any]], BatchRequestTableModel],
-        get_credential: Any,
         output_table_details: Optional[TableDetails] = None,
     ) -> Optional[OnlineFeaturesResponseModel]:
         """
@@ -52,8 +51,6 @@ class OnlineServingService:
             Feature List
         request_data: Union[List[Dict[str, Any]], BatchRequestTableModel]
             Request data containing entity serving names
-        get_credential: Any
-            Get credential handler
         output_table_details: Optional[TableDetails]
             Output table details
 
@@ -98,7 +95,6 @@ class OnlineServingService:
 
         db_session = await self.session_manager_service.get_feature_store_session(
             feature_store=feature_store,
-            get_credential=get_credential,
         )
         features = await get_online_features(
             session=db_session,

--- a/featurebyte/worker/task/batch_feature_table.py
+++ b/featurebyte/worker/task/batch_feature_table.py
@@ -71,7 +71,6 @@ class BatchFeatureTableTask(DataWarehouseMixin, BaseTask):
             await online_serving_service.get_online_features_from_feature_list(
                 feature_list=feature_list,
                 request_data=batch_request_table_model,
-                get_credential=self.get_credential,
                 output_table_details=location.table_details,
             )
             (

--- a/featurebyte/worker/task/deployment_create_update.py
+++ b/featurebyte/worker/task/deployment_create_update.py
@@ -75,7 +75,6 @@ class DeploymentCreateUpdateTask(BaseLockTask):
                 deployment_id=payload.output_document_id,
                 deployment_name=create_deployment_payload.name,
                 to_enable_deployment=create_deployment_payload.enabled,
-                get_credential=self.get_credential,
                 update_progress=self.update_progress,
                 use_case_id=create_deployment_payload.use_case_id,
                 context_id=create_deployment_payload.context_id,
@@ -86,6 +85,5 @@ class DeploymentCreateUpdateTask(BaseLockTask):
             await self.app_container.deploy_service.update_deployment(
                 deployment_id=payload.output_document_id,
                 enabled=update_deployment_payload.enabled,
-                get_credential=self.get_credential,
                 update_progress=self.update_progress,
             )

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -608,7 +608,6 @@ async def deployed_feature_list_fixture(
         deployment_id=ObjectId(),
         deployment_name="test-deployment",
         to_enable_deployment=True,
-        get_credential=Mock(),
     )
     updated_feature_list = await feature_list_service.get_document(
         document_id=production_ready_feature_list.id

--- a/tests/unit/service/test_deploy.py
+++ b/tests/unit/service/test_deploy.py
@@ -1,7 +1,7 @@
 """
 Tests for DeployService
 """
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio

--- a/tests/unit/service/test_deploy.py
+++ b/tests/unit/service/test_deploy.py
@@ -21,7 +21,6 @@ async def disabled_deployment_fixture(app_container, feature_list):
         deployment_id=deployment_id,
         deployment_name=None,
         to_enable_deployment=False,
-        get_credential=Mock(),
     )
     deployment = await app_container.deployment_service.get_document(document_id=deployment_id)
     assert deployment.enabled is False
@@ -49,7 +48,6 @@ async def test_create_enabled_deployment__not_all_features_are_online_enabled(
             deployment_id=deployment_id,
             deployment_name=None,
             to_enable_deployment=True,
-            get_credential=Mock(),
         )
 
     expected_msg = "Only FeatureList object of all production ready features can be deployed."
@@ -67,7 +65,7 @@ async def test_update_deployment__not_all_features_are_online_enabled(
     """Test update deployment (not all features are online enabled validation error)"""
     with pytest.raises(DocumentError) as exc:
         await app_container.deploy_service.update_deployment(
-            deployment_id=disabled_deployment.id, enabled=True, get_credential=Mock()
+            deployment_id=disabled_deployment.id, enabled=True
         )
 
     expected_msg = "Only FeatureList object of all production ready features can be deployed."
@@ -84,7 +82,7 @@ async def test_update_deployment__not_all_features_are_online_enabled(
 async def test_update_deployment__no_update(app_container, disabled_deployment):
     """Test update feature list when deployed status is the same"""
     await app_container.deploy_service.update_deployment(
-        deployment_id=disabled_deployment.id, enabled=False, get_credential=Mock()
+        deployment_id=disabled_deployment.id, enabled=False
     )
 
     # check that deployment is not updated
@@ -137,7 +135,6 @@ async def disabled_deployment_with_prod_ready_features(
         deployment_id=deployment_id,
         deployment_name=None,
         to_enable_deployment=False,
-        get_credential=Mock(),
     )
     deployment = await app_container.deployment_service.get_document(document_id=deployment_id)
     assert deployment.enabled is False
@@ -159,7 +156,6 @@ async def test_update_deployment(
         deployment_id=deployment_id,
         deployment_name=None,
         to_enable_deployment=True,
-        get_credential=Mock(),
     )
     deployment = await app_container.deployment_service.get_document(document_id=deployment_id)
     deployed_feature_list = await app_container.feature_list_service.get_document(
@@ -182,7 +178,6 @@ async def test_update_deployment(
     await app_container.deploy_service.update_deployment(
         deployment_id=deployment_id,
         enabled=False,
-        get_credential=Mock(),
     )
     deployed_disabled_feature_list = await app_container.feature_list_service.get_document(
         document_id=deployment.feature_list_id
@@ -215,7 +210,6 @@ async def test_update_deployment(
         await app_container.deploy_service.update_deployment(
             deployment_id=deployment.id,
             enabled=True,
-            get_credential=Mock(),
         )
 
     expected_msg = "Deprecated feature list cannot be deployed."
@@ -240,7 +234,6 @@ async def test_update_deployment_error__state_is_reverted_when_update_feature_li
             _ = await app_container.deploy_service.update_deployment(
                 deployment_id=disabled_deployment_with_production_ready_features.id,
                 enabled=True,
-                get_credential=Mock(),
             )
 
         # check exception message
@@ -280,7 +273,6 @@ async def test_update_deployment_error__state_is_reverted_when_update_feature_is
             _ = await app_container.deploy_service.update_deployment(
                 deployment_id=disabled_deployment_with_production_ready_features.id,
                 enabled=True,
-                get_credential=Mock(),
             )
 
         # check exception message
@@ -334,7 +326,6 @@ async def test_update_feature_list_error__state_is_reverted_after_feature_list_n
     with pytest.raises(ValueError) as exc:
         _ = await deploy_service._update_feature_list(
             feature_list_id=feature_list.id,
-            get_credential=AsyncMock(),
             update_progress=fake_update_progress,
         )
 
@@ -357,7 +348,6 @@ async def test_update_feature_list_error__state_is_reverted_after_feature_list_n
             mock_update_feature.side_effect = Exception("Error during revert changes")
             _ = await deploy_service._update_feature_list(
                 feature_list_id=feature_list.id,
-                get_credential=AsyncMock(),
                 update_progress=fake_update_progress,
             )
 

--- a/tests/unit/service/test_feature_list_status.py
+++ b/tests/unit/service/test_feature_list_status.py
@@ -1,7 +1,6 @@
 """
 Test the feature list status service.
 """
-from unittest.mock import Mock
 
 import pytest
 import pytest_asyncio
@@ -37,7 +36,6 @@ async def feature_list_namespace_deployed_fixture(
         deployment_id=ObjectId(),
         deployment_name="test_deployment",
         to_enable_deployment=True,
-        get_credential=Mock(),
     )
     namespace = await feature_list_namespace_service.get_document(document_id=namespace.id)
     assert namespace.status == FeatureListStatus.DEPLOYED
@@ -153,7 +151,6 @@ async def test_feature_list_status__deployed_feature_namespace_transit_to_public
         await deploy_service.update_deployment(
             deployment_id=deployment["_id"],
             enabled=False,
-            get_credential=Mock(),
         )
 
     namespace = await feature_list_namespace_service.get_document(

--- a/tests/unit/service/test_online_serving.py
+++ b/tests/unit/service/test_online_serving.py
@@ -39,7 +39,6 @@ async def test_feature_list_not_deployed(
         await online_serving_service.get_online_features_from_feature_list(
             feature_list=feature_list,
             request_data=entity_serving_names,
-            get_credential=Mock(),
         )
     assert str(exc.value) == "Feature List is not online enabled"
 
@@ -53,7 +52,6 @@ async def test_missing_entity_error(online_serving_service, deployed_feature_lis
         await online_serving_service.get_online_features_from_feature_list(
             feature_list=deployed_feature_list,
             request_data=[{"wrong_entity": 123}],
-            get_credential=Mock(),
         )
     expected = (
         'Required entities are not provided in the request: customer (serving name: "cust_id")'
@@ -161,7 +159,6 @@ async def test_feature_list_deployed(
         result = await online_serving_service.get_online_features_from_feature_list(
             feature_list=deployed_feature_list,
             request_data=entity_serving_names,
-            get_credential=Mock(),
         )
 
     # Check result
@@ -191,7 +188,6 @@ async def test_feature_list_deployed_with_output_table(
         await online_serving_service.get_online_features_from_feature_list(
             feature_list=deployed_feature_list,
             request_data=entity_serving_names,
-            get_credential=Mock(),
             output_table_details=TableDetails(
                 database_name="output_db_name",
                 schema_name="output_schema_name",
@@ -249,7 +245,6 @@ async def test_feature_list_deployed_with_batch_request_table(
         await online_serving_service.get_online_features_from_feature_list(
             feature_list=deployed_feature_list,
             request_data=batch_request_table,
-            get_credential=Mock(),
             output_table_details=TableDetails(
                 database_name="some_database", schema_name="some_schema", table_name="some_table"
             ),


### PR DESCRIPTION
## Description
Remove the unused `get_credential` param as we now read the credential from the mongo backed credential provider.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
