### PR TITLE
[chore] obs_table_upload: refactor to not require filename as part of upload

### DIFF
--- a/featurebyte/routes/observation_table/controller.py
+++ b/featurebyte/routes/observation_table/controller.py
@@ -126,7 +126,10 @@ class ObservationTableController(
                 "Only csv and parquet file formats are supported for observation set upload"
             )
         payload = await self.service.get_observation_table_upload_task_payload(
-            data=data, observation_set_dataframe=observation_set_dataframe, file_format=file_format
+            data=data,
+            observation_set_dataframe=observation_set_dataframe,
+            file_format=file_format,
+            uploaded_file_name=observation_set_file.filename,
         )
         task_id = await self.task_manager.submit(payload=payload)
         return await self.task_controller.get_task(task_id=str(task_id))

--- a/featurebyte/schema/observation_table.py
+++ b/featurebyte/schema/observation_table.py
@@ -35,8 +35,6 @@ class ObservationTableUpload(FeatureByteBaseModel):
     name: StrictStr
     purpose: Optional[Purpose] = Field(default=None)
     primary_entity_ids: List[PydanticObjectId]
-    # This is the name of the file that was uploaded by the user
-    uploaded_file_name: StrictStr
 
 
 class ObservationTableList(PaginationMixin):

--- a/featurebyte/schema/worker/task/observation_table_upload.py
+++ b/featurebyte/schema/worker/task/observation_table_upload.py
@@ -18,3 +18,5 @@ class ObservationTableUploadTaskPayload(BaseTaskPayload, ObservationTableUpload)
     command = WorkerCommand.OBSERVATION_TABLE_UPLOAD
     observation_set_storage_path: str
     file_format: UploadFileFormat
+    # This is the name of the file that was uploaded by the user
+    uploaded_file_name: str

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -226,6 +226,7 @@ class ObservationTableService(
         data: ObservationTableUpload,
         observation_set_dataframe: pd.DataFrame,
         file_format: UploadFileFormat,
+        uploaded_file_name: str,
     ) -> ObservationTableUploadTaskPayload:
         """
         Validate and convert a ObservationTableUpload schema to a ObservationTableUploadTaskPayload schema
@@ -239,6 +240,8 @@ class ObservationTableService(
             Observation set DataFrame
         file_format: UploadFileFormat
             File format of the uploaded file
+        uploaded_file_name: str
+            Name of the uploaded file
 
         Returns
         -------
@@ -264,6 +267,7 @@ class ObservationTableService(
             output_document_id=output_document_id,
             observation_set_storage_path=observation_set_storage_path,
             file_format=file_format,
+            uploaded_file_name=uploaded_file_name,
         )
 
     @staticmethod

--- a/tests/unit/routes/test_observation_table.py
+++ b/tests/unit/routes/test_observation_table.py
@@ -2,6 +2,7 @@
 Tests for ObservationTable routes
 """
 import copy
+import os
 import tempfile
 from http import HTTPStatus
 
@@ -272,12 +273,10 @@ class TestObservationTableApi(BaseMaterializedTableTestSuite):
         test_api_client, _ = test_api_client_persistent
 
         # Prepare upload request
-        uploaded_file_name = f"uploaded_file.{file_type}"
         upload_request = ObservationTableUpload(
             name="uploaded_observation_table",
             purpose="other",
             primary_entity_ids=["63f94ed6ea1f050131379214"],
-            uploaded_file_name=uploaded_file_name,
         )
         df = pd.DataFrame(
             {
@@ -286,6 +285,7 @@ class TestObservationTableApi(BaseMaterializedTableTestSuite):
             }
         )
         with tempfile.NamedTemporaryFile(mode="wb", suffix=f".{file_type}") as write_file_obj:
+            uploaded_file_name = os.path.basename(write_file_obj.name)
             if file_type == "csv":
                 df.to_csv(write_file_obj, index=False)
             elif file_type == "parquet":


### PR DESCRIPTION
## Description
Move the `uploaded_file_name` param into the task upload schema only, so that it doesn't need to be provided as part of the API upload request.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
