### PR TITLE
[DEV-2345] Enable ObservationTable with multiple use cases - Part 1

### DIFF
--- a/.changelog/DEV-2435_1.yaml
+++ b/.changelog/DEV-2435_1.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: endpoints
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Enable observation table to associate with multiple use cases from endpoints"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/exception.py
+++ b/featurebyte/exception.py
@@ -432,6 +432,12 @@ class ObservationTableInvalidContextError(BaseUnprocessableEntityError):
     """
 
 
+class ObservationTableInvalidUseCaseError(BaseUnprocessableEntityError):
+    """
+    Raise when invalid use_case_id is specified when updating observation table
+    """
+
+
 class UnsupportedRequestCodeTemplateLanguage(BaseUnprocessableEntityError):
     """
     Raise when the language for request code template is not supported

--- a/featurebyte/models/observation_table.py
+++ b/featurebyte/models/observation_table.py
@@ -127,7 +127,7 @@ class ObservationTableModel(MaterializedTableModel):
     request_input: ObservationInput
     most_recent_point_in_time: StrictStr
     context_id: Optional[PydanticObjectId] = Field(default=None)
-    use_case_ids: Optional[List[PydanticObjectId]] = Field(default_factory=list)
+    use_case_ids: List[PydanticObjectId] = Field(default_factory=list)
     purpose: Optional[Purpose] = Field(default=None)
     least_recent_point_in_time: Optional[StrictStr] = Field(default=None)
     entity_column_name_to_count: Optional[Dict[str, int]] = Field(default_factory=dict)

--- a/featurebyte/models/observation_table.py
+++ b/featurebyte/models/observation_table.py
@@ -3,7 +3,7 @@ ObservationTableModel models
 """
 from __future__ import annotations
 
-from typing import Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 from typing_extensions import Annotated, Literal
 
 from datetime import datetime  # pylint: disable=wrong-import-order
@@ -120,11 +120,14 @@ class ObservationTableModel(MaterializedTableModel):
         The input that defines how the observation table is created
     context_id: Optional[PydanticObjectId]
         The id of the context that the observation table is associated with
+    use_case_ids: Optional[List[PydanticObjectId]]
+        The ids of the use cases that the observation table is associated with
     """
 
     request_input: ObservationInput
     most_recent_point_in_time: StrictStr
     context_id: Optional[PydanticObjectId] = Field(default=None)
+    use_case_ids: Optional[List[PydanticObjectId]] = Field(default_factory=list)
     purpose: Optional[Purpose] = Field(default=None)
     least_recent_point_in_time: Optional[StrictStr] = Field(default=None)
     entity_column_name_to_count: Optional[Dict[str, int]] = Field(default_factory=dict)

