### PR TITLE
[DEV-2364] api/target: use window from namespace instead 

### DIFF
--- a/.changelog/DEV-2364.yaml
+++ b/.changelog/DEV-2364.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: target
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Use window from target namespace instead of the target version."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/target.py
+++ b/featurebyte/api/target.py
@@ -189,11 +189,7 @@ class Target(
         ValueError
             If the target does not have a window.
         """
-        try:
-            # TODO: Should use window value from TargetNamespace once it is available
-            window = self.cached_model.graph.get_forward_aggregate_window(self.node_name)
-        except RecordRetrievalException:
-            window = self.graph.get_forward_aggregate_window(self.node_name)
+        window = self.target_namespace.window
         if window is None:
             raise ValueError("Target does not have a window")
         return window

--- a/featurebyte/api/target.py
+++ b/featurebyte/api/target.py
@@ -33,7 +33,6 @@ from featurebyte.common.utils import dataframe_to_arrow_bytes, enforce_observati
 from featurebyte.core.accessor.target_datetime import TargetDtAccessorMixin
 from featurebyte.core.accessor.target_string import TargetStrAccessorMixin
 from featurebyte.core.series import Series
-from featurebyte.exception import RecordRetrievalException
 from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.models.observation_table import TargetInput
 from featurebyte.models.request_input import RequestInputType

--- a/featurebyte/query_graph/graph.py
+++ b/featurebyte/query_graph/graph.py
@@ -176,28 +176,6 @@ class QueryGraph(QueryGraphModel):
             output.append(node.parameters.function_id)
         return sorted(set(output))
 
-    def get_forward_aggregate_window(self, node_name: str) -> Optional[str]:
-        """
-        Get the window of the forward aggregate node
-
-        Parameters
-        ----------
-        node_name: str
-            Name of the node to get the window for
-
-        Returns
-        -------
-        Optional[str]
-            window of the forward aggregate node
-        """
-        target_node = self.get_node_by_name(node_name)
-        for node in self.iterate_nodes(
-            target_node=target_node, node_type=NodeType.FORWARD_AGGREGATE
-        ):
-            assert isinstance(node, ForwardAggregateNode)
-            return node.parameters.window
-        return None
-
     def get_entity_columns(self, node_name: str) -> List[str]:
         """
         Get entity columns of the query graph given the target node name

--- a/featurebyte/query_graph/graph.py
+++ b/featurebyte/query_graph/graph.py
@@ -36,12 +36,7 @@ from featurebyte.query_graph.node.cleaning_operation import (
     TableIdCleaningOperation,
 )
 from featurebyte.query_graph.node.function import GenericFunctionNode
-from featurebyte.query_graph.node.generic import (
-    ForwardAggregateNode,
-    GroupByNode,
-    LookupNode,
-    LookupTargetNode,
-)
+from featurebyte.query_graph.node.generic import GroupByNode, LookupNode, LookupTargetNode
 from featurebyte.query_graph.node.input import InputNode
 from featurebyte.query_graph.node.metadata.operation import (
     DerivedDataColumn,

--- a/tests/unit/api/test_target.py
+++ b/tests/unit/api/test_target.py
@@ -97,6 +97,13 @@ class TestTargetTestSuite(FeatureOrTargetBaseTestSuite):
         new_target = float_target + 1
         float_target[arbitrary_mask] = new_target
 
+    def test_window(self, float_target):
+        """
+        Test window is present
+        """
+        float_target.save()
+        assert float_target.window == "1d"
+
     def test_list_includes_namespace(self, float_target, cust_id_entity):
         """
         Test list includes namespace targets.


### PR DESCRIPTION
## Description
We have the window stored in the `TargetNamespace` now, so we can clean up this todo and use the window from there.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
