### PR TITLE
[chore] app_container: register get_temp_storage, and mv to instance map

### DIFF
--- a/featurebyte/migration/run.py
+++ b/featurebyte/migration/run.py
@@ -154,13 +154,16 @@ async def catalog_specific_migration_method_constructor(
             logger.info(f"Run migration for catalog {catalog.id}")
 
             # construct the app container for the catalog & retrieve the migrate method
+            instance_map = {
+                "user": user,
+                "persistent": persistent,
+                "catalog_id": catalog.id,
+                "temp_storage": temp_storage,
+                "celery": celery,
+            }
             app_container = LazyAppContainer(
-                user=user,
-                persistent=persistent,
-                catalog_id=catalog.id,
-                temp_storage=temp_storage,
-                celery=celery,
                 app_container_config=app_container_config,
+                instance_map=instance_map,
             )
             migrate_service = app_container.get(migrate_service_instance_name)
             migrate_method = getattr(migrate_service, migrate_method_name)
@@ -212,13 +215,16 @@ async def migrate_method_generator(
     migrate_method
         Migration method
     """
+    instance_map = {
+        "user": user,
+        "persistent": persistent,
+        "catalog_id": DEFAULT_CATALOG_ID,
+        "temp_storage": get_temp_storage(),
+        "celery": get_celery(),
+    }
     app_container = LazyAppContainer(
-        user=user,
-        persistent=persistent,
-        catalog_id=DEFAULT_CATALOG_ID,
-        temp_storage=get_temp_storage(),
-        celery=get_celery(),
         app_container_config=app_container_config,
+        instance_map=instance_map,
     )
     migrate_methods = retrieve_all_migration_methods()
     version_start = schema_metadata.version + 1

--- a/featurebyte/migration/run.py
+++ b/featurebyte/migration/run.py
@@ -109,7 +109,6 @@ async def catalog_specific_migration_method_constructor(
     all_catalog_service: AllCatalogService,
     user: Any,
     persistent: Persistent,
-    celery: Celery,
     migrate_service_instance_name: str,
     migrate_method_name: str,
     migration_marker: MigrationInfo,
@@ -127,8 +126,6 @@ async def catalog_specific_migration_method_constructor(
         User object
     persistent: Persistent
         Persistent storage object
-    celery: Celery
-        Celery object
     migrate_service_instance_name: str
         Migrate service instance name
     migrate_method_name: str
@@ -153,7 +150,6 @@ async def catalog_specific_migration_method_constructor(
                 "user": user,
                 "persistent": persistent,
                 "catalog_id": catalog.id,
-                "celery": celery,
             }
             app_container = LazyAppContainer(
                 app_container_config=app_container_config,
@@ -213,7 +209,6 @@ async def migrate_method_generator(
         "user": user,
         "persistent": persistent,
         "catalog_id": DEFAULT_CATALOG_ID,
-        "celery": get_celery(),
     }
     app_container = LazyAppContainer(
         app_container_config=app_container_config,
@@ -241,7 +236,6 @@ async def migrate_method_generator(
                     all_catalog_service=app_container.all_catalog_service,
                     user=user,
                     persistent=persistent,
-                    celery=app_container.celery,
                     migrate_service_instance_name=migrate_service_instance_name,
                     migrate_method_name=migrate_method_name,
                     migration_marker=_extract_migrate_method_marker(migrate_method),

--- a/featurebyte/migration/run.py
+++ b/featurebyte/migration/run.py
@@ -29,7 +29,6 @@ from featurebyte.routes.block_modification_handler import BlockModificationHandl
 from featurebyte.routes.lazy_app_container import LazyAppContainer
 from featurebyte.routes.registry import app_container_config
 from featurebyte.service.catalog import AllCatalogService
-from featurebyte.storage import Storage
 from featurebyte.utils.credential import MongoBackedCredentialProvider
 from featurebyte.worker import get_celery
 
@@ -110,7 +109,6 @@ async def catalog_specific_migration_method_constructor(
     all_catalog_service: AllCatalogService,
     user: Any,
     persistent: Persistent,
-    temp_storage: Storage,
     celery: Celery,
     migrate_service_instance_name: str,
     migrate_method_name: str,
@@ -129,8 +127,6 @@ async def catalog_specific_migration_method_constructor(
         User object
     persistent: Persistent
         Persistent storage object
-    temp_storage: Storage
-        Temporary storage object
     celery: Celery
         Celery object
     migrate_service_instance_name: str
@@ -157,7 +153,6 @@ async def catalog_specific_migration_method_constructor(
                 "user": user,
                 "persistent": persistent,
                 "catalog_id": catalog.id,
-                "temp_storage": temp_storage,
                 "celery": celery,
             }
             app_container = LazyAppContainer(
@@ -246,7 +241,6 @@ async def migrate_method_generator(
                     all_catalog_service=app_container.all_catalog_service,
                     user=user,
                     persistent=persistent,
-                    temp_storage=app_container.temp_storage,
                     celery=app_container.celery,
                     migrate_service_instance_name=migrate_service_instance_name,
                     migrate_method_name=migrate_method_name,

--- a/featurebyte/migration/run.py
+++ b/featurebyte/migration/run.py
@@ -31,7 +31,6 @@ from featurebyte.routes.registry import app_container_config
 from featurebyte.service.catalog import AllCatalogService
 from featurebyte.storage import Storage
 from featurebyte.utils.credential import MongoBackedCredentialProvider
-from featurebyte.utils.storage import get_temp_storage
 from featurebyte.worker import get_celery
 
 logger = get_logger(__name__)
@@ -219,7 +218,6 @@ async def migrate_method_generator(
         "user": user,
         "persistent": persistent,
         "catalog_id": DEFAULT_CATALOG_ID,
-        "temp_storage": get_temp_storage(),
         "celery": get_celery(),
     }
     app_container = LazyAppContainer(

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -132,7 +132,6 @@ from featurebyte.service.validator.production_ready_validator import ProductionR
 from featurebyte.service.version import VersionService
 from featurebyte.service.view_construction import ViewConstructionService
 from featurebyte.service.working_schema import WorkingSchemaService
-from featurebyte.storage import Storage
 from featurebyte.utils.credential import MongoBackedCredentialProvider
 from featurebyte.utils.messaging import Progress
 from featurebyte.utils.persistent import MongoDBImpl

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -136,7 +136,7 @@ from featurebyte.storage import Storage
 from featurebyte.utils.credential import MongoBackedCredentialProvider
 from featurebyte.utils.messaging import Progress
 from featurebyte.utils.persistent import MongoDBImpl
-from featurebyte.utils.storage import get_storage
+from featurebyte.utils.storage import get_storage, get_temp_storage
 from featurebyte.worker import get_redis
 from featurebyte.worker.task.batch_feature_create import BatchFeatureCreateTask
 from featurebyte.worker.task.batch_feature_table import BatchFeatureTableTask
@@ -343,10 +343,10 @@ app_container_config.register_class(FeatureMigrationServiceV4)
 
 app_container_config.register_factory_method(get_storage)
 app_container_config.register_factory_method(get_redis, name_override="redis")
+app_container_config.register_factory_method(get_temp_storage, name_override="temp_storage")
 
 # These have force_no_deps set as True, as they are manually initialized.
 app_container_config.register_class(Celery, force_no_deps=True)
-app_container_config.register_class(Storage, force_no_deps=True, name_override="temp_storage")
 app_container_config.register_class(User, force_no_deps=True)
 
 

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -4,8 +4,6 @@ Registrations module.
 This contains all the dependencies that we want to register in order to get our fast API app up and running.
 """
 
-from celery import Celery
-
 from featurebyte.migration.migration_data_service import SchemaMetadataService
 from featurebyte.migration.service.data_warehouse import (
     DataWarehouseMigrationServiceV1,
@@ -136,7 +134,7 @@ from featurebyte.utils.credential import MongoBackedCredentialProvider
 from featurebyte.utils.messaging import Progress
 from featurebyte.utils.persistent import MongoDBImpl
 from featurebyte.utils.storage import get_storage, get_temp_storage
-from featurebyte.worker import get_redis
+from featurebyte.worker import get_celery, get_redis
 from featurebyte.worker.task.batch_feature_create import BatchFeatureCreateTask
 from featurebyte.worker.task.batch_feature_table import BatchFeatureTableTask
 from featurebyte.worker.task.batch_request_table import BatchRequestTableTask
@@ -343,9 +341,9 @@ app_container_config.register_class(FeatureMigrationServiceV4)
 app_container_config.register_factory_method(get_storage)
 app_container_config.register_factory_method(get_redis, name_override="redis")
 app_container_config.register_factory_method(get_temp_storage, name_override="temp_storage")
+app_container_config.register_factory_method(get_celery)
 
 # These have force_no_deps set as True, as they are manually initialized.
-app_container_config.register_class(Celery, force_no_deps=True)
 app_container_config.register_class(User, force_no_deps=True)
 
 

--- a/featurebyte/worker/task_executor.py
+++ b/featurebyte/worker/task_executor.py
@@ -27,7 +27,6 @@ from featurebyte.routes.lazy_app_container import LazyAppContainer
 from featurebyte.routes.registry import app_container_config
 from featurebyte.utils.messaging import Progress
 from featurebyte.utils.persistent import MongoDBImpl
-from featurebyte.utils.storage import get_temp_storage
 from featurebyte.worker import get_celery
 from featurebyte.worker.registry import TASK_REGISTRY_MAP
 from featurebyte.worker.util.task_progress_updater import TaskProgressUpdater
@@ -210,7 +209,6 @@ class BaseCeleryTask(Task):
             # Default instances
             "celery": get_celery(),
             "persistent": MongoDBImpl(),
-            "temp_storage": get_temp_storage(),
             # Task specific parameters
             "user": User(id=payload.get("user_id")),
             "catalog_id": ObjectId(payload.get("catalog_id")),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1302,33 +1302,11 @@ def storage_fixture():
         yield LocalStorage(base_path=tempdir)
 
 
-@pytest.fixture(name="temp_storage", scope="session")
-def temp_storage_fixture():
-    """
-    Storage object fixture
-    """
-    yield LocalTempStorage()
-
-
-@pytest.fixture(name="mock_app_callbacks", scope="session")
-def mock_app_callbacks(temp_storage):
-    """
-    Mock app callbacks: get_credential, get_storage, get_temp_storage
-
-    This fixture is used such that these callbacks are consistent with those used in
-    mock_task_manager.
-    """
-    with mock.patch("featurebyte.app.get_temp_storage") as mock_get_temp_storage:
-        mock_get_temp_storage.return_value = temp_storage
-        yield
-
-
 @pytest.fixture(autouse=True, scope="module")
-def mock_task_manager(request, persistent, storage, temp_storage, mock_app_callbacks):
+def mock_task_manager(request, persistent, storage, temp_storage):
     """
     Mock celery task manager for testing
     """
-    _ = mock_app_callbacks
     if request.module.__name__ == "test_task_manager":
         yield
     else:
@@ -1340,15 +1318,16 @@ def mock_task_manager(request, persistent, storage, temp_storage, mock_app_callb
                 kwargs["task_output_path"] = payload.task_output_path
                 task_id = str(uuid4())
                 user = User(id=kwargs.get("user_id"))
+                instance_map = {
+                    "user": user,
+                    "persistent": persistent,
+                    "celery": Mock(),
+                    "redis": Mock(),
+                    "storage": storage,
+                    "catalog_id": payload.catalog_id,
+                }
                 app_container = LazyAppContainer(
-                    user=user,
-                    persistent=persistent,
-                    temp_storage=temp_storage,
-                    celery=Mock(),
-                    redis=Mock(),
-                    storage=storage,
-                    catalog_id=payload.catalog_id,
-                    app_container_config=app_container_config,
+                    app_container_config=app_container_config, instance_map=instance_map
                 )
                 app_container.override_instance_for_test("task_id", UUID(task_id))
                 app_container.override_instance_for_test("progress", Mock())
@@ -1454,15 +1433,15 @@ def app_container_fixture(persistent, user, catalog):
     """
     Return an app container used in tests. This will allow us to easily retrieve instances of the right type.
     """
-    return LazyAppContainer(
-        user=user,
-        persistent=persistent,
-        temp_storage=LocalTempStorage(),
-        celery=get_celery(),
-        storage=LocalTempStorage(),
-        catalog_id=catalog.id,
-        app_container_config=app_container_config,
-    )
+    instance_map = {
+        "user": user,
+        "persistent": persistent,
+        "temp_storage": LocalTempStorage(),
+        "celery": get_celery(),
+        "storage": LocalTempStorage(),
+        "catalog_id": catalog.id,
+    }
+    return LazyAppContainer(app_container_config=app_container_config, instance_map=instance_map)
 
 
 @pytest.fixture(name="feature_manager_service")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1303,7 +1303,7 @@ def storage_fixture():
 
 
 @pytest.fixture(autouse=True, scope="module")
-def mock_task_manager(request, persistent, storage, temp_storage):
+def mock_task_manager(request, persistent, storage):
     """
     Mock celery task manager for testing
     """
@@ -1436,7 +1436,6 @@ def app_container_fixture(persistent, user, catalog):
     instance_map = {
         "user": user,
         "persistent": persistent,
-        "temp_storage": LocalTempStorage(),
         "celery": get_celery(),
         "storage": LocalTempStorage(),
         "catalog_id": catalog.id,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1656,15 +1656,18 @@ def mock_task_manager(request, persistent, storage, temp_storage):
                 kwargs["task_output_path"] = payload.task_output_path
                 task_id = str(uuid4())
                 user = User(id=kwargs.get("user_id"))
+                instance_map = {
+                    "user": user,
+                    "persistent": persistent,
+                    "temp_storage": temp_storage,
+                    "celery": get_celery(),
+                    "redis": get_redis(),
+                    "storage": storage,
+                    "catalog_id": payload.catalog_id,
+                }
                 app_container = LazyAppContainer(
-                    user=user,
-                    persistent=persistent,
-                    temp_storage=temp_storage,
-                    celery=get_celery(),
-                    redis=get_redis(),
-                    storage=storage,
-                    catalog_id=payload.catalog_id,
                     app_container_config=app_container_config,
+                    instance_map=instance_map,
                 )
                 app_container.override_instance_for_test("task_id", UUID(task_id))
                 app_container.override_instance_for_test("progress", Mock())

--- a/tests/unit/routes/relationship_info/test_api.py
+++ b/tests/unit/routes/relationship_info/test_api.py
@@ -70,15 +70,17 @@ class TestRelationshipInfoApi(BaseCatalogApiTestSuite):
     @staticmethod
     def create_app_container(persistent, user_id, catalog_id):
         """App container fixture"""
-        user = User(id=user_id)
+        instance_map = {
+            "user": User(id=user_id),
+            "persistent": persistent,
+            "temp_storage": LocalTempStorage(),
+            "celery": get_celery(),
+            "storage": LocalTempStorage(),
+            "catalog_id": catalog_id,
+        }
         return LazyAppContainer(
-            user=user,
-            persistent=persistent,
-            temp_storage=LocalTempStorage(),
-            celery=get_celery(),
-            storage=LocalTempStorage(),
-            catalog_id=catalog_id,
             app_container_config=app_container_config,
+            instance_map=instance_map,
         )
 
     @pytest_asyncio.fixture

--- a/tests/unit/routes/relationship_info/test_api.py
+++ b/tests/unit/routes/relationship_info/test_api.py
@@ -12,7 +12,6 @@ from featurebyte.routes.lazy_app_container import LazyAppContainer
 from featurebyte.routes.registry import app_container_config
 from featurebyte.schema.relationship_info import RelationshipInfoCreate, RelationshipInfoUpdate
 from featurebyte.storage import LocalTempStorage
-from featurebyte.worker import get_celery
 from tests.unit.routes.base import BaseCatalogApiTestSuite
 
 
@@ -73,7 +72,6 @@ class TestRelationshipInfoApi(BaseCatalogApiTestSuite):
         instance_map = {
             "user": User(id=user_id),
             "persistent": persistent,
-            "celery": get_celery(),
             "storage": LocalTempStorage(),
             "catalog_id": catalog_id,
         }

--- a/tests/unit/routes/relationship_info/test_api.py
+++ b/tests/unit/routes/relationship_info/test_api.py
@@ -73,7 +73,6 @@ class TestRelationshipInfoApi(BaseCatalogApiTestSuite):
         instance_map = {
             "user": User(id=user_id),
             "persistent": persistent,
-            "temp_storage": LocalTempStorage(),
             "celery": get_celery(),
             "storage": LocalTempStorage(),
             "catalog_id": catalog_id,

--- a/tests/unit/routes/test_lazy_app_container.py
+++ b/tests/unit/routes/test_lazy_app_container.py
@@ -10,7 +10,6 @@ from featurebyte.models.base import DEFAULT_CATALOG_ID, User
 from featurebyte.routes.app_container_config import AppContainerConfig, ClassDefinition
 from featurebyte.routes.lazy_app_container import LazyAppContainer, get_all_deps_for_key
 from featurebyte.utils.persistent import MongoDBImpl
-from featurebyte.worker import get_celery
 
 
 class NoDeps:
@@ -71,7 +70,6 @@ def app_container_constructor_params_fixture():
     user = User()
     return {
         "user": user,
-        "celery": get_celery(),
         "catalog_id": DEFAULT_CATALOG_ID,
     }
 
@@ -145,7 +143,7 @@ def test_construction__get_attr(app_container_constructor_params):
         app_container_config=app_container_config,
     )
     # This has been initialized
-    assert app_container.celery is not None
+    assert app_container.catalog_id is not None
 
     # random_item has not been initialized
     with pytest.raises(KeyError):

--- a/tests/unit/routes/test_lazy_app_container.py
+++ b/tests/unit/routes/test_lazy_app_container.py
@@ -10,7 +10,6 @@ from featurebyte.models.base import DEFAULT_CATALOG_ID, User
 from featurebyte.routes.app_container_config import AppContainerConfig, ClassDefinition
 from featurebyte.routes.lazy_app_container import LazyAppContainer, get_all_deps_for_key
 from featurebyte.utils.persistent import MongoDBImpl
-from featurebyte.utils.storage import get_temp_storage
 from featurebyte.worker import get_celery
 
 
@@ -72,7 +71,6 @@ def app_container_constructor_params_fixture():
     user = User()
     return {
         "user": user,
-        "temp_storage": get_temp_storage(),
         "celery": get_celery(),
         "catalog_id": DEFAULT_CATALOG_ID,
     }

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -38,7 +38,6 @@ from featurebyte.schema.target import TargetCreate
 from featurebyte.service.catalog import CatalogService
 from featurebyte.storage import LocalTempStorage
 from featurebyte.utils.messaging import REDIS_URI
-from featurebyte.worker import get_celery
 
 
 @pytest.fixture(name="get_credential")

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -63,7 +63,6 @@ def app_container_fixture(persistent, user, catalog):
         "user": user,
         "persistent": persistent,
         "temp_storage": LocalTempStorage(),
-        "celery": get_celery(),
         "storage": LocalTempStorage(),
         "catalog_id": catalog.id,
         "user_id": user.id,


### PR DESCRIPTION
## Description
Small refactor to register the `get_temp_storage` and `get_celery` factory methods, and move callers to use instance map instead. Longer term, using the instance map should help simplify the construction of app containers, making them easier to be reused across the codebase. Ideally, the instance maps should be shared as much as possible as well.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
