### PR TITLE
[chore] get_credential: rm from task, and request.state

### DIFF
--- a/featurebyte/app.py
+++ b/featurebyte/app.py
@@ -72,9 +72,6 @@ def _dep_injection_func(
     """
     request.state.persistent = get_persistent()
     request.state.user = User()
-    request.state.get_credential = MongoBackedCredentialProvider(
-        persistent=request.state.persistent
-    ).get_credential
     request.state.app_container = LazyAppContainer(
         user=request.state.user,
         persistent=request.state.persistent,

--- a/featurebyte/app.py
+++ b/featurebyte/app.py
@@ -48,7 +48,6 @@ from featurebyte.routes.use_case.api import UseCaseRouter
 from featurebyte.routes.user_defined_function.api import UserDefinedFunctionRouter
 from featurebyte.schema import APIServiceStatus
 from featurebyte.schema.task import TaskId
-from featurebyte.utils.credential import MongoBackedCredentialProvider
 from featurebyte.utils.messaging import REDIS_URI
 from featurebyte.utils.persistent import get_persistent
 from featurebyte.utils.storage import get_storage, get_temp_storage

--- a/featurebyte/routes/feature_store/api.py
+++ b/featurebyte/routes/feature_store/api.py
@@ -171,7 +171,6 @@ class FeatureStoreRouter(
         controller = request.state.app_container.feature_store_controller
         result: List[str] = await controller.list_databases(
             feature_store=feature_store,
-            get_credential=request.state.get_credential,
         )
         return result
 

--- a/featurebyte/routes/feature_store/controller.py
+++ b/featurebyte/routes/feature_store/controller.py
@@ -3,7 +3,7 @@ FeatureStore API route controller
 """
 from __future__ import annotations
 
-from typing import Any, List
+from typing import Any, List, Optional
 
 from bson.objectid import ObjectId
 
@@ -159,7 +159,7 @@ class FeatureStoreController(
     async def list_databases(
         self,
         feature_store: FeatureStoreModel,
-        get_credential: Any,
+        get_credential: Optional[Any] = None,
     ) -> List[str]:
         """
         List databases accessible by the feature store
@@ -168,7 +168,7 @@ class FeatureStoreController(
         ----------
         feature_store: FeatureStoreModel
             FeatureStoreModel object
-        get_credential: Any
+        get_credential: Optional[Any]
             Get credential handler function
 
         Returns

--- a/featurebyte/service/feature_store_warehouse.py
+++ b/featurebyte/service/feature_store_warehouse.py
@@ -5,7 +5,7 @@ We split this into a separate service, as these typically require a session obje
 """
 from __future__ import annotations
 
-from typing import Any, List
+from typing import Any, List, Optional
 
 from featurebyte.exception import DatabaseNotFoundError, SchemaNotFoundError, TableNotFoundError
 from featurebyte.models.feature_store import FeatureStoreModel
@@ -49,7 +49,7 @@ class FeatureStoreWarehouseService:
         await db_session.check_user_defined_function(user_defined_function=user_defined_function)
 
     async def list_databases(
-        self, feature_store: FeatureStoreModel, get_credential: Any
+        self, feature_store: FeatureStoreModel, get_credential: Optional[Any]
     ) -> List[str]:
         """
         List databases in feature store
@@ -58,7 +58,7 @@ class FeatureStoreWarehouseService:
         ----------
         feature_store: FeatureStoreModel
             FeatureStoreModel object
-        get_credential: Any
+        get_credential: Optional[Any]
             Get credential handler function
 
         Returns

--- a/featurebyte/worker/task/base.py
+++ b/featurebyte/worker/task/base.py
@@ -36,14 +36,12 @@ class BaseTask:  # pylint: disable=too-many-instance-attributes
         task_id: UUID,
         payload: dict[str, Any],
         progress: Any,
-        get_credential: Any,
         app_container: LazyAppContainer,
     ):
         if self.payload_class == BaseTaskPayload:
             raise NotImplementedError
         self.task_id = task_id
         self.payload = self.payload_class(**payload)
-        self.get_credential = get_credential
         self.progress = progress
         self.app_container = app_container
 

--- a/featurebyte/worker/task/mixin.py
+++ b/featurebyte/worker/task/mixin.py
@@ -3,7 +3,7 @@ Mixin classes for tasks
 """
 from __future__ import annotations
 
-from typing import Any, AsyncIterator, Callable
+from typing import AsyncIterator
 
 from contextlib import asynccontextmanager
 
@@ -25,7 +25,6 @@ class DataWarehouseMixin:
 
     payload: BaseTaskPayload
     app_container: LazyAppContainer
-    get_credential: Callable[..., Any]
 
     async def get_db_session(self, feature_store: FeatureStoreModel) -> BaseSession:
         """

--- a/featurebyte/worker/task_executor.py
+++ b/featurebyte/worker/task_executor.py
@@ -24,7 +24,6 @@ from featurebyte.models.base import User
 from featurebyte.models.task import Task as TaskModel
 from featurebyte.routes.lazy_app_container import LazyAppContainer
 from featurebyte.routes.registry import app_container_config
-from featurebyte.utils.credential import MongoBackedCredentialProvider
 from featurebyte.utils.messaging import Progress
 from featurebyte.utils.persistent import get_persistent
 from featurebyte.utils.storage import get_storage, get_temp_storage
@@ -103,7 +102,6 @@ class TaskExecutor:
     def __init__(self, payload: dict[str, Any], task_id: UUID, progress: Any = None) -> None:
         self.task_id = task_id
         command = self.command_type(payload["command"])
-        credential_provider = MongoBackedCredentialProvider(persistent=get_persistent())
         user = User(id=payload.get("user_id"))
         task_class = TASK_MAP[command]
         payload_object = task_class.payload_class(**payload)
@@ -121,7 +119,6 @@ class TaskExecutor:
             task_id=task_id,
             payload=payload,
             progress=progress,
-            get_credential=credential_provider.get_credential,
             app_container=app_container,
         )
         self._setup_worker_config()

--- a/tests/integration/api/test_feature_store_operations.py
+++ b/tests/integration/api/test_feature_store_operations.py
@@ -17,9 +17,7 @@ from featurebyte.service.session_validator import SessionValidatorService
 @pytest.mark.skip(reason="skipping while we rollback the default state")
 @pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
 @pytest.mark.asyncio
-async def test_feature_store_create__no_writes_on_error(
-    mongo_persistent, feature_store_details, get_cred
-):
+async def test_feature_store_create__no_writes_on_error(mongo_persistent, feature_store_details):
     """
     Test that nothing is written to mongo if we error halfway through
     while interacting with snowflake
@@ -30,7 +28,6 @@ async def test_feature_store_create__no_writes_on_error(
         feature_store_name: str,
         session_type: SourceType,
         details: DatabaseDetails,
-        get_credential: Any,
         users_feature_store_id: Optional[PydanticObjectId],
     ):
         raise FeatureStoreSchemaCollisionError

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1327,7 +1327,7 @@ def mock_app_callbacks(storage, temp_storage):
 
 
 @pytest.fixture(autouse=True, scope="module")
-def mock_task_manager(request, persistent, storage, temp_storage, get_cred, mock_app_callbacks):
+def mock_task_manager(request, persistent, storage, temp_storage, mock_app_callbacks):
     """
     Mock celery task manager for testing
     """
@@ -1347,7 +1347,6 @@ def mock_task_manager(request, persistent, storage, temp_storage, get_cred, mock
                     task_id=UUID(task_id),
                     payload=kwargs,
                     progress=Mock(),
-                    get_credential=get_cred,
                     app_container=LazyAppContainer(
                         user=user,
                         persistent=persistent,

--- a/tests/unit/api/test_feature_list.py
+++ b/tests/unit/api/test_feature_list.py
@@ -24,7 +24,7 @@ from featurebyte.exception import (
     RecordUpdateException,
 )
 from featurebyte.models.feature_list import FeatureListStatus
-from featurebyte.models.feature_namespace import DefaultVersionMode, FeatureReadiness
+from featurebyte.models.feature_namespace import FeatureReadiness
 from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1583,7 +1583,7 @@ def get_credential_fixture(credentials):
 
 
 @pytest.fixture(autouse=True, scope="function")
-def mock_task_manager(request, persistent, storage, temp_storage, get_credential):
+def mock_task_manager(request, persistent, storage, temp_storage):
     """
     Mock celery task manager for testing
     """
@@ -1602,7 +1602,6 @@ def mock_task_manager(request, persistent, storage, temp_storage, get_credential
                     task_id=UUID(task_id),
                     payload=kwargs,
                     progress=Mock(),
-                    get_credential=get_credential,
                     app_container=LazyAppContainer(
                         user=user,
                         persistent=persistent,

--- a/tests/unit/worker/task/base.py
+++ b/tests/unit/worker/task/base.py
@@ -74,9 +74,7 @@ class BaseTaskTestSuite:
         """
         yield Mock()
 
-    async def execute_task(
-        self, task_class, payload, persistent, progress, storage, temp_storage, get_credential
-    ):
+    async def execute_task(self, task_class, payload, persistent, progress, storage, temp_storage):
         """
         Execute task with payload
         """
@@ -86,7 +84,6 @@ class BaseTaskTestSuite:
             task_id=uuid4(),
             payload=payload,
             progress=progress,
-            get_credential=get_credential,
             app_container=LazyAppContainer(
                 user=user,
                 persistent=persistent,
@@ -102,9 +99,7 @@ class BaseTaskTestSuite:
         await task.execute()
 
     @pytest_asyncio.fixture()
-    async def task_completed(
-        self, mongo_persistent, progress, storage, temp_storage, get_credential, catalog
-    ):
+    async def task_completed(self, mongo_persistent, progress, storage, temp_storage, catalog):
         """
         Test execution of the task
         """
@@ -117,5 +112,4 @@ class BaseTaskTestSuite:
             progress=progress,
             storage=storage,
             temp_storage=temp_storage,
-            get_credential=get_credential,
         )

--- a/tests/unit/worker/task/test_batch_feature_create.py
+++ b/tests/unit/worker/task/test_batch_feature_create.py
@@ -107,7 +107,6 @@ async def test_get_task_description():
         task_id=uuid4(),
         payload=payload.dict(by_alias=True),
         progress=Mock(),
-        get_credential=Mock(),
         app_container=Mock(),
     )
     assert await task.get_task_description() == "Save 2 features"

--- a/tests/unit/worker/task/test_batch_feature_table.py
+++ b/tests/unit/worker/task/test_batch_feature_table.py
@@ -27,7 +27,6 @@ async def test_get_task_description(catalog):
         task_id=uuid4(),
         payload=payload.dict(by_alias=True),
         progress=Mock(),
-        get_credential=Mock(),
         app_container=Mock(),
     )
     assert await task.get_task_description() == 'Save batch feature table "Test Features"'

--- a/tests/unit/worker/task/test_batch_request_table.py
+++ b/tests/unit/worker/task/test_batch_request_table.py
@@ -34,7 +34,6 @@ async def test_get_task_description(catalog):
         task_id=uuid4(),
         payload=payload.dict(by_alias=True),
         progress=Mock(),
-        get_credential=Mock(),
         app_container=Mock(),
     )
     assert (

--- a/tests/unit/worker/task/test_deployment_create_update.py
+++ b/tests/unit/worker/task/test_deployment_create_update.py
@@ -34,7 +34,6 @@ async def test_get_task_description_create():
         task_id=uuid4(),
         payload=payload.dict(by_alias=True),
         progress=Mock(),
-        get_credential=Mock(),
         app_container=Mock(),
     )
     assert await task.get_task_description() == 'Create deployment "Test deployment"'
@@ -74,7 +73,6 @@ async def test_get_task_description_update(persistent, enabled, expected):
         task_id=uuid4(),
         payload=payload.dict(by_alias=True),
         progress=Mock(),
-        get_credential=Mock(),
         app_container=LazyAppContainer(
             user=Mock(),
             persistent=persistent,

--- a/tests/unit/worker/task/test_feature_job_setting_analysis.py
+++ b/tests/unit/worker/task/test_feature_job_setting_analysis.py
@@ -145,9 +145,7 @@ class TestFeatureJobSettingAnalysisTask(BaseTaskTestSuite):
         )
 
     @pytest.mark.asyncio
-    async def test_execute_fail(
-        self, mongo_persistent, progress, storage, temp_storage, get_credential
-    ):
+    async def test_execute_fail(self, mongo_persistent, progress, storage, temp_storage):
         """
         Test failed task execution
         """
@@ -165,7 +163,6 @@ class TestFeatureJobSettingAnalysisTask(BaseTaskTestSuite):
                 progress=progress,
                 storage=storage,
                 temp_storage=temp_storage,
-                get_credential=get_credential,
             )
         assert (
             str(excinfo.value)
@@ -186,7 +183,6 @@ class TestFeatureJobSettingAnalysisTask(BaseTaskTestSuite):
         update_fixtures,
         storage,
         temp_storage,
-        get_credential,
     ):
         """
         Test successful task execution without using existing event table
@@ -213,7 +209,6 @@ class TestFeatureJobSettingAnalysisTask(BaseTaskTestSuite):
             progress=progress,
             storage=storage,
             temp_storage=temp_storage,
-            get_credential=get_credential,
         )
 
         output_document_id = payload["output_document_id"]
@@ -236,7 +231,6 @@ class TestFeatureJobSettingAnalysisTask(BaseTaskTestSuite):
             task_id=uuid4(),
             payload=payload.dict(by_alias=True),
             progress=Mock(),
-            get_credential=Mock(),
             app_container=LazyAppContainer(
                 user=Mock(),
                 persistent=persistent,

--- a/tests/unit/worker/task/test_feature_job_setting_analysis_backtest.py
+++ b/tests/unit/worker/task/test_feature_job_setting_analysis_backtest.py
@@ -67,7 +67,6 @@ class TestFeatureJobSettingAnalysisBacktestTask(BaseTaskTestSuite):
         storage,
         temp_storage,
         mock_event_dataset,
-        get_credential,
         catalog,
         insert_credential,
     ):
@@ -87,7 +86,6 @@ class TestFeatureJobSettingAnalysisBacktestTask(BaseTaskTestSuite):
             progress=None,
             storage=storage,
             temp_storage=temp_storage,
-            get_credential=get_credential,
         )
 
     @pytest.mark.asyncio
@@ -158,9 +156,7 @@ class TestFeatureJobSettingAnalysisBacktestTask(BaseTaskTestSuite):
         }
 
     @pytest.mark.asyncio
-    async def test_execute_fail(
-        self, mongo_persistent, progress, storage, temp_storage, get_credential
-    ):
+    async def test_execute_fail(self, mongo_persistent, progress, storage, temp_storage):
         """
         Test failed task execution
         """
@@ -179,7 +175,6 @@ class TestFeatureJobSettingAnalysisBacktestTask(BaseTaskTestSuite):
                 progress=progress,
                 storage=storage,
                 temp_storage=temp_storage,
-                get_credential=get_credential,
             )
         assert str(excinfo.value) == (
             f'FeatureJobSettingAnalysis (id: "{feature_job_setting_analysis_id}") not found. '
@@ -201,7 +196,6 @@ class TestFeatureJobSettingAnalysisBacktestTask(BaseTaskTestSuite):
             task_id=uuid4(),
             payload=payload.dict(by_alias=True),
             progress=Mock(),
-            get_credential=Mock(),
             app_container=LazyAppContainer(
                 user=Mock(),
                 persistent=persistent,

--- a/tests/unit/worker/task/test_feature_list_batch_feature_create.py
+++ b/tests/unit/worker/task/test_feature_list_batch_feature_create.py
@@ -33,7 +33,6 @@ async def test_get_task_description():
         task_id=uuid4(),
         payload=payload.dict(by_alias=True),
         progress=Mock(),
-        get_credential=Mock(),
         app_container=Mock(),
     )
     assert await task.get_task_description() == 'Save feature list "Test Feature list"'

--- a/tests/unit/worker/task/test_historical_feature_table.py
+++ b/tests/unit/worker/task/test_historical_feature_table.py
@@ -40,7 +40,6 @@ async def test_get_task_description():
         task_id=uuid4(),
         payload=payload.dict(by_alias=True),
         progress=Mock(),
-        get_credential=Mock(),
         app_container=Mock(),
     )
     assert (

--- a/tests/unit/worker/task/test_materialized_table_delete.py
+++ b/tests/unit/worker/task/test_materialized_table_delete.py
@@ -71,7 +71,6 @@ async def test_get_task_description(persistent, collection_name, expected_descri
         task_id=uuid4(),
         payload=payload.dict(by_alias=True),
         progress=Mock(),
-        get_credential=Mock(),
         app_container=LazyAppContainer(
             user=Mock(),
             persistent=persistent,

--- a/tests/unit/worker/task/test_observation_table.py
+++ b/tests/unit/worker/task/test_observation_table.py
@@ -34,7 +34,6 @@ async def test_get_task_description(catalog):
         task_id=uuid4(),
         payload=payload.dict(by_alias=True),
         progress=Mock(),
-        get_credential=Mock(),
         app_container=Mock(),
     )
     assert await task.get_task_description() == 'Save observation table "Test Observation Table"'

--- a/tests/unit/worker/task/test_online_store_cleanup.py
+++ b/tests/unit/worker/task/test_online_store_cleanup.py
@@ -25,7 +25,6 @@ async def test_get_task_description():
         task_id=uuid4(),
         payload=payload.dict(by_alias=True),
         progress=Mock(),
-        get_credential=Mock(),
         app_container=Mock(),
     )
     assert (

--- a/tests/unit/worker/task/test_static_source_table.py
+++ b/tests/unit/worker/task/test_static_source_table.py
@@ -34,7 +34,6 @@ async def test_get_task_description(catalog):
         task_id=uuid4(),
         payload=payload.dict(by_alias=True),
         progress=Mock(),
-        get_credential=Mock(),
         app_container=Mock(),
     )
     assert (

--- a/tests/unit/worker/task/test_target_table.py
+++ b/tests/unit/worker/task/test_target_table.py
@@ -38,7 +38,6 @@ async def test_get_task_description(catalog):
         task_id=uuid4(),
         payload=payload.dict(by_alias=True),
         progress=Mock(),
-        get_credential=Mock(),
         app_container=Mock(),
     )
     assert await task.get_task_description() == 'Save target table "Test Target Table"'

--- a/tests/unit/worker/task/test_tile_task.py
+++ b/tests/unit/worker/task/test_tile_task.py
@@ -41,7 +41,6 @@ async def test_get_task_description(catalog):
         task_id=uuid4(),
         payload=payload.dict(by_alias=True),
         progress=Mock(),
-        get_credential=Mock(),
         app_container=Mock(),
     )
     assert await task.get_task_description() == 'Generate tile for "tile_id:aggregation_id"'

--- a/tests/unit/worker/test_task_executor.py
+++ b/tests/unit/worker/test_task_executor.py
@@ -143,7 +143,7 @@ async def test_task_executor(random_task_class, persistent):
     assert document["description"] == "Execute random task"
 
 
-def test_task_has_been_implemented(app_container, random_task_class, command_class, get_credential):
+def test_task_has_been_implemented(app_container, random_task_class, command_class):
     """
     Test implement a task whose command has been implemented before
     """
@@ -189,7 +189,6 @@ def test_task_has_been_implemented(app_container, random_task_class, command_cla
             payload={},
             progress=None,
             app_container=app_container,
-            get_credential=get_credential,
         )
 
 


### PR DESCRIPTION
## Description
Fully cleanup and remove `get_credential` from tasks since they aren't needed directly.

After this PR, we should mostly only see `get_credential` appear in the code paths that are close to where it's used. For example, this would be in areas where we are trying to get a session (eg. `SessionManagerService`), or trying to use the credential to create a feature store and we use the credential to test the connection to the feature store.
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
