### PR TITLE
[chore] Implement route to retrieve sample entity_serving_names for a deployment

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -176,7 +176,7 @@ tasks:
       - featurebyte/**/*
     cmds:
       - poetry run pip-licenses --packages '{{ .PACKAGES }}' --allow-only='{{ .PERMISSIVE_LICENSES }}'
-      - poetry run pip-audit --ignore-vuln GHSA-wfm5-v35h-vwf4 --ignore-vuln GHSA-cwvm-v4w8-q58c --ignore-vuln GHSA-v8gr-m533-ghj9 --ignore-vuln PYSEC-2023-175 --ignore-vuln PYSEC-2023-177 --ignore-vuln GHSA-v845-jxx5-vc9f --ignore-vuln GHSA-j7hp-h8jx-5ppr --ignore-vuln GHSA-56pw-mpj4-fxww
+      - poetry run pip-audit --ignore-vuln PYSEC-2023-177
 
   lint-bandit:
     desc: "Run the linter[bandit]"

--- a/featurebyte/query_graph/sql/interpreter/preview.py
+++ b/featurebyte/query_graph/sql/interpreter/preview.py
@@ -239,6 +239,35 @@ class PreviewMixin(BaseGraphInterpreter):
         )
         return sql_to_string(sql_tree, source_type=self.source_type), type_conversions
 
+    def construct_unique_values_sql(
+        self, node_name: str, column_name: str, num_rows: int = 10
+    ) -> str:
+        """Construct SQL to get unique values in a column from a given node
+
+        Parameters
+        ----------
+        node_name : str
+            Query graph node name
+        column_name : str
+            Column name to get unique values for
+        num_rows : int
+            Number of rows to include in the preview
+
+        Returns
+        -------
+        str
+            SQL code for getting unique column values and type conversions to apply on results
+        """
+        sql_tree, _ = self._construct_sample_sql(node_name=node_name, num_rows=0)
+        output_expr = (
+            construct_cte_sql([("data", sql_tree)])
+            .select(
+                expressions.Distinct(expressions=[quoted_identifier(column_name)]),
+            )
+            .from_("data")
+        )
+        return sql_to_string(output_expr.limit(num_rows), source_type=self.source_type)
+
     @staticmethod
     def _empty_value_expr(column_name: str) -> expressions.Expression:
         """

--- a/featurebyte/routes/deployment/api.py
+++ b/featurebyte/routes/deployment/api.py
@@ -31,7 +31,11 @@ from featurebyte.schema.deployment import (
     OnlineFeaturesResponseModel,
 )
 from featurebyte.schema.feature_list import OnlineFeaturesRequestPayload
-from featurebyte.schema.info import DeploymentInfo, DeploymentRequestCodeTemplate
+from featurebyte.schema.info import (
+    DeploymentInfo,
+    DeploymentRequestCodeTemplate,
+    DeploymentSampleEntityServingNames,
+)
 from featurebyte.schema.task import Task
 
 router = APIRouter(prefix="/deployment")
@@ -234,3 +238,22 @@ async def get_deployment_request_code_template(
         )
     )
     return request_code_template
+
+
+@router.get(
+    "/{deployment_id}/sample_entity_serving_names",
+    response_model=DeploymentSampleEntityServingNames,
+)
+async def get_deployment_sample_entity_serving_names(
+    request: Request,
+    deployment_id: PydanticObjectId,
+    count: int = Query(default=1, gt=0, le=10),
+) -> DeploymentSampleEntityServingNames:
+    """
+    Get Deployment Request Sample Entity Serving Names
+    """
+    controller = request.state.app_container.deployment_controller
+    sample_entity_serving_names: DeploymentSampleEntityServingNames = (
+        await controller.get_sample_entity_serving_names(deployment_id=deployment_id, count=count)
+    )
+    return sample_entity_serving_names

--- a/featurebyte/schema/info.py
+++ b/featurebyte/schema/info.py
@@ -3,7 +3,7 @@ Info related schema
 """
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from datetime import datetime
 
@@ -439,6 +439,14 @@ class DeploymentInfo(BaseInfo):
     enabled: bool
     serving_endpoint: Optional[str]
     use_case_name: Optional[str]
+
+
+class DeploymentSampleEntityServingNames(FeatureByteBaseModel):
+    """
+    Schema for deployment sample entity serving names
+    """
+
+    entity_serving_names: List[Dict[str, str]]
 
 
 class DeploymentRequestCodeTemplate(FeatureByteBaseModel):

--- a/featurebyte/service/online_serving.py
+++ b/featurebyte/service/online_serving.py
@@ -290,6 +290,11 @@ class OnlineServingService:
             ]
             if entity_columns:
                 for column in entity_columns:
