### PR TITLE
[DEV-2487] target: allow users to add target with just target id

### DIFF
--- a/.changelog/DEV-2487.yaml
+++ b/.changelog/DEV-2487.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: target
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Allow users to create observation table with just a target id, but no graph."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/target.py
+++ b/featurebyte/api/target.py
@@ -350,7 +350,8 @@ class Target(
             observation_table_id=observation_table_id,
             feature_store_id=self.feature_store.id,
             serving_names_mapping=serving_names_mapping,
-            target_id=self.id,
+            graph=self.graph,
+            node_name=self.node.name,
             request_input=TargetInput(
                 target_id=self.id,
                 observation_table_id=observation_table_id,

--- a/featurebyte/api/target.py
+++ b/featurebyte/api/target.py
@@ -352,7 +352,7 @@ class Target(
             serving_names_mapping=serving_names_mapping,
             target_id=self.id,
             graph=self.graph,
-            node_names=[self.node.name],
+            node_name=self.node.name,
             request_input=TargetInput(
                 target_id=self.id,
                 observation_table_id=observation_table_id,

--- a/featurebyte/api/target.py
+++ b/featurebyte/api/target.py
@@ -351,8 +351,6 @@ class Target(
             feature_store_id=self.feature_store.id,
             serving_names_mapping=serving_names_mapping,
             target_id=self.id,
-            graph=self.graph,
-            node_name=self.node.name,
             request_input=TargetInput(
                 target_id=self.id,
                 observation_table_id=observation_table_id,

--- a/featurebyte/routes/target_table/controller.py
+++ b/featurebyte/routes/target_table/controller.py
@@ -94,9 +94,10 @@ class TargetTableController(
         data: TargetTableCreate,
         observation_set: Optional[UploadFile],
     ) -> Task:
-        if data.graph is None:
+        if data.graph is None and data.target_id is not None:
             data_dict = data.dict()
             target_doc = await self.target_service.get_document(data.target_id)
+            data_dict["target_id"] = None
             data_dict["graph"] = target_doc.graph
             data_dict["node_name"] = target_doc.node_name
             data = TargetTableCreate(**data_dict)

--- a/featurebyte/routes/target_table/controller.py
+++ b/featurebyte/routes/target_table/controller.py
@@ -98,6 +98,6 @@ class TargetTableController(
             data_dict = data.dict()
             target_doc = await self.target_service.get_document(data.target_id)
             data_dict["graph"] = target_doc.graph
-            data_dict["node_names"] = [target_doc.node_name]
+            data_dict["node_name"] = target_doc.node_name
             data = TargetTableCreate(**data_dict)
         return await super().create_table(data=data, observation_set=observation_set)

--- a/featurebyte/routes/target_table/controller.py
+++ b/featurebyte/routes/target_table/controller.py
@@ -9,7 +9,6 @@ import pandas as pd
 from fastapi import UploadFile
 
 from featurebyte.models.target_table import TargetTableModel
-from featurebyte.models.task import Task
 from featurebyte.routes.common.feature_or_target_table import (
     FeatureOrTargetTableController,
     ValidationParameters,
@@ -17,6 +16,7 @@ from featurebyte.routes.common.feature_or_target_table import (
 from featurebyte.routes.task.controller import TaskController
 from featurebyte.schema.info import TargetTableInfo
 from featurebyte.schema.target_table import TargetTableCreate, TargetTableList
+from featurebyte.schema.task import Task
 from featurebyte.schema.worker.task.target_table import TargetTableTaskPayload
 from featurebyte.service.entity_validation import EntityValidationService
 from featurebyte.service.feature_store import FeatureStoreService
@@ -76,8 +76,10 @@ class TargetTableController(
         feature_store = await self.feature_store_service.get_document(
             document_id=table_create.feature_store_id
         )
+        graph = table_create.graph
+        assert graph is not None
         return ValidationParameters(
-            graph=table_create.graph,
+            graph=graph,
             nodes=table_create.nodes,
             feature_store=feature_store,
             serving_names_mapping=table_create.serving_names_mapping,

--- a/featurebyte/schema/target_table.py
+++ b/featurebyte/schema/target_table.py
@@ -30,6 +30,19 @@ class TargetTableCreate(FeatureOrTargetTableCreate):
     context_id: Optional[PydanticObjectId]
     skip_entity_validation_checks: bool = Field(default=False)
 
+    @root_validator(pre=True)
+    @classmethod
+    def _check_graph_and_node_names(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        graph = values["graph"]
+        node_names = values["node_names"]
+        both_are_none = graph is None and node_names is None
+        both_are_not_none = graph is not None and node_names is not None
+        if both_are_not_none or both_are_none:
+            return values
+        raise ValueError(
+            "Both graph and node_names should be provided, or neither should be provided."
+        )
+
     @property
     def nodes(self) -> List[Node]:
         """

--- a/featurebyte/schema/target_table.py
+++ b/featurebyte/schema/target_table.py
@@ -23,9 +23,9 @@ class TargetTableCreate(FeatureOrTargetTableCreate):
     """
 
     serving_names_mapping: Optional[Dict[str, str]]
-    target_id: Optional[PydanticObjectId]
-    graph: QueryGraph
-    node_names: List[StrictStr]
+    target_id: PydanticObjectId
+    graph: Optional[QueryGraph]
+    node_names: Optional[List[StrictStr]]
     request_input: ObservationInput
     context_id: Optional[PydanticObjectId]
     skip_entity_validation_checks: bool = Field(default=False)

--- a/featurebyte/schema/target_table.py
+++ b/featurebyte/schema/target_table.py
@@ -39,6 +39,8 @@ class TargetTableCreate(FeatureOrTargetTableCreate):
         -------
         List[Node]
         """
+        if self.graph is None or self.node_names is None:
+            return []
         return [self.graph.get_node_by_name(name) for name in self.node_names]
 
 

--- a/featurebyte/schema/target_table.py
+++ b/featurebyte/schema/target_table.py
@@ -25,7 +25,7 @@ class TargetTableCreate(FeatureOrTargetTableCreate):
     serving_names_mapping: Optional[Dict[str, str]]
     target_id: PydanticObjectId
     graph: Optional[QueryGraph] = Field(default=None)
-    node_names: Optional[List[StrictStr]] = Field(default=None)
+    node_name: Optional[StrictStr] = Field(default=None)
     request_input: ObservationInput
     context_id: Optional[PydanticObjectId]
     skip_entity_validation_checks: bool = Field(default=False)
@@ -34,7 +34,7 @@ class TargetTableCreate(FeatureOrTargetTableCreate):
     @classmethod
     def _check_graph_and_node_names(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         graph = values.get("graph", None)
-        node_names = values.get("node_names", None)
+        node_names = values.get("node_name", None)
         both_are_none = graph is None and node_names is None
         both_are_not_none = graph is not None and node_names is not None
         if both_are_not_none or both_are_none:
@@ -52,9 +52,9 @@ class TargetTableCreate(FeatureOrTargetTableCreate):
         -------
         List[Node]
         """
-        if self.graph is None or self.node_names is None:
+        if self.graph is None or self.node_name is None:
             return []
-        return [self.graph.get_node_by_name(name) for name in self.node_names]
+        return [self.graph.get_node_by_name(self.node_name)]
 
 
 class TargetTableList(PaginationMixin):

--- a/featurebyte/schema/target_table.py
+++ b/featurebyte/schema/target_table.py
@@ -23,7 +23,7 @@ class TargetTableCreate(FeatureOrTargetTableCreate):
     """
 
     serving_names_mapping: Optional[Dict[str, str]]
-    target_id: PydanticObjectId
+    target_id: Optional[PydanticObjectId]
     graph: Optional[QueryGraph] = Field(default=None)
     node_name: Optional[StrictStr] = Field(default=None)
     request_input: ObservationInput
@@ -35,9 +35,21 @@ class TargetTableCreate(FeatureOrTargetTableCreate):
     def _check_graph_and_node_names(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         graph = values.get("graph", None)
         node_names = values.get("node_name", None)
+        target_id = values.get("target_id", None)
         both_are_none = graph is None and node_names is None
+
+        # Check if target is provided
+        if target_id is not None:
+            # Valid if target_id is provided, and no graph and node_names are provided
+            if both_are_none:
+                return values
+            raise ValueError(
+                "If target_id is provided, graph and node_names should not be provided."
+            )
+
+        # If target is not provided, graph and node_names should be provided.
         both_are_not_none = graph is not None and node_names is not None
-        if both_are_not_none or both_are_none:
+        if both_are_not_none:
             return values
         raise ValueError(
             "Both graph and node_names should be provided, or neither should be provided."

--- a/featurebyte/schema/target_table.py
+++ b/featurebyte/schema/target_table.py
@@ -24,8 +24,8 @@ class TargetTableCreate(FeatureOrTargetTableCreate):
 
     serving_names_mapping: Optional[Dict[str, str]]
     target_id: PydanticObjectId
-    graph: Optional[QueryGraph]
-    node_names: Optional[List[StrictStr]]
+    graph: Optional[QueryGraph] = Field(default=None)
+    node_names: Optional[List[StrictStr]] = Field(default=None)
     request_input: ObservationInput
     context_id: Optional[PydanticObjectId]
     skip_entity_validation_checks: bool = Field(default=False)
@@ -33,8 +33,8 @@ class TargetTableCreate(FeatureOrTargetTableCreate):
     @root_validator(pre=True)
     @classmethod
     def _check_graph_and_node_names(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        graph = values["graph"]
-        node_names = values["node_names"]
+        graph = values.get("graph", None)
+        node_names = values.get("node_names", None)
         both_are_none = graph is None and node_names is None
         both_are_not_none = graph is not None and node_names is not None
         if both_are_not_none or both_are_none:

--- a/featurebyte/worker/task/target_table.py
+++ b/featurebyte/worker/task/target_table.py
@@ -64,21 +64,21 @@ class TargetTableTask(DataWarehouseMixin, BaseTask[TargetTableTaskPayload]):
         ):
             # Graphs and nodes being processed in this task should not be None anymore.
             graph = payload.graph
-            node_names = payload.node_names
+            node_name = payload.node_name
             assert graph is not None
-            assert node_names is not None
+            assert node_name is not None
             await self.target_computer.compute(
                 observation_set=observation_set,
                 compute_request=ComputeTargetRequest(
                     feature_store_id=payload.feature_store_id,
                     graph=graph,
-                    node_names=node_names,
+                    node_names=[node_name],
                     serving_names_mapping=payload.serving_names_mapping,
                     target_id=payload.target_id,
                 ),
                 output_table_details=location.table_details,
             )
-            entity_ids = graph.get_entity_ids(node_names[0])
+            entity_ids = graph.get_entity_ids(node_name)
             primary_entity_ids = await self.derive_primary_entity_helper.derive_primary_entity_ids(
                 entity_ids
             )

--- a/featurebyte/worker/task/target_table.py
+++ b/featurebyte/worker/task/target_table.py
@@ -62,18 +62,23 @@ class TargetTableTask(DataWarehouseMixin, BaseTask[TargetTableTaskPayload]):
         async with self.drop_table_on_error(
             db_session=db_session, table_details=location.table_details, payload=payload
         ):
+            # Graphs and nodes being processed in this task should not be None anymore.
+            graph = payload.graph
+            node_names = payload.node_names
+            assert graph is not None
+            assert node_names is not None
             await self.target_computer.compute(
                 observation_set=observation_set,
                 compute_request=ComputeTargetRequest(
                     feature_store_id=payload.feature_store_id,
-                    graph=payload.graph,
-                    node_names=payload.node_names,
+                    graph=graph,
+                    node_names=node_names,
                     serving_names_mapping=payload.serving_names_mapping,
                     target_id=payload.target_id,
                 ),
                 output_table_details=location.table_details,
             )
-            entity_ids = payload.graph.get_entity_ids(payload.node_names[0])
+            entity_ids = graph.get_entity_ids(node_names[0])
             primary_entity_ids = await self.derive_primary_entity_helper.derive_primary_entity_ids(
                 entity_ids
             )

--- a/tests/unit/routes/test_target.py
+++ b/tests/unit/routes/test_target.py
@@ -282,6 +282,9 @@ class TestTargetApi(BaseCatalogApiTestSuite):
     async def test_creating_target_table_with_just_target_id(
         self, test_api_client_persistent, create_success_response, create_observation_table
     ):
+        """
+        Test that we can create a target table without a graph and node_names, but with just the target id.
+        """
         test_api_client, _ = test_api_client_persistent
         target = create_success_response.json()
         # Create an observation table

--- a/tests/unit/routes/test_target.py
+++ b/tests/unit/routes/test_target.py
@@ -13,6 +13,9 @@ from pandas._testing import assert_frame_equal
 from featurebyte.common.utils import dataframe_from_json
 from featurebyte.models import EntityModel
 from featurebyte.models.entity import ParentEntity
+from featurebyte.models.observation_table import UploadedFileInput
+from featurebyte.models.request_input import RequestInputType
+from featurebyte.schema.target_table import TargetTableCreate
 from tests.unit.routes.base import BaseCatalogApiTestSuite
 
 
@@ -274,3 +277,38 @@ class TestTargetApi(BaseCatalogApiTestSuite):
         response = test_api_client.delete(f"/target_namespace/{namespace_id}")
         assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
         assert response.json()["detail"] == "TargetNamespace is referenced by Target: float_target"
+
+    @pytest.mark.asyncio
+    async def test_creating_target_table_with_just_target_id(
+        self, test_api_client_persistent, create_success_response, create_observation_table
+    ):
+        test_api_client, _ = test_api_client_persistent
+        target = create_success_response.json()
+        # Create an observation table
+        obs_table_id = ObjectId()
+        await create_observation_table(obs_table_id)
+
+        # Create payload with no graph and no node names
+        create = TargetTableCreate(
+            name="target_name",
+            feature_store_id=ObjectId(),
+            serving_names_mapping={},
+            target_id=target["_id"],
+            context_id=None,
+            request_input=UploadedFileInput(
+                type=RequestInputType.UPLOADED_FILE,
+                file_name="random_file_name",
+            ),
+            observation_table_id=obs_table_id,
+        )
+        data = {"payload": create.json()}
+
+        with mock.patch(
+            "featurebyte.routes.common.feature_or_target_table.FeatureOrTargetTableController.create_table"
+        ) as mock_create_table:
+            test_api_client.post("/target_table", data=data)
+            assert mock_create_table.call_count == 1
+            call_args = mock_create_table.call_args_list[0][1]
+            # Check that node names is in the call args of mock_create_table
+            assert call_args["data"].node_names == ["project_1"]
+            assert call_args["data"].graph is not None

--- a/tests/unit/routes/test_target.py
+++ b/tests/unit/routes/test_target.py
@@ -313,5 +313,5 @@ class TestTargetApi(BaseCatalogApiTestSuite):
             assert mock_create_table.call_count == 1
             call_args = mock_create_table.call_args_list[0][1]
             # Check that node names is in the call args of mock_create_table
-            assert call_args["data"].node_names == ["project_1"]
+            assert call_args["data"].node_name == "project_1"
             assert call_args["data"].graph is not None

--- a/tests/unit/schema/test_target_table.py
+++ b/tests/unit/schema/test_target_table.py
@@ -1,0 +1,45 @@
+"""
+Test target table schema
+"""
+import pytest
+from bson import ObjectId
+
+from featurebyte.models.observation_table import UploadedFileInput
+from featurebyte.models.request_input import RequestInputType
+from featurebyte.query_graph.model.graph import QueryGraphModel
+from featurebyte.schema.target_table import TargetTableCreate
+
+
+@pytest.mark.parametrize(
+    "graph, node_names, expected_error",
+    [
+        (None, None, None),
+        (None, ["node_name"], ValueError),
+        (QueryGraphModel(), None, ValueError),
+        (QueryGraphModel(), ["node_name"], None),
+    ],
+)
+def test_target_table_create(graph, node_names, expected_error):
+    """
+    Test target table create schema
+    """
+    target_id = ObjectId()
+    common_params = {
+        "name": "target_name",
+        "feature_store_id": ObjectId(),
+        "serving_names_mapping": {},
+        "target_id": target_id,
+        "context_id": None,
+        "request_input": UploadedFileInput(
+            type=RequestInputType.UPLOADED_FILE,
+            file_name="random_file_name",
+        ),
+    }
+    if expected_error:
+        with pytest.raises(expected_error):
+            TargetTableCreate(graph=graph, node_names=node_names, **common_params)
+        return
+    else:
+        target_table_create = TargetTableCreate(graph=graph, node_names=node_names, **common_params)
+        assert target_table_create.name == "target_name"
+        assert target_table_create.target_id == target_id

--- a/tests/unit/schema/test_target_table.py
+++ b/tests/unit/schema/test_target_table.py
@@ -11,15 +11,15 @@ from featurebyte.schema.target_table import TargetTableCreate
 
 
 @pytest.mark.parametrize(
-    "graph, node_names, expected_error",
+    "graph, node_name, expected_error",
     [
         (None, None, None),
-        (None, ["node_name"], ValueError),
+        (None, "node_name", ValueError),
         (QueryGraphModel(), None, ValueError),
-        (QueryGraphModel(), ["node_name"], None),
+        (QueryGraphModel(), "node_name", None),
     ],
 )
-def test_target_table_create(graph, node_names, expected_error):
+def test_target_table_create(graph, node_name, expected_error):
     """
     Test target table create schema
     """
@@ -37,9 +37,9 @@ def test_target_table_create(graph, node_names, expected_error):
     }
     if expected_error:
         with pytest.raises(expected_error):
-            TargetTableCreate(graph=graph, node_names=node_names, **common_params)
+            TargetTableCreate(graph=graph, node_name=node_name, **common_params)
         return
     else:
-        target_table_create = TargetTableCreate(graph=graph, node_names=node_names, **common_params)
+        target_table_create = TargetTableCreate(graph=graph, node_name=node_name, **common_params)
         assert target_table_create.name == "target_name"
         assert target_table_create.target_id == target_id

--- a/tests/unit/schema/test_target_table.py
+++ b/tests/unit/schema/test_target_table.py
@@ -11,19 +11,22 @@ from featurebyte.schema.target_table import TargetTableCreate
 
 
 @pytest.mark.parametrize(
-    "graph, node_name, expected_error",
+    "target_id, graph, node_name, expected_error",
     [
-        (None, None, None),
-        (None, "node_name", ValueError),
-        (QueryGraphModel(), None, ValueError),
-        (QueryGraphModel(), "node_name", None),
+        (ObjectId(), None, None, None),
+        (ObjectId(), None, "node_name", ValueError),
+        (ObjectId(), QueryGraphModel(), None, ValueError),
+        (ObjectId(), QueryGraphModel(), "node_name", ValueError),
+        (None, None, None, ValueError),
+        (None, None, "node_name", ValueError),
+        (None, QueryGraphModel(), None, ValueError),
+        (None, QueryGraphModel(), "node_name", None),
     ],
 )
-def test_target_table_create(graph, node_name, expected_error):
+def test_target_table_create(target_id, graph, node_name, expected_error):
     """
     Test target table create schema
     """
-    target_id = ObjectId()
     common_params = {
         "name": "target_name",
         "feature_store_id": ObjectId(),

--- a/tests/unit/worker/task/test_target_table.py
+++ b/tests/unit/worker/task/test_target_table.py
@@ -24,7 +24,7 @@ async def test_get_task_description(catalog, app_container):
         catalog_id=catalog.id,
         target_id=ObjectId(),
         graph=QueryGraph(),
-        node_names=["node_1"],
+        node_name="node_1",
         request_input=SourceTableObservationInput(
             source=TabularSource(
                 feature_store_id=ObjectId(),

--- a/tests/unit/worker/task/test_target_table.py
+++ b/tests/unit/worker/task/test_target_table.py
@@ -22,7 +22,6 @@ async def test_get_task_description(catalog, app_container):
         name="Test Target Table",
         feature_store_id=ObjectId(),
         catalog_id=catalog.id,
-        target_id=ObjectId(),
         graph=QueryGraph(),
         node_name="node_1",
         request_input=SourceTableObservationInput(


### PR DESCRIPTION
## Description
Update endpoint to make graph and node names optional, but make target ID required. This way, we can lookup the graph and node from the persisted target if needed.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
