### PR TITLE
[DEV-2393] observation_table: add purpose into model

### DIFF
--- a/.changelog/DEV-2393.yaml
+++ b/.changelog/DEV-2393.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: observation_table
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add an optional purpose to observation table when creating a new observation table."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/models/observation_table.py
+++ b/featurebyte/models/observation_table.py
@@ -11,6 +11,7 @@ from datetime import datetime  # pylint: disable=wrong-import-order
 import pymongo
 from pydantic import Field, StrictStr, validator
 
+from featurebyte.enum import StrEnum
 from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
 from featurebyte.models.materialized_table import MaterializedTableModel
 from featurebyte.models.request_input import (
@@ -72,6 +73,18 @@ ObservationInput = Annotated[
 ]
 
 
+class Purpose(StrEnum):
+    """
+    Purpose of the observation table
+    """
+
+    PREVIEW = "preview"
+    EDA = "eda"
+    TRAINING = "training"
+    VALIDATION_TEST = "validation_test"
+    OTHER = "other"
+
+
 class ObservationTableModel(MaterializedTableModel):
     """
     ObservationTableModel is a table that can be used to request historical features
@@ -85,6 +98,7 @@ class ObservationTableModel(MaterializedTableModel):
     request_input: ObservationInput
     most_recent_point_in_time: StrictStr
     context_id: Optional[PydanticObjectId] = Field(default=None)
+    purpose: Optional[Purpose] = Field(default=None)
 
     @validator("most_recent_point_in_time")
     @classmethod

--- a/featurebyte/schema/observation_table.py
+++ b/featurebyte/schema/observation_table.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 from pydantic import Field
 
 from featurebyte.models.base import PydanticObjectId
-from featurebyte.models.observation_table import ObservationInput, ObservationTableModel
+from featurebyte.models.observation_table import ObservationInput, ObservationTableModel, Purpose
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema, PaginationMixin
 from featurebyte.schema.request_table import BaseRequestTableCreate, BaseRequestTableListRecord
 
@@ -21,6 +21,7 @@ class ObservationTableCreate(BaseRequestTableCreate):
     sample_rows: Optional[int] = Field(ge=0)
     request_input: ObservationInput
     skip_entity_validation_checks: bool = Field(default=False)
+    purpose: Optional[Purpose] = Field(default=None)
 
 
 class ObservationTableList(PaginationMixin):

--- a/featurebyte/worker/task/observation_table.py
+++ b/featurebyte/worker/task/observation_table.py
@@ -65,6 +65,7 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask):
                 location=location,
                 context_id=payload.context_id,
                 request_input=payload.request_input,
+                purpose=payload.purpose,
                 **additional_metadata,
             )
             await observation_table_service.create_document(observation_table)

--- a/tests/fixtures/request_payloads/observation_table.json
+++ b/tests/fixtures/request_payloads/observation_table.json
@@ -21,5 +21,6 @@
         },
         "type": "source_table"
     },
-    "sample_rows": null
+    "sample_rows": null,
+    "purpose": "other"
 }

--- a/tests/unit/routes/test_observation_table.py
+++ b/tests/unit/routes/test_observation_table.py
@@ -92,6 +92,14 @@ class TestObservationTableApi(BaseMaterializedTableTestSuite):
             "description": None,
         }
 
+    def test_get_purpose(self, test_api_client_persistent, create_success_response):
+        """Test get purpose"""
+        test_api_client, _ = test_api_client_persistent
+        doc_id = create_success_response.json()["_id"]
+        response = test_api_client.get(f"{self.base_route}/{doc_id}")
+        response_dict = response.json()
+        assert response_dict["purpose"] == "other"
+
     def test_update_context(self, test_api_client_persistent, create_success_response):
         """Test update context route"""
         test_api_client, _ = test_api_client_persistent


### PR DESCRIPTION
## Description
Add another field into the `ObservationTable` model to keep track of the purpose of the table.

This will be used when creating observation tables from the UI.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-2393

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
