### PR TITLE
[DEV-2569] Use published featurebyte SDK in notebook tests

### DIFF
--- a/.changelog/DEV-2569.yaml
+++ b/.changelog/DEV-2569.yaml
@@ -16,7 +16,7 @@ component: tests
 issues: []
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "USe published featurebyte library in notebook tests."
+note: "Use published featurebyte library in notebook tests."
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.changelog/DEV-2569.yaml
+++ b/.changelog/DEV-2569.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: tests
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "USe published featurebyte library in notebook tests."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/.github/workflows/test-notebooks_gen.yaml
+++ b/.github/workflows/test-notebooks_gen.yaml
@@ -64,6 +64,12 @@ jobs:
         password: ${{ secrets.GCR_DOCKER_CREDENTIALS_R_B64 }}
         registry: ${{ env.GCR_DOCKER_LOCATION }}-docker.pkg.dev
         username: _json_key_base64
+    - name: Build docker image
+      run: task docker-build
+    - name: Install published featurebyte version
+      run: task install-published-featurebyte
+    - name: Retag docker image
+      run: task docker-tag-featurebyte-version
     - name: Run notebook tests
       run: task test-deep-dive-notebooks
     timeout-minutes: 30
@@ -111,6 +117,12 @@ jobs:
         password: ${{ secrets.GCR_DOCKER_CREDENTIALS_R_B64 }}
         registry: ${{ env.GCR_DOCKER_LOCATION }}-docker.pkg.dev
         username: _json_key_base64
+    - name: Build docker image
+      run: task docker-build
+    - name: Install published featurebyte version
+      run: task install-published-featurebyte
+    - name: Retag docker image
+      run: task docker-tag-featurebyte-version
     - name: Run notebook tests
       run: task test-quick-start-notebooks
     timeout-minutes: 45
@@ -158,6 +170,12 @@ jobs:
         password: ${{ secrets.GCR_DOCKER_CREDENTIALS_R_B64 }}
         registry: ${{ env.GCR_DOCKER_LOCATION }}-docker.pkg.dev
         username: _json_key_base64
+    - name: Build docker image
+      run: task docker-build
+    - name: Install published featurebyte version
+      run: task install-published-featurebyte
+    - name: Retag docker image
+      run: task docker-tag-featurebyte-version
     - name: Run notebook tests
       run: task test-playground-notebooks
     timeout-minutes: 30

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -301,22 +301,22 @@ tasks:
   test-notebooks:
     desc: "Runs the notebook tests"
     cmds:
-      - poetry run pytest --junitxml=pytest.xml tests/notebooks
+      - pytest --junitxml=pytest.xml tests/notebooks
 
   test-quick-start-notebooks:
     desc: "Runs the notebook tests"
     cmds:
-      - poetry run pytest --junitxml=pytest-quick.xml -k quick tests/notebooks
+      - pytest --junitxml=pytest-quick.xml -k quick tests/notebooks
 
   test-deep-dive-notebooks:
     desc: "Runs the notebook tests"
     cmds:
-      - poetry run pytest --junitxml=pytest.xml -k deep tests/notebooks
+      - pytest --junitxml=pytest.xml -k deep tests/notebooks
 
   test-playground-notebooks:
     desc: "Runs the notebook tests"
     cmds:
-      - poetry run pytest --junitxml=pytest.xml -k playground tests/notebooks
+      - pytest --junitxml=pytest.xml -k playground tests/notebooks
 
   test-setup:
     desc: "Setup the test environment"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -301,22 +301,22 @@ tasks:
   test-notebooks:
     desc: "Runs the notebook tests"
     cmds:
-      - pytest --junitxml=pytest.xml tests/notebooks
+      - poetry run pytest --junitxml=pytest.xml tests/notebooks
 
   test-quick-start-notebooks:
     desc: "Runs the notebook tests"
     cmds:
-      - pytest --junitxml=pytest-quick.xml -k quick tests/notebooks
+      - poetry run pytest --junitxml=pytest-quick.xml -k quick tests/notebooks
 
   test-deep-dive-notebooks:
     desc: "Runs the notebook tests"
     cmds:
