### PR TITLE
[DEV-2503] use_case: look up target namespace instead of target

### DIFF
--- a/.changelog/DEV-2503.yaml
+++ b/.changelog/DEV-2503.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: use_case
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Allow use cases to be created with descriptive only targets"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/use_case.py
+++ b/featurebyte/api/use_case.py
@@ -18,6 +18,7 @@ from featurebyte.api.context import Context
 from featurebyte.api.observation_table import ObservationTable
 from featurebyte.api.savable_api_object import DeletableApiObject, SavableApiObject
 from featurebyte.api.target import Target
+from featurebyte.api.target_namespace import TargetNamespace
 from featurebyte.api.use_case_or_context_mixin import UseCaseOrContextMixin
 from featurebyte.common.doc_util import FBAutoDoc
 from featurebyte.enum import ConflictResolution
@@ -59,19 +60,22 @@ class UseCase(SavableApiObject, DeletableApiObject, UseCaseOrContextMixin):
     ]
 
     # pydantic instance variable (public)
-    target_id: PydanticObjectId
+    target_id: Optional[PydanticObjectId]
+    target_namespace_id: PydanticObjectId
     context_id: PydanticObjectId
 
     @property
-    def target(self) -> Target:
+    def target(self) -> Optional[Target]:
         """
         Returns the target object of the UseCase.
 
         Returns
         -------
-        Target
+        Optional[Target]
             The target object of the UseCase.
         """
+        if self.target_id is None:
+            return None
         return Target.get_by_id(self.target_id)
 
     @property
@@ -124,9 +128,11 @@ class UseCase(SavableApiObject, DeletableApiObject, UseCaseOrContextMixin):
         ... )
         >>> use_case_1 = catalog.get_use_case("use_case_1")  # doctest: +SKIP
         """
+        target_namespace = TargetNamespace.get(target_name)
         use_case = UseCase(
             name=name,
-            target_id=Target.get(target_name).id,
+            target_id=target_namespace.default_target_id,
+            target_namespace_id=target_namespace.id,
             context_id=Context.get(context_name).id,
             description=description,
         )

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -10,7 +10,7 @@ import pytest
 from bson.objectid import ObjectId
 from pandas.testing import assert_frame_equal
 
-from featurebyte import Catalog, UseCase
+from featurebyte import Catalog, TargetNamespace, UseCase
 from featurebyte.api.base_table import TableColumn
 from featurebyte.api.entity import Entity
 from featurebyte.api.event_table import EventTable
@@ -395,10 +395,12 @@ def use_case_fixture(catalog, float_target, context):
     """
     _ = catalog
     float_target.save()
+    target_namespace = TargetNamespace.get(float_target.name)
 
     use_case = UseCase(
         name="test_use_case",
         target_id=float_target.id,
+        target_namespace_id=target_namespace.id,
         context_id=context.id,
         description="test_use_case description",
     )

--- a/tests/unit/api/test_context.py
+++ b/tests/unit/api/test_context.py
@@ -3,7 +3,7 @@ Unit test for Context class
 """
 import pytest
 
-from featurebyte import Context, UseCase
+from featurebyte import Context, TargetNamespace, UseCase
 
 
 @pytest.fixture(name="context_1")
@@ -119,9 +119,11 @@ def test_info(context_1, float_target, target_table, cust_id_entity):
     Test Context.info method
     """
 
+    target_namespace = TargetNamespace.get(float_target.name)
     use_case = UseCase(
         name="test_use_case",
         target_id=float_target.id,
+        target_namespace_id=target_namespace.id,
         context_id=context_1.id,
         description="test_use_case description",
     )

--- a/tests/unit/api/test_use_case.py
+++ b/tests/unit/api/test_use_case.py
@@ -1,7 +1,31 @@
 """
 Unit test for UseCase class
 """
-from featurebyte import ObservationTable, UseCase
+from featurebyte import ObservationTable, TargetNamespace, UseCase
+
+
+def test_create_use_case_with_descriptive_target(catalog, cust_id_entity, context):
+    """
+    Test create use case with descriptive target
+    """
+    if not context.saved:
+        context.save()
+
+    target_name = "target_name"
+    namespace = TargetNamespace.create(
+        name=target_name,
+        window="28d",
+        primary_entity=[cust_id_entity.name],
+    )
+    assert namespace.name == target_name
+    use_case = UseCase.create(
+        name="test_use_case_1",
+        target_name=target_name,
+        context_name=context.name,
+        description="test_use_case_1 description",
+    )
+    assert use_case.target_namespace_id == namespace.id
+    assert use_case.target is None
 
 
 def test_create_use_case(catalog, float_target, context):


### PR DESCRIPTION
## Description
Currently, creating a use case with a descriptive target throws an error since there’s no actual target version object.

We made some changes to store the target namespace ID in the use case, but never updated this create function to handle that correctly. This PR fixes that.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-2503

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
