### PR TITLE
[chore] observation_table: combine stats into single query

### DIFF
--- a/featurebyte/query_graph/sql/materialisation.py
+++ b/featurebyte/query_graph/sql/materialisation.py
@@ -8,7 +8,7 @@ from typing import Optional
 from sqlglot import expressions
 from sqlglot.expressions import Select, alias_, select
 
-from featurebyte.enum import SourceType, SpecialColumnName
+from featurebyte.enum import SourceType
 from featurebyte.query_graph.model.graph import QueryGraphModel
 from featurebyte.query_graph.node.schema import TableDetails
 from featurebyte.query_graph.sql.common import (
@@ -83,31 +83,6 @@ def get_view_expr(
     interpreter = GraphInterpreter(query_graph=graph, source_type=source_type)
     table_expr = interpreter.construct_materialize_expr(node_name)
     return table_expr
-
-
-def get_least_and_most_recent_point_in_time_sql(
-    destination: TableDetails,
-    source_type: SourceType,
-) -> str:
-    """
-    Construct SQL query to get the least and most recent point in time
-
-    Parameters
-    ----------
-    destination: TableDetails
-        Destination table details
-    source_type: SourceType
-        Source type information
-
-    Returns
-    -------
-    str
-    """
-    query = expressions.select(
-        expressions.Min(this=quoted_identifier(SpecialColumnName.POINT_IN_TIME)),
-        expressions.Max(this=quoted_identifier(SpecialColumnName.POINT_IN_TIME)),
-    ).from_(get_fully_qualified_table_name(destination.dict()))
-    return sql_to_string(query, source_type=source_type)
 
 
 def get_row_count_sql(table_expr: Select, source_type: SourceType) -> str:

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -48,11 +48,10 @@ class PointInTimeStats:
 
 
 def _convert_ts_to_str(timestamp_str: str) -> str:
-    current_timestamp = pd.Timestamp(timestamp_str)
-    if current_timestamp.tzinfo is not None:
-        current_timestamp = current_timestamp.tz_convert("UTC").tz_localize(None)
-    current_timestamp = current_timestamp.isoformat()
-    return cast(str, current_timestamp)
+    timestamp_obj = pd.Timestamp(timestamp_str)
+    if timestamp_obj.tzinfo is not None:
+        timestamp_obj = timestamp_obj.tz_convert("UTC").tz_localize(None)
+    return cast(str, timestamp_obj.isoformat())
 
 
 def validate_columns_info(
@@ -225,11 +224,11 @@ class ObservationTableService(
                 "unique", col_name
             ]
         least_recent_time_str = describe_stats_dataframe.loc[  # pylint: disable=no-member
-            "min", "POINT_IN_TIME"
+            "min", SpecialColumnName.POINT_IN_TIME
         ]
         least_recent_time_str = _convert_ts_to_str(least_recent_time_str)
         most_recent_time_str = describe_stats_dataframe.loc[  # pylint: disable=no-member
-            "max", "POINT_IN_TIME"
+            "max", SpecialColumnName.POINT_IN_TIME
         ]
         most_recent_time_str = _convert_ts_to_str(most_recent_time_str)
         return column_name_to_count, PointInTimeStats(
@@ -272,11 +271,6 @@ class ObservationTableService(
         )
         # Perform validation on column info
         validate_columns_info(columns_info, skip_entity_validation_checks)
-        # Get point in time metadata
-        # point_in_time_stats = await get_point_in_time_stats(
-        #     db_session=db_session,
-        #     destination=table_details,
-        # )
         # Get entity statistics metadata
         column_name_to_count, point_in_time_stats = await self._get_column_name_to_entity_count(
             feature_store, table_details, columns_info

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -224,13 +224,13 @@ class ObservationTableService(
             ] = describe_stats_dataframe.loc[  # pylint: disable=no-member
                 "unique", col_name
             ]
-        least_recent_time_str = describe_stats_dataframe.loc[
+        least_recent_time_str = describe_stats_dataframe.loc[  # pylint: disable=no-member
             "min", "POINT_IN_TIME"
-        ]  # pylint: disable=no-member
+        ]
         least_recent_time_str = _convert_ts_to_str(least_recent_time_str)
-        most_recent_time_str = describe_stats_dataframe.loc[
+        most_recent_time_str = describe_stats_dataframe.loc[  # pylint: disable=no-member
             "max", "POINT_IN_TIME"
-        ]  # pylint: disable=no-member
+        ]
         most_recent_time_str = _convert_ts_to_str(most_recent_time_str)
         return column_name_to_count, PointInTimeStats(
             least_recent=least_recent_time_str, most_recent=most_recent_time_str

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -224,9 +224,13 @@ class ObservationTableService(
             ] = describe_stats_dataframe.loc[  # pylint: disable=no-member
                 "unique", col_name
             ]
-        least_recent_time_str = describe_stats_dataframe.loc["min", "POINT_IN_TIME"]
+        least_recent_time_str = describe_stats_dataframe.loc[
+            "min", "POINT_IN_TIME"
+        ]  # pylint: disable=no-member
         least_recent_time_str = _convert_ts_to_str(least_recent_time_str)
-        most_recent_time_str = describe_stats_dataframe.loc["max", "POINT_IN_TIME"]
+        most_recent_time_str = describe_stats_dataframe.loc[
+            "max", "POINT_IN_TIME"
+        ]  # pylint: disable=no-member
         most_recent_time_str = _convert_ts_to_str(most_recent_time_str)
         return column_name_to_count, PointInTimeStats(
             least_recent=least_recent_time_str, most_recent=most_recent_time_str


### PR DESCRIPTION
## Description
Replace the `point_in_time_stats` query to utilize the min and max stats query from the describe function.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
