### PR TITLE
[chore] task_executor: pass app container into constructor

### DIFF
--- a/featurebyte/routes/lazy_app_container.py
+++ b/featurebyte/routes/lazy_app_container.py
@@ -240,7 +240,18 @@ class LazyAppContainer:
         instance: Any
             instance to override with
         """
-        self.instance_map[key] = instance
+        self.override_instances_for_test({key: instance})
+
+    def override_instances_for_test(self, instances_to_update: Dict[str, Any]) -> None:
+        """
+        Override multiple instances for testing purposes.
+
+        Parameters
+        ----------
+        instances_to_update: Dict[str, Any]
+            mapping of key to instance
+        """
+        self.instance_map.update(instances_to_update)
 
     def invalidate_dep_for_test(self, key: Union[str, Type[Any]]) -> None:
         """

--- a/featurebyte/worker/task_executor.py
+++ b/featurebyte/worker/task_executor.py
@@ -193,6 +193,15 @@ class BaseCeleryTask(Task):
         """
         Get app container
 
+        Parameters
+        ----------
+        task_id: UUID
+            Task ID
+        payload: dict[str, Any]
+            Task payload
+        progress: Any
+            Task progress
+
         Returns
         -------
         LazyAppContainer

--- a/featurebyte/worker/task_executor.py
+++ b/featurebyte/worker/task_executor.py
@@ -105,7 +105,7 @@ class TaskExecutor:
         self,
         payload: dict[str, Any],
         task_id: UUID,
-        app_container: Optional[LazyAppContainer] = None,
+        app_container: LazyAppContainer,
     ) -> None:
         self.task_id = task_id
         command = self.command_type(payload["command"])

--- a/featurebyte/worker/task_executor.py
+++ b/featurebyte/worker/task_executor.py
@@ -113,7 +113,7 @@ class TaskExecutor:
         self.user = User(id=payload.get("user_id"))
         self.task = app_container.get(TASK_REGISTRY_MAP[command])
         self.task_progress_updater = app_container.get(TaskProgressUpdater)
-        self._setup_worker_config()
+        self.setup_worker_config()
         self.payload_dict = payload
 
     async def _update_task_start_time_and_description(self, payload: Any) -> None:
@@ -138,7 +138,8 @@ class TaskExecutor:
             user_id=self.user.id,
         )
 
-    def _setup_worker_config(self) -> None:
+    @staticmethod
+    def setup_worker_config() -> None:
         """
         Setup featurebyte config file for the worker
         """


### PR DESCRIPTION
## Description
This PR passes the app container into the task executor, instead of initializing the app container inside the constructor.

This makes the code a bit easier to extend, and is a step to getting the task executor constructed via the container as well. Also also is one step closer in allowing the child implementation in featurebyte-app to call the parent constructor more easily as well. Overall, improves dependency injection and makes the code more soliD.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