-      - pytest --junitxml=pytest.xml -k deep tests/notebooks
+      - poetry run pytest --junitxml=pytest.xml -k deep tests/notebooks
 
   test-playground-notebooks:
     desc: "Runs the notebook tests"
     cmds:
-      - pytest --junitxml=pytest.xml -k playground tests/notebooks
+      - poetry run pytest --junitxml=pytest.xml -k playground tests/notebooks
 
   test-setup:
     desc: "Setup the test environment"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -425,8 +425,11 @@ tasks:
 
   docker-tag-featurebyte-version:
     desc: "Tag the featurebyte-server docker image with the version extracted from running 'featurebyte version'."
+    vars:
+      FB_VERSION:
+        sh: poetry run featurebyte version | cut -d' ' -f2
     cmds:
-      - poetry run docker tag featurebyte-server:latest featurebyte/featurebyte-server:$(featurebyte version | cut -d' ' -f2)
+      - poetry run docker tag featurebyte-server:latest featurebyte/featurebyte-server:{{.FB_VERSION}}
 
   publish-mongodb:
     desc: "Publish mongodb package to public featurebyte registry"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -426,7 +426,7 @@ tasks:
   docker-tag-featurebyte-version:
     desc: "Tag the featurebyte-server docker image with the version extracted from running 'featurebyte version'."
     cmds:
-      - docker tag featurebyte-server:latest featurebyte/featurebyte-server:$(featurebyte version | cut -d' ' -f2)
+      - poetry run docker tag featurebyte-server:latest featurebyte/featurebyte-server:$(featurebyte version | cut -d' ' -f2)
 
   publish-mongodb:
     desc: "Publish mongodb package to public featurebyte registry"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -425,6 +425,11 @@ tasks:
       - rm -rf ~/.spark
       - rm -rf ~/.featurebyte/data
 
+  docker-tag-featurebyte-version:
+    desc: "Tag the featurebyte-server docker image with the version extracted from running 'featurebyte version'."
+    cmds:
+      - docker tag featurebyte-server:latest featurebyte/featurebyte-server:$(featurebyte version | cut -d' ' -f2)
+
   publish-mongodb:
     desc: "Publish mongodb package to public featurebyte registry"
     dir: docker/

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -28,6 +28,12 @@ tasks:
     cmds:
       - poetry install -n --sync --extras=server
 
+  install-published-featurebyte:
+    desc: "Install the published version of the featurebyte SDK"
+    cmds:
+      - poetry run pip uninstall --yes featurebyte
+      - poetry run pip install featurebyte
+
   lint-java:
     desc: "Run linter for java"
     sources:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -300,29 +300,21 @@ tasks:
 
   test-notebooks:
     desc: "Runs the notebook tests"
-    deps:
-      - task: docker-build
     cmds:
       - poetry run pytest --junitxml=pytest.xml tests/notebooks
 
   test-quick-start-notebooks:
     desc: "Runs the notebook tests"
-    deps:
-      - task: docker-build
     cmds:
       - poetry run pytest --junitxml=pytest-quick.xml -k quick tests/notebooks
 
   test-deep-dive-notebooks:
     desc: "Runs the notebook tests"
-    deps:
-      - task: docker-build
     cmds:
       - poetry run pytest --junitxml=pytest.xml -k deep tests/notebooks
 
   test-playground-notebooks:
     desc: "Runs the notebook tests"
-    deps:
-      - task: docker-build
     cmds:
       - poetry run pytest --junitxml=pytest.xml -k playground tests/notebooks
 