--- a/featurebyte/routes/observation_table/controller.py
+++ b/featurebyte/routes/observation_table/controller.py
@@ -170,8 +170,13 @@ class ObservationTableController(
             observation_table = await self.observation_table_service.get_document(
                 document_id=observation_table_id
             )
-            use_case_ids = observation_table.use_case_ids if observation_table.use_case_ids else []
 
+            if not observation_table.context_id:
+                raise ObservationTableInvalidUseCaseError(
+                    f"Cannot add/remove UseCase as the ObservationTable {observation_table_id} is not associated with any Context."
+                )
+
+            use_case_ids = observation_table.use_case_ids
             # validate use case id to add
             if data.use_case_id_to_add:
                 if data.use_case_id_to_add in use_case_ids:

--- a/featurebyte/routes/observation_table/controller.py
+++ b/featurebyte/routes/observation_table/controller.py
@@ -9,6 +9,7 @@ from bson import ObjectId
 from fastapi import UploadFile
 
 from featurebyte.common.utils import dataframe_from_arrow_stream
+from featurebyte.exception import ObservationTableInvalidUseCaseError
 from featurebyte.models.observation_table import ObservationTableModel
 from featurebyte.routes.common.base_materialized_table import BaseMaterializedTableController
 from featurebyte.routes.task.controller import TaskController
@@ -25,6 +26,7 @@ from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.service.observation_table import ObservationTableService
 from featurebyte.service.preview import PreviewService
 from featurebyte.service.task_manager import TaskManager
+from featurebyte.service.use_case import UseCaseService
 from featurebyte.service.validator.materialized_table_delete import ObservationTableDeleteValidator
 
 
@@ -48,6 +50,7 @@ class ObservationTableController(
         observation_table_delete_validator: ObservationTableDeleteValidator,
         context_service: ContextService,
         task_manager: TaskManager,
+        use_case_service: UseCaseService,
     ):
         super().__init__(service=observation_table_service, preview_service=preview_service)
         self.observation_table_service = observation_table_service
@@ -56,6 +59,7 @@ class ObservationTableController(
         self.observation_table_delete_validator = observation_table_delete_validator
         self.context_service = context_service
         self.task_manager = task_manager
+        self.use_case_service = use_case_service
 
     async def create_observation_table(
         self,
@@ -149,10 +153,52 @@ class ObservationTableController(
         data: ObservationTableUpdate
             ObservationTable update payload
 
+        Raises
+        ------
+        ObservationTableInvalidUseCaseError
+            if use_case_ids is provided in the payload or use_case_id_to_add/use_case_id_to_remove is invalid
+
         Returns
         -------
         Optional[ObservationTableModel]
         """
+
+        if data.use_case_ids:
+            raise ObservationTableInvalidUseCaseError("use_case_ids is not a valid field to update")
+
+        if data.use_case_id_to_add or data.use_case_id_to_remove:
+            observation_table = await self.observation_table_service.get_document(
+                document_id=observation_table_id
+            )
+            use_case_ids = observation_table.use_case_ids if observation_table.use_case_ids else []
+
+            # validate use case id to add
+            if data.use_case_id_to_add:
+                if data.use_case_id_to_add in use_case_ids:
+                    raise ObservationTableInvalidUseCaseError(
+                        f"Cannot add UseCase {data.use_case_id_to_add} as it is already associated with the ObservationTable."
+                    )
+                use_case = await self.use_case_service.get_document(
+                    document_id=data.use_case_id_to_add
+                )
+                if use_case.context_id != observation_table.context_id:
+                    raise ObservationTableInvalidUseCaseError(
+                        f"Cannot add UseCase {data.use_case_id_to_add} as its context_id is different from the existing context_id."
+                    )
+
+                use_case_ids.append(data.use_case_id_to_add)
+
+            # validate use case id to remove
+            if data.use_case_id_to_remove:
+                if data.use_case_id_to_remove not in use_case_ids:
+                    raise ObservationTableInvalidUseCaseError(
+                        f"Cannot remove UseCase {data.use_case_id_to_remove} as it is not associated with the ObservationTable."
+                    )
+                use_case_ids.remove(data.use_case_id_to_remove)
+
+            # update use case ids
+            data.use_case_ids = use_case_ids
+
         return await self.observation_table_service.update_observation_table(
             observation_table_id, data
         )

--- a/featurebyte/schema/observation_table.py
+++ b/featurebyte/schema/observation_table.py
@@ -55,4 +55,9 @@ class ObservationTableUpdate(BaseDocumentServiceUpdateSchema):
     ObservationTable Update Context schema
     """
 
-    context_id: PydanticObjectId
+    context_id: Optional[PydanticObjectId]
+    use_case_id_to_add: Optional[PydanticObjectId]
+    use_case_id_to_remove: Optional[PydanticObjectId]
+
+    # for update model only and not from input
+    use_case_ids: Optional[List[PydanticObjectId]]

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -358,22 +358,22 @@ class ObservationTableService(
             If the entity ids are different from the existing Context
         """
 
-        # validate that the context exists
-        await self.context_service.get_document(document_id=data.context_id)
-
-        exist_observation_table = await self.get_document(document_id=observation_table_id)
-        if (
-            exist_observation_table.context_id
-            and exist_observation_table.context_id != data.context_id
-        ):
-            exist_context = await self.context_service.get_document(
-                document_id=exist_observation_table.context_id
-            )
+        if data.context_id:
+            # validate that the context exists
             new_context = await self.context_service.get_document(document_id=data.context_id)
-            if set(exist_context.primary_entity_ids) != set(new_context.primary_entity_ids):
-                raise ObservationTableInvalidContextError(
-                    "Cannot update Context as the entities are different from the existing Context."
+
+            exist_observation_table = await self.get_document(document_id=observation_table_id)
+            if (
+                exist_observation_table.context_id
+                and exist_observation_table.context_id != data.context_id
+            ):
+                exist_context = await self.context_service.get_document(
+                    document_id=exist_observation_table.context_id
                 )
+                if set(exist_context.primary_entity_ids) != set(new_context.primary_entity_ids):
+                    raise ObservationTableInvalidContextError(
+                        "Cannot update Context as the entities are different from the existing Context."
+                    )
 
         observation_table: Optional[ObservationTableModel] = await self.update_document(
             document_id=observation_table_id, data=data, return_document=True


### PR DESCRIPTION
Part 1 of the requirement to enable observation table with multiple use cases. 

This PR implements the requirement from the endpoints

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
