### PR TITLE
[chore] app: refactor get_persistent to class

### DIFF
--- a/docker/migration.py
+++ b/docker/migration.py
@@ -7,7 +7,7 @@ from featurebyte.app import User
 from featurebyte.logging import get_logger
 from featurebyte.migration.run import run_migration
 from featurebyte.utils.credential import MongoBackedCredentialProvider
-from featurebyte.utils.persistent import get_persistent
+from featurebyte.utils.persistent import MongoDBImpl
 from featurebyte.worker import get_celery
 
 logger = get_logger(__name__)
@@ -15,11 +15,11 @@ logger = get_logger(__name__)
 
 if __name__ == "__main__":
     logger.info("Running database migration")
-    credential_provider = MongoBackedCredentialProvider(persistent=get_persistent())
+    credential_provider = MongoBackedCredentialProvider(persistent=MongoDBImpl())
     # Note that the user ID here is an arbitrary one. For collections that have user specific data, special handling
     # will be required.
     asyncio.run(
-        run_migration(user=User(), persistent=get_persistent(), get_credential=credential_provider.get_credential, celery=get_celery())
+        run_migration(user=User(), persistent=MongoDBImpl(), get_credential=credential_provider.get_credential, celery=get_celery())
     )
 
     logger.info("Database migration completed")

--- a/featurebyte/app.py
+++ b/featurebyte/app.py
@@ -49,7 +49,7 @@ from featurebyte.routes.user_defined_function.api import UserDefinedFunctionRout
 from featurebyte.schema import APIServiceStatus
 from featurebyte.schema.task import TaskId
 from featurebyte.utils.messaging import REDIS_URI
-from featurebyte.utils.persistent import get_persistent
+from featurebyte.utils.persistent import MongoDBImpl
 from featurebyte.utils.storage import get_storage, get_temp_storage
 from featurebyte.worker import get_celery, get_redis
 
