### PR TITLE
[DEV-2611] Make data warehouse session creation asynchronous

### DIFF
--- a/.changelog/DEV-2611.yaml
+++ b/.changelog/DEV-2611.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: session
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Make data warehouse session creation asynchronous with a timeout to avoid blocking the asyncio main thread. This prevents the API service from being unresponsive when certain compute clusters takes a long time to start up."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/exception.py
+++ b/featurebyte/exception.py
@@ -270,9 +270,21 @@ class GraphInconsistencyError(DocumentError):
     """
 
 
-class QueryExecutionTimeOut(DocumentError):
+class TimeOutError(FeatureByteException):
+    """
+    Time Out related exception
+    """
+
+
+class QueryExecutionTimeOut(TimeOutError):
     """
     Raise when the SQL query execution times out
+    """
+
+
+class SessionInitializationTimeOut(TimeOutError):
+    """
+    Raise when the session initialization times out
     """
 
 

--- a/featurebyte/middleware.py
+++ b/featurebyte/middleware.py
@@ -18,6 +18,7 @@ from featurebyte.exception import (
     ColumnNotFoundError,
     DocumentNotFoundError,
     QueryNotSupportedError,
+    TimeOutError,
 )
 from featurebyte.logging import get_logger
 
@@ -187,6 +188,13 @@ ExecutionContext.register(
 ExecutionContext.register(
     BaseFailedDependencyError,
     handle_status_code=HTTPStatus.FAILED_DEPENDENCY,
+)
+
+
+# TimeoutError errors
+ExecutionContext.register(
+    TimeOutError,
+    handle_status_code=HTTPStatus.REQUEST_TIMEOUT,
 )
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,7 @@
 """
 Common test fixtures used across files in integration directory
 """
-from typing import Dict, List
+from typing import Dict, List, cast
 
 import asyncio
 import json
@@ -29,6 +29,7 @@ import pytest_asyncio
 import yaml
 from botocore.exceptions import ClientError
 from bson.objectid import ObjectId
+from databricks import sql as databricks_sql
 from fastapi.testclient import TestClient
 from motor.motor_asyncio import AsyncIOMotorClient
 
@@ -407,18 +408,41 @@ def feature_store_credential_fixture(feature_store_name, credentials_mapping):
     return credentials_mapping.get(feature_store_name)
 
 
+@pytest.fixture(name="data_warehouse_initialization", scope="session")
+def data_warehouse_initialization_fixture(
+    source_type,
+    feature_store_details,
+    feature_store_credential,
+):
+    """
+    Data warehouse initialization fixture
+    """
+    if source_type == "databricks":
+        # wait for databricks compute cluster to be ready
+        databricks_details = cast(DatabricksDetails, feature_store_details)
+        databricks_sql.connect(
+            server_hostname=databricks_details.host,
+            http_path=databricks_details.http_path,
+            access_token=feature_store_credential.database_credential.access_token,
+            catalog=databricks_details.featurebyte_catalog,
+            schema=databricks_details.featurebyte_schema,
+        )
+
+
 @pytest.fixture(name="feature_store", scope="session")
 def feature_store_fixture(
     source_type,
     feature_store_name,
     feature_store_details,
     feature_store_credential,
+    data_warehouse_initialization,
     mock_get_persistent,
 ):
     """
     Feature store fixture
     """
     _ = mock_get_persistent
+    _ = data_warehouse_initialization
     feature_store = FeatureStore.create(
         name=feature_store_name,
         source_type=source_type,


### PR DESCRIPTION
## Description

Data warehouse session creation can take a long time for some providers when the compute cluster is waking up from sleep. This fix will prevent the session creation from rendering the REST API unresponsive, and raises a timeout error when it takes too long.

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-2611

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