+                    # skip if sample values already exists unless column is a primary key for the table
+                    existing_sample_values = entities[column.entity_id].get("sample_value")
+                    if existing_sample_values and column.name not in table.primary_key_columns:
+                        continue
+
                     entities[column.entity_id][
                         "sample_value"
                     ] = await self.get_table_column_unique_values(

--- a/featurebyte/service/online_serving.py
+++ b/featurebyte/service/online_serving.py
@@ -256,11 +256,6 @@ class OnlineServingService:
         Returns
         -------
         List[Dict[str, str]]
-
-        Raises
-        ------
-        UnsupportedRequestCodeTemplateLanguage
-            When the provided language is not supported
         """
         # get entities and tables used for the feature list
         feature_list_namespace = await self.feature_list_namespace_service.get_document(

--- a/poetry.lock
+++ b/poetry.lock
@@ -4,7 +4,7 @@
 server = ["aioredis", "cachetools", "celery", "celerybeat-mongo", "databricks-cli", "databricks-sql-connector", "fastapi", "featurebyte-freeware", "gevent", "motor", "pdfkit", "pyhive", "redis", "requests-kerberos", "sasl", "smart-open", "snowflake-connector-python", "tenacity", "thrift-sasl", "uvicorn"]
 
 [metadata]
-content-hash = "466c2a08ae371b3fe6b58995c0130a72912dc559b9e45d1798010468c31ac194"
+content-hash = "b98283d789288db30002b42b8d0edbda711c4b8dbca82bdc7800b2d13d25727e"
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
 
@@ -1242,34 +1242,34 @@ toml = ["tomli"]
 [[package]]
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 files = [
-    {file = "cryptography-41.0.3-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:652627a055cb52a84f8c448185922241dd5217443ca194d5739b44612c5e6507"},
-    {file = "cryptography-41.0.3-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:8f09daa483aedea50d249ef98ed500569841d6498aa9c9f4b0531b9964658922"},
-    {file = "cryptography-41.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4fd871184321100fb400d759ad0cddddf284c4b696568204d281c902fc7b0d81"},
-    {file = "cryptography-41.0.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84537453d57f55a50a5b6835622ee405816999a7113267739a1b4581f83535bd"},
-    {file = "cryptography-41.0.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:3fb248989b6363906827284cd20cca63bb1a757e0a2864d4c1682a985e3dca47"},
-    {file = "cryptography-41.0.3-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:42cb413e01a5d36da9929baa9d70ca90d90b969269e5a12d39c1e0d475010116"},
-    {file = "cryptography-41.0.3-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:aeb57c421b34af8f9fe830e1955bf493a86a7996cc1338fe41b30047d16e962c"},
-    {file = "cryptography-41.0.3-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:6af1c6387c531cd364b72c28daa29232162010d952ceb7e5ca8e2827526aceae"},
-    {file = "cryptography-41.0.3-cp37-abi3-win32.whl", hash = "sha256:0d09fb5356f975974dbcb595ad2d178305e5050656affb7890a1583f5e02a306"},
-    {file = "cryptography-41.0.3-cp37-abi3-win_amd64.whl", hash = "sha256:a983e441a00a9d57a4d7c91b3116a37ae602907a7618b882c8013b5762e80574"},
-    {file = "cryptography-41.0.3-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5259cb659aa43005eb55a0e4ff2c825ca111a0da1814202c64d28a985d33b087"},
-    {file = "cryptography-41.0.3-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:67e120e9a577c64fe1f611e53b30b3e69744e5910ff3b6e97e935aeb96005858"},
-    {file = "cryptography-41.0.3-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:7efe8041897fe7a50863e51b77789b657a133c75c3b094e51b5e4b5cec7bf906"},
-    {file = "cryptography-41.0.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:ce785cf81a7bdade534297ef9e490ddff800d956625020ab2ec2780a556c313e"},
-    {file = "cryptography-41.0.3-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:57a51b89f954f216a81c9d057bf1a24e2f36e764a1ca9a501a6964eb4a6800dd"},
-    {file = "cryptography-41.0.3-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:4c2f0d35703d61002a2bbdcf15548ebb701cfdd83cdc12471d2bae80878a4207"},
-    {file = "cryptography-41.0.3-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:23c2d778cf829f7d0ae180600b17e9fceea3c2ef8b31a99e3c694cbbf3a24b84"},
-    {file = "cryptography-41.0.3-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:95dd7f261bb76948b52a5330ba5202b91a26fbac13ad0e9fc8a3ac04752058c7"},
-    {file = "cryptography-41.0.3-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:41d7aa7cdfded09b3d73a47f429c298e80796c8e825ddfadc84c8a7f12df212d"},
-    {file = "cryptography-41.0.3-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d0d651aa754ef58d75cec6edfbd21259d93810b73f6ec246436a21b7841908de"},
-    {file = "cryptography-41.0.3-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:ab8de0d091acbf778f74286f4989cf3d1528336af1b59f3e5d2ebca8b5fe49e1"},
-    {file = "cryptography-41.0.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:a74fbcdb2a0d46fe00504f571a2a540532f4c188e6ccf26f1f178480117b33c4"},
-    {file = "cryptography-41.0.3.tar.gz", hash = "sha256:6d192741113ef5e30d89dcb5b956ef4e1578f304708701b8b73d38e3e1461f34"},
+    {file = "cryptography-41.0.4-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:80907d3faa55dc5434a16579952ac6da800935cd98d14dbd62f6f042c7f5e839"},
+    {file = "cryptography-41.0.4-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:35c00f637cd0b9d5b6c6bd11b6c3359194a8eba9c46d4e875a3660e3b400005f"},
+    {file = "cryptography-41.0.4-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cecfefa17042941f94ab54f769c8ce0fe14beff2694e9ac684176a2535bf9714"},
+    {file = "cryptography-41.0.4-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e40211b4923ba5a6dc9769eab704bdb3fbb58d56c5b336d30996c24fcf12aadb"},
+    {file = "cryptography-41.0.4-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:23a25c09dfd0d9f28da2352503b23e086f8e78096b9fd585d1d14eca01613e13"},
+    {file = "cryptography-41.0.4-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2ed09183922d66c4ec5fdaa59b4d14e105c084dd0febd27452de8f6f74704143"},
+    {file = "cryptography-41.0.4-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:5a0f09cefded00e648a127048119f77bc2b2ec61e736660b5789e638f43cc397"},
+    {file = "cryptography-41.0.4-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:9eeb77214afae972a00dee47382d2591abe77bdae166bda672fb1e24702a3860"},
+    {file = "cryptography-41.0.4-cp37-abi3-win32.whl", hash = "sha256:3b224890962a2d7b57cf5eeb16ccaafba6083f7b811829f00476309bce2fe0fd"},
+    {file = "cryptography-41.0.4-cp37-abi3-win_amd64.whl", hash = "sha256:c880eba5175f4307129784eca96f4e70b88e57aa3f680aeba3bab0e980b0f37d"},
+    {file = "cryptography-41.0.4-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:004b6ccc95943f6a9ad3142cfabcc769d7ee38a3f60fb0dddbfb431f818c3a67"},
+    {file = "cryptography-41.0.4-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:86defa8d248c3fa029da68ce61fe735432b047e32179883bdb1e79ed9bb8195e"},
+    {file = "cryptography-41.0.4-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:37480760ae08065437e6573d14be973112c9e6dcaf5f11d00147ee74f37a3829"},
+    {file = "cryptography-41.0.4-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:b5f4dfe950ff0479f1f00eda09c18798d4f49b98f4e2006d644b3301682ebdca"},
+    {file = "cryptography-41.0.4-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7e53db173370dea832190870e975a1e09c86a879b613948f09eb49324218c14d"},
+    {file = "cryptography-41.0.4-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:5b72205a360f3b6176485a333256b9bcd48700fc755fef51c8e7e67c4b63e3ac"},
+    {file = "cryptography-41.0.4-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:93530900d14c37a46ce3d6c9e6fd35dbe5f5601bf6b3a5c325c7bffc030344d9"},
+    {file = "cryptography-41.0.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:efc8ad4e6fc4f1752ebfb58aefece8b4e3c4cae940b0994d43649bdfce8d0d4f"},
+    {file = "cryptography-41.0.4-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c3391bd8e6de35f6f1140e50aaeb3e2b3d6a9012536ca23ab0d9c35ec18c8a91"},
+    {file = "cryptography-41.0.4-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:0d9409894f495d465fe6fda92cb70e8323e9648af912d5b9141d616df40a87b8"},
+    {file = "cryptography-41.0.4-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:8ac4f9ead4bbd0bc8ab2d318f97d85147167a488be0e08814a37eb2f439d5cf6"},
+    {file = "cryptography-41.0.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:047c4603aeb4bbd8db2756e38f5b8bd7e94318c047cfe4efeb5d715e08b49311"},
+    {file = "cryptography-41.0.4.tar.gz", hash = "sha256:7febc3094125fc126a7f6fb1f420d0da639f3f32cb15c8ff0dc3997c4549f51a"},
 ]
 name = "cryptography"
 optional = false
 python-versions = ">=3.7"
-version = "41.0.3"
+version = "41.0.4"
 
 [package.dependencies]
 cffi = ">=1.12"
@@ -1576,43 +1576,43 @@ devel = ["colorama", "json-spec", "jsonschema", "pylint", "pytest", "pytest-benc
 [[package]]
 description = "Free utilities from FeatureByte"
 files = [
-    {file = "featurebyte_freeware-0.2.15-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6e27976a93a5c35f7ed8a1a247da7a7c8f078336a1a24bc11f5747185c4b5e29"},
-    {file = "featurebyte_freeware-0.2.15-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b6892ce492a6c377c3fe8c6a562dc6eed59dad7711992325f5afbd67c98f0852"},
-    {file = "featurebyte_freeware-0.2.15-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b317e96c0cf11523a15113cc3c9e70607bba8cce2279207f142501138f355bb6"},
-    {file = "featurebyte_freeware-0.2.15-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c6854a93ae8e88d998821226fdb5525944f176f2356efd41123f1e42da8690a9"},
-    {file = "featurebyte_freeware-0.2.15-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ed68358e3d8cb2b40b3f1a1568423959b875ed4666f88ab91c19bef57a87387"},
-    {file = "featurebyte_freeware-0.2.15-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4b9e82444b11885abda5104c9654acc2a02deaa98bb37d8d8a41eceaffa57f36"},
-    {file = "featurebyte_freeware-0.2.15-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2b144a376314a7b671f8151275d1b3df46b68b60359b9351078709efc947f836"},
-    {file = "featurebyte_freeware-0.2.15-cp310-cp310-win_amd64.whl", hash = "sha256:7197e5564da23d21cc05c8a7b4924bbd0f8b7793d984542accba1fc2911200cd"},
-    {file = "featurebyte_freeware-0.2.15-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0fd75c5c5577256f6b6654447aab893b6fb4c811d4e267bef3fcd859b39567c7"},
-    {file = "featurebyte_freeware-0.2.15-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:91af1e6f6bdcbaaadbf8aed5b1b266bff2dbd1d6d3c72a45a561662c031d2990"},
-    {file = "featurebyte_freeware-0.2.15-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:021d6c274f0ce644e417bad0c3949711fe95778e8786851b020e12627f83ec46"},
-    {file = "featurebyte_freeware-0.2.15-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:408e29f3262a32fe6aeff69ea418a0565495b64b159527fddcb693770de90c67"},
-    {file = "featurebyte_freeware-0.2.15-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48b7f542e0172df825fd53cef8d4c4c75d1f217112791da6ec6bbab95122e37d"},
-    {file = "featurebyte_freeware-0.2.15-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:71a9957e3f77e39d0eb963cf84dc3d63ff714b7bae550e2ac00eafedb4462e57"},
-    {file = "featurebyte_freeware-0.2.15-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0a3a453bed690c4dff00d51023530204f42acb8ce3977235026e4724ebaba7bc"},
-    {file = "featurebyte_freeware-0.2.15-cp311-cp311-win_amd64.whl", hash = "sha256:0f9592ad65e0b2b1c29d86766f89010a3cbaed276ab9f389af3da88baf0b55fd"},
-    {file = "featurebyte_freeware-0.2.15-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:1b96122b3cf71cf0f2bb45b89904ac0a782fae68b7eb04f0c2ed61563816b555"},
-    {file = "featurebyte_freeware-0.2.15-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:33c59572ae9e58d9e8cbcd48b9834cc40b26e1a05bf39ab60831015393f5f2b7"},
-    {file = "featurebyte_freeware-0.2.15-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:cfbd49c669c69041eb50058479b4770d87327a002a642d8cd11f3a5979163be3"},
-    {file = "featurebyte_freeware-0.2.15-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b6967675797cc473cca15da5c1ba500262d20959604d99ec678c3b77207646c"},
-    {file = "featurebyte_freeware-0.2.15-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:509cc0b4ef102c0b605266f6cc3aef3f39d6d56da0b0ea1cfec6906481d00f44"},
-    {file = "featurebyte_freeware-0.2.15-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:1457c240f64560c97f8661fcbbed4f706968e1dd11accc7032bdbdf77227464f"},
-    {file = "featurebyte_freeware-0.2.15-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:82c4e8430995cf3f7ed7758ad241c9f7386cddcff4662310de22d62eded00ff7"},
-    {file = "featurebyte_freeware-0.2.15-cp38-cp38-win_amd64.whl", hash = "sha256:d569607127838fdebb82eb236da827085bcef91bda12309dd1da3acbaa1f41ed"},
-    {file = "featurebyte_freeware-0.2.15-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:1855c12b9fa13aa80207a25c42bd186c9329b1f7e016ea95f11739a2047babdf"},
-    {file = "featurebyte_freeware-0.2.15-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:190d54906b4e68f38281f4d4707d579372ff1730a58cdc49c089b8901a562e79"},
-    {file = "featurebyte_freeware-0.2.15-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2f62a6c59dea2254fa4deee6195e08c512e1599b874618505bdbf1dc84ced531"},
-    {file = "featurebyte_freeware-0.2.15-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a942c144777a6acc194253b226e5675d7c472b1d7e5bc91c6869f80d8ff63a6b"},
-    {file = "featurebyte_freeware-0.2.15-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f43f2e002dcd807a68d832c96a74f7acd941cbb2581220bd3f8ecb257e11b19c"},
-    {file = "featurebyte_freeware-0.2.15-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:85cb134eb303bc81ca1795c729603796252db2599b9987911e6fc045f11f21ec"},
-    {file = "featurebyte_freeware-0.2.15-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:bc5093c61acd02be8c908d0bfde6899e090da0e9fd76d946991cef67099c72fe"},
-    {file = "featurebyte_freeware-0.2.15-cp39-cp39-win_amd64.whl", hash = "sha256:035a9a1986214b40dadfea1a1e003e8d260ce1db5e2089108b1f0cb1e5cf0c31"},
+    {file = "featurebyte_freeware-0.2.16-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:95d0249e62e75b09b9091575b7a6779b8c2c039a033bb80dfb86ea9aa128266a"},
+    {file = "featurebyte_freeware-0.2.16-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:56f7c2da68a7f936cd6a9776e982a8d097a06957570a5e470d295744d412c60d"},
+    {file = "featurebyte_freeware-0.2.16-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9b301980caee99b75696e87135cba748aec9e0b59d4e1fcba937076655214b26"},
+    {file = "featurebyte_freeware-0.2.16-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47de8b34776d54750393e41ee9531c080d4b75b1682cd2b6b867357032921919"},
+    {file = "featurebyte_freeware-0.2.16-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:332bfcf51c8bf6ad2c53098bec25da3da06841127d014293459b91b6f04e9c88"},
+    {file = "featurebyte_freeware-0.2.16-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:ba4650ac19a7808ba9fe3821651230f19507c35729384a8147c21d4e37296849"},
+    {file = "featurebyte_freeware-0.2.16-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:37380e7d5dffd022d0657e998a9b6a0c480c24a30f72af988751d6a7a67932f3"},
+    {file = "featurebyte_freeware-0.2.16-cp310-cp310-win_amd64.whl", hash = "sha256:accc65ff78a4c020fd747fd01ee3386a7bb6590e4b4792f2407e9f53c4762a04"},
+    {file = "featurebyte_freeware-0.2.16-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ca0f49d276c7525556afa778fc60584899394975684e6d02e243b48f5147bee4"},
+    {file = "featurebyte_freeware-0.2.16-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b66fd132cc26985308a6c09bcaca6eaec678aa1956c85fb0d036c2c03bf5a18f"},
+    {file = "featurebyte_freeware-0.2.16-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b0f56e5719b7d70c97157e0537c83523f0933760c40653ee6cdd6c3f917ec377"},
+    {file = "featurebyte_freeware-0.2.16-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35812e3664e9c4e1a5367e49a28a25ac0cf46e91b1971eda504bd6e081689d3e"},
+    {file = "featurebyte_freeware-0.2.16-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:327cb40d6d77f427641076c242ac378a675e7da82d729f3953524491dc3f8eba"},
+    {file = "featurebyte_freeware-0.2.16-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:b1e2050045ca44562bf74f37232e908d3cf70bcbc8889aab96fa26f7bbb0d952"},
+    {file = "featurebyte_freeware-0.2.16-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d3452cb438ff3e8277f5f23378305b94f904452e3d69259f3e58ac3759f9748a"},
+    {file = "featurebyte_freeware-0.2.16-cp311-cp311-win_amd64.whl", hash = "sha256:beab58bdd3f3b7a22c89fe89d6ddbc56813f8f9fb23b8f439e06484265d9b564"},
+    {file = "featurebyte_freeware-0.2.16-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:818db1a2463a802666f5f03d72a63a1eab9169e5c605cc2eba41e0e02de57267"},
+    {file = "featurebyte_freeware-0.2.16-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:360c20c52be93c591c8bc35037d4c31b5cfe19c55666ce742809eb04dc67cd80"},
+    {file = "featurebyte_freeware-0.2.16-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a5231d2c584442116d71e7e3dbebfa68ac8dbb960a9a2214eabffa197256463c"},
+    {file = "featurebyte_freeware-0.2.16-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cca7fc5ddcf81dc8a64088ae85db34c0cd261a4050b63ff7022d51834150446"},
+    {file = "featurebyte_freeware-0.2.16-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb04084bc9a7cbe89dbc84c932c653e82a75c32939e939da95ccf7acf4ab5a8b"},
+    {file = "featurebyte_freeware-0.2.16-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:d1a7d1222bd1b9ca776a057373453a8cdf78858837eb024a2cb3ba06ab905a63"},
+    {file = "featurebyte_freeware-0.2.16-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:529440c255c5853f8804407241977d0c9ed84e5f05089d36a805519aaa38cefd"},
+    {file = "featurebyte_freeware-0.2.16-cp38-cp38-win_amd64.whl", hash = "sha256:49dee6d9998bdbc3fcfdadbe12958c60a466b5f9386e07c693459fff645f3627"},
+    {file = "featurebyte_freeware-0.2.16-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b685a98c4a222cba3c42c3688acf77d1f8d50c4f1ff4177bf3013878c01ecd5f"},
+    {file = "featurebyte_freeware-0.2.16-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b1ace3c27a0e428dcbdf3cdac515f6248a30b928b7b14ff2b6c17a2ef0730700"},
+    {file = "featurebyte_freeware-0.2.16-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ae37322c835b33527401ce96db0885f8140081a2591d3853e8f2ebe554b19bde"},
+    {file = "featurebyte_freeware-0.2.16-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6d2351dabb3a91ce50a96fc035e4adfcada7ceaf3aa13016fc573a92ed836fef"},
+    {file = "featurebyte_freeware-0.2.16-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f354ba3651a7c13d9e4781b7036309491313d2974edacf2e4297a3dd033997fd"},
+    {file = "featurebyte_freeware-0.2.16-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:753cb0c03d3e136a4f64c18f8b9be6813b3db09309a07be19240b496ebcfdad8"},
+    {file = "featurebyte_freeware-0.2.16-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:65403e67021bf10e1781ea26df87d556ff98feab7f1284d0653203d0b8641aa0"},
+    {file = "featurebyte_freeware-0.2.16-cp39-cp39-win_amd64.whl", hash = "sha256:e27bd580597e007cb2b46f37ee03ec4b3337663e5a545fe4c29f73507c29a075"},
 ]
 name = "featurebyte-freeware"
 optional = true
 python-versions = "<3.12,>=3.8"
-version = "0.2.15"
+version = "0.2.16"
 
 [package.dependencies]
 Jinja2 = ">=3.1.2"
@@ -1906,16 +1906,19 @@ smmap = ">=3.0.1,<6"
 [[package]]
 description = "GitPython is a Python library used to interact with Git repositories"
 files = [
-    {file = "GitPython-3.1.34-py3-none-any.whl", hash = "sha256:5d3802b98a3bae1c2b8ae0e1ff2e4aa16bcdf02c145da34d092324f599f01395"},
-    {file = "GitPython-3.1.34.tar.gz", hash = "sha256:85f7d365d1f6bf677ae51039c1ef67ca59091c7ebd5a3509aa399d4eda02d6dd"},
+    {file = "GitPython-3.1.37-py3-none-any.whl", hash = "sha256:5f4c4187de49616d710a77e98ddf17b4782060a1788df441846bddefbb89ab33"},
+    {file = "GitPython-3.1.37.tar.gz", hash = "sha256:f9b9ddc0761c125d5780eab2d64be4873fc6817c2899cbcb34b02344bdc7bc54"},
 ]
 name = "gitpython"
 optional = false
 python-versions = ">=3.7"
-version = "3.1.34"
+version = "3.1.37"
 
 [package.dependencies]
 gitdb = ">=4.0.1,<5"
+
+[package.extras]
+test = ["black", "coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mypy", "pre-commit", "pytest", "pytest-cov", "pytest-sugar"]
 
 [[package]]
 description = "Google API client core library"
@@ -2655,7 +2658,6 @@ dev = ["hypothesis"]
 description = "Identify specific nodes in a JSON document (RFC 6901)"
 files = [
     {file = "jsonpointer-2.4-py2.py3-none-any.whl", hash = "sha256:15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a"},
-    {file = "jsonpointer-2.4.tar.gz", hash = "sha256:585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88"},
 ]
 name = "jsonpointer"
 optional = false
@@ -4474,67 +4476,65 @@ version = "0.7.5"
 [[package]]
 description = "Python Imaging Library (Fork)"
 files = [
-    {file = "Pillow-10.0.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1f62406a884ae75fb2f818694469519fb685cc7eaff05d3451a9ebe55c646891"},
-    {file = "Pillow-10.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d5db32e2a6ccbb3d34d87c87b432959e0db29755727afb37290e10f6e8e62614"},
-    {file = "Pillow-10.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edf4392b77bdc81f36e92d3a07a5cd072f90253197f4a52a55a8cec48a12483b"},
-    {file = "Pillow-10.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:520f2a520dc040512699f20fa1c363eed506e94248d71f85412b625026f6142c"},
-    {file = "Pillow-10.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:8c11160913e3dd06c8ffdb5f233a4f254cb449f4dfc0f8f4549eda9e542c93d1"},
-    {file = "Pillow-10.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a74ba0c356aaa3bb8e3eb79606a87669e7ec6444be352870623025d75a14a2bf"},
-    {file = "Pillow-10.0.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d5d0dae4cfd56969d23d94dc8e89fb6a217be461c69090768227beb8ed28c0a3"},
-    {file = "Pillow-10.0.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:22c10cc517668d44b211717fd9775799ccec4124b9a7f7b3635fc5386e584992"},
-    {file = "Pillow-10.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:dffe31a7f47b603318c609f378ebcd57f1554a3a6a8effbc59c3c69f804296de"},
-    {file = "Pillow-10.0.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:9fb218c8a12e51d7ead2a7c9e101a04982237d4855716af2e9499306728fb485"},
-    {file = "Pillow-10.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d35e3c8d9b1268cbf5d3670285feb3528f6680420eafe35cccc686b73c1e330f"},
-    {file = "Pillow-10.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ed64f9ca2f0a95411e88a4efbd7a29e5ce2cea36072c53dd9d26d9c76f753b3"},
-    {file = "Pillow-10.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b6eb5502f45a60a3f411c63187db83a3d3107887ad0d036c13ce836f8a36f1d"},
-    {file = "Pillow-10.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:c1fbe7621c167ecaa38ad29643d77a9ce7311583761abf7836e1510c580bf3dd"},
-    {file = "Pillow-10.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:cd25d2a9d2b36fcb318882481367956d2cf91329f6892fe5d385c346c0649629"},
-    {file = "Pillow-10.0.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:3b08d4cc24f471b2c8ca24ec060abf4bebc6b144cb89cba638c720546b1cf538"},
-    {file = "Pillow-10.0.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d737a602fbd82afd892ca746392401b634e278cb65d55c4b7a8f48e9ef8d008d"},
-    {file = "Pillow-10.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:3a82c40d706d9aa9734289740ce26460a11aeec2d9c79b7af87bb35f0073c12f"},
-    {file = "Pillow-10.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:bc2ec7c7b5d66b8ec9ce9f720dbb5fa4bace0f545acd34870eff4a369b44bf37"},
-    {file = "Pillow-10.0.0-cp312-cp312-macosx_10_10_x86_64.whl", hash = "sha256:d80cf684b541685fccdd84c485b31ce73fc5c9b5d7523bf1394ce134a60c6883"},
-    {file = "Pillow-10.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:76de421f9c326da8f43d690110f0e79fe3ad1e54be811545d7d91898b4c8493e"},
-    {file = "Pillow-10.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:81ff539a12457809666fef6624684c008e00ff6bf455b4b89fd00a140eecd640"},
-    {file = "Pillow-10.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce543ed15570eedbb85df19b0a1a7314a9c8141a36ce089c0a894adbfccb4568"},
-    {file = "Pillow-10.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:685ac03cc4ed5ebc15ad5c23bc555d68a87777586d970c2c3e216619a5476223"},
-    {file = "Pillow-10.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d72e2ecc68a942e8cf9739619b7f408cc7b272b279b56b2c83c6123fcfa5cdff"},
-    {file = "Pillow-10.0.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d50b6aec14bc737742ca96e85d6d0a5f9bfbded018264b3b70ff9d8c33485551"},
-    {file = "Pillow-10.0.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:00e65f5e822decd501e374b0650146063fbb30a7264b4d2744bdd7b913e0cab5"},
-    {file = "Pillow-10.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:f31f9fdbfecb042d046f9d91270a0ba28368a723302786c0009ee9b9f1f60199"},
-    {file = "Pillow-10.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:1ce91b6ec08d866b14413d3f0bbdea7e24dfdc8e59f562bb77bc3fe60b6144ca"},
-    {file = "Pillow-10.0.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:349930d6e9c685c089284b013478d6f76e3a534e36ddfa912cde493f235372f3"},
-    {file = "Pillow-10.0.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:3a684105f7c32488f7153905a4e3015a3b6c7182e106fe3c37fbb5ef3e6994c3"},
-    {file = "Pillow-10.0.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b4f69b3700201b80bb82c3a97d5e9254084f6dd5fb5b16fc1a7b974260f89f43"},
-    {file = "Pillow-10.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f07ea8d2f827d7d2a49ecf1639ec02d75ffd1b88dcc5b3a61bbb37a8759ad8d"},
-    {file = "Pillow-10.0.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:040586f7d37b34547153fa383f7f9aed68b738992380ac911447bb78f2abe530"},
-    {file = "Pillow-10.0.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:f88a0b92277de8e3ca715a0d79d68dc82807457dae3ab8699c758f07c20b3c51"},
-    {file = "Pillow-10.0.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:c7cf14a27b0d6adfaebb3ae4153f1e516df54e47e42dcc073d7b3d76111a8d86"},
-    {file = "Pillow-10.0.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:3400aae60685b06bb96f99a21e1ada7bc7a413d5f49bce739828ecd9391bb8f7"},
-    {file = "Pillow-10.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:dbc02381779d412145331789b40cc7b11fdf449e5d94f6bc0b080db0a56ea3f0"},
-    {file = "Pillow-10.0.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:9211e7ad69d7c9401cfc0e23d49b69ca65ddd898976d660a2fa5904e3d7a9baa"},
-    {file = "Pillow-10.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:faaf07ea35355b01a35cb442dd950d8f1bb5b040a7787791a535de13db15ed90"},
-    {file = "Pillow-10.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c9f72a021fbb792ce98306ffb0c348b3c9cb967dce0f12a49aa4c3d3fdefa967"},
-    {file = "Pillow-10.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f7c16705f44e0504a3a2a14197c1f0b32a95731d251777dcb060aa83022cb2d"},
-    {file = "Pillow-10.0.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:76edb0a1fa2b4745fb0c99fb9fb98f8b180a1bbceb8be49b087e0b21867e77d3"},
-    {file = "Pillow-10.0.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:368ab3dfb5f49e312231b6f27b8820c823652b7cd29cfbd34090565a015e99ba"},
-    {file = "Pillow-10.0.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:608bfdee0d57cf297d32bcbb3c728dc1da0907519d1784962c5f0c68bb93e5a3"},
-    {file = "Pillow-10.0.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5c6e3df6bdd396749bafd45314871b3d0af81ff935b2d188385e970052091017"},
-    {file = "Pillow-10.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:7be600823e4c8631b74e4a0d38384c73f680e6105a7d3c6824fcf226c178c7e6"},
-    {file = "Pillow-10.0.0-pp310-pypy310_pp73-macosx_10_10_x86_64.whl", hash = "sha256:92be919bbc9f7d09f7ae343c38f5bb21c973d2576c1d45600fce4b74bafa7ac0"},
-    {file = "Pillow-10.0.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f8182b523b2289f7c415f589118228d30ac8c355baa2f3194ced084dac2dbba"},
-    {file = "Pillow-10.0.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:38250a349b6b390ee6047a62c086d3817ac69022c127f8a5dc058c31ccef17f3"},
-    {file = "Pillow-10.0.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:88af2003543cc40c80f6fca01411892ec52b11021b3dc22ec3bc9d5afd1c5334"},
-    {file = "Pillow-10.0.0-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:c189af0545965fa8d3b9613cfdb0cd37f9d71349e0f7750e1fd704648d475ed2"},
-    {file = "Pillow-10.0.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce7b031a6fc11365970e6a5686d7ba8c63e4c1cf1ea143811acbb524295eabed"},
-    {file = "Pillow-10.0.0-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:db24668940f82321e746773a4bc617bfac06ec831e5c88b643f91f122a785684"},
-    {file = "Pillow-10.0.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:efe8c0681042536e0d06c11f48cebe759707c9e9abf880ee213541c5b46c5bf3"},
-    {file = "Pillow-10.0.0.tar.gz", hash = "sha256:9c82b5b3e043c7af0d95792d0d20ccf68f61a1fec6b3530e718b688422727396"},
+    {file = "Pillow-10.0.1-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:8f06be50669087250f319b706decf69ca71fdecd829091a37cc89398ca4dc17a"},
+    {file = "Pillow-10.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:50bd5f1ebafe9362ad622072a1d2f5850ecfa44303531ff14353a4059113b12d"},
+    {file = "Pillow-10.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6a90167bcca1216606223a05e2cf991bb25b14695c518bc65639463d7db722d"},
+    {file = "Pillow-10.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f11c9102c56ffb9ca87134bd025a43d2aba3f1155f508eff88f694b33a9c6d19"},
+    {file = "Pillow-10.0.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:186f7e04248103482ea6354af6d5bcedb62941ee08f7f788a1c7707bc720c66f"},
+    {file = "Pillow-10.0.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:0462b1496505a3462d0f35dc1c4d7b54069747d65d00ef48e736acda2c8cbdff"},
+    {file = "Pillow-10.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d889b53ae2f030f756e61a7bff13684dcd77e9af8b10c6048fb2c559d6ed6eaf"},
+    {file = "Pillow-10.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:552912dbca585b74d75279a7570dd29fa43b6d93594abb494ebb31ac19ace6bd"},
+    {file = "Pillow-10.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:787bb0169d2385a798888e1122c980c6eff26bf941a8ea79747d35d8f9210ca0"},
+    {file = "Pillow-10.0.1-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:fd2a5403a75b54661182b75ec6132437a181209b901446ee5724b589af8edef1"},
+    {file = "Pillow-10.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2d7e91b4379f7a76b31c2dda84ab9e20c6220488e50f7822e59dac36b0cd92b1"},
+    {file = "Pillow-10.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19e9adb3f22d4c416e7cd79b01375b17159d6990003633ff1d8377e21b7f1b21"},
+    {file = "Pillow-10.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:93139acd8109edcdeffd85e3af8ae7d88b258b3a1e13a038f542b79b6d255c54"},
+    {file = "Pillow-10.0.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:92a23b0431941a33242b1f0ce6c88a952e09feeea9af4e8be48236a68ffe2205"},
+    {file = "Pillow-10.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:cbe68deb8580462ca0d9eb56a81912f59eb4542e1ef8f987405e35a0179f4ea2"},
+    {file = "Pillow-10.0.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:522ff4ac3aaf839242c6f4e5b406634bfea002469656ae8358644fc6c4856a3b"},
+    {file = "Pillow-10.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:84efb46e8d881bb06b35d1d541aa87f574b58e87f781cbba8d200daa835b42e1"},
+    {file = "Pillow-10.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:898f1d306298ff40dc1b9ca24824f0488f6f039bc0e25cfb549d3195ffa17088"},
+    {file = "Pillow-10.0.1-cp312-cp312-macosx_10_10_x86_64.whl", hash = "sha256:bcf1207e2f2385a576832af02702de104be71301c2696d0012b1b93fe34aaa5b"},
+    {file = "Pillow-10.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5d6c9049c6274c1bb565021367431ad04481ebb54872edecfcd6088d27edd6ed"},
+    {file = "Pillow-10.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28444cb6ad49726127d6b340217f0627abc8732f1194fd5352dec5e6a0105635"},
+    {file = "Pillow-10.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de596695a75496deb3b499c8c4f8e60376e0516e1a774e7bc046f0f48cd620ad"},
+    {file = "Pillow-10.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:2872f2d7846cf39b3dbff64bc1104cc48c76145854256451d33c5faa55c04d1a"},
+    {file = "Pillow-10.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4ce90f8a24e1c15465048959f1e94309dfef93af272633e8f37361b824532e91"},
+    {file = "Pillow-10.0.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ee7810cf7c83fa227ba9125de6084e5e8b08c59038a7b2c9045ef4dde61663b4"},
+    {file = "Pillow-10.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:b1be1c872b9b5fcc229adeadbeb51422a9633abd847c0ff87dc4ef9bb184ae08"},
+    {file = "Pillow-10.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:98533fd7fa764e5f85eebe56c8e4094db912ccbe6fbf3a58778d543cadd0db08"},
+    {file = "Pillow-10.0.1-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:764d2c0daf9c4d40ad12fbc0abd5da3af7f8aa11daf87e4fa1b834000f4b6b0a"},
+    {file = "Pillow-10.0.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:fcb59711009b0168d6ee0bd8fb5eb259c4ab1717b2f538bbf36bacf207ef7a68"},
+    {file = "Pillow-10.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:697a06bdcedd473b35e50a7e7506b1d8ceb832dc238a336bd6f4f5aa91a4b500"},
+    {file = "Pillow-10.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f665d1e6474af9f9da5e86c2a3a2d2d6204e04d5af9c06b9d42afa6ebde3f21"},
+    {file = "Pillow-10.0.1-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:2fa6dd2661838c66f1a5473f3b49ab610c98a128fc08afbe81b91a1f0bf8c51d"},
+    {file = "Pillow-10.0.1-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:3a04359f308ebee571a3127fdb1bd01f88ba6f6fb6d087f8dd2e0d9bff43f2a7"},
+    {file = "Pillow-10.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:723bd25051454cea9990203405fa6b74e043ea76d4968166dfd2569b0210886a"},
+    {file = "Pillow-10.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:71671503e3015da1b50bd18951e2f9daf5b6ffe36d16f1eb2c45711a301521a7"},
+    {file = "Pillow-10.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:44e7e4587392953e5e251190a964675f61e4dae88d1e6edbe9f36d6243547ff3"},
+    {file = "Pillow-10.0.1-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:3855447d98cced8670aaa63683808df905e956f00348732448b5a6df67ee5849"},
+    {file = "Pillow-10.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ed2d9c0704f2dc4fa980b99d565c0c9a543fe5101c25b3d60488b8ba80f0cce1"},
+    {file = "Pillow-10.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5bb289bb835f9fe1a1e9300d011eef4d69661bb9b34d5e196e5e82c4cb09b37"},
+    {file = "Pillow-10.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a0d3e54ab1df9df51b914b2233cf779a5a10dfd1ce339d0421748232cea9876"},
+    {file = "Pillow-10.0.1-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:2cc6b86ece42a11f16f55fe8903595eff2b25e0358dec635d0a701ac9586588f"},
+    {file = "Pillow-10.0.1-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:ca26ba5767888c84bf5a0c1a32f069e8204ce8c21d00a49c90dabeba00ce0145"},
+    {file = "Pillow-10.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f0b4b06da13275bc02adfeb82643c4a6385bd08d26f03068c2796f60d125f6f2"},
+    {file = "Pillow-10.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:bc2e3069569ea9dbe88d6b8ea38f439a6aad8f6e7a6283a38edf61ddefb3a9bf"},
+    {file = "Pillow-10.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:8b451d6ead6e3500b6ce5c7916a43d8d8d25ad74b9102a629baccc0808c54971"},
+    {file = "Pillow-10.0.1-pp310-pypy310_pp73-macosx_10_10_x86_64.whl", hash = "sha256:32bec7423cdf25c9038fef614a853c9d25c07590e1a870ed471f47fb80b244db"},
+    {file = "Pillow-10.0.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7cf63d2c6928b51d35dfdbda6f2c1fddbe51a6bc4a9d4ee6ea0e11670dd981e"},
+    {file = "Pillow-10.0.1-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:f6d3d4c905e26354e8f9d82548475c46d8e0889538cb0657aa9c6f0872a37aa4"},
+    {file = "Pillow-10.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:847e8d1017c741c735d3cd1883fa7b03ded4f825a6e5fcb9378fd813edee995f"},
+    {file = "Pillow-10.0.1-pp39-pypy39_pp73-macosx_10_10_x86_64.whl", hash = "sha256:7f771e7219ff04b79e231d099c0a28ed83aa82af91fd5fa9fdb28f5b8d5addaf"},
+    {file = "Pillow-10.0.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:459307cacdd4138edee3875bbe22a2492519e060660eaf378ba3b405d1c66317"},
+    {file = "Pillow-10.0.1-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b059ac2c4c7a97daafa7dc850b43b2d3667def858a4f112d1aa082e5c3d6cf7d"},
+    {file = "Pillow-10.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:d6caf3cd38449ec3cd8a68b375e0c6fe4b6fd04edb6c9766b55ef84a6e8ddf2d"},
+    {file = "Pillow-10.0.1.tar.gz", hash = "sha256:d72967b06be9300fed5cfbc8b5bafceec48bf7cdc7dab66b1d2549035287191d"},
 ]
 name = "pillow"
 optional = true
 python-versions = ">=3.8"
-version = "10.0.0"
+version = "10.0.1"
 
 [package.extras]
 docs = ["furo", "olefile", "sphinx (>=2.4)", "sphinx-copybutton", "sphinx-inline-tabs", "sphinx-removed-in", "sphinxext-opengraph"]
@@ -6924,16 +6924,16 @@ dev = ["flake8", "flake8-annotations", "flake8-bandit", "flake8-bugbear", "flake
 [[package]]
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 files = [
-    {file = "urllib3-1.26.16-py2.py3-none-any.whl", hash = "sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f"},
-    {file = "urllib3-1.26.16.tar.gz", hash = "sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14"},
+    {file = "urllib3-1.26.17-py2.py3-none-any.whl", hash = "sha256:94a757d178c9be92ef5539b8840d48dc9cf1b2709c9d6b588232a055c524458b"},
+    {file = "urllib3-1.26.17.tar.gz", hash = "sha256:24d6a242c28d29af46c3fae832c36db3bbebcc533dd1bb549172cd739c82df21"},
 ]
 name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
-version = "1.26.16"
+version = "1.26.17"
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+brotli = ["brotli (==1.0.9)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
 secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ cryptography = "^41.0.3"
 databricks-cli = { version = "^0.17.3", optional = true }
 databricks-sql-connector = { version = "2.8.0", optional = true }  # Awaiting snowflake-connector-python to support urllib3>=2.0
 fastapi = { version =  "^0.95.1", optional = true }
-featurebyte-freeware = { version = "^0.2.15", optional = true }
+featurebyte-freeware = { version = "^0.2.16", optional = true }
 gevent = {version = "^22.10.2", optional = true}
 humanize = "^4.4.0"
 importlib_metadata = { version = "*", python = "^3.8"}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -430,11 +430,11 @@ def feature_store_fixture(
 
 
 @pytest.fixture(name="data_source", scope="session")
-def data_source_fixture(feature_store):
+def data_source_fixture(catalog):
     """
     Data source fixture
     """
-    return feature_store.get_data_source()
+    return catalog.get_data_source()
 
 
 @pytest.fixture(name="catalog", scope="session")

--- a/tests/unit/api/test_deployment.py
+++ b/tests/unit/api/test_deployment.py
@@ -113,10 +113,10 @@ def test_get_online_serving_code(deployment, catalog, config_file):
     assert deployment.enabled is True
     url = f"http://localhost:8080/deployment/{deployment.id}/online_features"
 
-    with patch("featurebyte.service.preview.PreviewService.preview") as mock_preview:
-        mock_preview.return_value = dataframe_to_json(
-            pd.DataFrame({"col_int": ["sample_col_int"], "cust_id": ["sample_cust_id"]})
-        )
+    with patch(
+        "featurebyte.service.online_serving.OnlineServingService.get_table_column_unique_values"
+    ) as mock_preview:
+        mock_preview.return_value = ["sample_cust_id"]
         assert (
             deployment.get_online_serving_code().strip()
             == textwrap.dedent(

--- a/tests/unit/routes/test_deployment.py
+++ b/tests/unit/routes/test_deployment.py
@@ -437,7 +437,7 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
         mock_get_session,
         default_catalog_id,
     ):
-        """Test feature list request_code_template"""
+        """Test getting sample entity serving names for a deployment"""
         test_api_client, _ = test_api_client_persistent
         deployment_doc = create_success_response.json()
         self.update_deployment_enabled(test_api_client, deployment_doc["_id"], default_catalog_id)


### PR DESCRIPTION
## Description

Implement route to retrieve sample entity_serving_names for a deployment.
This can be used to support preview functionalities for deployments

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
