### PR TITLE
[DEV-2430] Fix repeated columns validation during joins

### DIFF
--- a/.changelog/DEV-2430.yaml
+++ b/.changelog/DEV-2430.yaml
@@ -16,7 +16,7 @@ component: service
 issues: []
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Update repeated columns validation logic to handle excluded columns"
+note: "Update repeated columns validation logic to handle excluded columns."
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/featurebyte/api/view.py
+++ b/featurebyte/api/view.py
@@ -1219,7 +1219,11 @@ class View(ProtectedColumnsQueryObject, Frame, ABC):
         """
         # Validate whether there are overlapping column names
         _, right_join_key = self._get_join_keys(other_view, on)
-        right_excluded_columns = other_view.get_excluded_columns_as_other_view(right_join_key)
+        right_excluded_columns = apply_column_name_modifiers(
+            other_view.get_excluded_columns_as_other_view(right_join_key),
+            rsuffix=rsuffix,
+            rprefix=rprefix,
+        )
         current_column_names = {col.name for col in self.columns_info}
         repeated_column_names = []
         for other_col in apply_column_name_modifiers_columns_info(

--- a/tests/unit/api/test_scd_view.py
+++ b/tests/unit/api/test_scd_view.py
@@ -354,3 +354,20 @@ def test_join_scd_view_repeated_effective_timestamp_column_allowed(
         "cust_id",
         "date_of_birth",
     ]
+
+
+def test_change_view_join_scd_view_with_rprefix(snowflake_scd_table):
+    """
+    Test joining change view with SCDView with rprefix same as change view column prefix
+    """
+    change_view = snowflake_scd_table.get_change_view("col_boolean")
+    scd_view = snowflake_scd_table.get_view()[["col_float"]]
+    joined_view = change_view.join(scd_view, rprefix="new_")
+    assert joined_view.columns == [
+        "col_text",
+        "new_effective_timestamp",
+        "past_effective_timestamp",
+        "new_col_boolean",
+        "past_col_boolean",
+        "new_col_float",
+    ]

--- a/tests/unit/api/test_view.py
+++ b/tests/unit/api/test_view.py
@@ -510,6 +510,29 @@ def test_validate_join__additional_excluded_columns():
     base_view.join(other_view)
 
 
+def test_validate_join__repeated_caused_by_modifiers():
+    """
+    Test the case where repeated column names are caused by modifiers
+    """
+    col_info_a, col_info_b, col_info_c = (
+        ColumnInfo(name="colA", dtype=DBVarType.INT),
+        ColumnInfo(name="colB", dtype=DBVarType.INT),
+        ColumnInfo(name="colC", dtype=DBVarType.INT),
+    )
+    col_info_a_short, col_info_b_short = (
+        ColumnInfo(name="A", dtype=DBVarType.INT),
+        ColumnInfo(name="B", dtype=DBVarType.INT),
+    )
+    base_view = SimpleTestView(columns_info=[col_info_a, col_info_b, col_info_c])
+    other_view = SimpleTestView(
+        columns_info=[col_info_a_short, col_info_b_short, col_info_c],
+        join_col=col_info_b_short.name,
+    )
+    with pytest.raises(RepeatedColumnNamesError) as exc_info:
+        base_view.join(other_view, rprefix="col", on="colB")
+    assert "Duplicate column names ['colA'] found" in str(exc_info.value)
+
+
 @pytest.mark.usefixtures("patch_graph_operations")
 def test_validate_join__check_on_column():
     """


### PR DESCRIPTION
## Description

This is a follow up to https://github.com/featurebyte/featurebyte/pull/1818. The rprefix or rsuffix modifiers should be applied to the excluded columns when validating the joins.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
