### PR TITLE
[DEV-2399] observation_table: track earliest point in time and entity count

### DIFF
--- a/.changelog/DEV-2399.yaml
+++ b/.changelog/DEV-2399.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: observation_table
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Track earliest point in time, and unique entity col counts as part of metadata."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/models/observation_table.py
+++ b/featurebyte/models/observation_table.py
@@ -99,10 +99,10 @@ class ObservationTableModel(MaterializedTableModel):
     most_recent_point_in_time: StrictStr
     context_id: Optional[PydanticObjectId] = Field(default=None)
     purpose: Optional[Purpose] = Field(default=None)
-    earliest_point_in_time: Optional[StrictStr] = Field(default=None)
+    least_recent_point_in_time: Optional[StrictStr] = Field(default=None)
     entity_column_name_to_count: Optional[Dict[str, int]] = Field(default_factory=dict)
 
-    @validator("most_recent_point_in_time", "earliest_point_in_time")
+    @validator("most_recent_point_in_time", "least_recent_point_in_time")
     @classmethod
     def _validate_most_recent_point_in_time(cls, value: Optional[str]) -> Optional[str]:
         if value is None:

--- a/featurebyte/models/observation_table.py
+++ b/featurebyte/models/observation_table.py
@@ -3,7 +3,7 @@ ObservationTableModel models
 """
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 from typing_extensions import Annotated, Literal
 
 from datetime import datetime  # pylint: disable=wrong-import-order
@@ -99,10 +99,14 @@ class ObservationTableModel(MaterializedTableModel):
     most_recent_point_in_time: StrictStr
     context_id: Optional[PydanticObjectId] = Field(default=None)
     purpose: Optional[Purpose] = Field(default=None)
+    earliest_point_in_time: Optional[StrictStr] = Field(default=None)
+    entity_column_name_to_count: Optional[Dict[str, int]] = Field(default_factory=dict)
 
-    @validator("most_recent_point_in_time")
+    @validator("most_recent_point_in_time", "earliest_point_in_time")
     @classmethod
-    def _validate_most_recent_point_in_time(cls, value: str) -> str:
+    def _validate_most_recent_point_in_time(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
         # Check that most_recent_point_in_time is a valid ISO 8601 datetime
         _ = datetime.fromisoformat(value)
         return value

--- a/featurebyte/query_graph/sql/materialisation.py
+++ b/featurebyte/query_graph/sql/materialisation.py
@@ -85,7 +85,7 @@ def get_view_expr(
     return table_expr
 
 
-def get_most_recent_point_in_time_sql(
+def get_earliest_and_most_recent_point_in_time_sql(
     destination: TableDetails,
     source_type: SourceType,
 ) -> str:
@@ -104,7 +104,8 @@ def get_most_recent_point_in_time_sql(
     str
     """
     query = expressions.select(
-        expressions.Max(this=quoted_identifier(SpecialColumnName.POINT_IN_TIME))
+        expressions.Min(this=quoted_identifier(SpecialColumnName.POINT_IN_TIME)),
+        expressions.Max(this=quoted_identifier(SpecialColumnName.POINT_IN_TIME)),
     ).from_(get_fully_qualified_table_name(destination.dict()))
     return sql_to_string(query, source_type=source_type)
 

