### PR TITLE
[chore] feature_job_setting_analysis: split backtest to separate file

### DIFF
--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -141,9 +141,9 @@ from featurebyte.worker.task.batch_feature_create import BatchFeatureCreateTask
 from featurebyte.worker.task.batch_feature_table import BatchFeatureTableTask
 from featurebyte.worker.task.batch_request_table import BatchRequestTableTask
 from featurebyte.worker.task.deployment_create_update import DeploymentCreateUpdateTask
-from featurebyte.worker.task.feature_job_setting_analysis import (
+from featurebyte.worker.task.feature_job_setting_analysis import FeatureJobSettingAnalysisTask
+from featurebyte.worker.task.feature_job_setting_analysis_backtest import (
     FeatureJobSettingAnalysisBacktestTask,
-    FeatureJobSettingAnalysisTask,
 )
 from featurebyte.worker.task.feature_list_batch_feature_create import (
     FeatureListCreateWithBatchFeatureCreationTask,

--- a/featurebyte/worker/registry.py
+++ b/featurebyte/worker/registry.py
@@ -11,9 +11,9 @@ from featurebyte.worker.task.batch_feature_create import BatchFeatureCreateTask
 from featurebyte.worker.task.batch_feature_table import BatchFeatureTableTask
 from featurebyte.worker.task.batch_request_table import BatchRequestTableTask
 from featurebyte.worker.task.deployment_create_update import DeploymentCreateUpdateTask
-from featurebyte.worker.task.feature_job_setting_analysis import (
+from featurebyte.worker.task.feature_job_setting_analysis import FeatureJobSettingAnalysisTask
+from featurebyte.worker.task.feature_job_setting_analysis_backtest import (
     FeatureJobSettingAnalysisBacktestTask,
-    FeatureJobSettingAnalysisTask,
 )
 from featurebyte.worker.task.feature_list_batch_feature_create import (
     FeatureListCreateWithBatchFeatureCreationTask,

--- a/featurebyte/worker/task/feature_job_setting_analysis.py
+++ b/featurebyte/worker/task/feature_job_setting_analysis.py
@@ -5,26 +5,19 @@ from __future__ import annotations
 
 from typing import Any
 
-from datetime import datetime
 from pathlib import Path
 
-from featurebyte_freeware.feature_job_analysis.analysis import (
-    FeatureJobSettingsAnalysisResult,
-    create_feature_job_settings_analysis,
-)
+from featurebyte_freeware.feature_job_analysis.analysis import create_feature_job_settings_analysis
 from featurebyte_freeware.feature_job_analysis.database import EventDataset
-from featurebyte_freeware.feature_job_analysis.schema import FeatureJobSetting
 
 from featurebyte import SourceType
 from featurebyte.logging import get_logger
 from featurebyte.models.feature_job_setting_analysis import (
-    BackTestSummary,
     FeatureJobSettingAnalysisData,
     FeatureJobSettingAnalysisModel,
 )
 from featurebyte.schema.feature_job_setting_analysis import EventTableCandidate
 from featurebyte.schema.worker.task.feature_job_setting_analysis import (
-    FeatureJobSettingAnalysisBackTestTaskPayload,
     FeatureJobSettingAnalysisTaskPayload,
 )
 from featurebyte.service.event_table import EventTableService
@@ -147,106 +140,6 @@ class FeatureJobSettingAnalysisTask(BaseTask[FeatureJobSettingAnalysisTaskPayloa
 
         logger.debug(
             "Completed feature job setting analysis",
-            extra={"document_id": payload.output_document_id},
-        )
-        await self.task_progress_updater.update_progress(percent=100, message="Analysis Completed")
-
-
-class FeatureJobSettingAnalysisBacktestTask(BaseTask[FeatureJobSettingAnalysisBackTestTaskPayload]):
-    """
-    Feature Job Setting Analysis Task
-    """
-
-    payload_class = FeatureJobSettingAnalysisBackTestTaskPayload
-
-    def __init__(
-        self,
-        storage: Storage,
-        temp_storage: Storage,
-        feature_job_setting_analysis_service: FeatureJobSettingAnalysisService,
-        task_progress_updater: TaskProgressUpdater,
-    ):
-        super().__init__()
-        self.storage = storage
-        self.temp_storage = temp_storage
-        self.feature_job_setting_analysis_service = feature_job_setting_analysis_service
-        self.task_progress_updater = task_progress_updater
-
-    async def get_task_description(
-        self, payload: FeatureJobSettingAnalysisBackTestTaskPayload
-    ) -> str:
-        analysis = await self.feature_job_setting_analysis_service.get_document(
-            document_id=payload.feature_job_setting_analysis_id
-        )
-        return f'Backtest feature job settings for table "{analysis.analysis_parameters.event_table_name}"'
-
-    async def execute(self, payload: FeatureJobSettingAnalysisBackTestTaskPayload) -> None:
-        """
-        Execute the task
-
-        Parameters
-        ----------
-        payload: FeatureJobSettingAnalysisBackTestTaskPayload
-            Payload
-        """
-        await self.task_progress_updater.update_progress(percent=0, message="Preparing table")
-
-        # retrieve analysis doc from persistent
-        document_id = payload.feature_job_setting_analysis_id
-        analysis_doc = await self.feature_job_setting_analysis_service.get_document(
-            document_id=document_id
-        )
-        document = analysis_doc.dict(by_alias=True)
-
-        # retrieve analysis data from storage
-        remote_path = Path(f"feature_job_setting_analysis/{document_id}/data.json")
-        analysis_data_raw = await self.storage.get_object(remote_path=remote_path)
-        analysis_data = FeatureJobSettingAnalysisData(**analysis_data_raw).dict()
-
-        # reconstruct analysis object
-        analysis_result = analysis_data.pop("analysis_result")
-        document.update(**analysis_data)
-        document["analysis_result"].update(analysis_result)
-        analysis = FeatureJobSettingsAnalysisResult.from_dict(document)
-
-        # run backtest
-        await self.task_progress_updater.update_progress(percent=5, message="Running Analysis")
-        feature_job_setting = FeatureJobSetting(
-            frequency=payload.frequency,
-            blind_spot=payload.blind_spot,
-            job_time_modulo_frequency=payload.job_time_modulo_frequency,
-            feature_cutoff_modulo_frequency=0,
-        )
-        backtest_result, backtest_report = analysis.backtest(
-            feature_job_setting=feature_job_setting
-        )
-
-        # update analysis with backtest summary
-        late_series = backtest_result.results
-        total_pct_late_data = (
-            1 - late_series["count_on_time"].sum() / late_series["total_count"].sum()
-        )
-        pct_incomplete_jobs = (late_series.pct_late_data > 0).sum() / late_series.shape[0]
-        await self.feature_job_setting_analysis_service.add_backtest_summary(
-            document_id=document_id,
-            backtest_summary=BackTestSummary(
-                output_document_id=payload.output_document_id,
-                user_id=payload.user_id,
-                created_at=datetime.utcnow(),
-                feature_job_setting=feature_job_setting.dict(),
-                total_pct_late_data=total_pct_late_data * 100,
-                pct_incomplete_jobs=pct_incomplete_jobs * 100,
-            ),
-        )
-
-        # store results in temp storage
-        await self.task_progress_updater.update_progress(percent=95, message="Saving Analysis")
-        prefix = f"feature_job_setting_analysis/backtest/{payload.output_document_id}"
-        await self.temp_storage.put_text(backtest_report, Path(f"{prefix}.html"))
-        await self.temp_storage.put_dataframe(backtest_result.results, Path(f"{prefix}.parquet"))
-
-        logger.debug(
-            "Completed feature job setting analysis backtest",
             extra={"document_id": payload.output_document_id},
         )
         await self.task_progress_updater.update_progress(percent=100, message="Analysis Completed")

--- a/featurebyte/worker/task/feature_job_setting_analysis_backtest.py
+++ b/featurebyte/worker/task/feature_job_setting_analysis_backtest.py
@@ -1,0 +1,125 @@
+"""
+Feature job setting analysis backtest
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from featurebyte_freeware.feature_job_analysis.analysis import FeatureJobSettingsAnalysisResult
+from featurebyte_freeware.feature_job_analysis.schema import FeatureJobSetting
+
+from featurebyte.logging import get_logger
+from featurebyte.models.feature_job_setting_analysis import (
+    BackTestSummary,
+    FeatureJobSettingAnalysisData,
+)
+from featurebyte.schema.worker.task.feature_job_setting_analysis import (
+    FeatureJobSettingAnalysisBackTestTaskPayload,
+)
+from featurebyte.service.feature_job_setting_analysis import FeatureJobSettingAnalysisService
+from featurebyte.storage import Storage
+from featurebyte.worker.task.base import BaseTask
+from featurebyte.worker.util.task_progress_updater import TaskProgressUpdater
+
+logger = get_logger(__name__)
+
+
+class FeatureJobSettingAnalysisBacktestTask(BaseTask[FeatureJobSettingAnalysisBackTestTaskPayload]):
+    """
+    Feature Job Setting Analysis Task
+    """
+
+    payload_class = FeatureJobSettingAnalysisBackTestTaskPayload
+
+    def __init__(
+        self,
+        storage: Storage,
+        temp_storage: Storage,
+        feature_job_setting_analysis_service: FeatureJobSettingAnalysisService,
+        task_progress_updater: TaskProgressUpdater,
+    ):
+        super().__init__()
+        self.storage = storage
+        self.temp_storage = temp_storage
+        self.feature_job_setting_analysis_service = feature_job_setting_analysis_service
+        self.task_progress_updater = task_progress_updater
+
+    async def get_task_description(
+        self, payload: FeatureJobSettingAnalysisBackTestTaskPayload
+    ) -> str:
+        analysis = await self.feature_job_setting_analysis_service.get_document(
+            document_id=payload.feature_job_setting_analysis_id
+        )
+        return f'Backtest feature job settings for table "{analysis.analysis_parameters.event_table_name}"'
+
+    async def execute(self, payload: FeatureJobSettingAnalysisBackTestTaskPayload) -> None:
+        """
+        Execute the task
+
+        Parameters
+        ----------
+        payload: FeatureJobSettingAnalysisBackTestTaskPayload
+            Payload
+        """
+        await self.task_progress_updater.update_progress(percent=0, message="Preparing table")
+
+        # retrieve analysis doc from persistent
+        document_id = payload.feature_job_setting_analysis_id
+        analysis_doc = await self.feature_job_setting_analysis_service.get_document(
+            document_id=document_id
+        )
+        document = analysis_doc.dict(by_alias=True)
+
+        # retrieve analysis data from storage
+        remote_path = Path(f"feature_job_setting_analysis/{document_id}/data.json")
+        analysis_data_raw = await self.storage.get_object(remote_path=remote_path)
+        analysis_data = FeatureJobSettingAnalysisData(**analysis_data_raw).dict()
+
+        # reconstruct analysis object
+        analysis_result = analysis_data.pop("analysis_result")
+        document.update(**analysis_data)
+        document["analysis_result"].update(analysis_result)
+        analysis = FeatureJobSettingsAnalysisResult.from_dict(document)
+
+        # run backtest
+        await self.task_progress_updater.update_progress(percent=5, message="Running Analysis")
+        feature_job_setting = FeatureJobSetting(
+            frequency=payload.frequency,
+            blind_spot=payload.blind_spot,
+            job_time_modulo_frequency=payload.job_time_modulo_frequency,
+            feature_cutoff_modulo_frequency=0,
+        )
+        backtest_result, backtest_report = analysis.backtest(
+            feature_job_setting=feature_job_setting
+        )
+
+        # update analysis with backtest summary
+        late_series = backtest_result.results
+        total_pct_late_data = (
+            1 - late_series["count_on_time"].sum() / late_series["total_count"].sum()
+        )
+        pct_incomplete_jobs = (late_series.pct_late_data > 0).sum() / late_series.shape[0]
+        await self.feature_job_setting_analysis_service.add_backtest_summary(
+            document_id=document_id,
+            backtest_summary=BackTestSummary(
+                output_document_id=payload.output_document_id,
+                user_id=payload.user_id,
+                created_at=datetime.utcnow(),
+                feature_job_setting=feature_job_setting.dict(),
+                total_pct_late_data=total_pct_late_data * 100,
+                pct_incomplete_jobs=pct_incomplete_jobs * 100,
+            ),
+        )
+
+        # store results in temp storage
+        await self.task_progress_updater.update_progress(percent=95, message="Saving Analysis")
+        prefix = f"feature_job_setting_analysis/backtest/{payload.output_document_id}"
+        await self.temp_storage.put_text(backtest_report, Path(f"{prefix}.html"))
+        await self.temp_storage.put_dataframe(backtest_result.results, Path(f"{prefix}.parquet"))
+
+        logger.debug(
+            "Completed feature job setting analysis backtest",
+            extra={"document_id": payload.output_document_id},
+        )
+        await self.task_progress_updater.update_progress(percent=100, message="Analysis Completed")

--- a/tests/unit/worker/task/test_feature_job_setting_analysis_backtest.py
+++ b/tests/unit/worker/task/test_feature_job_setting_analysis_backtest.py
@@ -16,9 +16,9 @@ from featurebyte.models.event_table import EventTableModel
 from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.persistent import DuplicateDocumentError
 from featurebyte.routes.lazy_app_container import LazyAppContainer
-from featurebyte.worker.task.feature_job_setting_analysis import (
+from featurebyte.worker.task.feature_job_setting_analysis import FeatureJobSettingAnalysisTask
+from featurebyte.worker.task.feature_job_setting_analysis_backtest import (
     FeatureJobSettingAnalysisBacktestTask,
-    FeatureJobSettingAnalysisTask,
 )
 from featurebyte.worker.util.task_progress_updater import TaskProgressUpdater
 from tests.unit.worker.task.base import BaseTaskTestSuite


### PR DESCRIPTION
## Description
Minor refactor to split the backtest task into its own file. This makes it consistent such that each task has its own file.

This makes it slightly less confusing for me as I was debugging some task and kept getting confused whether it was the backtest task, or the normal analysis task that was failing since it just pointed to the same file.
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
