### PR TITLE
[chore] Add routes to download materialized tables as parquet files

### DIFF
--- a/featurebyte/routes/batch_feature_table/api.py
+++ b/featurebyte/routes/batch_feature_table/api.py
@@ -158,6 +158,20 @@ async def download_table_as_pyarrow_table(
     return result
 
 
+@router.get("/parquet/{batch_feature_table_id}")
+async def download_table_as_parquet(
+    request: Request, batch_feature_table_id: PydanticObjectId
+) -> StreamingResponse:
+    """
+    Download BatchFeatureTable as parquet file
+    """
+    controller = request.state.app_container.batch_feature_table_controller
+    result: StreamingResponse = await controller.download_materialized_table_as_parquet(
+        document_id=batch_feature_table_id,
+    )
+    return result
+
+
 @router.patch("/{batch_feature_table_id}/description", response_model=BatchFeatureTableModel)
 async def update_batch_feature_table_description(
     request: Request,

--- a/featurebyte/routes/batch_request_table/api.py
+++ b/featurebyte/routes/batch_request_table/api.py
@@ -160,6 +160,20 @@ async def download_table_as_pyarrow_table(
     return result
 
 
+@router.get("/parquet/{batch_request_table_id}")
+async def download_table_as_parquet(
+    request: Request, batch_request_table_id: PydanticObjectId
+) -> StreamingResponse:
+    """
+    Download BatchRequestTable as parquet file
+    """
+    controller = request.state.app_container.batch_request_table_controller
+    result: StreamingResponse = await controller.download_materialized_table_as_parquet(
+        document_id=batch_request_table_id,
+    )
+    return result
+
+
 @router.patch("/{batch_request_table_id}/description", response_model=BatchRequestTableModel)
 async def update_batch_request_table_description(
     request: Request,

--- a/featurebyte/routes/historical_feature_table/api.py
+++ b/featurebyte/routes/historical_feature_table/api.py
@@ -167,6 +167,20 @@ async def download_table_as_pyarrow_table(
     return result
 
 
+@router.get("/parquet/{historical_feature_table_id}")
+async def download_table_as_parquet(
+    request: Request, historical_feature_table_id: PydanticObjectId
+) -> StreamingResponse:
+    """
+    Download HistoricalFeatureTable as parquet file
+    """
+    controller = request.state.app_container.historical_feature_table_controller
+    result: StreamingResponse = await controller.download_materialized_table_as_parquet(
+        document_id=historical_feature_table_id,
+    )
+    return result
+
+
 @router.patch(
     "/{historical_feature_table_id}/description", response_model=HistoricalFeatureTableModel
 )

--- a/featurebyte/routes/observation_table/api.py
+++ b/featurebyte/routes/observation_table/api.py
@@ -182,6 +182,20 @@ async def download_table_as_pyarrow_table(
     return result
 
 
+@router.get("/parquet/{observation_table_id}")
+async def download_table_as_parquet(
+    request: Request, observation_table_id: PydanticObjectId
+) -> StreamingResponse:
+    """
+    Download ObservationTable as parquet file
+    """
+    controller = request.state.app_container.observation_table_controller
+    result: StreamingResponse = await controller.download_materialized_table_as_parquet(
+        document_id=observation_table_id,
+    )
+    return result
+
+
 @router.patch("/{observation_table_id}/description", response_model=ObservationTableModel)
 async def update_observation_table_description(
     request: Request,

--- a/featurebyte/routes/static_source_table/api.py
+++ b/featurebyte/routes/static_source_table/api.py
@@ -155,6 +155,20 @@ async def download_table_as_pyarrow_table(
     return result
 
 
+@router.get("/parquet/{static_source_table_id}")
+async def download_table_as_parquet(
+    request: Request, static_source_table_id: PydanticObjectId
+) -> StreamingResponse:
+    """
+    Download StaticSourceTable as parquet file
+    """
+    controller = request.state.app_container.static_source_table_controller
+    result: StreamingResponse = await controller.download_materialized_table_as_parquet(
+        document_id=static_source_table_id,
+    )
+    return result
+
+
 @router.patch("/{static_source_table_id}/description", response_model=StaticSourceTableModel)
 async def update_static_source_table_description(
     request: Request,

--- a/featurebyte/routes/target_table/api.py
+++ b/featurebyte/routes/target_table/api.py
@@ -81,6 +81,11 @@ class TargetTableRouter(BaseMaterializedTableRouter[TargetTableModel]):
             methods=["GET"],
         )
         self.router.add_api_route(
+            "/parquet/{target_table_id}",
+            self.download_table_as_parquet,
+            methods=["GET"],
+        )
+        self.router.add_api_route(
             "/{target_table_id}/description",
             self.update_target_table_description,
             methods=["PATCH"],
@@ -189,6 +194,19 @@ class TargetTableRouter(BaseMaterializedTableRouter[TargetTableModel]):
         """
         controller = request.state.app_container.target_table_controller
         result: StreamingResponse = await controller.download_materialized_table(
+            document_id=target_table_id,
+        )
+        return result
+
+    @staticmethod
+    async def download_table_as_parquet(
+        request: Request, target_table_id: PydanticObjectId
+    ) -> StreamingResponse:
+        """
+        Download TargetTable as parquet file
+        """
+        controller = request.state.app_container.target_table_controller
+        result: StreamingResponse = await controller.download_materialized_table_as_parquet(
             document_id=target_table_id,
         )
         return result


### PR DESCRIPTION
## Description

Add routes to download materialized tables as parquet files

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
