### PR TITLE
[chore] Remove unnecessary columns from entity tracking tables

### DIFF
--- a/featurebyte/sql/tile_generate_entity_tracking.py
+++ b/featurebyte/sql/tile_generate_entity_tracking.py
@@ -59,8 +59,15 @@ class TileGenerateEntityTracking(BaseSqlModel):
         # create table or insert new records or update existing records
         tile_last_start_date_column = InternalName.TILE_LAST_START_DATE
         if not tracking_table_exist_flag:
+            cols = ", ".join(
+                [
+                    self.quote_column(col)
+                    for col in self.entity_column_names + [tile_last_start_date_column]
+                ]
+            )
+            entity_table = f"select {cols} from ({self.entity_table})"
             create_sql = construct_create_table_query(
-                tracking_table_name, self.entity_table, session=self._session
+                tracking_table_name, entity_table, session=self._session
             )
             await retry_sql(self._session, create_sql)
         else:

--- a/tests/integration/tile/test_tile_cache.py
+++ b/tests/integration/tile/test_tile_cache.py
@@ -86,6 +86,10 @@ async def invoke_tile_manager_and_check_tracker_table(session, tile_cache, reque
 
         # The üser id column should be the primary key (unique) of the tracker table
         assert (df_entity_tracker["üser id".upper()].value_counts(dropna=False) == 1).all()
+        assert df_entity_tracker.columns.tolist() == [
+            "üser id".upper(),
+            InternalName.TILE_LAST_START_DATE.value,
+        ]
 
 
 @pytest.mark.parametrize("source_type", ["snowflake", "spark"], indirect=True)


### PR DESCRIPTION
## Description

This avoids adding columns such as `__FB_ENTITY_TABLE_END_DATE` and `__FB_ENTITY_TABLE_START_DATE` to the entity tracking tables. It's not required to persist these columns and they are actually never updated after table creation.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
