### PR TITLE
[DEV-2626] Support renaming of context, use case, observation table and historical feature table

### DIFF
--- a/.changelog/DEV-2626.yaml
+++ b/.changelog/DEV-2626.yaml
@@ -6,7 +6,7 @@
 
 # --- TEMPLATE --- #
 # One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
-change_type: bug_fix
+change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern
 # (e.g. gh-actions, docs, middleware, worker)

--- a/.changelog/DEV-2626.yaml
+++ b/.changelog/DEV-2626.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Support rename of context, use case, observation table and historical feature table"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/routes/context/controller.py
+++ b/featurebyte/routes/context/controller.py
@@ -14,7 +14,7 @@ from featurebyte.routes.common.base import BaseDocumentController
 from featurebyte.routes.common.primary_entity_validator import PrimaryEntityValidator
 from featurebyte.schema.context import ContextCreate, ContextList, ContextUpdate
 from featurebyte.schema.info import ContextInfo, EntityBriefInfo, EntityBriefInfoList
-from featurebyte.schema.observation_table import ObservationTableUpdate
+from featurebyte.schema.observation_table import ObservationTableServiceUpdate
 from featurebyte.service.batch_feature_table import BatchFeatureTableService
 from featurebyte.service.catalog import CatalogService
 from featurebyte.service.context import ContextService
