### PR TITLE
[DEV-2430] Update repeated columns validation logic to handle excluded columns

### DIFF
--- a/.changelog/DEV-2430.yaml
+++ b/.changelog/DEV-2430.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update repeated columns validation logic to handle excluded columns"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/view.py
+++ b/featurebyte/api/view.py
@@ -1218,7 +1218,7 @@ class View(ProtectedColumnsQueryObject, Frame, ABC):
             raised when the on column provided, is not present in the columns
         """
         # Validate whether there are overlapping column names
-        left_join_key, right_join_key = self._get_join_keys(other_view, on)
+        _, right_join_key = self._get_join_keys(other_view, on)
         right_excluded_columns = other_view.get_excluded_columns_as_other_view(right_join_key)
         current_column_names = {col.name for col in self.columns_info}
         repeated_column_names = []

--- a/featurebyte/api/view.py
+++ b/featurebyte/api/view.py
@@ -1218,14 +1218,18 @@ class View(ProtectedColumnsQueryObject, Frame, ABC):
             raised when the on column provided, is not present in the columns
         """
         # Validate whether there are overlapping column names
-        left_join_key, _ = self._get_join_keys(other_view, on)
+        left_join_key, right_join_key = self._get_join_keys(other_view, on)
+        right_excluded_columns = other_view.get_excluded_columns_as_other_view(right_join_key)
         current_column_names = {col.name for col in self.columns_info}
         repeated_column_names = []
         for other_col in apply_column_name_modifiers_columns_info(
             other_view.columns_info, rsuffix, rprefix
         ):
