### PR TITLE
[DEV-2591] observation_table: add way to update purpose

### DIFF
--- a/.changelog/DEV-2591.yaml
+++ b/.changelog/DEV-2591.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: session
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Make data warehouse session creation asynchronous with a timeout to avoid blocking the asyncio main thread. This prevents the API service from being unresponsive when certain compute clusters takes a long time to start up."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/.changelog/DEV-2591.yaml
+++ b/.changelog/DEV-2591.yaml
@@ -6,17 +6,17 @@
 
 # --- TEMPLATE --- #
 # One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
-change_type: bug_fix
+change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern
 # (e.g. gh-actions, docs, middleware, worker)
-component: session
+component: observation_table
 
 # (Optional) One or more tracking issues or pull requests related to the change
 issues: []
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Make data warehouse session creation asynchronous with a timeout to avoid blocking the asyncio main thread. This prevents the API service from being unresponsive when certain compute clusters takes a long time to start up."
+note: "Add way to update purpose for observation table."
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/featurebyte/api/observation_table.py
+++ b/featurebyte/api/observation_table.py
@@ -212,6 +212,28 @@ class ObservationTable(ObservationTableModel, ApiObject, MaterializedTableMixin)
         """
         super().update_description(description)
 
+    @typechecked
+    def update_purpose(self, purpose: Purpose) -> None:
+        """
+        Update purpose for the observation table.
+
+        Parameters
+        ----------
+        purpose: Purpose
+            Purpose for the observation table.
+
+        Examples
+        --------
+        >>> observation_table = catalog.get_observation_table("observation_table")  # doctest: +SKIP
+        >>> observation_table.update_purpose(Purpose.EDA)  # doctest: +SKIP
+        """
+        self.update(
+            update_payload={"purpose": purpose},
+            allow_update_local=False,
+            url=f"{self._route}/{self.id}",
+            skip_update_schema_check=True,
+        )
+
     @classmethod
     def upload(
         cls,

--- a/featurebyte/common/documentation/documentation_layout.py
+++ b/featurebyte/common/documentation/documentation_layout.py
@@ -992,7 +992,6 @@ def _get_historical_feature_table_layout() -> List[DocLayoutItem]:
         DocLayoutItem(
             [HISTORICAL_FEATURE_TABLE, MANAGE, "HistoricalFeatureTable.update_description"]
         ),
-        DocLayoutItem([HISTORICAL_FEATURE_TABLE, MANAGE, "HistoricalFeatureTable.update_purpose"]),
     ]
 
 

--- a/featurebyte/common/documentation/documentation_layout.py
+++ b/featurebyte/common/documentation/documentation_layout.py
@@ -951,6 +951,7 @@ def _get_observation_table_layout() -> List[DocLayoutItem]:
         DocLayoutItem([OBSERVATION_TABLE, INFO, "ObservationTable.context_id"]),
         DocLayoutItem([OBSERVATION_TABLE, MANAGE, "ObservationTable.to_pandas"]),
         DocLayoutItem([OBSERVATION_TABLE, MANAGE, "ObservationTable.update_description"]),
+        DocLayoutItem([OBSERVATION_TABLE, MANAGE, "ObservationTable.update_purpose"]),
         DocLayoutItem([OBSERVATION_TABLE, CREATE, "ObservationTable.upload"]),
     ]
 
@@ -991,6 +992,7 @@ def _get_historical_feature_table_layout() -> List[DocLayoutItem]:
         DocLayoutItem(
             [HISTORICAL_FEATURE_TABLE, MANAGE, "HistoricalFeatureTable.update_description"]
         ),
+        DocLayoutItem([HISTORICAL_FEATURE_TABLE, MANAGE, "HistoricalFeatureTable.update_purpose"]),
     ]
 
 

--- a/featurebyte/schema/observation_table.py
+++ b/featurebyte/schema/observation_table.py
@@ -53,13 +53,14 @@ class ObservationTableListRecord(BaseRequestTableListRecord):
 
 class ObservationTableUpdate(BaseDocumentServiceUpdateSchema):
     """
-    ObservationTable Update Context schema
+    ObservationTable Update schema
     """
 
     context_id: Optional[PydanticObjectId]
     context_id_to_remove: Optional[PydanticObjectId]
     use_case_id_to_add: Optional[PydanticObjectId]
     use_case_id_to_remove: Optional[PydanticObjectId]
+    purpose: Optional[Purpose]
 
     # for update model only and not from input
     use_case_ids: Optional[List[PydanticObjectId]]

--- a/tests/unit/api/test_observation_table.py
+++ b/tests/unit/api/test_observation_table.py
@@ -9,6 +9,7 @@ import pytest
 
 from featurebyte.api.observation_table import ObservationTable
 from featurebyte.api.source_table import SourceTable
+from featurebyte.models.observation_table import Purpose
 from tests.unit.api.base_materialize_table_test import BaseMaterializedTableApiTest
 
 
@@ -127,3 +128,12 @@ def test_describe(observation_table_from_source, mock_source_table):
     result = observation_table_from_source.describe(size=123, seed=456)
     assert mock_source_table.describe.call_args == call(size=123, seed=456)
     assert result is mock_source_table.describe.return_value
+
+
+def test_update_purpose(observation_table_from_source):
+    """
+    Test update purpose
+    """
+    assert observation_table_from_source.purpose is None
+    observation_table_from_source.update_purpose(purpose=Purpose.EDA)
+    assert observation_table_from_source.purpose == Purpose.EDA


### PR DESCRIPTION
## Description
Expose a simple function to allow users to update purpose of the observation table.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue
https://featurebyte.atlassian.net/browse/DEV-2591

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
