### PR TITLE
[chore][DEV-2365] sample: update docs to indicate upper bound of 10k rows

### DIFF
--- a/featurebyte/api/base_table.py
+++ b/featurebyte/api/base_table.py
@@ -339,7 +339,7 @@ class TableColumn(FeatureByteBaseModel, ParentMixin):
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample, with an upper bound to 10,000 rows.
+            Maximum number of rows to sample, with an upper bound of 10,000 rows.
         seed: int
             Seed to use for random sampling.
         from_timestamp: Optional[datetime]

--- a/featurebyte/api/base_table.py
+++ b/featurebyte/api/base_table.py
@@ -339,7 +339,7 @@ class TableColumn(FeatureByteBaseModel, ParentMixin):
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample.
+            Maximum number of rows to sample, with an upper bound to 10,000 rows.
         seed: int
             Seed to use for random sampling.
         from_timestamp: Optional[datetime]

--- a/featurebyte/api/batch_feature_table.py
+++ b/featurebyte/api/batch_feature_table.py
@@ -70,7 +70,7 @@ class BatchFeatureTable(BatchFeatureTableModel, ApiObject, MaterializedTableMixi
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample, with an upper bound to 10,000 rows.
+            Maximum number of rows to sample, with an upper bound of 10,000 rows.
         seed: int
             Seed to use for random sampling.
 

--- a/featurebyte/api/batch_feature_table.py
+++ b/featurebyte/api/batch_feature_table.py
@@ -70,7 +70,7 @@ class BatchFeatureTable(BatchFeatureTableModel, ApiObject, MaterializedTableMixi
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample.
+            Maximum number of rows to sample, with an upper bound to 10,000 rows.
         seed: int
             Seed to use for random sampling.
 

--- a/featurebyte/api/batch_request_table.py
+++ b/featurebyte/api/batch_request_table.py
@@ -84,7 +84,7 @@ class BatchRequestTable(BatchRequestTableModel, ApiObject, MaterializedTableMixi
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample, with an upper bound to 10,000 rows.
+            Maximum number of rows to sample, with an upper bound of 10,000 rows.
         seed: int
             Seed to use for random sampling.
 

--- a/featurebyte/api/batch_request_table.py
+++ b/featurebyte/api/batch_request_table.py
@@ -84,7 +84,7 @@ class BatchRequestTable(BatchRequestTableModel, ApiObject, MaterializedTableMixi
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample.
+            Maximum number of rows to sample, with an upper bound to 10,000 rows.
         seed: int
             Seed to use for random sampling.
 

--- a/featurebyte/api/historical_feature_table.py
+++ b/featurebyte/api/historical_feature_table.py
@@ -70,7 +70,7 @@ class HistoricalFeatureTable(HistoricalFeatureTableModel, ApiObject, Materialize
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample, with an upper bound to 10,000 rows.
+            Maximum number of rows to sample, with an upper bound of 10,000 rows.
         seed: int
             Seed to use for random sampling.
 

--- a/featurebyte/api/historical_feature_table.py
+++ b/featurebyte/api/historical_feature_table.py
@@ -70,7 +70,7 @@ class HistoricalFeatureTable(HistoricalFeatureTableModel, ApiObject, Materialize
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample.
+            Maximum number of rows to sample, with an upper bound to 10,000 rows.
         seed: int
             Seed to use for random sampling.
 

--- a/featurebyte/api/materialized_table.py
+++ b/featurebyte/api/materialized_table.py
@@ -116,7 +116,7 @@ class MaterializedTableMixin(MaterializedTableModel):
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample, with an upper bound to 10,000 rows.
+            Maximum number of rows to sample, with an upper bound of 10,000 rows.
         seed: int
             Seed to use for random sampling.
 

--- a/featurebyte/api/materialized_table.py
+++ b/featurebyte/api/materialized_table.py
@@ -116,7 +116,7 @@ class MaterializedTableMixin(MaterializedTableModel):
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample.
+            Maximum number of rows to sample, with an upper bound to 10,000 rows.
         seed: int
             Seed to use for random sampling.
 

--- a/featurebyte/api/observation_table.py
+++ b/featurebyte/api/observation_table.py
@@ -102,7 +102,7 @@ class ObservationTable(ObservationTableModel, ApiObject, MaterializedTableMixin)
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample, with an upper bound to 10,000 rows.
+            Maximum number of rows to sample, with an upper bound of 10,000 rows.
         seed: int
             Seed to use for random sampling.
 

--- a/featurebyte/api/observation_table.py
+++ b/featurebyte/api/observation_table.py
@@ -102,7 +102,7 @@ class ObservationTable(ObservationTableModel, ApiObject, MaterializedTableMixin)
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample.
+            Maximum number of rows to sample, with an upper bound to 10,000 rows.
         seed: int
             Seed to use for random sampling.
 

--- a/featurebyte/api/source_table.py
+++ b/featurebyte/api/source_table.py
@@ -274,7 +274,7 @@ class AbstractTableData(ConstructGraphMixin, FeatureByteBaseModel, ABC):
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample, with an upper bound to 10,000 rows.
+            Maximum number of rows to sample, with an upper bound of 10,000 rows.
         seed: int
             Seed to use for random sampling.
         from_timestamp: Optional[datetime]

--- a/featurebyte/api/source_table.py
+++ b/featurebyte/api/source_table.py
@@ -274,7 +274,7 @@ class AbstractTableData(ConstructGraphMixin, FeatureByteBaseModel, ABC):
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample.
+            Maximum number of rows to sample, with an upper bound to 10,000 rows.
         seed: int
             Seed to use for random sampling.
         from_timestamp: Optional[datetime]

--- a/featurebyte/api/static_source_table.py
+++ b/featurebyte/api/static_source_table.py
@@ -83,7 +83,7 @@ class StaticSourceTable(StaticSourceTableModel, ApiObject, MaterializedTableMixi
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample.
+            Maximum number of rows to sample, with an upper bound to 10,000 rows.
         seed: int
             Seed to use for random sampling.
 

--- a/featurebyte/api/static_source_table.py
+++ b/featurebyte/api/static_source_table.py
@@ -83,7 +83,7 @@ class StaticSourceTable(StaticSourceTableModel, ApiObject, MaterializedTableMixi
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample, with an upper bound to 10,000 rows.
+            Maximum number of rows to sample, with an upper bound of 10,000 rows.
         seed: int
             Seed to use for random sampling.
 

--- a/featurebyte/api/view.py
+++ b/featurebyte/api/view.py
@@ -155,7 +155,7 @@ class ViewColumn(Series, SampleMixin):
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample, with an upper bound to 10,000 rows.
+            Maximum number of rows to sample, with an upper bound of 10,000 rows.
         seed: int
             Seed to use for random sampling.
         from_timestamp: Optional[datetime]
@@ -879,7 +879,7 @@ class View(ProtectedColumnsQueryObject, Frame, ABC):
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample, with an upper bound to 10,000 rows.
+            Maximum number of rows to sample, with an upper bound of 10,000 rows.
         seed: int
             Seed to use for random sampling.
         from_timestamp: Optional[datetime]

--- a/featurebyte/api/view.py
+++ b/featurebyte/api/view.py
@@ -155,7 +155,7 @@ class ViewColumn(Series, SampleMixin):
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample.
+            Maximum number of rows to sample, with an upper bound to 10,000 rows.
         seed: int
             Seed to use for random sampling.
         from_timestamp: Optional[datetime]
@@ -879,7 +879,7 @@ class View(ProtectedColumnsQueryObject, Frame, ABC):
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample.
+            Maximum number of rows to sample, with an upper bound to 10,000 rows.
         seed: int
             Seed to use for random sampling.
         from_timestamp: Optional[datetime]

--- a/featurebyte/core/mixin.py
+++ b/featurebyte/core/mixin.py
@@ -378,7 +378,7 @@ class SampleMixin:
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample.
+            Maximum number of rows to sample, with an upper bound to 10,000 rows.
         seed: int
             Seed to use for random sampling.
         from_timestamp: Optional[datetime]

--- a/featurebyte/core/mixin.py
+++ b/featurebyte/core/mixin.py
@@ -378,7 +378,7 @@ class SampleMixin:
         Parameters
         ----------
         size: int
-            Maximum number of rows to sample, with an upper bound to 10,000 rows.
+            Maximum number of rows to sample, with an upper bound of 10,000 rows.
         seed: int
             Seed to use for random sampling.
         from_timestamp: Optional[datetime]


### PR DESCRIPTION
## Description
Upper docstring to indicate upper bound of 10k rows in sample.

![Screenshot 2023-10-02 at 5 34 30 PM](https://github.com/featurebyte/featurebyte/assets/2313101/3ddc7d9e-806d-42cd-8691-821a9fcada13)



<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-2365

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
