### PR TITLE
[chore][DEV-1502] docs: mv table#catalog_id to table>lineage

### DIFF
--- a/featurebyte/common/documentation/documentation_layout.py
+++ b/featurebyte/common/documentation/documentation_layout.py
@@ -178,12 +178,12 @@ def _get_table_layout() -> List[DocLayoutItem]:
             doc_path_override="api.base_table.TableApiObject.type.md",
         ),
         DocLayoutItem([TABLE, INFO, "Table.updated_at"]),
-        DocLayoutItem(
-            [TABLE, INFO, "Table.catalog_id"],
-            doc_path_override="api.base_table.TableApiObject.catalog_id.md",
-        ),
         DocLayoutItem([TABLE, INFO, "EventTable.default_feature_job_setting"]),
         DocLayoutItem([TABLE, INFO, "ItemTable.default_feature_job_setting"]),
+        DocLayoutItem(
+            [TABLE, LINEAGE, "Table.catalog_id"],
+            doc_path_override="api.base_table.TableApiObject.catalog_id.md",
+        ),
         DocLayoutItem(
             [TABLE, LINEAGE, "Table.entity_ids"],
             doc_path_override="api.base_table.TableApiObject.entity_ids.md",


### PR DESCRIPTION
## Description
Move table#catalog_id to be under the `Table` > `Lineage` section instead.

![Screenshot 2023-10-03 at 1 35 15 PM](https://github.com/featurebyte/featurebyte/assets/2313101/96717a8b-d8b4-45b9-9034-1d4c4dc4aae1)


<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-1502
<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
