### PR TITLE
[DEV-2409] observation_table: allow users to upload parquet files too

### DIFF
--- a/.changelog/DEV-2409-2.yaml
+++ b/.changelog/DEV-2409-2.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: observation_table
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Allow users to upload .parquet files, in addition to csv files when creating observation tables."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/routes/observation_table/controller.py
+++ b/featurebyte/routes/observation_table/controller.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 
 from typing import Optional
 
+import os.path
+
+import pandas as pd
 from bson import ObjectId
 from fastapi import UploadFile
 
@@ -98,7 +101,16 @@ class ObservationTableController(
         -------
         Task
         """
-        observation_set_dataframe = dataframe_from_arrow_stream(observation_set_file.file)
+        # Check that filename is a .csv or .parquet file
+        uploaded_filename_extension = os.path.splitext(data.name)[-1]
+
+        if uploaded_filename_extension == ".csv":
+            observation_set_dataframe = dataframe_from_arrow_stream(observation_set_file.file)
+        elif uploaded_filename_extension == ".parquet":
+            observation_set_dataframe = pd.read_parquet(observation_set_file.file)
+        else:
+            raise ValueError("Uploaded file must be a .csv or .parquet file.")
+
         payload = await self.service.get_observation_table_upload_task_payload(
             data=data, observation_set_dataframe=observation_set_dataframe
         )

--- a/featurebyte/routes/observation_table/controller.py
+++ b/featurebyte/routes/observation_table/controller.py
@@ -100,6 +100,11 @@ class ObservationTableController(
         Returns
         -------
         Task
+
+        Raises
+        ------
+        ValueError
+            if uploaded file is not a .csv or .parquet file
         """
         # Check that filename is a .csv or .parquet file
         uploaded_filename_extension = os.path.splitext(data.name)[-1]

--- a/tests/integration/api/test_observation_table.py
+++ b/tests/integration/api/test_observation_table.py
@@ -150,7 +150,7 @@ async def test_observation_table_upload(
     _ = catalog, customer_entity
     # Create upload request
     upload_request = ObservationTableUpload(
-        name="uploaded_observation_table",
+        name="uploaded_observation_table.csv",
         feature_store_id=feature_store.id,
     )
     # Read CSV file
@@ -172,7 +172,7 @@ async def test_observation_table_upload(
     observation_table = ObservationTable.get_by_id(observation_table_id)
 
     # Assert response
-    assert observation_table.name == "uploaded_observation_table"
+    assert observation_table.name == upload_request.name
     assert observation_table.request_input == UploadedFileInput(type=RequestInputType.UPLOADED_FILE)
     expected_columns = {SpecialColumnName.POINT_IN_TIME, "cust_id"}
     actual_columns = {column.name for column in observation_table.columns_info}

--- a/tests/unit/routes/test_observation_table.py
+++ b/tests/unit/routes/test_observation_table.py
@@ -327,6 +327,9 @@ class TestObservationTableApi(BaseMaterializedTableTestSuite):
     def test_upload_observation_errors_with_unknown_file(
         self, test_api_client_persistent, snowflake_feature_store_id, sample_upload_dataframe
     ):
+        """
+        Test upload route with unknown file
+        """
         test_api_client, _ = test_api_client_persistent
         # Prepare upload request with random file extension
         upload_request = ObservationTableUpload(

--- a/tests/unit/routes/test_observation_table.py
+++ b/tests/unit/routes/test_observation_table.py
@@ -278,6 +278,9 @@ class TestObservationTableApi(BaseMaterializedTableTestSuite):
 
     @pytest.fixture(name="sample_upload_dataframe")
     def sample_dataframe_fixture(self):
+        """
+        Sample dataframe fixture
+        """
         return pd.DataFrame(
             {
                 "POINT_IN_TIME": ["2023-01-15 10:00:00"],


### PR DESCRIPTION
## Description
Allow users to upload parquet files too. This adds on to the existing functionality where users could upload csv files.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
