### PR TITLE
[chore] Make primary entity optional for observation table creation

### DIFF
--- a/featurebyte/api/source_table.py
+++ b/featurebyte/api/source_table.py
@@ -1030,6 +1030,8 @@ class SourceTable(AbstractTableData):
         if primary_entities is not None:
             for entity_name in primary_entities:
                 primary_entity_ids.append(Entity.get(entity_name).id)
+        else:
+            logger.warning("Primary entities will be a mandatory parameter in SDK version 0.7.")
 
         payload = ObservationTableCreate(
             name=name,

--- a/featurebyte/schema/observation_table.py
+++ b/featurebyte/schema/observation_table.py
@@ -23,7 +23,7 @@ class ObservationTableCreate(BaseRequestTableCreate):
     request_input: ObservationInput
     skip_entity_validation_checks: bool = Field(default=False)
     purpose: Optional[Purpose] = Field(default=None)
-    primary_entity_ids: List[PydanticObjectId]
+    primary_entity_ids: Optional[List[PydanticObjectId]]
 
 
 class ObservationTableUpload(FeatureByteBaseModel):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,6 +4,7 @@ Common test fixtures used across unit test directories
 """
 import copy
 import json
+import logging
 import tempfile
 import traceback
 from datetime import datetime
@@ -38,6 +39,7 @@ from featurebyte.api.item_table import ItemTable
 from featurebyte.app import User, app, get_celery
 from featurebyte.enum import AggFunc, InternalName, SourceType
 from featurebyte.exception import DuplicatedRecordException, ObjectHasBeenSavedError
+from featurebyte.logging import CONSOLE_LOG_FORMATTER
 from featurebyte.models.credential import CredentialModel
 from featurebyte.models.feature_namespace import FeatureReadiness
 from featurebyte.models.task import Task as TaskModel
@@ -1715,3 +1717,25 @@ def mock_task_manager(request, persistent, storage, temp_storage):
                 mock_get_celery.return_value.AsyncResult.side_effect = get_task
                 mock_get_celery_worker.return_value.AsyncResult.side_effect = get_task
                 yield
+
+
+class MockLogHandler(logging.Handler):
+    """
+    Mock LogHandler to record logs for testing
+    """
+
+    records = []
+
+    def emit(self, record):
+        self.records.append(self.format(record))
+
+
+@pytest.fixture(name="mock_log_handler")
+def mock_log_handler_fixture():
+    """
+    Mock log handler fixture
+    """
+    mock_handler = MockLogHandler()
+    mock_handler.setFormatter(CONSOLE_LOG_FORMATTER)
+    mock_handler.records.clear()
+    return mock_handler

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -3,38 +3,24 @@ Test Logger
 """
 import logging
 
-from featurebyte.logging import CONSOLE_LOG_FORMATTER, get_logger
+from featurebyte.logging import get_logger
 
 logger = get_logger(__name__)
 
 
-class MockLogHandler(logging.Handler):
-    """
-    Mock LogHandler to record logs for testing
-    """
-
-    records = []
-
-    def emit(self, record):
-        self.records.append(self.format(record))
-
-
-def test_logging():
+def test_logging(mock_log_handler):
     """
     Test basic logging works
     """
-    mock_handler = MockLogHandler()
-    mock_handler.setFormatter(CONSOLE_LOG_FORMATTER)
-    logger.addHandler(mock_handler)
+    logger.addHandler(mock_log_handler)
     logger.setLevel(logging.DEBUG)
-    mock_handler.records.clear()
     logger.debug("Test Message", extra={"a": 1})
 
     # check logging format looks like:
     # 2022-06-20 14:33:41.328 | DEBUG    | Test Message | {'extra': {'a': 1}}
-    assert len(mock_handler.records) == 1
-    parts = mock_handler.records[0].split("|")
+    assert len(mock_log_handler.records) == 1
+    parts = mock_log_handler.records[0].split("|")
     assert (
         "|".join(parts[1:])
-        == " DEBUG    | tests.unit.test_logger | test_logging:31 | Test Message | {'a': 1}"
+        == " DEBUG    | tests.unit.test_logger | test_logging:17 | Test Message | {'a': 1}"
     )


### PR DESCRIPTION
## Description

Make primary entity optional for observation table creation for now to maintain backward compatibility

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