@@ -69,11 +69,10 @@ def _dep_injection_func(
     active_catalog_id: Optional[PydanticObjectId]
         Catalog ID to be used for the request
     """
-    request.state.persistent = get_persistent()
     request.state.user = User()
     request.state.app_container = LazyAppContainer(
         user=request.state.user,
-        persistent=request.state.persistent,
+        persistent=MongoDBImpl(),
         temp_storage=get_temp_storage(),
         celery=get_celery(),
         redis=get_redis(),

--- a/featurebyte/utils/persistent.py
+++ b/featurebyte/utils/persistent.py
@@ -5,20 +5,19 @@ from __future__ import annotations
 
 import os
 
-from featurebyte.persistent.base import Persistent
 from featurebyte.persistent.mongo import MongoDB
 
 DATABASE_NAME = os.environ.get("MONGODB_DB", "featurebyte")
 MONGO_URI = os.environ.get("MONGODB_URI", "mongodb://localhost:27021")
 
 
-def get_persistent() -> Persistent:
+class MongoDBImpl(MongoDB):
     """
-    Return global Persistent object
+    Default MongoDB implementation for featurebyte
+    """
 
-    Returns
-    -------
-    Persistent
-        Persistent object
-    """
-    return MongoDB(uri=MONGO_URI, database=DATABASE_NAME)
+    def __init__(self) -> None:
+        """
+        Initialize MongoDBImpl
+        """
+        super().__init__(uri=MONGO_URI, database=DATABASE_NAME)

--- a/featurebyte/worker/task_executor.py
+++ b/featurebyte/worker/task_executor.py
@@ -25,7 +25,7 @@ from featurebyte.models.task import Task as TaskModel
 from featurebyte.routes.lazy_app_container import LazyAppContainer
 from featurebyte.routes.registry import app_container_config
 from featurebyte.utils.messaging import Progress
-from featurebyte.utils.persistent import get_persistent
+from featurebyte.utils.persistent import MongoDBImpl
 from featurebyte.utils.storage import get_storage, get_temp_storage
 from featurebyte.worker import get_celery, get_redis
 from featurebyte.worker.task.base import TASK_MAP
@@ -107,7 +107,7 @@ class TaskExecutor:
         payload_object = task_class.payload_class(**payload)
         app_container = LazyAppContainer(
             user=user,
-            persistent=get_persistent(),
+            persistent=MongoDBImpl(),
             temp_storage=get_temp_storage(),
             celery=get_celery(),
             redis=get_redis(),

--- a/tests/integration/backward_compatibility/test_get_route.py
+++ b/tests/integration/backward_compatibility/test_get_route.py
@@ -39,7 +39,7 @@ def test_api_client_fixture(mongo_persistent):
     """
     Test API client
     """
-    with mock.patch("featurebyte.app.get_persistent") as mock_get_persistent:
+    with mock.patch("featurebyte.app.MongoDBImpl") as mock_get_persistent:
         with mock.patch("featurebyte.app.User") as mock_user:
             mock_user.return_value.id = ObjectId()
             mock_get_persistent.return_value = mongo_persistent

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -290,8 +290,8 @@ def mock_get_persistent_fixture(persistent):
     """
     Mock get_persistent in featurebyte/app.py
     """
-    with mock.patch("featurebyte.app.get_persistent") as mock_persistent, mock.patch(
-        "featurebyte.worker.task_executor.get_persistent"
+    with mock.patch("featurebyte.app.MongoDBImpl") as mock_persistent, mock.patch(
+        "featurebyte.worker.task_executor.MongoDBImpl"
     ) as mock_persistent_worker:
         mock_persistent.return_value = persistent
         mock_persistent_worker.return_value = persistent

--- a/tests/integration/service/test_session_validator.py
+++ b/tests/integration/service/test_session_validator.py
@@ -43,7 +43,7 @@ async def get_reset_session_fixture(session_manager, feature_store_details, feat
 @pytest.mark.skip(reason="skipping while we rollback the default state")
 @pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
 @pytest.mark.asyncio
-@mock.patch("featurebyte.app.get_persistent")
+@mock.patch("featurebyte.app.MongoDBImpl")
 async def test_validate_feature_store_id_not_used_in_warehouse(
     mock_persistent,
     session_validator_service,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -136,7 +136,7 @@ def mock_get_persistent_function(mongo_persistent):
     """
     Mock get_persistent in featurebyte.app
     """
-    with mock.patch("featurebyte.app.get_persistent") as mock_persistent:
+    with mock.patch("featurebyte.app.MongoDBImpl") as mock_persistent:
         persistent, _ = mongo_persistent
         mock_persistent.return_value = persistent
         yield mock_persistent

--- a/tests/unit/persistent/test_mongo.py
+++ b/tests/unit/persistent/test_mongo.py
@@ -13,7 +13,7 @@ from pymongo.errors import DuplicateKeyError
 
 from featurebyte.models.persistent import AuditActionType
 from featurebyte.persistent import DuplicateDocumentError
-from featurebyte.utils.persistent import get_persistent
+from featurebyte.utils.persistent import MongoDBImpl
 
 
 @pytest.mark.parametrize("disable_audit", [False, True])
@@ -467,6 +467,6 @@ async def test_get_audit_logs(mongo_persistent, test_document):
 
 def test_check_mongo_persistent_is_not_shared():
     """Test that get_persistent is not shared"""
-    persistent1 = get_persistent()
-    persistent2 = get_persistent()
+    persistent1 = MongoDBImpl()
+    persistent2 = MongoDBImpl()
     assert id(persistent1) != id(persistent2)

--- a/tests/unit/routes/conftest.py
+++ b/tests/unit/routes/conftest.py
@@ -30,7 +30,7 @@ def api_client_persistent(persistent, user_id, temp_storage):
     """
     Test API client
     """
-    with patch("featurebyte.app.get_persistent") as mock_get_persistent:
+    with patch("featurebyte.app.MongoDBImpl") as mock_get_persistent:
         with patch("featurebyte.app.get_temp_storage") as mock_get_temp_storage:
             with patch("featurebyte.app.User") as mock_user:
                 mock_user.return_value.id = user_id

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -21,10 +21,10 @@ def test_get_persistent():
     Test get_persistent works as expected
     """
     importlib.reload(persistent)
-    with patch("featurebyte.utils.persistent.MongoDB") as mock_mongodb:
+    with patch("featurebyte.utils.persistent.MongoDB.__init__") as mock_mongodb:
         with pytest.raises(ValueError):
             mock_mongodb.side_effect = ValueError()
-            persistent.get_persistent()
+            persistent.MongoDBImpl()
     mock_mongodb.assert_called_once_with(uri="mongodb://localhost:27022", database="featurebyte")
 
 

--- a/tests/unit/worker/test_task_executor.py
+++ b/tests/unit/worker/test_task_executor.py
@@ -113,7 +113,7 @@ async def test_task_executor(random_task_class, persistent):
     # run executor
     user_id = ObjectId()
     document_id = ObjectId()
-    with patch("featurebyte.worker.task_executor.get_persistent") as mock_get_persistent:
+    with patch("featurebyte.worker.task_executor.MongoDBImpl") as mock_get_persistent:
         mock_get_persistent.return_value = persistent
         await TaskExecutor(
             payload={


### PR DESCRIPTION
## Description
This PR refactors the `get_persistent` method to a class. This will allow us to register this class as a normal dependency, and not require any special handling when constructing the `app_container`.

Pushing more deps into a normal dependency will also allow us to take advantage of the lazy initialization more, meaning that we don't have to pre-create the dependencies, and can only construct them when they're used.

We also don't have to pass this dependency as part of the `request.state` too.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
