### PR TITLE
[DEV-2540] Feature preview with array column in dataframe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -573,3 +573,7 @@ docs/notebooks/.ipynb_checkpoints/
 model.pkl
 training_data.csv
 training_data.parquet
+
+# sublime
+*.sublime-project
+*.sublime-workspace

--- a/featurebyte/models/base.py
+++ b/featurebyte/models/base.py
@@ -9,6 +9,7 @@ import json
 import re
 from datetime import datetime
 
+import numpy as np
 from bson.errors import InvalidId
 from bson.objectid import ObjectId
 from pydantic import BaseModel, Field, StrictStr, root_validator, validator
@@ -140,7 +141,10 @@ class FeatureByteBaseModel(BaseModel):
         use_enum_values = True
 
         # With this mapping, `ObjectId` type attribute is converted to string during json serialization.
-        json_encoders = {ObjectId: str}
+        json_encoders = {
+            ObjectId: str,
+            np.ndarray: lambda arr: arr.tolist(),
+        }
 
 
 class UniqueConstraintResolutionSignature(StrEnum):

--- a/tests/integration/api/test_features.py
+++ b/tests/integration/api/test_features.py
@@ -1,6 +1,7 @@
 """
 Tests for more features
 """
+import numpy as np
 import pandas as pd
 import pytest
 from pandas._testing import assert_frame_equal
@@ -121,6 +122,31 @@ def test_combined_simple_aggregate_and_window_aggregate(event_table, item_table)
     feature_list = FeatureList([feature], name="my_feature_list")
     df_feature_list_preview = feature_list.preview(observation_table)
     assert_frame_equal(df_feature_preview, df_feature_list_preview)
+
+
+def test_preview_with_numpy_array(item_table):
+    item_view = item_table.get_view()
+    item_feature = item_view.groupby("order_id").aggregate(
+        method="count", feature_name="my_item_feature"
+    )
+    df_observation = pd.DataFrame(
+        {
+            "POINT_IN_TIME": pd.to_datetime(["2001-11-15 10:00:00"]),
+            "order_id": ["T1"],
+            "array_field": [np.array([0.0, 1.0])],
+        }
+    )
+    df_preview = item_feature.preview(df_observation)
+
+    expected = [
+        {
+            "POINT_IN_TIME": pd.Timestamp("2001-11-15 10:00:00"),
+            "array_field": [0, 1],
+            "my_item_feature": 3,
+            "order_id": "T1",
+        }
+    ]
+    assert df_preview.to_dict("records") == expected
 
 
 def test_relative_frequency_with_filter(event_table, scd_table):


### PR DESCRIPTION
## Description

If data frame contains array column (which is the case for DLT with embedding), feature preview fails during json serialisation: 
```
TypeError: Object of type 'ndarray' is not JSON serializable
```
Previews created from featurelist + observation tables work fine.

## Related Issue

[DEV-2540](https://featurebyte.atlassian.net/browse/DEV-2540)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly


[DEV-2540]: https://featurebyte.atlassian.net/browse/DEV-2540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