-            # Raise an error if the name is repeated, but it is not a join key
-            if other_col.name in current_column_names and other_col.name != left_join_key:
+            # Raise an error if the name is repeated and will be included in the join result
+            if (
+                other_col.name in current_column_names
+                and other_col.name not in right_excluded_columns
+            ):
                 repeated_column_names.append(other_col.name)
         if len(repeated_column_names) > 0:
             raise RepeatedColumnNamesError(

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -182,6 +182,25 @@ def saved_scd_table_fixture(snowflake_scd_table, catalog):
     yield snowflake_scd_table
 
 
+@pytest.fixture(name="snowflake_scd_table_v2")
+def snowflake_scd_table_v2_fixture(snowflake_data_source, catalog):
+    """SCDTable object fixture"""
+    _ = catalog
+    scd_table = snowflake_data_source.get_source_table(
+        database_name="sf_database",
+        schema_name="sf_schema",
+        table_name="scd_table_v2",
+    ).create_scd_table(
+        name="sf_scd_table_v2",
+        natural_key_column="col_text",
+        surrogate_key_column="col_int",
+        effective_timestamp_column="event_timestamp",
+        end_timestamp_column="end_timestamp",
+        current_flag_column="is_active",
+    )
+    yield scd_table
+
+
 @pytest.fixture(name="snowflake_item_table")
 def snowflake_item_table_fixture(
     snowflake_database_table_item_table,

--- a/tests/unit/api/test_scd_view.py
+++ b/tests/unit/api/test_scd_view.py
@@ -333,3 +333,24 @@ def test_event_view_join_scd_view__feature_info(
         "Input3": {"data": "sf_scd_table", "column_name": "cust_id", "semantic": None},
         "Input4": {"data": "sf_event_table", "column_name": "col_float", "semantic": None},
     }
+
+
+def test_join_scd_view_repeated_effective_timestamp_column_allowed(
+    snowflake_event_view, snowflake_scd_table_v2
+):
+    """
+    Test effective timestamp column is excluded from repeated column validation
+    """
+    scd_view = snowflake_scd_table_v2.get_view()
+    joined_view = snowflake_event_view.join(scd_view[["date_of_birth"]])
+    assert joined_view.columns == [
+        "col_int",
+        "col_float",
+        "col_char",
+        "col_text",
+        "col_binary",
+        "col_boolean",
+        "event_timestamp",
+        "cust_id",
+        "date_of_birth",
+    ]

--- a/tests/unit/api/test_view.py
+++ b/tests/unit/api/test_view.py
@@ -1,7 +1,7 @@
 """
 Test view class
 """
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from unittest.mock import MagicMock, Mock, patch
 
@@ -44,6 +44,7 @@ class SimpleTestView(View):
     )
 
     join_col = ""
+    excluded_columns_override: Optional[List[str]] = None
 
     @property
     def node(self):
@@ -69,6 +70,11 @@ class SimpleTestView(View):
         Test helper to set the join column override.
         """
         self.join_col = join_col_override
+
+    def _get_additional_excluded_columns_as_other_view(self) -> list[str]:
+        if self.excluded_columns_override is None:
+            return super()._get_additional_excluded_columns_as_other_view()
+        return self.excluded_columns_override
 
 
 @pytest.fixture(name="simple_test_view")
@@ -482,6 +488,26 @@ def test_validate_join__multiple_overlapping_columns():
 
     # also ok if prefix is provided
     base_view.join(view_with_multiple_overlapping, rprefix="prefix")
+
+
+@pytest.mark.usefixtures("patch_graph_operations")
+def test_validate_join__additional_excluded_columns():
+    """
+    Test join validation with additional excluded columns
+    """
+    col_info_a, col_info_b, col_info_c = (
+        ColumnInfo(name="colA", dtype=DBVarType.INT),
+        ColumnInfo(name="colB", dtype=DBVarType.INT),
+        ColumnInfo(name="colC", dtype=DBVarType.INT),
+    )
+    base_view = SimpleTestView(columns_info=[col_info_a, col_info_b, col_info_c])
+    other_view = SimpleTestView(
+        columns_info=[col_info_a, col_info_b, col_info_c],
+        join_col=col_info_b.name,
+        excluded_columns_override=["colA", "colC"],
+    )
+    # should have no error since the repeated columns are excluded from join result
+    base_view.join(other_view)
 
 
 @pytest.mark.usefixtures("patch_graph_operations")

--- a/tests/unit/api/test_view.py
+++ b/tests/unit/api/test_view.py
@@ -71,7 +71,7 @@ class SimpleTestView(View):
         """
         self.join_col = join_col_override
 
-    def _get_additional_excluded_columns_as_other_view(self) -> list[str]:
+    def _get_additional_excluded_columns_as_other_view(self):
         if self.excluded_columns_override is None:
             return super()._get_additional_excluded_columns_as_other_view()
         return self.excluded_columns_override

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,6 +2,7 @@
 """
 Common test fixtures used across unit test directories
 """
+import copy
 import json
 import tempfile
 import traceback
@@ -330,7 +331,24 @@ def snowflake_query_map_fixture():
     query_map['SHOW COLUMNS IN "sf_database"."sf_schema"."dimension_table"'] = query_map[
         'SHOW COLUMNS IN "sf_database"."sf_schema"."sf_table"'
     ]
+    query_map[
+        'SHOW COLUMNS IN "sf_database"."sf_schema"."scd_table_v2"'
+    ] = get_show_columns_query_result_for_scd_table_v2(
+        query_map['SHOW COLUMNS IN "sf_database"."sf_schema"."scd_table"']
+    )
     return query_map
+
+
+def get_show_columns_query_result_for_scd_table_v2(scd_table_query_result):
+    """
+    Get SHOW COLUMNS query result for scd_table_v2 where effective_timestamp is renamed to
+    event_timestamp
+    """
+    result = copy.deepcopy(scd_table_query_result)
+    for info in result:
+        if info["column_name"] == "effective_timestamp":
+            info["column_name"] = "event_timestamp"
+    return result
 
 
 @pytest.fixture(name="snowflake_execute_query")


### PR DESCRIPTION
## Description

This updates the repeated columns validation logic to handle excluded columns during join. With this, we can for example join an event view with an SCD view where the event timestamp column and effective timestamp column have the same name.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
