### PR TITLE
[DEV-2571] Fix a join node pruning bugs that causes generated feature not savable

### DIFF
--- a/.changelog/DEV-2571.yaml
+++ b/.changelog/DEV-2571.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fixes a view join issue that causes the generated feature not savable due to graph inconsistency."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/core/frame.py
+++ b/featurebyte/core/frame.py
@@ -66,7 +66,7 @@ class BaseFrame(QueryObject, SampleMixin):
         -------
         list[str]
         """
-        return list(self.column_var_type_map)
+        return [col.name for col in self.columns_info]
 
 
 FrozenFrameT = TypeVar("FrozenFrameT", bound="FrozenFrame")

--- a/tests/unit/api/test_scd_view.py
+++ b/tests/unit/api/test_scd_view.py
@@ -377,7 +377,13 @@ def test_join_parameters_columns__should_not_trigger_graph_inconsistency(
     snowflake_scd_view, snowflake_event_view_with_entity, feature_group_feature_job_setting
 ):
     """Test join parameters column order"""
+    # reassigned an existing column to cause a change in column order
+    original_columns = snowflake_scd_view.columns
+    assert "col_float" in original_columns and original_columns != "col_float"
     snowflake_scd_view["col_float"] = snowflake_scd_view["col_float"].astype(int)
+    assert snowflake_scd_view.columns[-1] == "col_float"
+
+    # create a feature without using the assigned column so that the assign operation is going to be pruned
     joined_view = snowflake_event_view_with_entity.join(snowflake_scd_view, rsuffix="_scd")
     filtered_joined_view = joined_view[joined_view["col_boolean_scd"] == True]
     feature = filtered_joined_view.groupby("cust_id").aggregate_over(
@@ -387,5 +393,17 @@ def test_join_parameters_columns__should_not_trigger_graph_inconsistency(
         windows=["3d"],
         feature_job_setting=feature_group_feature_job_setting,
     )["col_int_max"]
+
+    # check the feature is savable
     feature.save()
-    assert feature.saved
+
+    # check that the col_float is not at the end of the column list
+    join_node_parameters = feature.cached_model.graph.get_node_by_name("join_1").parameters
+    assert join_node_parameters.right_input_columns == [
+        "col_float",
+        "col_binary",
+        "col_boolean",
+        "date_of_birth",
+        "created_at",
+        "cust_id",
+    ]

--- a/tests/unit/query_graph/test_graph_pruning.py
+++ b/tests/unit/query_graph/test_graph_pruning.py
@@ -310,9 +310,9 @@ def test_join_with_assign_node__join_node_parameters_pruning(
         "left_input_columns": ["cust_id", "order_id", "order_method"],
         "left_on": "order_id",
         "left_output_columns": ["cust_id", "order_id", "order_method"],
-        "right_input_columns": ["item_type", "item_name"],
+        "right_input_columns": ["item_name", "item_type"],
         "right_on": "order_id",
-        "right_output_columns": ["item_type", "item_name"],
+        "right_output_columns": ["item_name", "item_type"],
         "scd_parameters": None,
         "metadata": join_node_parameters["metadata"],
     }


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR attempts to fix a join node parameters pruning graph that causes the generated feature not savable due to graph inconsistency issue.


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
