### PR TITLE
[DEV-2318] observation_table: validate entities are present on creation

### DIFF
--- a/.changelog/DEV-2318.yaml
+++ b/.changelog/DEV-2318.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: observation_table
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Validate that entities are present when creating an observation table."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/.changelog/DEV-2318.yaml
+++ b/.changelog/DEV-2318.yaml
@@ -6,7 +6,7 @@
 
 # --- TEMPLATE --- #
 # One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern
 # (e.g. gh-actions, docs, middleware, worker)

--- a/featurebyte/api/source_table.py
+++ b/featurebyte/api/source_table.py
@@ -966,6 +966,7 @@ class SourceTable(AbstractTableData):
         columns: Optional[list[str]] = None,
         columns_rename_mapping: Optional[dict[str, str]] = None,
         context_name: Optional[str] = None,
+        skip_entity_validation_checks: Optional[bool] = False,
     ) -> ObservationTable:
         """
         Creates an ObservationTable from the SourceTable.
@@ -990,6 +991,8 @@ class SourceTable(AbstractTableData):
             column names when creating the observation table. If None, no columns are renamed.
         context_name: Optional[str]
             Context name for the observation table.
+        skip_entity_validation_checks: Optional[bool]
+            Skip entity validation checks when creating the observation table.
 
         Returns
         -------
@@ -1030,6 +1033,7 @@ class SourceTable(AbstractTableData):
             ),
             sample_rows=sample_rows,
             context_id=context_id,
+            skip_entity_validation_checks=skip_entity_validation_checks,
         )
         observation_table_doc = ObservationTable.post_async_task(
             route="/observation_table", payload=payload.json_dict()

--- a/featurebyte/api/target.py
+++ b/featurebyte/api/target.py
@@ -264,6 +264,7 @@ class Target(
         self,
         observation_table: Union[ObservationTable, pd.DataFrame],
         serving_names_mapping: Optional[Dict[str, str]] = None,
+        skip_entity_validation_checks: bool = False,
     ) -> pd.DataFrame:
         """
         Returns a DataFrame with target values for analysis, model training, or evaluation. The target
@@ -282,6 +283,8 @@ class Target(
         serving_names_mapping : Optional[Dict[str, str]]
             Optional serving names mapping if the training events table has different serving name columns than those
             defined in Entities, mapping from original serving name to new name.
+        skip_entity_validation_checks: bool
+            Whether to skip entity validation checks.
 
         Returns
         -------
@@ -300,6 +303,7 @@ class Target(
             observation_table=observation_table,
             observation_table_name=temp_target_table_name,
             serving_names_mapping=serving_names_mapping,
+            skip_entity_validation_checks=skip_entity_validation_checks,
         )
         try:
             return temp_target_table.to_pandas()
@@ -312,6 +316,7 @@ class Target(
         observation_table: Union[ObservationTable, pd.DataFrame],
         observation_table_name: str,
         serving_names_mapping: Optional[Dict[str, str]] = None,
+        skip_entity_validation_checks: bool = False,
     ) -> ObservationTable:
         """
         Materialize feature list using an observation table asynchronously. The targets
@@ -325,7 +330,9 @@ class Target(
         observation_table_name: str
             Name of the observation table to be created with the target values
         serving_names_mapping : Optional[Dict[str, str]]
-            Optional serving names mapping if the training events table has different serving name
+            Optional serving names mapping if the training events table has different serving name.
+        skip_entity_validation_checks: bool
+            Whether to skip entity validation checks
 
         Returns
         -------
@@ -357,6 +364,7 @@ class Target(
                 type=input_type,
             ),
             context_id=observation_table.context_id if is_input_observation_table else None,
+            skip_entity_validation_checks=skip_entity_validation_checks,
         )
         if is_input_observation_table:
             files = None

--- a/featurebyte/api/view.py
+++ b/featurebyte/api/view.py
@@ -1656,6 +1656,7 @@ class View(ProtectedColumnsQueryObject, Frame, ABC):
         columns: Optional[list[str]] = None,
         columns_rename_mapping: Optional[dict[str, str]] = None,
         context_name: Optional[str] = None,
+        skip_entity_validation_checks: Optional[bool] = False,
     ) -> ObservationTable:
         """
         Creates an ObservationTable from the View.
@@ -1680,6 +1681,8 @@ class View(ProtectedColumnsQueryObject, Frame, ABC):
             when creating the observation table. If None, no columns are renamed.
         context_name: Optional[str]
             Context name for the observation table.
+        skip_entity_validation_checks: Optional[bool]
+            Skip entity validation checks when creating the observation table.
 
         Returns
         -------
@@ -1714,6 +1717,7 @@ class View(ProtectedColumnsQueryObject, Frame, ABC):
             ),
             sample_rows=sample_rows,
             context_id=context_id,
