### PR TITLE
[chore] obs_table: sort primary entity ids when storing

### DIFF
--- a/featurebyte/models/observation_table.py
+++ b/featurebyte/models/observation_table.py
@@ -11,6 +11,7 @@ from datetime import datetime  # pylint: disable=wrong-import-order
 import pymongo
 from pydantic import Field, StrictStr, validator
 
+from featurebyte.common.validator import construct_sort_validator
 from featurebyte.enum import StrEnum
 from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
 from featurebyte.models.materialized_table import MaterializedTableModel
@@ -133,6 +134,10 @@ class ObservationTableModel(MaterializedTableModel):
     entity_column_name_to_count: Optional[Dict[str, int]] = Field(default_factory=dict)
     min_interval_secs_between_entities: Optional[float] = Field(default_factory=None)
     primary_entity_ids: Optional[List[PydanticObjectId]] = Field(default_factory=list)
+
+    _sort_feature_ids_validator = validator("primary_entity_ids", allow_reuse=True)(
+        construct_sort_validator()
+    )
 
     @validator("most_recent_point_in_time", "least_recent_point_in_time")
     @classmethod

--- a/featurebyte/models/observation_table.py
+++ b/featurebyte/models/observation_table.py
@@ -135,7 +135,7 @@ class ObservationTableModel(MaterializedTableModel):
     min_interval_secs_between_entities: Optional[float] = Field(default_factory=None)
     primary_entity_ids: Optional[List[PydanticObjectId]] = Field(default_factory=list)
 
-    _sort_feature_ids_validator = validator("primary_entity_ids", allow_reuse=True)(
+    _sort_primary_entity_ids_validator = validator("primary_entity_ids", allow_reuse=True)(
         construct_sort_validator()
     )
 


### PR DESCRIPTION
## Description
Sort the primary entity IDs when storing them in mongo.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
