### PR TITLE
[workflow] Always show dependency changes

### DIFF
--- a/.github/workflows/dependencies_gen.yaml
+++ b/.github/workflows/dependencies_gen.yaml
@@ -16,6 +16,8 @@ name: dependencies
     branches:
     - main
     - release/*
+    paths:
+    - pyproject.toml
 permissions:
   contents: write
   pull-requests: write
@@ -26,7 +28,6 @@ concurrency:
 jobs:
   diff-deps:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') }}
     strategy:
       matrix:
         python-version:
@@ -64,6 +65,7 @@ jobs:
         tar xvf dist/featurebyte-1.tar.gz --strip-components 1 featurebyte-1/PKG-INFO
         awk -F: '/^Provides-Extra|Requires-Dist/ {print $0}' PKG-INFO | sort > main.PKG-INFO
     - name: Diff dependencies
+      continue-on-error: true
       run: |-
         # Write diff to env
         echo "DIFF<<EOF" >> $GITHUB_ENV
@@ -74,11 +76,14 @@ jobs:
 
         # Test if it actually fails
         diff -u main.PKG-INFO branch.PKG-INFO
-    - if: failure()
-      uses: mshick/add-pr-comment@v2
+    - uses: mshick/add-pr-comment@v2
       with:
         message: |-
           **Diff**
           ```diff
           ${{ env.DIFF }}
           ```
+    - name: Check failure if not labelled as dependency
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') }}
+      run: |-
+        diff -u main.PKG-INFO branch.PKG-INFO


### PR DESCRIPTION
## Description

+ Reduce workflow to only when `pyproject.toml` changes
+ Always print the changes [if exists]
+ If dependency label is added, do not fail if there are a change between required dependencies. This is to provide visibility for developers on the explicit changes required when new users install `featurebyte`

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