--- a/featurebyte/api/target.py
+++ b/featurebyte/api/target.py
@@ -371,7 +371,7 @@ class Target(
             node_name=pruned_node_name,
             target_id=target_id,
             request_input=TargetInput(
-                target_id=target_id,
+                target_id=self.id,
                 observation_table_id=observation_table_id,
                 type=input_type,
             ),

--- a/featurebyte/api/target.py
+++ b/featurebyte/api/target.py
@@ -352,7 +352,7 @@ class Target(
             else RequestInputType.DATAFRAME
         )
 
-        target_id = self.id
+        target_id: Optional[ObjectId] = self.id
         pruned_graph, pruned_node_name = None, None
         if not self.saved:
             # if the target is not saved, we use the graph & node to run the target table creation
@@ -369,6 +369,7 @@ class Target(
             serving_names_mapping=serving_names_mapping,
             graph=pruned_graph,
             node_name=pruned_node_name,
+            target_id=target_id,
             request_input=TargetInput(
                 target_id=target_id,
                 observation_table_id=observation_table_id,

--- a/featurebyte/api/target.py
+++ b/featurebyte/api/target.py
@@ -37,7 +37,6 @@ from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.models.observation_table import TargetInput
 from featurebyte.models.request_input import RequestInputType
 from featurebyte.models.target import TargetModel
-from featurebyte.query_graph.graph import GlobalQueryGraph
 from featurebyte.query_graph.model.common_table import TabularSource
 from featurebyte.schema.target import TargetCreate, TargetUpdate
 from featurebyte.schema.target_table import TargetTableCreate
@@ -351,25 +350,13 @@ class Target(
             if is_input_observation_table
             else RequestInputType.DATAFRAME
         )
-
-        target_id: Optional[ObjectId] = self.id
-        pruned_graph, pruned_node_name = None, None
-        if not self.saved:
-            # if the target is not saved, we use the graph & node to run the target table creation
-            target_id = None
-            pruned_graph, node_name_map = GlobalQueryGraph().quick_prune(
-                target_node_names=[self.node.name]
-            )
-            pruned_node_name = node_name_map[self.node.name]
-
         target_table_create_params = TargetTableCreate(
             name=observation_table_name,
             observation_table_id=observation_table_id,
             feature_store_id=self.feature_store.id,
             serving_names_mapping=serving_names_mapping,
-            graph=pruned_graph,
-            node_name=pruned_node_name,
-            target_id=target_id,
+            graph=self.graph,
+            node_name=self.node.name,
             request_input=TargetInput(
                 target_id=self.id,
                 observation_table_id=observation_table_id,

--- a/featurebyte/api/target.py
+++ b/featurebyte/api/target.py
@@ -37,6 +37,7 @@ from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.models.observation_table import TargetInput
 from featurebyte.models.request_input import RequestInputType
 from featurebyte.models.target import TargetModel
+from featurebyte.query_graph.graph import GlobalQueryGraph
 from featurebyte.query_graph.model.common_table import TabularSource
 from featurebyte.schema.target import TargetCreate, TargetUpdate
 from featurebyte.schema.target_table import TargetTableCreate
@@ -350,15 +351,26 @@ class Target(
             if is_input_observation_table
             else RequestInputType.DATAFRAME
         )
+
+        target_id = self.id
+        pruned_graph, pruned_node_name = None, None
+        if not self.saved:
+            # if the target is not saved, we use the graph & node to run the target table creation
+            target_id = None
+            pruned_graph, node_name_map = GlobalQueryGraph().quick_prune(
+                target_node_names=[self.node.name]
+            )
+            pruned_node_name = node_name_map[self.node.name]
+
         target_table_create_params = TargetTableCreate(
             name=observation_table_name,
             observation_table_id=observation_table_id,
             feature_store_id=self.feature_store.id,
             serving_names_mapping=serving_names_mapping,
-            graph=self.graph,
-            node_name=self.node.name,
+            graph=pruned_graph,
+            node_name=pruned_node_name,
             request_input=TargetInput(
-                target_id=self.id,
+                target_id=target_id,
                 observation_table_id=observation_table_id,
                 type=input_type,
             ),

--- a/featurebyte/api/target.py
+++ b/featurebyte/api/target.py
@@ -356,7 +356,7 @@ class Target(
             feature_store_id=self.feature_store.id,
             serving_names_mapping=serving_names_mapping,
             graph=self.graph,
-            node_name=self.node.name,
+            node_names=[self.node.name],
             request_input=TargetInput(
                 target_id=self.id,
                 observation_table_id=observation_table_id,

--- a/featurebyte/routes/target_table/api.py
+++ b/featurebyte/routes/target_table/api.py
@@ -109,7 +109,13 @@ class TargetTableRouter(BaseMaterializedTableRouter[TargetTableModel]):
         """
         Create TargetTable by submitting a materialization task
         """
-        data = TargetTableCreate(**json.loads(payload))
+        payload_dict = json.loads(payload)
+        # Note that only target_id, or graph should be passed in.
+        # This cleanup is done here on the API layer due to backwards compatibility, where older clients may be passing
+        # in payloads that have both. This is ok to change as the target_id was not being used for anything.
+        if payload_dict["target_id"] is not None and payload_dict["graph"] is not None:
+            payload_dict["target_id"] = None
+        data = TargetTableCreate(**payload_dict)
         controller = request.state.app_container.target_table_controller
         task_submit: Task = await controller.create_table(
             data=data,

--- a/featurebyte/routes/target_table/controller.py
+++ b/featurebyte/routes/target_table/controller.py
@@ -94,11 +94,11 @@ class TargetTableController(
         data: TargetTableCreate,
         observation_set: Optional[UploadFile],
     ) -> Task:
-        data_dict = data.dict()
         if data.graph is None and data.target_id is not None:
+            data_dict = data.dict()
             target_doc = await self.target_service.get_document(data.target_id)
+            data_dict["target_id"] = None
             data_dict["graph"] = target_doc.graph
             data_dict["node_names"] = [target_doc.node_name]
             data = TargetTableCreate(**data_dict)
-        data_dict["target_id"] = None
         return await super().create_table(data=data, observation_set=observation_set)

--- a/featurebyte/routes/target_table/controller.py
+++ b/featurebyte/routes/target_table/controller.py
@@ -94,11 +94,11 @@ class TargetTableController(
         data: TargetTableCreate,
         observation_set: Optional[UploadFile],
     ) -> Task:
+        data_dict = data.dict()
         if data.graph is None and data.target_id is not None:
-            data_dict = data.dict()
             target_doc = await self.target_service.get_document(data.target_id)
-            data_dict["target_id"] = None
             data_dict["graph"] = target_doc.graph
             data_dict["node_names"] = [target_doc.node_name]
             data = TargetTableCreate(**data_dict)
+        data_dict["target_id"] = None
         return await super().create_table(data=data, observation_set=observation_set)

--- a/featurebyte/routes/target_table/controller.py
+++ b/featurebyte/routes/target_table/controller.py
@@ -99,6 +99,6 @@ class TargetTableController(
             target_doc = await self.target_service.get_document(data.target_id)
             data_dict["target_id"] = None
             data_dict["graph"] = target_doc.graph
-            data_dict["node_name"] = target_doc.node_name
+            data_dict["node_names"] = [target_doc.node_name]
             data = TargetTableCreate(**data_dict)
         return await super().create_table(data=data, observation_set=observation_set)

--- a/featurebyte/schema/target_table.py
+++ b/featurebyte/schema/target_table.py
@@ -47,14 +47,13 @@ class TargetTableCreate(FeatureOrTargetTableCreate):
                 "If target_id is provided, graph and node_names should not be provided."
             )
 
-        # DEV-2594: skip the following check until we fix the issue
-        # # If target is not provided, graph and node_names should be provided.
-        # both_are_not_none = graph is not None and node_names is not None
-        # if both_are_not_none:
-        #     return values
-        # raise ValueError(
-        #     "Both graph and node_names should be provided, or neither should be provided."
-        # )
+        # If target is not provided, graph and node_names should be provided.
+        both_are_not_none = graph is not None and node_names is not None
+        if both_are_not_none:
+            return values
+        raise ValueError(
+            "Both graph and node_names should be provided, or neither should be provided."
+        )
         return values
 
     @property

--- a/featurebyte/schema/target_table.py
+++ b/featurebyte/schema/target_table.py
@@ -54,7 +54,6 @@ class TargetTableCreate(FeatureOrTargetTableCreate):
         raise ValueError(
             "Both graph and node_names should be provided, or neither should be provided."
         )
-        return values
 
     @property
     def nodes(self) -> List[Node]:

--- a/featurebyte/schema/target_table.py
+++ b/featurebyte/schema/target_table.py
@@ -25,16 +25,18 @@ class TargetTableCreate(FeatureOrTargetTableCreate):
     serving_names_mapping: Optional[Dict[str, str]]
     target_id: Optional[PydanticObjectId]
     graph: Optional[QueryGraph] = Field(default=None)
-    node_name: Optional[StrictStr] = Field(default=None)
+    # Note that even though node_names is a list, we typically only expect one node. We can't change this to a non-list
+    # for backwards compatibility reasons.
+    node_names: Optional[List[StrictStr]] = Field(default=None)
     request_input: ObservationInput
     context_id: Optional[PydanticObjectId]
     skip_entity_validation_checks: bool = Field(default=False)
 
-    # @root_validator(pre=True)  # DEV-2594: disable this to fix backward compatibility for release client
+    @root_validator(pre=True)
     @classmethod
     def _check_graph_and_node_names(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         graph = values.get("graph", None)
-        node_names = values.get("node_name", None)
+        node_names = values.get("node_names", None)
         target_id = values.get("target_id", None)
         both_are_none = graph is None and node_names is None
 
@@ -64,9 +66,9 @@ class TargetTableCreate(FeatureOrTargetTableCreate):
         -------
         List[Node]
         """
-        if self.graph is None or self.node_name is None:
+        if self.graph is None or self.node_names is None:
             return []
-        return [self.graph.get_node_by_name(self.node_name)]
+        return [self.graph.get_node_by_name(self.node_names[0])]
 
 
 class TargetTableList(PaginationMixin):

--- a/featurebyte/schema/target_table.py
+++ b/featurebyte/schema/target_table.py
@@ -68,7 +68,7 @@ class TargetTableCreate(FeatureOrTargetTableCreate):
         """
         if self.graph is None or self.node_names is None:
             return []
-        return [self.graph.get_node_by_name(self.node_names[0])]
+        return [self.graph.get_node_by_name(name) for name in self.node_names]
 
 
 class TargetTableList(PaginationMixin):

--- a/featurebyte/schema/target_table.py
+++ b/featurebyte/schema/target_table.py
@@ -30,7 +30,7 @@ class TargetTableCreate(FeatureOrTargetTableCreate):
     context_id: Optional[PydanticObjectId]
     skip_entity_validation_checks: bool = Field(default=False)
 
-    @root_validator(pre=True)
+    # @root_validator(pre=True)  # DEV-2594: disable this to fix backward compatibility for release client
     @classmethod
     def _check_graph_and_node_names(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         graph = values.get("graph", None)

--- a/featurebyte/schema/target_table.py
+++ b/featurebyte/schema/target_table.py
@@ -47,13 +47,15 @@ class TargetTableCreate(FeatureOrTargetTableCreate):
                 "If target_id is provided, graph and node_names should not be provided."
             )
 
-        # If target is not provided, graph and node_names should be provided.
-        both_are_not_none = graph is not None and node_names is not None
-        if both_are_not_none:
-            return values
-        raise ValueError(
-            "Both graph and node_names should be provided, or neither should be provided."
-        )
+        # DEV-2594: skip the following check until we fix the issue
+        # # If target is not provided, graph and node_names should be provided.
+        # both_are_not_none = graph is not None and node_names is not None
+        # if both_are_not_none:
+        #     return values
+        # raise ValueError(
+        #     "Both graph and node_names should be provided, or neither should be provided."
+        # )
+        return values
 
     @property
     def nodes(self) -> List[Node]:

--- a/featurebyte/worker/task/target_table.py
+++ b/featurebyte/worker/task/target_table.py
@@ -64,21 +64,21 @@ class TargetTableTask(DataWarehouseMixin, BaseTask[TargetTableTaskPayload]):
         ):
             # Graphs and nodes being processed in this task should not be None anymore.
             graph = payload.graph
-            node_name = payload.node_name
+            node_names = payload.node_names
             assert graph is not None
-            assert node_name is not None
+            assert node_names is not None
             await self.target_computer.compute(
                 observation_set=observation_set,
                 compute_request=ComputeTargetRequest(
                     feature_store_id=payload.feature_store_id,
                     graph=graph,
-                    node_names=[node_name],
+                    node_names=node_names,
                     serving_names_mapping=payload.serving_names_mapping,
                     target_id=payload.target_id,
                 ),
                 output_table_details=location.table_details,
             )
-            entity_ids = graph.get_entity_ids(node_name)
+            entity_ids = graph.get_entity_ids(node_names[0])
             primary_entity_ids = await self.derive_primary_entity_helper.derive_primary_entity_ids(
                 entity_ids
             )

--- a/tests/unit/routes/test_target.py
+++ b/tests/unit/routes/test_target.py
@@ -328,5 +328,5 @@ class TestTargetApi(BaseCatalogApiTestSuite):
             assert mock_create_table.call_count == 1
             call_args = mock_create_table.call_args_list[0][1]
             # Check that node names is in the call args of mock_create_table
-            assert call_args["data"].node_name == "project_1"
+            assert call_args["data"].node_names == ["project_1"]
             assert call_args["data"].graph is not None

--- a/tests/unit/schema/test_target_table.py
+++ b/tests/unit/schema/test_target_table.py
@@ -11,19 +11,19 @@ from featurebyte.schema.target_table import TargetTableCreate
 
 
 @pytest.mark.parametrize(
-    "target_id, graph, node_name, expected_error",
+    "target_id, graph, node_names, expected_error",
     [
         (ObjectId(), None, None, None),
-        (ObjectId(), None, "node_name", ValueError),
+        (ObjectId(), None, ["node1"], ValueError),
         (ObjectId(), QueryGraphModel(), None, ValueError),
-        (ObjectId(), QueryGraphModel(), "node_name", ValueError),
+        (ObjectId(), QueryGraphModel(), ["node1"], ValueError),
         (None, None, None, ValueError),
-        (None, None, "node_name", ValueError),
+        (None, None, ["node1"], ValueError),
         (None, QueryGraphModel(), None, ValueError),
-        (None, QueryGraphModel(), "node_name", None),
+        (None, QueryGraphModel(), ["node1"], None),
     ],
 )
-def test_target_table_create(target_id, graph, node_name, expected_error):
+def test_target_table_create(target_id, graph, node_names, expected_error):
     """
     Test target table create schema
     """
@@ -40,9 +40,9 @@ def test_target_table_create(target_id, graph, node_name, expected_error):
     }
     if expected_error:
         with pytest.raises(expected_error):
-            TargetTableCreate(graph=graph, node_name=node_name, **common_params)
+            TargetTableCreate(graph=graph, node_names=node_names, **common_params)
         return
     else:
-        target_table_create = TargetTableCreate(graph=graph, node_name=node_name, **common_params)
+        target_table_create = TargetTableCreate(graph=graph, node_names=node_names, **common_params)
         assert target_table_create.name == "target_name"
         assert target_table_create.target_id == target_id

--- a/tests/unit/worker/task/test_target_table.py
+++ b/tests/unit/worker/task/test_target_table.py
@@ -23,7 +23,7 @@ async def test_get_task_description(catalog, app_container):
         feature_store_id=ObjectId(),
         catalog_id=catalog.id,
         graph=QueryGraph(),
-        node_name="node_1",
+        node_names=["node_1"],
         request_input=SourceTableObservationInput(
             source=TabularSource(
                 feature_store_id=ObjectId(),


### PR DESCRIPTION
## Description

In order to get test coverage on changes that break backwards compatibility we can use the published version of the SDK when running the notebook tests.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [x] I have labeled my Pull Request correctly
