### PR TITLE
[chore] Remove unary_op_series_params and binary_op_series_params methods

### DIFF
--- a/featurebyte/api/feature.py
+++ b/featurebyte/api/feature.py
@@ -38,7 +38,7 @@ from featurebyte.api.templates.feature_or_target_doc import (
 from featurebyte.api.templates.series_doc import ISNULL_DOC, NOTNULL_DOC
 from featurebyte.common.descriptor import ClassInstanceMethodDescriptor
 from featurebyte.common.doc_util import FBAutoDoc
-from featurebyte.common.typing import Scalar, ScalarSequence
+from featurebyte.common.typing import ScalarSequence
 from featurebyte.common.utils import enforce_observation_set_row_order
 from featurebyte.config import Configurations
 from featurebyte.core.accessor.count_dict import CdAccessorMixin
@@ -696,30 +696,6 @@ class Feature(
         >>> float_invoice_count_feature = feature.astype(float)
         """
         return super().astype(new_type=new_type)  # type: ignore[no-any-return,misc]
-
-    def binary_op_series_params(
-        self, other: Scalar | FrozenSeries | ScalarSequence
-    ) -> dict[str, Any]:
-        """
-        Parameters that will be passed to series-like constructor in _binary_op method
-
-
-        Parameters
-        ----------
-        other: other: Scalar | FrozenSeries | ScalarSequence
-            Other object
-
-        Returns
-        -------
-        dict[str, Any]
-        """
-        entity_ids = set(self.entity_ids)
-        if isinstance(other, FrozenSeries):
-            entity_ids = entity_ids.union(getattr(other, "entity_ids", []))
-        return {"entity_ids": sorted(entity_ids)}
-
-    def unary_op_series_params(self) -> dict[str, Any]:
-        return {"entity_ids": self.entity_ids}
 
     @substitute_docstring(
         doc_template=PREVIEW_DOC,

--- a/featurebyte/api/lag.py
+++ b/featurebyte/api/lag.py
@@ -88,5 +88,4 @@ class LaggableViewColumn(ViewColumn):
             node_name=node.name,
             name=None,
             dtype=self.dtype,
-            **self.unary_op_series_params(),
         )

--- a/featurebyte/common/doc_util.py
+++ b/featurebyte/common/doc_util.py
@@ -31,7 +31,6 @@ COMMON_SKIPPED_ATTRIBUTES = [
     "json_dict",
     "dict",
     "extract_pruned_graph_and_node",
-    "unary_op_series_params",
     "node_types_lineage",
     "pytype_dbtype_map",
     "node",

--- a/featurebyte/common/doc_util.py
+++ b/featurebyte/common/doc_util.py
@@ -30,7 +30,6 @@ COMMON_SKIPPED_ATTRIBUTES = [
     "json",
     "json_dict",
     "dict",
-    "binary_op_series_params",
     "extract_pruned_graph_and_node",
     "unary_op_series_params",
     "node_types_lineage",

--- a/featurebyte/core/accessor/count_dict.py
+++ b/featurebyte/core/accessor/count_dict.py
@@ -92,7 +92,6 @@ class CountDictAccessor:
             node_type=NodeType.COUNT_DICT_TRANSFORM,
             output_var_type=output_var_type,
             node_params=node_params,
-            **self._feature_obj.unary_op_series_params(),
         )
 
     def entropy(self) -> Feature:

--- a/featurebyte/core/accessor/datetime.py
+++ b/featurebyte/core/accessor/datetime.py
@@ -486,7 +486,6 @@ class DatetimeAccessor:
             node_type=self._node_type,
             output_var_type=var_type,
             node_params=node_params,
-            **self._obj.unary_op_series_params(),
         )
 
     def _infer_timezone_offset(self, series: FrozenSeries) -> Optional[Union[FrozenSeries, str]]:

--- a/featurebyte/core/accessor/string.py
+++ b/featurebyte/core/accessor/string.py
@@ -87,7 +87,6 @@ class StringAccessor:
             node_type=NodeType.LENGTH,
             output_var_type=DBVarType.INT,
             node_params={},
-            **self._obj.unary_op_series_params(),
         )
 
     def lower(self) -> FrozenSeries:
@@ -119,7 +118,6 @@ class StringAccessor:
             node_type=NodeType.STR_CASE,
             output_var_type=DBVarType.VARCHAR,
             node_params={"case": "lower"},
-            **self._obj.unary_op_series_params(),
         )
 
     def upper(self) -> FrozenSeries:
@@ -151,7 +149,6 @@ class StringAccessor:
             node_type=NodeType.STR_CASE,
             output_var_type=DBVarType.VARCHAR,
             node_params={"case": "upper"},
-            **self._obj.unary_op_series_params(),
         )
 
     @typechecked
@@ -189,7 +186,6 @@ class StringAccessor:
             node_type=NodeType.TRIM,
             output_var_type=DBVarType.VARCHAR,
             node_params={"character": to_strip, "side": "both"},
-            **self._obj.unary_op_series_params(),
         )
 
     @typechecked
@@ -227,7 +223,6 @@ class StringAccessor:
             node_type=NodeType.TRIM,
             output_var_type=DBVarType.VARCHAR,
             node_params={"character": to_strip, "side": "left"},
-            **self._obj.unary_op_series_params(),
         )
 
     @typechecked
@@ -264,7 +259,6 @@ class StringAccessor:
             node_type=NodeType.TRIM,
             output_var_type=DBVarType.VARCHAR,
             node_params={"character": to_strip, "side": "right"},
-            **self._obj.unary_op_series_params(),
         )
 
     @typechecked
@@ -304,7 +298,6 @@ class StringAccessor:
             node_type=NodeType.REPLACE,
             output_var_type=DBVarType.VARCHAR,
             node_params={"pattern": pat, "replacement": repl},
-            **self._obj.unary_op_series_params(),
         )
 
     @typechecked
@@ -346,7 +339,6 @@ class StringAccessor:
             node_type=NodeType.PAD,
             output_var_type=DBVarType.VARCHAR,
             node_params={"side": side, "length": width, "pad": fillchar},
-            **self._obj.unary_op_series_params(),
         )
 
     @typechecked
@@ -386,7 +378,6 @@ class StringAccessor:
             node_type=NodeType.STR_CONTAINS,
             output_var_type=DBVarType.BOOL,
             node_params={"pattern": pat, "case": bool(case)},
-            **self._obj.unary_op_series_params(),
         )
 
     @typechecked
@@ -440,5 +431,4 @@ class StringAccessor:
             node_type=NodeType.SUBSTRING,
             output_var_type=DBVarType.VARCHAR,
             node_params={"start": start, "length": length},
-            **self._obj.unary_op_series_params(),
         )

--- a/featurebyte/core/series.py
+++ b/featurebyte/core/series.py
@@ -153,24 +153,6 @@ class FrozenSeries(
             **self.unary_op_series_params(),
         )
 
-    def binary_op_series_params(
-        self: FrozenSeriesT, other: Scalar | FrozenSeries | ScalarSequence
-    ) -> dict[str, Any]:
-        """
-        Parameters that will be passed to series-like constructor in _binary_op method
-
-        Parameters
-        ----------
-        other: Scalar | FrozenSeries | ScalarSequence
-            Other object
-
-        Returns
-        -------
-        dict[str, Any]
-        """
-        _ = other
-        return {}
-
     @property
     def binary_op_output_class_priority(self) -> int:
         """

--- a/featurebyte/core/series.py
+++ b/featurebyte/core/series.py
@@ -150,7 +150,6 @@ class FrozenSeries(
             node_name=node.name,
             name=self.name,
             dtype=self.dtype,
-            **self.unary_op_series_params(),
         )
 
     @property
@@ -167,16 +166,6 @@ class FrozenSeries(
         int
         """
         return 0
-
-    def unary_op_series_params(self) -> dict[str, Any]:
-        """
-        Additional parameters that will be passed to unary operation output constructor
-
-        Returns
-        -------
-        dict[str, Any]
-        """
-        return {}
 
     def _assert_assignment_valid(self, value: Any) -> None:
         """
@@ -567,7 +556,6 @@ class FrozenSeries(
             node_type=NodeType.NOT,
             output_var_type=DBVarType.BOOL,
             node_params={},
-            **self.unary_op_series_params(),
         )
 
     @typechecked
@@ -635,7 +623,6 @@ class FrozenSeries(
             node_type=NodeType.IS_NULL,
             output_var_type=DBVarType.BOOL,
             node_params={},
-            **self.unary_op_series_params(),
         )
 
     def notnull(self: FrozenSeriesT) -> FrozenSeriesT:
@@ -715,7 +702,6 @@ class FrozenSeries(
             node_type=NodeType.CAST,
             output_var_type=output_var_type,
             node_params=node_params,
-            **self.unary_op_series_params(),
         )
 
     @numeric_only
@@ -752,7 +738,6 @@ class FrozenSeries(
             node_type=NodeType.ABS,
             output_var_type=self.dtype,
             node_params={},
-            **self.unary_op_series_params(),
         )
 
     @numeric_only
@@ -790,7 +775,6 @@ class FrozenSeries(
             node_type=NodeType.SQRT,
             output_var_type=DBVarType.FLOAT,
             node_params={},
-            **self.unary_op_series_params(),
         )
 
     @numeric_only
@@ -869,7 +853,6 @@ class FrozenSeries(
             node_type=NodeType.LOG,
             output_var_type=DBVarType.FLOAT,
             node_params={},
-            **self.unary_op_series_params(),
         )
 
     @numeric_only
@@ -907,7 +890,6 @@ class FrozenSeries(
             node_type=NodeType.EXP,
             output_var_type=DBVarType.FLOAT,
             node_params={},
-            **self.unary_op_series_params(),
         )
 
     @numeric_only
@@ -946,7 +928,6 @@ class FrozenSeries(
             node_type=NodeType.FLOOR,
             output_var_type=DBVarType.INT,
             node_params={},
-            **self.unary_op_series_params(),
         )
 
     @numeric_only
@@ -984,7 +965,6 @@ class FrozenSeries(
             node_type=NodeType.CEIL,
             output_var_type=DBVarType.INT,
             node_params={},
-            **self.unary_op_series_params(),
         )
 
     @numeric_only
@@ -1007,7 +987,6 @@ class FrozenSeries(
             node_type=NodeType.COS,
             output_var_type=DBVarType.FLOAT,
             node_params={},
-            **self.unary_op_series_params(),
         )
 
     @numeric_only
@@ -1030,7 +1009,6 @@ class FrozenSeries(
             node_type=NodeType.SIN,
             output_var_type=DBVarType.FLOAT,
             node_params={},
-            **self.unary_op_series_params(),
         )
 
     @numeric_only
@@ -1053,7 +1031,6 @@ class FrozenSeries(
             node_type=NodeType.TAN,
             output_var_type=DBVarType.FLOAT,
             node_params={},
-            **self.unary_op_series_params(),
         )
 
     @numeric_only
@@ -1076,7 +1053,6 @@ class FrozenSeries(
             node_type=NodeType.ACOS,
             output_var_type=DBVarType.FLOAT,
             node_params={},
-            **self.unary_op_series_params(),
         )
 
     @numeric_only
@@ -1099,7 +1075,6 @@ class FrozenSeries(
             node_type=NodeType.ASIN,
             output_var_type=DBVarType.FLOAT,
             node_params={},
-            **self.unary_op_series_params(),
         )
 
     @numeric_only
@@ -1122,7 +1097,6 @@ class FrozenSeries(
             node_type=NodeType.ATAN,
             output_var_type=DBVarType.FLOAT,
             node_params={},
-            **self.unary_op_series_params(),
         )
 
     def copy(self: FrozenSeriesT, *args: Any, **kwargs: Any) -> FrozenSeriesT:
@@ -1201,7 +1175,6 @@ class FrozenSeries(
                 node_type=NodeType.DICTIONARY_KEYS,
                 output_var_type=DBVarType.ARRAY,
                 node_params={},
-                **other.unary_op_series_params(),
             )
 
         # perform the is in check when the other series is an array

--- a/featurebyte/core/timedelta.py
+++ b/featurebyte/core/timedelta.py
@@ -55,7 +55,6 @@ def to_timedelta(series: Series, unit: TimedeltaSupportedUnitType) -> Series:
         node_type=NodeType.TIMEDELTA,
         output_var_type=DBVarType.TIMEDELTA,
         node_params={"unit": unit},
-        **series.unary_op_series_params(),
     )
 
     return timedelta_series

--- a/featurebyte/core/util.py
+++ b/featurebyte/core/util.py
@@ -136,17 +136,15 @@ def construct_binary_op_series_output(
     FrozenSeriesT
     """
     if input_series.binary_op_output_class_priority <= other.binary_op_output_class_priority:
-        output_type_series, other_series = input_series, other
+        output_type_series = input_series
     else:
-        output_type_series, other_series = other, input_series
-    kwargs = output_type_series.binary_op_series_params(other_series)
+        output_type_series = other
     return type(output_type_series)(  # type: ignore[return-value]
         feature_store=output_type_series.feature_store,
         tabular_source=output_type_series.tabular_source,
         node_name=node_name,
         name=None,
         dtype=output_var_type,
-        **kwargs,
     )
 
 
@@ -202,12 +200,10 @@ def series_binary_operation(
         node_output_type=NodeOutputType.SERIES,
         input_nodes=[input_series.node],
     )
-    kwargs = input_series.binary_op_series_params(other)
     return type(input_series)(
         feature_store=input_series.feature_store,
         tabular_source=input_series.tabular_source,
         node_name=node.name,
         name=None,
         dtype=output_var_type,
-        **kwargs,
     )


### PR DESCRIPTION
## Description

This removes the `unary_op_series_params` and `binary_op_series_params` methods in Series which are now unnecessary. Previously, these methods were used to collect the list of entity ids in Feature operations, but that information is now directly derived from the query graph.

Removing these methods improves performance because each call to Feature's `entity_ids` property incurs an API request, especially for unsaved objects. After this change such API requests during series operations should be eliminated.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