--- a/featurebyte/query_graph/sql/materialisation.py
+++ b/featurebyte/query_graph/sql/materialisation.py
@@ -85,12 +85,12 @@ def get_view_expr(
     return table_expr
 
 
-def get_earliest_and_most_recent_point_in_time_sql(
+def get_least_and_most_recent_point_in_time_sql(
     destination: TableDetails,
     source_type: SourceType,
 ) -> str:
     """
-    Construct SQL query to get the most recent point in time
+    Construct SQL query to get the least and most recent point in time
 
     Parameters
     ----------

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 import pandas as pd
 from bson import ObjectId
 
-from featurebyte import SourceTable
+from featurebyte.api.source_table import SourceTable
 from featurebyte.common.utils import dataframe_from_json
 from featurebyte.enum import DBVarType, MaterializedTableNamePrefix, SpecialColumnName
 from featurebyte.exception import (
@@ -18,8 +18,8 @@ from featurebyte.exception import (
     ObservationTableInvalidContextError,
     UnsupportedPointInTimeColumnTypeError,
 )
-from featurebyte.models import FeatureStoreModel
 from featurebyte.models.base import FeatureByteBaseDocumentModel
+from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.models.materialized_table import ColumnSpecWithEntityId
 from featurebyte.models.observation_table import ObservationTableModel
 from featurebyte.persistent import Persistent

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -253,7 +253,9 @@ class ObservationTableService(
         column_name_to_count = {}
         for col in entity_cols:
             col_name = col.name
-            column_name_to_count[col_name] = describe_stats_dataframe.loc["unique", col_name]
+            column_name_to_count[col_name] = describe_stats_dataframe.loc[
+                "unique", col_name
+            ]  # pylint: disable=no-member
         return column_name_to_count
 
     async def validate_materialized_table_and_get_metadata(

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -253,9 +253,11 @@ class ObservationTableService(
         column_name_to_count = {}
         for col in entity_cols:
             col_name = col.name
-            column_name_to_count[col_name] = describe_stats_dataframe.loc[
+            column_name_to_count[
+                col_name
+            ] = describe_stats_dataframe.loc[  # pylint: disable=no-member
                 "unique", col_name
-            ]  # pylint: disable=no-member
+            ]
         return column_name_to_count
 
     async def validate_materialized_table_and_get_metadata(

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -3,30 +3,134 @@ ObservationTableService class
 """
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, List, Optional, cast
+
+from dataclasses import dataclass
 
 import pandas as pd
 from bson import ObjectId
 
+from featurebyte import SourceTable
+from featurebyte.common.utils import dataframe_from_json
 from featurebyte.enum import DBVarType, MaterializedTableNamePrefix, SpecialColumnName
 from featurebyte.exception import (
     MissingPointInTimeColumnError,
     ObservationTableInvalidContextError,
     UnsupportedPointInTimeColumnTypeError,
 )
+from featurebyte.models import FeatureStoreModel
 from featurebyte.models.base import FeatureByteBaseDocumentModel
+from featurebyte.models.materialized_table import ColumnSpecWithEntityId
 from featurebyte.models.observation_table import ObservationTableModel
 from featurebyte.persistent import Persistent
+from featurebyte.query_graph.model.common_table import TabularSource
 from featurebyte.query_graph.node.schema import TableDetails
-from featurebyte.query_graph.sql.materialisation import get_most_recent_point_in_time_sql
+from featurebyte.query_graph.sql.materialisation import (
+    get_earliest_and_most_recent_point_in_time_sql,
+)
+from featurebyte.schema.feature_store import FeatureStoreSample
 from featurebyte.schema.observation_table import ObservationTableCreate, ObservationTableUpdate
 from featurebyte.schema.worker.task.observation_table import ObservationTableTaskPayload
 from featurebyte.service.context import ContextService
 from featurebyte.service.entity import EntityService
 from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.service.materialized_table import BaseMaterializedTableService
+from featurebyte.service.preview import PreviewService
 from featurebyte.service.session_manager import SessionManagerService
 from featurebyte.session.base import BaseSession
+
+
+@dataclass
+class PointInTimeStats:
+    """
+    Point in time stats
+    """
+
+    earliest: str
+    most_recent: str
+
+
+async def get_point_in_time_stats(
+    db_session: BaseSession,
+    destination: TableDetails,
+) -> PointInTimeStats:
+    """
+    Get the most recent point in time from the destination table.
+
+    Parameters
+    ----------
+    db_session: BaseSession
+        Database session
+    destination: TableDetails
+        Table details of the materialized table
+
+    Returns
+    -------
+    str
+    """
+    res = await db_session.execute_query(
+        get_earliest_and_most_recent_point_in_time_sql(
+            destination=destination,
+            source_type=db_session.source_type,
+        )
+    )
+    earliest_point_in_time = res.iloc[0, 0]  # type: ignore[union-attr]
+    most_recent_point_in_time = res.iloc[0, 1]  # type: ignore[union-attr]
+
+    def _convert_ts_to_str(timestamp_str: str) -> str:
+        current_timestamp = pd.Timestamp(timestamp_str)
+        if current_timestamp.tzinfo is not None:
+            current_timestamp = current_timestamp.tz_convert("UTC").tz_localize(None)
+        current_timestamp = current_timestamp.isoformat()
+        return cast(str, current_timestamp)
+
+    most_recent_point_in_time_str = _convert_ts_to_str(most_recent_point_in_time)
+    earliest_str = _convert_ts_to_str(earliest_point_in_time)
+    return PointInTimeStats(most_recent=most_recent_point_in_time_str, earliest=earliest_str)
+
+
+def validate_columns_info(
+    columns_info: List[ColumnSpecWithEntityId], skip_entity_validation_checks: bool = False
+) -> None:
+    """
+    Validate column info.
+
+    Parameters
+    ----------
+    columns_info: List[ColumnSpecWithEntityId]
+        List of column specs with entity id
+    skip_entity_validation_checks: bool
+        Whether to skip entity validation checks
+
+    Raises
+    ------
+    MissingPointInTimeColumnError
+        If the point in time column is missing.
+    UnsupportedPointInTimeColumnTypeError
+        If the point in time column is not of timestamp type.
+    ValueError
+        If no entity column is provided.
+    """
+    columns_info_mapping = {info.name: info for info in columns_info}
+
+    if SpecialColumnName.POINT_IN_TIME not in columns_info_mapping:
+        raise MissingPointInTimeColumnError(
+            f"Point in time column not provided: {SpecialColumnName.POINT_IN_TIME}"
+        )
+
+    point_in_time_dtype = columns_info_mapping[SpecialColumnName.POINT_IN_TIME].dtype
+    if point_in_time_dtype not in {
+        DBVarType.TIMESTAMP,
+        DBVarType.TIMESTAMP_TZ,
+    }:
+        raise UnsupportedPointInTimeColumnTypeError(
+            f"Point in time column should have timestamp type; got {point_in_time_dtype}"
+        )
+
+    if not skip_entity_validation_checks:
+        # Check that there's at least one entity mapped in the columns info
+        if not any(info.entity_id is not None for info in columns_info):
+            raise ValueError("At least one entity column should be provided.")
 
 
 class ObservationTableService(
@@ -48,6 +152,7 @@ class ObservationTableService(
         feature_store_service: FeatureStoreService,
         entity_service: EntityService,
         context_service: ContextService,
+        preview_service: PreviewService,
     ):
         super().__init__(
             user,
@@ -58,6 +163,7 @@ class ObservationTableService(
             entity_service,
         )
         self.context_service = context_service
+        self.preview_service = preview_service
 
     @property
     def class_name(self) -> str:
@@ -99,45 +205,62 @@ class ObservationTableService(
             output_document_id=output_document_id,
         )
 
-    @staticmethod
-    async def get_most_recent_point_in_time(
-        db_session: BaseSession,
-        destination: TableDetails,
-    ) -> str:
+    async def _get_column_name_to_entity_count(
+        self,
+        feature_store: FeatureStoreModel,
+        table_details: TableDetails,
+        columns_info: List[ColumnSpecWithEntityId],
+    ) -> Dict[str, int]:
         """
-        Get the most recent point in time from the destination table.
+        Get the entity column name to unique entity count mapping.
 
         Parameters
         ----------
-        db_session: BaseSession
-            Database session
-        destination: TableDetails
+        feature_store: FeatureStoreModel
+            Feature store document
+        table_details: TableDetails
             Table details of the materialized table
+        columns_info: List[ColumnSpecWithEntityId]
+            List of column specs with entity id
 
         Returns
         -------
-        str
+        Dict[str, int]
         """
-        res = await db_session.execute_query(
-            get_most_recent_point_in_time_sql(
-                destination=destination,
-                source_type=db_session.source_type,
-            )
+        # Get describe statistics
+        source_table = SourceTable(
+            feature_store=feature_store,
+            tabular_source=TabularSource(
+                feature_store_id=feature_store.id,
+                table_details=TableDetails(
+                    database_name=table_details.database_name,
+                    schema_name=table_details.schema_name,
+                    table_name=table_details.table_name,
+                ),
+            ),
+            columns_info=columns_info,
         )
-        most_recent_point_in_time = res.iloc[0, 0]  # type: ignore[union-attr]
-        most_recent_point_in_time = pd.Timestamp(most_recent_point_in_time)
-        if most_recent_point_in_time.tzinfo is not None:
-            most_recent_point_in_time = most_recent_point_in_time.tz_convert("UTC").tz_localize(
-                None
-            )
-        most_recent_point_in_time = most_recent_point_in_time.isoformat()
-
-        return cast(str, most_recent_point_in_time)
+        graph, node = source_table.frame.extract_pruned_graph_and_node()
+        sample = FeatureStoreSample(
+            feature_store_name=feature_store.name,
+            graph=graph,
+            node_name=node.name,
+            stats_names=["unique"],
+        )
+        describe_stats_json = await self.preview_service.describe(sample, 0, 1234)
+        describe_stats_dataframe = dataframe_from_json(describe_stats_json)
+        entity_cols = [col for col in columns_info if col.entity_id is not None]
+        column_name_to_count = {}
+        for col in entity_cols:
+            col_name = col.name
+            column_name_to_count[col_name] = describe_stats_dataframe.loc["unique", col_name]
+        return column_name_to_count
 
     async def validate_materialized_table_and_get_metadata(
         self,
         db_session: BaseSession,
         table_details: TableDetails,
+        feature_store: FeatureStoreModel,
         serving_names_remapping: Optional[Dict[str, str]] = None,
         skip_entity_validation_checks: bool = False,
     ) -> Dict[str, Any]:
@@ -150,6 +273,8 @@ class ObservationTableService(
             Database session
         table_details: TableDetails
             Table details of the materialized table
+        feature_store: FeatureStoreModel
+            Feature store document
         serving_names_remapping: Dict[str, str]
             Remapping of serving names
         skip_entity_validation_checks: bool
@@ -158,50 +283,30 @@ class ObservationTableService(
         Returns
         -------
         dict[str, Any]
-
-        Raises
-        ------
-        MissingPointInTimeColumnError
-            If the point in time column is missing.
-        UnsupportedPointInTimeColumnTypeError
-            If the point in time column is not of timestamp type.
-        ValueError
-            If no entity column is provided.
         """
+        # Get column info and number of row metadata
         columns_info, num_rows = await self.get_columns_info_and_num_rows(
             db_session=db_session,
             table_details=table_details,
             serving_names_remapping=serving_names_remapping,
         )
-        columns_info_mapping = {info.name: info for info in columns_info}
-
-        if SpecialColumnName.POINT_IN_TIME not in columns_info_mapping:
-            raise MissingPointInTimeColumnError(
-                f"Point in time column not provided: {SpecialColumnName.POINT_IN_TIME}"
-            )
-
-        point_in_time_dtype = columns_info_mapping[SpecialColumnName.POINT_IN_TIME].dtype
-        if point_in_time_dtype not in {
-            DBVarType.TIMESTAMP,
-            DBVarType.TIMESTAMP_TZ,
-        }:
-            raise UnsupportedPointInTimeColumnTypeError(
-                f"Point in time column should have timestamp type; got {point_in_time_dtype}"
-            )
-
-        if not skip_entity_validation_checks:
-            # Check that there's at least one entity mapped in the columns info
-            if not any(info.entity_id is not None for info in columns_info):
-                raise ValueError("At least one entity column should be provided.")
-
-        most_recent_point_in_time = await ObservationTableService.get_most_recent_point_in_time(
+        # Perform validation on column info
+        validate_columns_info(columns_info, skip_entity_validation_checks)
+        # Get point in time metadata
+        point_in_time_stats = await get_point_in_time_stats(
             db_session=db_session,
             destination=table_details,
+        )
+        # Get entity statistics metadata
+        column_name_to_count = await self._get_column_name_to_entity_count(
+            feature_store, table_details, columns_info
         )
         return {
             "columns_info": columns_info,
             "num_rows": num_rows,
-            "most_recent_point_in_time": most_recent_point_in_time,
+            "most_recent_point_in_time": point_in_time_stats.most_recent,
+            "earliest_point_in_time": point_in_time_stats.earliest,
+            "entity_column_name_to_count": column_name_to_count,
         }
 
     async def update_observation_table(

--- a/featurebyte/worker/task/observation_table.py
+++ b/featurebyte/worker/task/observation_table.py
@@ -54,9 +54,11 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask):
                 await observation_table_service.validate_materialized_table_and_get_metadata(
                     db_session,
                     location.table_details,
+                    feature_store=feature_store,
                     skip_entity_validation_checks=payload.skip_entity_validation_checks,
                 )
             )
+
             logger.debug("Creating a new ObservationTable", extra=location.table_details.dict())
             observation_table = ObservationTableModel(
                 _id=self.payload.output_document_id,

--- a/featurebyte/worker/task/target_table.py
+++ b/featurebyte/worker/task/target_table.py
@@ -71,7 +71,8 @@ class TargetTableTask(DataWarehouseMixin, BaseTask):
                 await observation_table_service.validate_materialized_table_and_get_metadata(
                     db_session,
                     location.table_details,
-                    payload.serving_names_mapping,
+                    feature_store=feature_store,
+                    serving_names_remapping=payload.serving_names_mapping,
                     skip_entity_validation_checks=payload.skip_entity_validation_checks,
                 )
             )

--- a/tests/integration/api/test_observation_table.py
+++ b/tests/integration/api/test_observation_table.py
@@ -94,6 +94,8 @@ async def test_observation_table_from_source_table(
     check_materialized_table_preview_methods(
         observation_table, expected_columns=["POINT_IN_TIME", "User ID"]
     )
+    assert observation_table.earliest_point_in_time is not None
+    assert "User ID" in observation_table.entity_column_name_to_count
 
 
 @pytest.mark.asyncio

--- a/tests/integration/api/test_observation_table.py
+++ b/tests/integration/api/test_observation_table.py
@@ -94,7 +94,7 @@ async def test_observation_table_from_source_table(
     check_materialized_table_preview_methods(
         observation_table, expected_columns=["POINT_IN_TIME", "User ID"]
     )
-    assert observation_table.earliest_point_in_time is not None
+    assert observation_table.least_recent_point_in_time is not None
     assert "User ID" in observation_table.entity_column_name_to_count
 
 

--- a/tests/unit/service/test_observation_table.py
+++ b/tests/unit/service/test_observation_table.py
@@ -201,7 +201,7 @@ async def test_validate__most_recent_point_in_time(
                     "entity_id": cust_id_entity.id,
                 },
             ],
-            "earliest_point_in_time": "2023-01-01T02:00:00",
+            "least_recent_point_in_time": "2023-01-01T02:00:00",
             "most_recent_point_in_time": "2023-01-15T02:00:00",
             "num_rows": 1000,
             "entity_column_name_to_count": {"cust_id": 2},


### PR DESCRIPTION
## Description
Track the earliest point in time, and the unique entity counts for entities in the observation table.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-2399

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
