### PR TITLE
[chore] Fix sample_entity_serving_names request counts exceed unique values

### DIFF
--- a/featurebyte/service/online_serving.py
+++ b/featurebyte/service/online_serving.py
@@ -306,7 +306,9 @@ class OnlineServingService:
 
         return [
             {
-                entity["serving_name"][0]: entity["sample_value"][row_idx]
+                entity["serving_name"][0]: entity["sample_value"][
+                    row_idx % len(entity["sample_value"])
+                ]
                 for entity in entities.values()
             }
             for row_idx in range(count)

--- a/tests/unit/routes/test_deployment.py
+++ b/tests/unit/routes/test_deployment.py
@@ -464,11 +464,22 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
         # Request code template
         deployment_id = deployment_doc["_id"]
         response = test_api_client.get(
-            f"{self.base_route}/{deployment_id}/sample_entity_serving_names?count=3",
+            f"{self.base_route}/{deployment_id}/sample_entity_serving_names?count=10",
         )
 
         # Check result
         assert response.status_code == HTTPStatus.OK, response.content
         assert response.json() == {
-            "entity_serving_names": [{"cust_id": "1"}, {"cust_id": "2"}, {"cust_id": "3"}],
+            "entity_serving_names": [
+                {"cust_id": "1"},
+                {"cust_id": "2"},
+                {"cust_id": "3"},
+                {"cust_id": "1"},
+                {"cust_id": "2"},
+                {"cust_id": "3"},
+                {"cust_id": "1"},
+                {"cust_id": "2"},
+                {"cust_id": "3"},
+                {"cust_id": "1"},
+            ],
         }


### PR DESCRIPTION
## Description

Fix bug in sample_entity_serving_names route when request counts exceed unique values

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