@@ -115,7 +115,7 @@ class ContextController(
             if obs_id:
                 await self.observation_table_service.update_observation_table(
                     observation_table_id=obs_id,
-                    data=ObservationTableUpdate(context_id=context_id),
+                    data=ObservationTableServiceUpdate(context_id=context_id),
                 )
 
         obs_table_id_remove = data.observation_table_id_to_remove
@@ -133,7 +133,7 @@ class ContextController(
 
             await self.observation_table_service.update_observation_table(
                 observation_table_id=obs_table_id_remove,
-                data=ObservationTableUpdate(context_id_to_remove=context_id),
+                data=ObservationTableServiceUpdate(context_id_to_remove=context_id),
             )
 
         if data.remove_default_preview_table:

--- a/featurebyte/routes/historical_feature_table/api.py
+++ b/featurebyte/routes/historical_feature_table/api.py
@@ -29,6 +29,7 @@ from featurebyte.schema.common.base import DescriptionUpdate
 from featurebyte.schema.historical_feature_table import (
     HistoricalFeatureTableCreate,
     HistoricalFeatureTableList,
+    HistoricalFeatureTableUpdate,
 )
 from featurebyte.schema.info import HistoricalFeatureTableInfo
 from featurebyte.schema.task import Task
@@ -196,5 +197,24 @@ async def update_historical_feature_table_description(
     historical_feature_table: HistoricalFeatureTableModel = await controller.update_description(
         document_id=historical_feature_table_id,
         description=data.description,
+    )
+    return historical_feature_table
+
+
+@router.patch("/{historical_feature_table_id}", response_model=HistoricalFeatureTableModel)
+async def update_historical_feature_table(
+    request: Request,
+    historical_feature_table_id: PydanticObjectId,
+    data: HistoricalFeatureTableUpdate,
+) -> HistoricalFeatureTableModel:
+    """
+    Update historical_feature_table
+    """
+    controller = request.state.app_container.historical_feature_table_controller
+    historical_feature_table: HistoricalFeatureTableModel = (
+        await controller.update_historical_feature_table(
+            historical_feature_table_id=historical_feature_table_id,
+            data=data,
+        )
     )
     return historical_feature_table

--- a/featurebyte/routes/historical_feature_table/controller.py
+++ b/featurebyte/routes/historical_feature_table/controller.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Any, Optional
 
 import pandas as pd
+from bson import ObjectId
 
 from featurebyte.models.historical_feature_table import HistoricalFeatureTableModel
 from featurebyte.routes.common.feature_or_target_table import (
@@ -16,6 +17,7 @@ from featurebyte.routes.task.controller import TaskController
 from featurebyte.schema.historical_feature_table import (
     HistoricalFeatureTableCreate,
     HistoricalFeatureTableList,
+    HistoricalFeatureTableUpdate,
 )
 from featurebyte.schema.info import HistoricalFeatureTableInfo
 from featurebyte.schema.worker.task.historical_feature_table import (
@@ -110,3 +112,22 @@ class HistoricalFeatureTableController(
             "feature_list_name": feature_list.name,
             "feature_list_version": feature_list.version.to_str(),
         }
+
+    async def update_historical_feature_table(
+        self, historical_feature_table_id: ObjectId, data: HistoricalFeatureTableUpdate
+    ) -> Optional[HistoricalFeatureTableModel]:
+        """
+        Update HistoricalFeatureTable
+
+        Parameters
+        ----------
+        historical_feature_table_id: ObjectId
+            HistoricalFeatureTable document_id
+        data: HistoricalFeatureTableUpdate
+            HistoricalFeatureTable update payload
+
+        Returns
+        -------
+        Optional[HistoricalFeatureTableModel]
+        """
+        return await self.service.update_document(historical_feature_table_id, data)

--- a/featurebyte/routes/observation_table/api.py
+++ b/featurebyte/routes/observation_table/api.py
@@ -214,7 +214,7 @@ async def update_observation_table_description(
 
 
 @router.patch("/{observation_table_id}", response_model=ObservationTableModel)
-async def update_observation_table_context(
+async def update_observation_table(
     request: Request,
     observation_table_id: PydanticObjectId,
     data: ObservationTableUpdate,

--- a/featurebyte/routes/observation_table/controller.py
+++ b/featurebyte/routes/observation_table/controller.py
@@ -19,6 +19,7 @@ from featurebyte.schema.info import ObservationTableInfo
 from featurebyte.schema.observation_table import (
     ObservationTableCreate,
     ObservationTableList,
+    ObservationTableServiceUpdate,
     ObservationTableUpdate,
     ObservationTableUpload,
 )
@@ -193,5 +194,5 @@ class ObservationTableController(
         """
 
         return await self.observation_table_service.update_observation_table(
-            observation_table_id, data
+            observation_table_id, ObservationTableServiceUpdate(**data.dict(by_alias=True))
         )

--- a/featurebyte/routes/use_case/controller.py
+++ b/featurebyte/routes/use_case/controller.py
@@ -14,7 +14,7 @@ from featurebyte.models.persistent import QueryFilter
 from featurebyte.models.use_case import UseCaseModel
 from featurebyte.routes.common.base import BaseDocumentController
 from featurebyte.schema.info import EntityBriefInfo, EntityBriefInfoList, UseCaseInfo
-from featurebyte.schema.observation_table import ObservationTableUpdate
+from featurebyte.schema.observation_table import ObservationTableServiceUpdate
 from featurebyte.schema.use_case import UseCaseCreate, UseCaseList, UseCaseUpdate
 from featurebyte.service.catalog import CatalogService
 from featurebyte.service.context import ContextService
@@ -135,7 +135,7 @@ class UseCaseController(
                 if use_case_id not in observation_table.use_case_ids:
                     await self.observation_table_service.update_observation_table(
                         observation_table_id=obs_id,
-                        data=ObservationTableUpdate(use_case_id_to_add=use_case_id),
+                        data=ObservationTableServiceUpdate(use_case_id_to_add=use_case_id),
                     )
 
         obs_table_id_remove = data.observation_table_id_to_remove
@@ -161,7 +161,7 @@ class UseCaseController(
 
             await self.observation_table_service.update_observation_table(
                 observation_table_id=obs_table_id_remove,
-                data=ObservationTableUpdate(use_case_id_to_remove=use_case_id),
+                data=ObservationTableServiceUpdate(use_case_id_to_remove=use_case_id),
             )
 
         if data.remove_default_preview_table:

--- a/featurebyte/schema/context.py
+++ b/featurebyte/schema/context.py
@@ -63,6 +63,8 @@ class ContextUpdate(BaseDocumentServiceUpdateSchema):
     remove_default_eda_table: Optional[bool]
     remove_default_preview_table: Optional[bool]
 
+    name: Optional[StrictStr]
+
     @root_validator(pre=True)
     @classmethod
     def _validate_parameters(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/featurebyte/schema/historical_feature_table.py
+++ b/featurebyte/schema/historical_feature_table.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import root_validator
+from pydantic import StrictStr, root_validator
 
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.historical_feature_table import HistoricalFeatureTableModel
-from featurebyte.schema.common.base import PaginationMixin
+from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema, PaginationMixin
 from featurebyte.schema.common.feature_or_target import FeatureOrTargetTableCreate
 from featurebyte.schema.feature_list import FeatureListGetHistoricalFeatures
 from featurebyte.schema.materialized_table import BaseMaterializedTableListRecord
@@ -44,3 +44,11 @@ class HistoricalFeatureTableListRecord(BaseMaterializedTableListRecord):
     def _extract(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         values["feature_store_id"] = values["location"]["feature_store_id"]
         return values
+
+
+class HistoricalFeatureTableUpdate(BaseDocumentServiceUpdateSchema):
+    """
+    HistoricalFeatureTable update payload
+    """
+
+    name: Optional[StrictStr]

--- a/featurebyte/schema/observation_table.py
+++ b/featurebyte/schema/observation_table.py
@@ -51,7 +51,7 @@ class ObservationTableListRecord(BaseRequestTableListRecord):
     """
 
 
-class ObservationTableUpdate(BaseDocumentServiceUpdateSchema):
+class ObservationTableUpdate(FeatureByteBaseModel):
     """
     ObservationTable Update schema
     """
@@ -61,6 +61,12 @@ class ObservationTableUpdate(BaseDocumentServiceUpdateSchema):
     use_case_id_to_add: Optional[PydanticObjectId]
     use_case_id_to_remove: Optional[PydanticObjectId]
     purpose: Optional[Purpose]
+    name: Optional[StrictStr]
 
-    # for update model only and not from input
+
+class ObservationTableServiceUpdate(BaseDocumentServiceUpdateSchema, ObservationTableUpdate):
+    """
+    ObservationTable Update schema for service
+    """
+
     use_case_ids: Optional[List[PydanticObjectId]]

--- a/featurebyte/schema/use_case.py
+++ b/featurebyte/schema/use_case.py
@@ -44,6 +44,8 @@ class UseCaseUpdate(BaseDocumentServiceUpdateSchema):
     remove_default_eda_table: Optional[bool]
     remove_default_preview_table: Optional[bool]
 
+    name: Optional[StrictStr]
+
     @root_validator(pre=True)
     @classmethod
     def _validate_input(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -47,7 +47,7 @@ from featurebyte.routes.common.primary_entity_validator import PrimaryEntityVali
 from featurebyte.schema.feature_store import FeatureStoreSample
 from featurebyte.schema.observation_table import (
     ObservationTableCreate,
-    ObservationTableUpdate,
+    ObservationTableServiceUpdate,
     ObservationTableUpload,
 )
 from featurebyte.schema.worker.task.observation_table import ObservationTableTaskPayload
@@ -505,7 +505,7 @@ class ObservationTableService(
         }
 
     async def update_observation_table(  # pylint: disable=too-many-branches
-        self, observation_table_id: ObjectId, data: ObservationTableUpdate
+        self, observation_table_id: ObjectId, data: ObservationTableServiceUpdate
     ) -> Optional[ObservationTableModel]:
         """
         Update ObservationTable
@@ -514,7 +514,7 @@ class ObservationTableService(
         ----------
         observation_table_id: ObjectId
             ObservationTable document_id
-        data: ObservationTableUpdate
+        data: ObservationTableServiceUpdate
             ObservationTable update payload
 
         Returns
@@ -528,10 +528,6 @@ class ObservationTableService(
         ObservationTableInvalidUseCaseError
             If the use case is invalid
         """
-
-        if data.use_case_ids:
-            raise ObservationTableInvalidUseCaseError("use_case_ids is not a valid field to update")
-
         observation_table = await self.get_document(document_id=observation_table_id)
         if data.use_case_id_to_add or data.use_case_id_to_remove:
             if not observation_table.context_id:

--- a/tests/unit/routes/test_context.py
+++ b/tests/unit/routes/test_context.py
@@ -537,3 +537,16 @@ class TestContextApi(BaseCatalogApiTestSuite):
         response = test_api_client.get(f"{self.base_route}/{context_id}")
         assert response.status_code == HTTPStatus.OK
         assert response.json()["default_eda_table_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_update_name(self, test_api_client_persistent, create_success_response):
+        """Test update name"""
+        test_api_client, _ = test_api_client_persistent
+        doc_id = create_success_response.json()["_id"]
+        response = test_api_client.patch(
+            f"{self.base_route}/{doc_id}", json={"name": "some other name"}
+        )
+        assert response.status_code == HTTPStatus.OK, response.json()
+        response = test_api_client.get(f"{self.base_route}/{doc_id}")
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["name"] == "some other name"

--- a/tests/unit/routes/test_historical_feature_table.py
+++ b/tests/unit/routes/test_historical_feature_table.py
@@ -240,3 +240,16 @@ class TestHistoricalFeatureTableApi(BaseMaterializedTableTestSuite):
         response = self.post(test_api_client, payload)
         assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
         assert "Either feature_clusters or feature_list_id must be set" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_update_name(self, test_api_client_persistent, create_success_response):
+        """Test update name"""
+        test_api_client, _ = test_api_client_persistent
+        doc_id = create_success_response.json()["_id"]
+        response = test_api_client.patch(
+            f"{self.base_route}/{doc_id}", json={"name": "some other name"}
+        )
+        assert response.status_code == HTTPStatus.OK, response.json()
+        response = test_api_client.get(f"{self.base_route}/{doc_id}")
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["name"] == "some other name"

--- a/tests/unit/routes/test_observation_table.py
+++ b/tests/unit/routes/test_observation_table.py
@@ -118,7 +118,7 @@ class TestObservationTableApi(BaseMaterializedTableTestSuite):
         assert response_dict["purpose"] == "other"
 
     def test_update_context(self, test_api_client_persistent, create_success_response):
-        """Test update context route"""
+        """Test update context"""
         test_api_client, _ = test_api_client_persistent
         doc_id = create_success_response.json()["_id"]
 
@@ -144,7 +144,7 @@ class TestObservationTableApi(BaseMaterializedTableTestSuite):
     async def test_update_use_case(
         self, test_api_client_persistent, create_success_response, create_observation_table
     ):
-        """Test update context route"""
+        """Test update use case"""
         test_api_client, _ = test_api_client_persistent
         _ = create_success_response
 
@@ -197,6 +197,32 @@ class TestObservationTableApi(BaseMaterializedTableTestSuite):
         assert response.status_code == HTTPStatus.OK
         assert response.json()["use_case_ids"] == []
 
+    @pytest.mark.asyncio
+    async def test_update_purpose(self, test_api_client_persistent, create_success_response):
+        """Test update purpose"""
+        test_api_client, _ = test_api_client_persistent
+        doc_id = create_success_response.json()["_id"]
+        response = test_api_client.patch(
+            f"{self.base_route}/{doc_id}", json={"purpose": "validation_test"}
+        )
+        assert response.status_code == HTTPStatus.OK
+        response = test_api_client.get(f"{self.base_route}/{doc_id}")
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["purpose"] == "validation_test"
+
+    @pytest.mark.asyncio
+    async def test_update_name(self, test_api_client_persistent, create_success_response):
+        """Test update name"""
+        test_api_client, _ = test_api_client_persistent
+        doc_id = create_success_response.json()["_id"]
+        response = test_api_client.patch(
+            f"{self.base_route}/{doc_id}", json={"name": "some other name"}
+        )
+        assert response.status_code == HTTPStatus.OK
+        response = test_api_client.get(f"{self.base_route}/{doc_id}")
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["name"] == "some other name"
+
     def test_update_use_case_with_error(self, test_api_client_persistent, create_success_response):
         """Test update context route"""
         test_api_client, _ = test_api_client_persistent
@@ -220,13 +246,6 @@ class TestObservationTableApi(BaseMaterializedTableTestSuite):
         use_case_payload["context_id"] = context_id
         response = test_api_client.post("/use_case", json=use_case_payload)
         assert response.status_code == HTTPStatus.CREATED, response.json()
-
-        # test update use_case_ids which is not allowed
-        response = test_api_client.patch(
-            f"{self.base_route}/{doc_id}", json={"use_case_ids": [use_case_id]}
-        )
-        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
-        assert response.json()["detail"] == "use_case_ids is not a valid field to update"
 
         # test add use_case that has different context
         response = test_api_client.patch(

--- a/tests/unit/routes/test_use_case.py
+++ b/tests/unit/routes/test_use_case.py
@@ -720,3 +720,16 @@ class TestUseCaseApi(BaseCatalogApiTestSuite):
         assert (
             response.json()["detail"] == f"Target is referenced by UseCase: {use_case_dict['name']}"
         )
+
+    @pytest.mark.asyncio
+    async def test_update_name(self, test_api_client_persistent, create_success_response):
+        """Test update name"""
+        test_api_client, _ = test_api_client_persistent
+        doc_id = create_success_response.json()["_id"]
+        response = test_api_client.patch(
+            f"{self.base_route}/{doc_id}", json={"name": "some other name"}
+        )
+        assert response.status_code == HTTPStatus.OK, response.json()
+        response = test_api_client.get(f"{self.base_route}/{doc_id}")
+        assert response.status_code == HTTPStatus.OK
+        assert response.json()["name"] == "some other name"


### PR DESCRIPTION
## Description

Support renaming of context, use case, observation table and historical feature table

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
