### PR TITLE
[DEV-2482] obs_table_upload: track uploaded filename

### DIFF
--- a/.changelog/DEV-2482.yaml
+++ b/.changelog/DEV-2482.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: observation_table
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Track uploaded file name when creating an observation table from an uploaded file."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/observation_table.py
+++ b/featurebyte/api/observation_table.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from typing import List, Optional, Union
 
+import os
 from pathlib import Path
 
 import pandas as pd
@@ -23,6 +24,13 @@ from featurebyte.schema.observation_table import (
     ObservationTableUpdate,
     ObservationTableUpload,
 )
+
+
+def get_file_name(file_path: Union[str, Path]) -> str:
+    """
+    Return the file name from a file path.
+    """
+    return os.path.basename(file_path)
 
 
 class ObservationTable(ObservationTableModel, ApiObject, MaterializedTableMixin):
@@ -223,11 +231,11 @@ class ObservationTable(ObservationTableModel, ApiObject, MaterializedTableMixin)
         if primary_entities is not None:
             for entity_name in primary_entities:
                 primary_entity_ids.append(Entity.get(entity_name).id)
-
         payload = ObservationTableUpload(
             name=name,
             purpose=purpose,
             primary_entity_ids=primary_entity_ids,
+            uploaded_file_name=get_file_name(file_path),
         )
         with open(file_path, "rb") as file_object:
             observation_table_doc = cls.post_async_task(

--- a/featurebyte/api/observation_table.py
+++ b/featurebyte/api/observation_table.py
@@ -26,13 +26,6 @@ from featurebyte.schema.observation_table import (
 )
 
 
-def get_file_name(file_path: Union[str, Path]) -> str:
-    """
-    Return the file name from a file path.
-    """
-    return os.path.basename(file_path)
-
-
 class ObservationTable(ObservationTableModel, ApiObject, MaterializedTableMixin):
     """
     ObservationTable class
@@ -235,7 +228,7 @@ class ObservationTable(ObservationTableModel, ApiObject, MaterializedTableMixin)
             name=name,
             purpose=purpose,
             primary_entity_ids=primary_entity_ids,
-            uploaded_file_name=get_file_name(file_path),
+            uploaded_file_name=os.path.basename(file_path),
         )
         with open(file_path, "rb") as file_object:
             observation_table_doc = cls.post_async_task(

--- a/featurebyte/models/observation_table.py
+++ b/featurebyte/models/observation_table.py
@@ -74,6 +74,7 @@ class UploadedFileInput(FeatureByteBaseModel):
     """
 
     type: Literal[RequestInputType.UPLOADED_FILE]
+    file_name: str
 
     async def materialize(
         self,

--- a/featurebyte/models/observation_table.py
+++ b/featurebyte/models/observation_table.py
@@ -74,7 +74,7 @@ class UploadedFileInput(FeatureByteBaseModel):
     """
 
     type: Literal[RequestInputType.UPLOADED_FILE]
-    file_name: str
+    file_name: Optional[str] = Field(default=None)
 
     async def materialize(
         self,

--- a/featurebyte/schema/observation_table.py
+++ b/featurebyte/schema/observation_table.py
@@ -35,6 +35,8 @@ class ObservationTableUpload(FeatureByteBaseModel):
     name: StrictStr
     purpose: Optional[Purpose] = Field(default=None)
     primary_entity_ids: List[PydanticObjectId]
+    # This is the name of the file that was uploaded by the user
+    uploaded_file_name: StrictStr
 
 
 class ObservationTableList(PaginationMixin):

--- a/featurebyte/worker/task/observation_table_upload.py
+++ b/featurebyte/worker/task/observation_table_upload.py
@@ -88,7 +88,10 @@ class ObservationTableUploadTask(DataWarehouseMixin, BaseTask[ObservationTableUp
                 user_id=payload.user_id,
                 name=payload.name,
                 location=location,
-                request_input=UploadedFileInput(type=RequestInputType.UPLOADED_FILE),
+                request_input=UploadedFileInput(
+                    type=RequestInputType.UPLOADED_FILE,
+                    file_name=payload.uploaded_file_name,
+                ),
                 purpose=payload.purpose,
                 primary_entity_ids=payload.primary_entity_ids,
                 **additional_metadata,

--- a/tests/integration/api/test_observation_table.py
+++ b/tests/integration/api/test_observation_table.py
@@ -173,9 +173,8 @@ async def test_observation_table_upload(
     _ = catalog, customer_entity
 
     # Upload observation table
-    file_path = os.path.join(
-        os.path.dirname(__file__), "fixtures", f"observation_table.{file_type}"
-    )
+    file_name = f"observation_table.{file_type}"
+    file_path = os.path.join(os.path.dirname(__file__), "fixtures", file_name)
     if file_type == "csv":
         df = pd.read_csv(file_path)
     elif file_type == "parquet":
@@ -190,7 +189,10 @@ async def test_observation_table_upload(
 
     # Assert response
     assert observation_table.name == f"uploaded_observation_table_{file_type}"
-    assert observation_table.request_input == UploadedFileInput(type=RequestInputType.UPLOADED_FILE)
+    assert observation_table.request_input == UploadedFileInput(
+        type=RequestInputType.UPLOADED_FILE,
+        file_name=file_name,
+    )
     expected_columns = {SpecialColumnName.POINT_IN_TIME, "cust_id"}
     actual_columns = {column.name for column in observation_table.columns_info}
     assert expected_columns == actual_columns

--- a/tests/unit/api/test_observation_table.py
+++ b/tests/unit/api/test_observation_table.py
@@ -3,12 +3,11 @@ Unit tests for ObservationTable class
 """
 from typing import Any, Dict
 
-from pathlib import Path
 from unittest.mock import Mock, call, patch
 
 import pytest
 
-from featurebyte.api.observation_table import ObservationTable, get_file_name
+from featurebyte.api.observation_table import ObservationTable
 from featurebyte.api.source_table import SourceTable
 from tests.unit.api.base_materialize_table_test import BaseMaterializedTableApiTest
 
@@ -128,20 +127,3 @@ def test_describe(observation_table_from_source, mock_source_table):
     result = observation_table_from_source.describe(size=123, seed=456)
     assert mock_source_table.describe.call_args == call(size=123, seed=456)
     assert result is mock_source_table.describe.return_value
-
-
-@pytest.mark.parametrize(
-    "file_path, expected_file_name",
-    [
-        ("a/b.csv", "b.csv"),
-        ("b.csv", "b.csv"),
-        (Path("a/b.csv"), "b.csv"),
-        (Path("b.csv"), "b.csv"),
-    ],
-)
-def test_get_file_name(file_path, expected_file_name):
-    """
-    Test get_file_name() method
-    """
-    file_name = get_file_name(file_path)
-    assert expected_file_name == file_name

--- a/tests/unit/api/test_observation_table.py
+++ b/tests/unit/api/test_observation_table.py
@@ -3,11 +3,12 @@ Unit tests for ObservationTable class
 """
 from typing import Any, Dict
 
+from pathlib import Path
 from unittest.mock import Mock, call, patch
 
 import pytest
 
-from featurebyte.api.observation_table import ObservationTable
+from featurebyte.api.observation_table import ObservationTable, get_file_name
 from featurebyte.api.source_table import SourceTable
 from tests.unit.api.base_materialize_table_test import BaseMaterializedTableApiTest
 
@@ -127,3 +128,20 @@ def test_describe(observation_table_from_source, mock_source_table):
     result = observation_table_from_source.describe(size=123, seed=456)
     assert mock_source_table.describe.call_args == call(size=123, seed=456)
     assert result is mock_source_table.describe.return_value
+
+
+@pytest.mark.parametrize(
+    "file_path, expected_file_name",
+    [
+        ("a/b.csv", "b.csv"),
+        ("b.csv", "b.csv"),
+        (Path("a/b.csv"), "b.csv"),
+        (Path("b.csv"), "b.csv"),
+    ],
+)
+def test_get_file_name(file_path, expected_file_name):
+    """
+    Test get_file_name() method
+    """
+    file_name = get_file_name(file_path)
+    assert expected_file_name == file_name

--- a/tests/unit/routes/test_observation_table.py
+++ b/tests/unit/routes/test_observation_table.py
@@ -271,10 +271,12 @@ class TestObservationTableApi(BaseMaterializedTableTestSuite):
         test_api_client, _ = test_api_client_persistent
 
         # Prepare upload request
+        uploaded_file_name = f"uploaded_file.{file_type}"
         upload_request = ObservationTableUpload(
             name="uploaded_observation_table",
             purpose="other",
             primary_entity_ids=["63f94ed6ea1f050131379214"],
+            uploaded_file_name=uploaded_file_name,
         )
         df = pd.DataFrame(
             {
@@ -307,7 +309,10 @@ class TestObservationTableApi(BaseMaterializedTableTestSuite):
 
         # Assert response
         assert response_dict["name"] == "uploaded_observation_table"
-        assert response_dict["request_input"] == {"type": "uploaded_file"}
+        assert response_dict["request_input"] == {
+            "type": "uploaded_file",
+            "file_name": uploaded_file_name,
+        }
         assert response_dict["purpose"] == "other"
         expected_columns = {"POINT_IN_TIME", "cust_id"}
         actual_columns = {column["name"] for column in response_dict["columns_info"]}

--- a/tests/unit/worker/task/test_observation_table_upload.py
+++ b/tests/unit/worker/task/test_observation_table_upload.py
@@ -22,10 +22,13 @@ async def test_get_task_description(catalog, app_container):
         name="Test Observation Table Upload",
         feature_store_id=ObjectId(),
         catalog_id=catalog.id,
-        request_input=UploadedFileInput(type=RequestInputType.UPLOADED_FILE),
+        request_input=UploadedFileInput(
+            type=RequestInputType.UPLOADED_FILE, file_name="random.csv"
+        ),
         observation_set_storage_path="filepath",
         primary_entity_ids=["63f94ed6ea1f050131379214"],
         file_format="csv",
+        uploaded_file_name="random.csv",
     )
     task = app_container.get(ObservationTableUploadTask)
     assert (


### PR DESCRIPTION
## Description
Persist the filename that the observation table was created from.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
