### PR TITLE
[chore] task: refactor TASK_MAP to TASK_REGISTRY_MAP

### DIFF
--- a/featurebyte/worker/registry.py
+++ b/featurebyte/worker/registry.py
@@ -1,0 +1,47 @@
+"""
+Task registry
+"""
+from typing import Dict
+
+from enum import Enum
+
+from featurebyte.enum import WorkerCommand
+from featurebyte.worker.task.base import BaseTask
+from featurebyte.worker.task.batch_feature_create import BatchFeatureCreateTask
+from featurebyte.worker.task.batch_feature_table import BatchFeatureTableTask
+from featurebyte.worker.task.batch_request_table import BatchRequestTableTask
+from featurebyte.worker.task.deployment_create_update import DeploymentCreateUpdateTask
+from featurebyte.worker.task.feature_job_setting_analysis import (
+    FeatureJobSettingAnalysisBacktestTask,
+    FeatureJobSettingAnalysisTask,
+)
+from featurebyte.worker.task.feature_list_batch_feature_create import (
+    FeatureListCreateWithBatchFeatureCreationTask,
+)
+from featurebyte.worker.task.historical_feature_table import HistoricalFeatureTableTask
+from featurebyte.worker.task.materialized_table_delete import MaterializedTableDeleteTask
+from featurebyte.worker.task.observation_table import ObservationTableTask
+from featurebyte.worker.task.observation_table_upload import ObservationTableUploadTask
+from featurebyte.worker.task.online_store_cleanup import OnlineStoreCleanupTask
+from featurebyte.worker.task.static_source_table import StaticSourceTableTask
+from featurebyte.worker.task.target_table import TargetTableTask
+from featurebyte.worker.task.tile_task import TileTask
+
+# TASK_REGISTRY_MAP contains a mapping of the worker command to the task.
+TASK_REGISTRY_MAP: Dict[Enum, type[BaseTask]] = {
+    WorkerCommand.FEATURE_JOB_SETTING_ANALYSIS_CREATE: FeatureJobSettingAnalysisTask,
+    WorkerCommand.FEATURE_JOB_SETTING_ANALYSIS_BACKTEST: FeatureJobSettingAnalysisBacktestTask,
+    WorkerCommand.HISTORICAL_FEATURE_TABLE_CREATE: HistoricalFeatureTableTask,
+    WorkerCommand.OBSERVATION_TABLE_CREATE: ObservationTableTask,
+    WorkerCommand.OBSERVATION_TABLE_UPLOAD: ObservationTableUploadTask,
+    WorkerCommand.DEPLOYMENT_CREATE_UPDATE: DeploymentCreateUpdateTask,
+    WorkerCommand.BATCH_REQUEST_TABLE_CREATE: BatchRequestTableTask,
+    WorkerCommand.BATCH_FEATURE_TABLE_CREATE: BatchFeatureTableTask,
+    WorkerCommand.MATERIALIZED_TABLE_DELETE: MaterializedTableDeleteTask,
+    WorkerCommand.BATCH_FEATURE_CREATE: BatchFeatureCreateTask,
+    WorkerCommand.FEATURE_LIST_CREATE_WITH_BATCH_FEATURE_CREATE: FeatureListCreateWithBatchFeatureCreationTask,
+    WorkerCommand.STATIC_SOURCE_TABLE_CREATE: StaticSourceTableTask,
+    WorkerCommand.TARGET_TABLE_CREATE: TargetTableTask,
+    WorkerCommand.TILE_COMPUTE: TileTask,
+    WorkerCommand.ONLINE_STORE_TABLE_CLEANUP: OnlineStoreCleanupTask,
+}

--- a/featurebyte/worker/registry.py
+++ b/featurebyte/worker/registry.py
@@ -1,7 +1,7 @@
 """
 Task registry
 """
-from typing import Dict
+from typing import Dict, Type
 
 from enum import Enum
 
@@ -28,7 +28,7 @@ from featurebyte.worker.task.target_table import TargetTableTask
 from featurebyte.worker.task.tile_task import TileTask
 
 # TASK_REGISTRY_MAP contains a mapping of the worker command to the task.
