### PR TITLE
[DEV-2475] Do not block modification when updating asset description

### DIFF
--- a/featurebyte/routes/common/base_table.py
+++ b/featurebyte/routes/common/base_table.py
@@ -178,7 +178,12 @@ class BaseTableDocumentController(
         return await self.get(document_id=document_id)
 
     async def update_table_columns_info(
-        self, document_id: ObjectId, column_name: str, field: str, data: Any
+        self,
+        document_id: ObjectId,
+        column_name: str,
+        field: str,
+        data: Any,
+        skip_block_modification_check: bool = False,
     ) -> TableDocumentT:
         """
         Update table columns info
@@ -193,6 +198,8 @@ class BaseTableDocumentController(
             Field to update
         data: Any
             Data to update
+        skip_block_modification_check: bool
+            Flag to skip block modification check (used only when updating table column description)
 
         Returns
         -------
@@ -217,6 +224,7 @@ class BaseTableDocumentController(
             table_id=document_id,
             columns_info=columns_info,
             service=self.service,
+            skip_block_modification_check=skip_block_modification_check,
         )
         return await self.get(document_id=document_id)
 
@@ -299,6 +307,7 @@ class BaseTableDocumentController(
             column_name=column_name,
             field="description",
             data=description,
+            skip_block_modification_check=True,
         )
 
     async def service_and_query_pairs_for_checking_reference(

--- a/featurebyte/service/base_document.py
+++ b/featurebyte/service/base_document.py
@@ -890,6 +890,7 @@ class BaseDocumentService(
         document: Document,
         update_dict: Dict[str, Any],
         update_document_class: Optional[Type[DocumentUpdateSchema]],
+        skip_block_modification_check: bool = False,
     ) -> None:
         """
         Update document to persistent
@@ -902,9 +903,13 @@ class BaseDocumentService(
             Update dictionary
         update_document_class: Optional[DocumentUpdateSchema]
             Document update schema class
+        skip_block_modification_check: bool
+            Whether to skip block modification check (use with caution,
+            should only be used when updating document description)
         """
-        # check if document is modifiable
-        self._check_document_modifiable(document=document.dict(by_alias=True))
+        if not skip_block_modification_check:
+            # check if document is modifiable
+            self._check_document_modifiable(document=document.dict(by_alias=True))
 
         # check any conflict with existing documents
         updated_document = self.document_class(**{**document.dict(by_alias=True), **update_dict})
@@ -931,6 +936,7 @@ class BaseDocumentService(
         exclude_none: bool = True,
         document: Optional[Document] = None,
         return_document: bool = True,
+        skip_block_modification_check: bool = False,
     ) -> Optional[Document]:
         """
         Update document at persistent
@@ -947,6 +953,8 @@ class BaseDocumentService(
             Document to be updated (when provided, this method won't query persistent for retrieval)
         return_document: bool
             Whether to make additional query to retrieval updated document & return
+        skip_block_modification_check: bool
+            Whether to skip block modification check (use with caution, only use when updating document description)
 
         Returns
         -------
@@ -960,7 +968,10 @@ class BaseDocumentService(
 
         # update document to persistent
         await self._update_document(
-            document=document, update_dict=update_dict, update_document_class=type(data)
+            document=document,
+            update_dict=update_dict,
+            update_document_class=type(data),
+            skip_block_modification_check=skip_block_modification_check,
         )
 
         if return_document:
@@ -1083,5 +1094,8 @@ class BaseDocumentService(
         """
         document = await self.get_document(document_id=document_id)
         await self._update_document(
-            document=document, update_dict={"description": description}, update_document_class=None
+            document=document,
+            update_dict={"description": description},
+            update_document_class=None,
+            skip_block_modification_check=True,
         )

--- a/featurebyte/service/context.py
+++ b/featurebyte/service/context.py
@@ -107,6 +107,7 @@ class ContextService(BaseDocumentService[ContextModel, ContextCreate, ContextUpd
         exclude_none: bool = True,
         document: Optional[ContextModel] = None,
         return_document: bool = True,
+        skip_block_modification_check: bool = False,
     ) -> Optional[ContextModel]:
         document = await self.get_document(document_id=document_id)
         if data.graph and data.node_name:
@@ -122,5 +123,6 @@ class ContextService(BaseDocumentService[ContextModel, ContextCreate, ContextUpd
             data=data,
             exclude_none=exclude_none,
             return_document=return_document,
+            skip_block_modification_check=skip_block_modification_check,
         )
         return document

--- a/featurebyte/service/credential.py
+++ b/featurebyte/service/credential.py
@@ -137,6 +137,7 @@ class CredentialService(
         exclude_none: bool = True,
         document: Optional[CredentialModel] = None,
         return_document: bool = True,
+        skip_block_modification_check: bool = False,
     ) -> Optional[CredentialModel]:
         """
         Update document at persistent
@@ -153,6 +154,8 @@ class CredentialService(
             Credential to be updated (when provided, this method won't query persistent for retrieval)
         return_document: bool
             Whether to make additional query to retrieval updated document & return
+        skip_block_modification_check: bool
+            Whether to skip block modification check (used only when updating description)
 
         Returns
         -------
@@ -179,4 +182,5 @@ class CredentialService(
             exclude_none=exclude_none,
             document=document,
             return_document=return_document,
+            skip_block_modification_check=skip_block_modification_check,
         )

--- a/featurebyte/service/table.py
+++ b/featurebyte/service/table.py
@@ -31,5 +31,6 @@ class TableService(BaseDocumentService[BaseDataModel, TableCreate, TableServiceU
         exclude_none: bool = True,
         document: Optional[Document] = None,
         return_document: bool = True,
+        skip_block_modification_check: bool = False,
     ) -> Optional[Document]:
         raise NotImplementedError

--- a/featurebyte/service/table_columns_info.py
+++ b/featurebyte/service/table_columns_info.py
@@ -89,7 +89,11 @@ class TableColumnsInfoService(OpsServiceMixin):
             )
 
     async def update_columns_info(
-        self, service: TableDocumentService, document_id: ObjectId, columns_info: List[ColumnInfo]
+        self,
+        service: TableDocumentService,
+        document_id: ObjectId,
+        columns_info: List[ColumnInfo],
+        skip_block_modification_check: bool = False,
     ) -> None:
         """
         Update table columns info
@@ -102,6 +106,8 @@ class TableColumnsInfoService(OpsServiceMixin):
             Document ID
         columns_info: List[ColumnInfo]
             Columns info
+        skip_block_modification_check: bool
+            Flag to skip block modification check (used only when updating table column description)
         """
         document = await service.get_document(document_id=document_id)
 
@@ -125,6 +131,7 @@ class TableColumnsInfoService(OpsServiceMixin):
                 await service.update_document(
                     document_id=document_id,
                     data=service.document_update_class(columns_info=columns_info),  # type: ignore
+                    skip_block_modification_check=skip_block_modification_check,
                 )
 
                 # update entity table reference

--- a/featurebyte/service/table_facade.py
+++ b/featurebyte/service/table_facade.py
@@ -71,6 +71,7 @@ class TableFacadeService:
         table_id: ObjectId,
         columns_info: List[ColumnInfo],
         service: Optional[TableDocumentService] = None,
+        skip_block_modification_check: bool = False,
     ) -> None:
         """
         Update table columns info
@@ -83,12 +84,17 @@ class TableFacadeService:
             Columns info
         service: Optional[TableDocumentService]
             Table document service
+        skip_block_modification_check: bool
+            Flag to skip block modification check (used only when updating table column description)
         """
         if service is None:
             table = await self.table_service.get_document(table_id)
             service = self.get_specific_table_service(table.type)
         await self.table_columns_info_service.update_columns_info(
-            service=service, document_id=table_id, columns_info=columns_info
+            service=service,
+            document_id=table_id,
+            columns_info=columns_info,
+            skip_block_modification_check=skip_block_modification_check,
         )
 
     async def update_table_column_cleaning_operations(

--- a/tests/unit/service/test_base_document.py
+++ b/tests/unit/service/test_base_document.py
@@ -499,6 +499,13 @@ async def test_document_not_modifiable_if_block_modification_by_not_empty(
         )
     assert expected_error in str(exc.value)
 
+    # try to update document description - should be no error
+    await document_service.update_document_description(
+        document_id=document.id, description="new_description"
+    )
+    document = await document_service.get_document(document_id=document.id)
+    assert document.description == "new_description"
+
     # try to delete document - expect an error
     with pytest.raises(DocumentModificationBlockedError) as exc:
         await document_service.delete_document(document_id=document.id)

--- a/tests/unit/service/test_relationship.py
+++ b/tests/unit/service/test_relationship.py
@@ -44,6 +44,7 @@ class FamilyDocumentService(BaseDocumentService):
         exclude_none=True,
         document=None,
         return_document=True,
+        skip_block_modification_check=False,
     ):
         await self.persistent.update_one(
             collection_name=self.collection_name,

--- a/tests/unit/service/test_table_document.py
+++ b/tests/unit/service/test_table_document.py
@@ -2,14 +2,20 @@
 Test BaseTableDocumentService subclasses
 """
 import pytest
+from bson import ObjectId
 
-from featurebyte.exception import DocumentConflictError, DocumentNotFoundError
+from featurebyte.exception import (
+    DocumentConflictError,
+    DocumentModificationBlockedError,
+    DocumentNotFoundError,
+)
+from featurebyte.models.base import ReferenceInfo
 from featurebyte.schema.event_table import EventTableCreate
 from featurebyte.schema.item_table import ItemTableCreate
 
 
 @pytest.mark.asyncio
-async def test_data_document_services__retrieval(
+async def test_table_document_services__retrieval(
     event_table_service, item_table_service, event_table, item_table
 ):
     """Test table document services retrieval"""
@@ -46,7 +52,7 @@ async def test_data_document_services__retrieval(
 
 
 @pytest.mark.asyncio
-async def test_data_document_services__creation_conflict(
+async def test_table_document_services__creation_conflict(
     event_table_service, item_table_service, event_table, item_table
 ):
     """Test table document services - document creation conflict"""
@@ -71,3 +77,39 @@ async def test_data_document_services__creation_conflict(
         f'Get the existing object by `EventTable.get(name="{event_table.name}")`.'
     )
     assert expected_msg in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_table_document_service__update_column_description(
+    scd_table_service, scd_table, app_container, entity
+):
+    """Test table document service - update column description"""
+    # add block_by_modification
+    reference_info = ReferenceInfo(asset_name="Asset", document_id=ObjectId())
+    await scd_table_service.add_block_modification_by(
+        query_filter={"_id": scd_table.id},
+        reference_info=reference_info,
+    )
+
+    # update column description
+    columns_info = scd_table.columns_info
+    columns_info[0].description = "new description"
+    await app_container.table_facade_service.update_table_columns_info(
+        table_id=scd_table.id,
+        columns_info=columns_info,
+        service=scd_table_service,
+        skip_block_modification_check=True,
+    )
+
+    # check column description is updated
+    retrieved_event_table = await scd_table_service.get_document(document_id=scd_table.id)
+    assert retrieved_event_table.columns_info[0].description == "new description"
+
+    # attempt to update other column info (should fail)
+    columns_info[0].entity_id = entity.id
+    with pytest.raises(DocumentModificationBlockedError):
+        await app_container.table_facade_service.update_table_columns_info(
+            table_id=scd_table.id,
+            columns_info=columns_info,
+            service=scd_table_service,
+        )


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR updates block modification logic so that it won't throw error when users update description only.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
