### PR TITLE
[chore] Simplify preview payloads to not require feature store name

### DIFF
--- a/featurebyte/api/feature_or_target_mixin.py
+++ b/featurebyte/api/feature_or_target_mixin.py
@@ -86,7 +86,6 @@ class FeatureOrTargetMixin(QueryObject, ApiObject):
 
         pruned_graph, mapped_node = self.extract_pruned_graph_and_node()
         preview_params = {
-            "feature_store_name": self.feature_store.name,
             "graph": pruned_graph,
             "node_name": mapped_node.name,
         }

--- a/featurebyte/core/mixin.py
+++ b/featurebyte/core/mixin.py
@@ -280,7 +280,6 @@ class SampleMixin:
         """
         pruned_graph, mapped_node = self.extract_pruned_graph_and_node(**kwargs)
         payload = FeatureStorePreview(
-            feature_store_name=self.feature_store.name,
             graph=pruned_graph,
             node_name=mapped_node.name,
         )
@@ -315,7 +314,6 @@ class SampleMixin:
 
         pruned_graph, mapped_node = self.extract_pruned_graph_and_node(**kwargs)
         return FeatureStoreSample(
-            feature_store_name=self.feature_store.name,
             graph=pruned_graph,
             node_name=mapped_node.name,
             from_timestamp=from_timestamp,
@@ -351,7 +349,6 @@ class SampleMixin:
         """
         pruned_graph, mapped_node = self.extract_pruned_graph_and_node(**kwargs)
         payload = FeatureStorePreview(
-            feature_store_name=self.feature_store.name,
             graph=pruned_graph,
             node_name=mapped_node.name,
         )
@@ -502,7 +499,6 @@ class SampleMixin:
 
         pruned_graph, mapped_node = self.extract_pruned_graph_and_node(**kwargs)
         payload = FeatureStoreSample(
-            feature_store_name=self.feature_store.name,
             graph=pruned_graph,
             node_name=mapped_node.name,
             from_timestamp=from_timestamp,

--- a/featurebyte/schema/feature_store.py
+++ b/featurebyte/schema/feature_store.py
@@ -44,7 +44,6 @@ class FeatureStorePreview(FeatureByteBaseModel):
     Generic preview schema
     """
 
-    feature_store_name: StrictStr
     graph: QueryGraph
     node_name: str
 

--- a/featurebyte/schema/preview.py
+++ b/featurebyte/schema/preview.py
@@ -3,8 +3,6 @@ Preview schema
 """
 from typing import Optional
 
-from pydantic import StrictStr
-
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.schema.common.feature_or_target import ComputeRequest
@@ -16,7 +14,6 @@ class FeatureOrTargetPreview(ComputeRequest, PreviewObservationSet):
     FeatureOrTargetPreview Preview schema
     """
 
-    feature_store_name: StrictStr
     graph: QueryGraph
     node_name: str
 
@@ -26,7 +23,6 @@ class FeaturePreview(ComputeRequest, PreviewObservationSet):
     Feature Preview schema
     """
 
-    feature_store_name: StrictStr
     graph: Optional[QueryGraph]
     node_name: Optional[str]
     feature_id: Optional[PydanticObjectId]
@@ -37,7 +33,6 @@ class TargetPreview(ComputeRequest, PreviewObservationSet):
     Target Preview schema
     """
 
-    feature_store_name: StrictStr
     graph: Optional[QueryGraph]
     node_name: Optional[str]
     target_id: Optional[PydanticObjectId]

--- a/featurebyte/service/feature_preview.py
+++ b/featurebyte/service/feature_preview.py
@@ -188,7 +188,6 @@ class FeaturePreviewService(PreviewService):
         feature_store, session = await self._get_feature_store_session(
             graph=graph,
             node_name=node_name,
-            feature_store_name=feature_or_target_preview.feature_store_name,
         )
         parent_serving_preparation = (
             await self.entity_validation_service.validate_entities_or_prepare_for_parent_serving(

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -406,7 +406,6 @@ class ObservationTableService(
         )
         graph, node = source_table.frame.extract_pruned_graph_and_node()
         sample = FeatureStoreSample(
-            feature_store_name=feature_store.name,
             graph=graph,
             node_name=node.name,
             stats_names=["unique", "max", "min"],

--- a/tests/unit/routes/test_feature.py
+++ b/tests/unit/routes/test_feature.py
@@ -618,20 +618,12 @@ class TestFeatureApi(BaseCatalogApiTestSuite):
         assert verbose_response_dict["versions_info"] is not None
 
     @pytest.fixture(name="feature_preview_payload")
-    def feature_preview_payload_fixture(self, create_success_response, test_api_client_persistent):
+    def feature_preview_payload_fixture(self, create_success_response):
         """
         feature_preview_payload fixture
         """
-        test_api_client, _ = test_api_client_persistent
         feature = create_success_response.json()
-
-        feature_store_id = feature["tabular_source"]["feature_store_id"]
-        response = test_api_client.get(f"/feature_store/{feature_store_id}")
-        assert response.status_code == HTTPStatus.OK
-        feature_store = response.json()
-
         return {
-            "feature_store_name": feature_store["name"],
             "graph": feature["graph"],
             "node_name": feature["node_name"],
             "point_in_time_and_serving_name_list": [

--- a/tests/unit/routes/test_feature_store.py
+++ b/tests/unit/routes/test_feature_store.py
@@ -351,7 +351,6 @@ class TestFeatureStoreApi(BaseApiTestSuite):  # pylint: disable=too-many-public-
         data_response_dict = response.json()
         snowflake_feature_store = FeatureStore(**snowflake_feature_store_params, type="snowflake")
         return FeatureStoreSample(
-            feature_store_name=snowflake_feature_store.name,
             graph={
                 "edges": [{"source": "input_1", "target": "project_1"}],
                 "nodes": [

--- a/tests/unit/routes/test_target.py
+++ b/tests/unit/routes/test_target.py
@@ -198,20 +198,12 @@ class TestTargetApi(BaseCatalogApiTestSuite):
         }
 
     @pytest.fixture(name="target_preview_payload")
-    def target_preview_payload_fixture(self, create_success_response, test_api_client_persistent):
+    def target_preview_payload_fixture(self, create_success_response):
         """
         target_preview_payload fixture
         """
-        test_api_client, _ = test_api_client_persistent
         target = create_success_response.json()
-
-        feature_store_id = target["tabular_source"]["feature_store_id"]
-        response = test_api_client.get(f"/feature_store/{feature_store_id}")
-        assert response.status_code == HTTPStatus.OK
-        feature_store = response.json()
-
         return {
-            "feature_store_name": feature_store["name"],
             "graph": target["graph"],
             "node_name": target["node_name"],
             "point_in_time_and_serving_name_list": [

--- a/tests/unit/service/test_preview.py
+++ b/tests/unit/service/test_preview.py
@@ -40,7 +40,6 @@ def feature_store_preview_fixture(feature_store):
     Fixture for a FeatureStorePreview
     """
     return FeatureStorePreview(
-        feature_store_name=feature_store.name,
         graph={
             "edges": [{"source": "input_1", "target": "project_1"}],
             "nodes": [


### PR DESCRIPTION
## Description

Simplify preview payloads to not require feature store name, and instead retrieve this from the database in the routes

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