-TASK_REGISTRY_MAP: Dict[Enum, type[BaseTask]] = {
+TASK_REGISTRY_MAP: Dict[Enum, Type[BaseTask]] = {
     WorkerCommand.FEATURE_JOB_SETTING_ANALYSIS_CREATE: FeatureJobSettingAnalysisTask,
     WorkerCommand.FEATURE_JOB_SETTING_ANALYSIS_BACKTEST: FeatureJobSettingAnalysisBacktestTask,
     WorkerCommand.HISTORICAL_FEATURE_TABLE_CREATE: HistoricalFeatureTableTask,

--- a/featurebyte/worker/registry.py
+++ b/featurebyte/worker/registry.py
@@ -25,6 +25,7 @@ from featurebyte.worker.task.observation_table_upload import ObservationTableUpl
 from featurebyte.worker.task.online_store_cleanup import OnlineStoreCleanupTask
 from featurebyte.worker.task.static_source_table import StaticSourceTableTask
 from featurebyte.worker.task.target_table import TargetTableTask
+from featurebyte.worker.task.test_task import TestTask
 from featurebyte.worker.task.tile_task import TileTask
 
 # TASK_REGISTRY_MAP contains a mapping of the worker command to the task.
@@ -44,4 +45,5 @@ TASK_REGISTRY_MAP: Dict[Enum, Type[BaseTask]] = {
     WorkerCommand.TARGET_TABLE_CREATE: TargetTableTask,
     WorkerCommand.TILE_COMPUTE: TileTask,
     WorkerCommand.ONLINE_STORE_TABLE_CLEANUP: OnlineStoreCleanupTask,
+    WorkerCommand.TEST: TestTask,
 }

--- a/featurebyte/worker/task/base.py
+++ b/featurebyte/worker/task/base.py
@@ -18,9 +18,6 @@ from featurebyte.schema.worker.progress import ProgressModel
 from featurebyte.schema.worker.task.base import BaseTaskPayload
 from featurebyte.storage import Storage
 
-TASK_MAP: Dict[Enum, type[BaseTask]] = {}
-
-
 logger = get_logger(__name__)
 
 
@@ -44,19 +41,6 @@ class BaseTask:  # pylint: disable=too-many-instance-attributes
         self.payload = self.payload_class(**payload)
         self.progress = progress
         self.app_container = app_container
-
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        super().__init_subclass__(**kwargs)
-
-        if cls.payload_class.command is None:
-            # handle the case where the command is not defined (e.g. abstract class)
-            return
-
-        assert isinstance(cls.payload_class.command, Enum)
-        command = cls.payload_class.command
-        if command in TASK_MAP:
-            logger.warning("Existing task command overridden.", extra={"command": command.value})
-        TASK_MAP[command] = cls
 
     @property
     def user(self) -> User:

--- a/featurebyte/worker/task/base.py
+++ b/featurebyte/worker/task/base.py
@@ -3,10 +3,9 @@ Base models for task and task payload
 """
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from abc import abstractmethod
-from enum import Enum
 from uuid import UUID
 
 from featurebyte.logging import get_logger

--- a/featurebyte/worker/task_executor.py
+++ b/featurebyte/worker/task_executor.py
@@ -28,7 +28,7 @@ from featurebyte.utils.messaging import Progress
 from featurebyte.utils.persistent import MongoDBImpl
 from featurebyte.utils.storage import get_storage, get_temp_storage
 from featurebyte.worker import get_celery, get_redis
-from featurebyte.worker.task.base import TASK_MAP
+from featurebyte.worker.registry import TASK_REGISTRY_MAP
 
 logger = get_logger(__name__)
 
@@ -103,7 +103,7 @@ class TaskExecutor:
         self.task_id = task_id
         command = self.command_type(payload["command"])
         user = User(id=payload.get("user_id"))
-        task_class = TASK_MAP[command]
+        task_class = TASK_REGISTRY_MAP[command]
         payload_object = task_class.payload_class(**payload)
         app_container = LazyAppContainer(
             user=user,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -66,7 +66,7 @@ from featurebyte.session.base_spark import BaseSparkSchemaInitializer
 from featurebyte.session.manager import SessionManager
 from featurebyte.storage import LocalStorage, LocalTempStorage
 from featurebyte.worker import get_celery, get_redis
-from featurebyte.worker.task.base import TASK_MAP
+from featurebyte.worker.registry import TASK_REGISTRY_MAP
 
 # Static testing mongodb connection from docker/test/docker-compose.yml
 MONGO_CONNECTION = "mongodb://localhost:27021,localhost:27022/?replicaSet=rs0"
@@ -1343,7 +1343,7 @@ def mock_task_manager(request, persistent, storage, temp_storage, mock_app_callb
                 kwargs["task_output_path"] = payload.task_output_path
                 task_id = str(uuid4())
                 user = User(id=kwargs.get("user_id"))
-                task = TASK_MAP[payload.command](
+                task = TASK_REGISTRY_MAP[payload.command](
                     task_id=UUID(task_id),
                     payload=kwargs,
                     progress=Mock(),

--- a/tests/integration/worker/test_task_manager.py
+++ b/tests/integration/worker/test_task_manager.py
@@ -8,12 +8,15 @@ import time
 import pytest
 from bson.objectid import ObjectId
 
+from featurebyte.enum import WorkerCommand
 from featurebyte.exception import DocumentNotFoundError
 from featurebyte.models.base import DEFAULT_CATALOG_ID, User
 from featurebyte.models.periodic_task import Interval
 from featurebyte.schema.task import TaskId
 from featurebyte.schema.worker.task.test import TestTaskPayload
 from featurebyte.service.task_manager import TaskManager
+from featurebyte.worker.registry import TASK_REGISTRY_MAP
+from featurebyte.worker.task.test_task import TestTask
 
 
 async def wait_for_async_task(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -52,7 +52,7 @@ from featurebyte.session.snowflake import SnowflakeSession
 from featurebyte.storage import LocalTempStorage
 from featurebyte.storage.local import LocalStorage
 from featurebyte.worker import get_redis
-from featurebyte.worker.task.base import TASK_MAP
+from featurebyte.worker.registry import TASK_REGISTRY_MAP
 from tests.unit.conftest_config import (
     config_file_fixture,
     config_fixture,
@@ -1598,7 +1598,7 @@ def mock_task_manager(request, persistent, storage, temp_storage):
                 kwargs["task_output_path"] = payload.task_output_path
                 task_id = str(uuid4())
                 user = User(id=kwargs.get("user_id"))
-                task = TASK_MAP[payload.command](
+                task = TASK_REGISTRY_MAP[payload.command](
                     task_id=UUID(task_id),
                     payload=kwargs,
                     progress=Mock(),

--- a/tests/unit/worker/test_registry.py
+++ b/tests/unit/worker/test_registry.py
@@ -9,9 +9,7 @@ def test_that_all_worker_command_enums_are_in_registry():
     """
     Test all worker command enums are in registry
     """
-    excluded_enums = {WorkerCommand.TEST}
-    assert len(excluded_enums) + len(TASK_REGISTRY_MAP) == len(WorkerCommand)
-    all_enums = excluded_enums.union(set(TASK_REGISTRY_MAP.keys()))
+    assert len(TASK_REGISTRY_MAP) == len(WorkerCommand)
     # Verify that all WorkerCommand enums are covered in the TASK_REGISTRY_MAP
-    for key in TASK_REGISTRY_MAP:
-        assert key in all_enums
+    for key in WorkerCommand:
+        assert key in TASK_REGISTRY_MAP

--- a/tests/unit/worker/test_registry.py
+++ b/tests/unit/worker/test_registry.py
@@ -1,0 +1,17 @@
+"""
+Test registry
+"""
+from featurebyte.enum import WorkerCommand
+from featurebyte.worker.registry import TASK_REGISTRY_MAP
+
+
+def test_that_all_worker_command_enums_are_in_registry():
+    """
+    Test all worker command enums are in registry
+    """
+    excluded_enums = {WorkerCommand.TEST}
+    assert len(excluded_enums) + len(TASK_REGISTRY_MAP) == len(WorkerCommand)
+    all_enums = excluded_enums.union(set(TASK_REGISTRY_MAP.keys()))
+    # Verify that all WorkerCommand enums are covered in the TASK_REGISTRY_MAP
+    for key in TASK_REGISTRY_MAP:
+        assert key in all_enums


### PR DESCRIPTION
## Description
This PR refactors the dynamically built `TASK_MAP` to a statically defined `TASK_REGISTRY_MAP`. 

The statically defined option should be easier to read, and make it easier to trace through code. We can also remove some of the validation that logs out when tasks with duplicate payload commands are used. I've added a test that will fail if a developer adds a new task but doesn't register it in the registry.

Down the line, this should also allow us to simplify how tasks are initialized as well since we can remove the override of the special magic `__init_subclass__` method that was used to dynamically build the `TASK_MAP` previously.
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