+            skip_entity_validation_checks=skip_entity_validation_checks,
         )
         observation_table_doc = ObservationTable.post_async_task(
             route="/observation_table", payload=payload.json_dict()

--- a/featurebyte/schema/observation_table.py
+++ b/featurebyte/schema/observation_table.py
@@ -20,6 +20,7 @@ class ObservationTableCreate(BaseRequestTableCreate):
 
     sample_rows: Optional[int] = Field(ge=0)
     request_input: ObservationInput
+    skip_entity_validation_checks: bool = Field(default=False)
 
 
 class ObservationTableList(PaginationMixin):

--- a/featurebyte/schema/target_table.py
+++ b/featurebyte/schema/target_table.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import StrictStr, root_validator
+from pydantic import Field, StrictStr, root_validator
 
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.observation_table import ObservationInput
@@ -28,6 +28,7 @@ class TargetTableCreate(FeatureOrTargetTableCreate):
     node_names: List[StrictStr]
     request_input: ObservationInput
     context_id: Optional[PydanticObjectId]
+    skip_entity_validation_checks: bool = Field(default=False)
 
     @property
     def nodes(self) -> List[Node]:

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -162,6 +162,8 @@ class ObservationTableService(
             If the point in time column is missing.
         UnsupportedPointInTimeColumnTypeError
             If the point in time column is not of timestamp type.
+        ValueError
+            If no entity column is provided.
         """
         columns_info, num_rows = await self.get_columns_info_and_num_rows(
             db_session=db_session,
@@ -183,6 +185,10 @@ class ObservationTableService(
             raise UnsupportedPointInTimeColumnTypeError(
                 f"Point in time column should have timestamp type; got {point_in_time_dtype}"
             )
+
+        # Check that there's at least one entity mapped in the columns info
+        if not any(info.entity_id is not None for info in columns_info):
+            raise ValueError("At least one entity column should be provided.")
 
         most_recent_point_in_time = await ObservationTableService.get_most_recent_point_in_time(
             db_session=db_session,

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -139,6 +139,7 @@ class ObservationTableService(
         db_session: BaseSession,
         table_details: TableDetails,
         serving_names_remapping: Optional[Dict[str, str]] = None,
+        skip_entity_validation_checks: bool = False,
     ) -> Dict[str, Any]:
         """
         Validate and get additional metadata for the materialized observation table.
@@ -151,6 +152,8 @@ class ObservationTableService(
             Table details of the materialized table
         serving_names_remapping: Dict[str, str]
             Remapping of serving names
+        skip_entity_validation_checks: bool
+            Whether to skip entity validation checks
 
         Returns
         -------
@@ -186,9 +189,10 @@ class ObservationTableService(
                 f"Point in time column should have timestamp type; got {point_in_time_dtype}"
             )
 
-        # Check that there's at least one entity mapped in the columns info
-        if not any(info.entity_id is not None for info in columns_info):
-            raise ValueError("At least one entity column should be provided.")
+        if not skip_entity_validation_checks:
+            # Check that there's at least one entity mapped in the columns info
+            if not any(info.entity_id is not None for info in columns_info):
+                raise ValueError("At least one entity column should be provided.")
 
         most_recent_point_in_time = await ObservationTableService.get_most_recent_point_in_time(
             db_session=db_session,

--- a/featurebyte/worker/task/observation_table.py
+++ b/featurebyte/worker/task/observation_table.py
@@ -52,7 +52,9 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask):
             assert not isinstance(payload_input, TargetInput)
             additional_metadata = (
                 await observation_table_service.validate_materialized_table_and_get_metadata(
-                    db_session, location.table_details
+                    db_session,
+                    location.table_details,
+                    skip_entity_validation_checks=payload.skip_entity_validation_checks,
                 )
             )
             logger.debug("Creating a new ObservationTable", extra=location.table_details.dict())

--- a/featurebyte/worker/task/target_table.py
+++ b/featurebyte/worker/task/target_table.py
@@ -69,7 +69,10 @@ class TargetTableTask(DataWarehouseMixin, BaseTask):
 
             additional_metadata = (
                 await observation_table_service.validate_materialized_table_and_get_metadata(
-                    db_session, location.table_details, payload.serving_names_mapping
+                    db_session,
+                    location.table_details,
+                    payload.serving_names_mapping,
+                    skip_entity_validation_checks=payload.skip_entity_validation_checks,
                 )
             )
 

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -518,7 +518,7 @@ def patched_num_features_per_query():
             yield
 
 
-@pytest.fixture(name="new_user_id_entity")
+@pytest.fixture(name="new_user_id_entity", scope="session")
 def new_user_id_entity_fixture():
     """
     Fixture for a new user id entity
@@ -536,7 +536,7 @@ def new_user_id_entity_fixture():
         ("table", "table"),
     ],
 )
-@pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
+@pytest.mark.parametrize("source_type", ["snowflake", "spark", "databricks"], indirect=True)
 @pytest.mark.usefixtures("patched_num_features_per_query")
 @pytest.mark.asyncio
 async def test_get_historical_features(

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -11,6 +11,7 @@ import pytest
 from bson import ObjectId
 
 from featurebyte import AggFunc, FeatureList, HistoricalFeatureTable, SourceType, to_timedelta
+from featurebyte.exception import RecordCreationException
 from featurebyte.feature_manager.model import ExtendedFeatureModel
 from tests.util.helper import (
     assert_preview_result_equal,
@@ -1280,3 +1281,15 @@ def test_create_observation_table(event_view):
     )
     expected_entity_ids = {col.entity_id for col in new_event_view.columns_info if col.entity_id}
     assert set(observation_table.entity_ids) == expected_entity_ids
+
+
+@pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
+def test_create_observation_table__errors_with_no_entities(event_view):
+    new_event_view = event_view.copy()
+    new_event_view["POINT_IN_TIME"] = new_event_view["ËVENT_TIMESTAMP"]
+    new_event_view = new_event_view[["POINT_IN_TIME", "SESSION_ID"]]
+    with pytest.raises(RecordCreationException) as exc:
+        new_event_view.create_observation_table(
+            f"observation_table_name_{ObjectId()}",
+        )
+    assert "At least one entity column" in str(exc)

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -10,7 +10,14 @@ import pandas as pd
 import pytest
 from bson import ObjectId
 
-from featurebyte import AggFunc, FeatureList, HistoricalFeatureTable, SourceType, to_timedelta
+from featurebyte import (
+    AggFunc,
+    Entity,
+    FeatureList,
+    HistoricalFeatureTable,
+    SourceType,
+    to_timedelta,
+)
 from featurebyte.exception import RecordCreationException
 from featurebyte.feature_manager.model import ExtendedFeatureModel
 from tests.util.helper import (
@@ -511,6 +518,16 @@ def patched_num_features_per_query():
             yield
 
 
+@pytest.fixture(name="new_user_id_entity")
+def new_user_id_entity_fixture():
+    """
+    Fixture for a new user id entity
+    """
+    entity = Entity(name="new user id", serving_names=["new_user id"])
+    entity.save()
+    return entity
+
+
 @pytest.mark.parametrize(
     "in_out_formats",
     [
@@ -519,16 +536,22 @@ def patched_num_features_per_query():
         ("table", "table"),
     ],
 )
-@pytest.mark.parametrize("source_type", ["snowflake", "spark", "databricks"], indirect=True)
+@pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
 @pytest.mark.usefixtures("patched_num_features_per_query")
 @pytest.mark.asyncio
 async def test_get_historical_features(
-    session, data_source, feature_group, feature_group_per_category, in_out_formats, user_entity
+    session,
+    data_source,
+    feature_group,
+    feature_group_per_category,
+    in_out_formats,
+    user_entity,
+    new_user_id_entity,
 ):
     """
     Test getting historical features from FeatureList
     """
-    _ = user_entity
+    _ = user_entity, new_user_id_entity
     input_format, output_format = in_out_formats
     assert input_format in {"dataframe", "table"}
     assert output_format in {"dataframe", "table"}

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -1316,3 +1316,8 @@ def test_create_observation_table__errors_with_no_entities(event_view):
             f"observation_table_name_{ObjectId()}",
         )
     assert "At least one entity column" in str(exc)
+
+    # Test that no error if we skip the entity validation check
+    new_event_view.create_observation_table(
+        f"observation_table_name_{ObjectId()}", skip_entity_validation_checks=True
+    )

--- a/tests/integration/api/test_observation_table.py
+++ b/tests/integration/api/test_observation_table.py
@@ -4,6 +4,7 @@ Integration tests for ObservationTable
 import pytest
 from sqlglot import parse_one
 
+from featurebyte.api.entity import Entity
 from featurebyte.exception import RecordCreationException
 from featurebyte.query_graph.sql.common import sql_to_string
 
@@ -58,13 +59,25 @@ def check_materialized_table_preview_methods(table, expected_columns):
     assert set(df_describe.index).issuperset(["top", "min", "max"])
 
 
+@pytest.fixture(name="normal_user_id_entity", scope="session")
+def new_user_id_entity_fixture():
+    """
+    Fixture for a new user id entity
+    """
+    entity = Entity(name="normal user id", serving_names=["User ID"])
+    entity.save()
+    return entity
+
+
+@pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
 @pytest.mark.asyncio
 async def test_observation_table_from_source_table(
-    data_source, feature_store, session, source_type
+    data_source, feature_store, session, source_type, catalog, normal_user_id_entity
 ):
     """
     Test creating an observation table from a source table
     """
+    _ = normal_user_id_entity
     source_table = data_source.get_source_table(
         database_name=session.database_name,
         schema_name=session.schema_name,

--- a/tests/integration/api/test_observation_table.py
+++ b/tests/integration/api/test_observation_table.py
@@ -84,10 +84,13 @@ async def test_observation_table_from_source_table(
 
 
 @pytest.mark.asyncio
-async def test_observation_table_from_view(event_table, scd_table, session, source_type):
+async def test_observation_table_from_view(
+    event_table, scd_table, session, source_type, user_entity
+):
     """
     Test creating an observation table from a view
     """
+    _ = user_entity
     view = event_table.get_view()
     scd_view = scd_table.get_view()
     view = view.join(scd_view, on="ÜSER ID")
@@ -96,7 +99,7 @@ async def test_observation_table_from_view(event_table, scd_table, session, sour
         f"MY_OBSERVATION_TABLE_FROM_VIEW_{source_type}",
         sample_rows=sample_rows,
         columns=[view.timestamp_column, "ÜSER ID"],
-        columns_rename_mapping={view.timestamp_column: "POINT_IN_TIME"},
+        columns_rename_mapping={view.timestamp_column: "POINT_IN_TIME", "ÜSER ID": "üser id"},
     )
     assert observation_table.name == f"MY_OBSERVATION_TABLE_FROM_VIEW_{source_type}"
     check_location_valid(observation_table, session)
@@ -104,7 +107,7 @@ async def test_observation_table_from_view(event_table, scd_table, session, sour
 
     check_materialized_table_preview_methods(
         observation_table,
-        expected_columns=["POINT_IN_TIME", "ÜSER ID"],
+        expected_columns=["POINT_IN_TIME", "üser id"],
     )
 
 


### PR DESCRIPTION
## Description
Add validation into the observation_table creation path to ensure that entities are present when creating the observation table. 

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
