### PR TITLE
[chore] rm unnecessary source_type overrides

### DIFF
--- a/tests/integration/api/test_change_view_operations.py
+++ b/tests/integration/api/test_change_view_operations.py
@@ -22,7 +22,6 @@ def freeze_time_for_change_view():
         yield
 
 
-@pytest.mark.parametrize("source_type", ["snowflake", "spark"], indirect=True)
 @pytest.mark.usefixtures("freeze_time_for_change_view")
 def test_change_view(scd_table):
     """
@@ -64,7 +63,6 @@ def test_change_view(scd_table):
     }
 
 
-@pytest.mark.parametrize("source_type", ["snowflake", "spark"], indirect=True)
 @pytest.mark.usefixtures("freeze_time_for_change_view")
 def test_change_view__feature_no_entity(scd_table):
     """
@@ -101,7 +99,6 @@ def test_change_view__feature_no_entity(scd_table):
     assert df.iloc[0].to_dict() == expected
 
 
-@pytest.mark.parametrize("source_type", ["snowflake", "spark"], indirect=True)
 @pytest.mark.asyncio
 async def test_change_view_correctness(session, data_source):
     """

--- a/tests/integration/api/test_dimension_view_operations.py
+++ b/tests/integration/api/test_dimension_view_operations.py
@@ -34,7 +34,6 @@ def count_item_type_dictionary_feature_fixture(item_table):
     )
 
 
-@pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
 def test_dimension_lookup_features(dimension_view):
     """
     Test lookup features from DimensionView

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -1290,7 +1290,6 @@ def test_non_float_tile_value_added_to_tile_table(event_view, source_type):
     }
 
 
-@pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
 def test_create_observation_table(event_view):
     new_event_view = event_view.copy()
     new_event_view["POINT_IN_TIME"] = new_event_view["ËVENT_TIMESTAMP"]
@@ -1306,7 +1305,6 @@ def test_create_observation_table(event_view):
     assert set(observation_table.entity_ids) == expected_entity_ids
 
 
-@pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
 def test_create_observation_table__errors_with_no_entities(event_view):
     new_event_view = event_view.copy()
     new_event_view["POINT_IN_TIME"] = new_event_view["ËVENT_TIMESTAMP"]


### PR DESCRIPTION
## Description
Remove source_type parameter to run for all source types by default.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
