### PR TITLE
[chore] app/registry: register persistent directly and make optional

### DIFF
--- a/featurebyte/routes/lazy_app_container.py
+++ b/featurebyte/routes/lazy_app_container.py
@@ -153,13 +153,13 @@ class LazyAppContainer:
     def __init__(
         self,
         user: Any,
-        persistent: Persistent,
         temp_storage: Storage,
         celery: Celery,
         redis: Redis[Any],
         storage: Storage,
         catalog_id: Optional[ObjectId],
         app_container_config: AppContainerConfig,
+        persistent: Optional[Persistent] = None,
     ):
         self.app_container_config = app_container_config
         self._enable_block_modification_check = True

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -126,6 +126,7 @@ from featurebyte.service.view_construction import ViewConstructionService
 from featurebyte.service.working_schema import WorkingSchemaService
 from featurebyte.storage import Storage
 from featurebyte.utils.credential import MongoBackedCredentialProvider
+from featurebyte.utils.persistent import MongoDBImpl
 from featurebyte.worker.util.observation_set_helper import ObservationSetHelper
 
 app_container_config = AppContainerConfig()
@@ -271,10 +272,10 @@ app_container_config.register_class(WorkingSchemaService)
 
 app_container_config.register_class(UseCaseService)
 app_container_config.register_class(UseCaseController)
+app_container_config.register_class(MongoDBImpl, name_override="persistent")
 
 # These have force_no_deps set as True, as they are manually initialized.
 app_container_config.register_class(Celery, force_no_deps=True)
-app_container_config.register_class(Persistent, force_no_deps=True)
 app_container_config.register_class(Storage, force_no_deps=True)
 app_container_config.register_class(Storage, force_no_deps=True, name_override="temp_storage")
 app_container_config.register_class(User, force_no_deps=True)

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -13,7 +13,6 @@ from featurebyte.migration.service.data_warehouse import (
 )
 from featurebyte.migration.service.mixin import DataWarehouseMigrationMixin
 from featurebyte.models.base import User
-from featurebyte.persistent import Persistent
 from featurebyte.routes.app_container_config import AppContainerConfig
 from featurebyte.routes.batch_feature_table.controller import BatchFeatureTableController
 from featurebyte.routes.batch_request_table.controller import BatchRequestTableController

--- a/tests/unit/routes/test_lazy_app_container.py
+++ b/tests/unit/routes/test_lazy_app_container.py
@@ -9,6 +9,7 @@ from bson import ObjectId
 from featurebyte.models.base import DEFAULT_CATALOG_ID, User
 from featurebyte.routes.app_container_config import AppContainerConfig, ClassDefinition
 from featurebyte.routes.lazy_app_container import LazyAppContainer, get_all_deps_for_key
+from featurebyte.utils.persistent import MongoDBImpl
 from featurebyte.utils.storage import get_storage, get_temp_storage
 from featurebyte.worker import get_celery, get_redis
 
@@ -62,7 +63,6 @@ def app_container_constructor_params_fixture(persistent):
     user = User()
     return {
         "user": user,
-        "persistent": persistent,
         "temp_storage": get_temp_storage(),
         "storage": get_storage(),
         "celery": get_celery(),
@@ -81,6 +81,7 @@ def test_app_config_fixture():
     app_container_config.register_class(TestService)
     app_container_config.register_class(TestServiceWithOtherDeps, {"other_dep": "test_service"})
     app_container_config.register_class(TestController)
+    app_container_config.register_class(MongoDBImpl, name_override="persistent")
     return app_container_config
 
 
@@ -120,7 +121,7 @@ def test_construction__get_attr(app_container_constructor_params):
         app_container_config=app_container_config,
     )
     # This has been initialized
-    assert app_container.persistent is not None
+    assert app_container.redis is not None
 
     # random_item has not been initialized
     with pytest.raises(KeyError):

--- a/tests/unit/routes/test_lazy_app_container.py
+++ b/tests/unit/routes/test_lazy_app_container.py
@@ -56,7 +56,7 @@ class TestController:
 
 
 @pytest.fixture(name="app_container_constructor_params")
-def app_container_constructor_params_fixture(persistent):
+def app_container_constructor_params_fixture():
     """
     Get app container constructor params
     """


### PR DESCRIPTION
## Description
This PR demonstrates how we can now register the `MongoDBImpl` class as `persistent`, similar to how we register other classes. We can't remove this parameter entirely from the construction of the `LazyAppContainer` as it's widely used. We can slowly clean up the callers in follow-ups!

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
