### PR TITLE
[chore] Use permanent table for uploaded observation tables

### DIFF
--- a/featurebyte/schema/observation_table.py
+++ b/featurebyte/schema/observation_table.py
@@ -23,7 +23,7 @@ class ObservationTableCreate(BaseRequestTableCreate):
     request_input: ObservationInput
     skip_entity_validation_checks: bool = Field(default=False)
     purpose: Optional[Purpose] = Field(default=None)
-    primary_entity_ids: Optional[List[PydanticObjectId]] = Field(default=None)
+    primary_entity_ids: List[PydanticObjectId]
 
 
 class ObservationTableUpload(FeatureByteBaseModel):
@@ -34,7 +34,7 @@ class ObservationTableUpload(FeatureByteBaseModel):
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
     name: StrictStr
     purpose: Optional[Purpose] = Field(default=None)
-    primary_entity_ids: Optional[List[PydanticObjectId]] = Field(default=None)
+    primary_entity_ids: List[PydanticObjectId]
 
 
 class ObservationTableList(PaginationMixin):

--- a/featurebyte/worker/task/observation_table_upload.py
+++ b/featurebyte/worker/task/observation_table_upload.py
@@ -66,7 +66,9 @@ class ObservationTableUploadTask(DataWarehouseMixin, BaseTask[ObservationTableUp
         )
 
         # Write the file to the warehouse
-        await db_session.register_table(location.table_details.table_name, uploaded_dataframe)
+        await db_session.register_table(
+            location.table_details.table_name, uploaded_dataframe, temporary=False
+        )
 
         async with self.drop_table_on_error(db_session, location.table_details, payload):
             # Validate table and retrieve metadata about the table

--- a/tests/fixtures/request_payloads/observation_table.json
+++ b/tests/fixtures/request_payloads/observation_table.json
@@ -22,5 +22,8 @@
         "type": "source_table"
     },
     "sample_rows": null,
-    "purpose": "other"
+    "purpose": "other",
+    "primary_entity_ids": [
+        "63f94ed6ea1f050131379214"
+    ]
 }

--- a/tests/unit/routes/test_observation_table.py
+++ b/tests/unit/routes/test_observation_table.py
@@ -274,6 +274,7 @@ class TestObservationTableApi(BaseMaterializedTableTestSuite):
         upload_request = ObservationTableUpload(
             name="uploaded_observation_table",
             purpose="other",
+            primary_entity_ids=["63f94ed6ea1f050131379214"],
         )
         df = pd.DataFrame(
             {

--- a/tests/unit/test_generate_payload_fixtures.py
+++ b/tests/unit/test_generate_payload_fixtures.py
@@ -150,6 +150,7 @@ def test_save_payload_fixtures(  # pylint: disable=too-many-arguments
             source=snowflake_event_table.tabular_source,
         ),
         context_id=context.id,
+        primary_entity_ids=[cust_id_entity.id],
     )
     historical_feature_table = HistoricalFeatureTableCreate(
         _id="646f6c1c0ed28a5271fb02d8",

--- a/tests/unit/worker/task/test_observation_table.py
+++ b/tests/unit/worker/task/test_observation_table.py
@@ -27,6 +27,7 @@ async def test_get_task_description(catalog, app_container):
                 table_details=TableDetails(table_name="test_table"),
             ),
         ),
+        primary_entity_ids=["63f94ed6ea1f050131379214"],
     )
     task = app_container.get(ObservationTableTask)
     assert (

--- a/tests/unit/worker/task/test_observation_table_upload.py
+++ b/tests/unit/worker/task/test_observation_table_upload.py
@@ -24,6 +24,7 @@ async def test_get_task_description(catalog, app_container):
         catalog_id=catalog.id,
         request_input=UploadedFileInput(type=RequestInputType.UPLOADED_FILE),
         observation_set_storage_path="filepath",
+        primary_entity_ids=["63f94ed6ea1f050131379214"],
     )
     task = app_container.get(ObservationTableUploadTask)
     assert (


### PR DESCRIPTION
## Description

Use permanent table for uploaded observation tables so they persist after session is closed

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
