### PR TITLE
[DEV-2639] Exclude soft-deleted catalog from the namespace

### DIFF
--- a/featurebyte/models/catalog.py
+++ b/featurebyte/models/catalog.py
@@ -81,6 +81,7 @@ class CatalogModel(FeatureByteBaseDocumentModel):
                 fields=("name", "user_id"),
                 conflict_fields_signature={"name": ["name"]},
                 resolution_signature=UniqueConstraintResolutionSignature.GET_NAME,
+                extra_query_params={"is_deleted": {"$ne": True}},
             ),
         ]
 

--- a/tests/unit/routes/test_catalog.py
+++ b/tests/unit/routes/test_catalog.py
@@ -244,6 +244,12 @@ class TestCatalogApi(BaseApiTestSuite):
             },
         )
         assert response.status_code == HTTPStatus.CREATED
+        new_response_dict = response.json()
+
+        # check retrieved catalog by name
+        response = test_api_client.get(f"{self.base_route}", params={"name": response_dict["name"]})
+        assert response.status_code == HTTPStatus.OK, response.json()
+        assert response.json()["data"][0]["_id"] == new_response_dict["_id"]
 
     @pytest.mark.asyncio
     async def test_soft_delete__with_active_deployment(

--- a/tests/unit/routes/test_catalog.py
+++ b/tests/unit/routes/test_catalog.py
@@ -234,6 +234,17 @@ class TestCatalogApi(BaseApiTestSuite):
         assert response.status_code == HTTPStatus.OK, response.json()
         assert response.json()["data"] == []
 
+        # create a new catalog with the same name should be ok
+        response = test_api_client.post(
+            self.base_route,
+            json={
+                "_id": str(ObjectId()),
+                "name": response_dict["name"],
+                "default_feature_store_ids": response_dict["default_feature_store_ids"],
+            },
+        )
+        assert response.status_code == HTTPStatus.CREATED
+
     @pytest.mark.asyncio
     async def test_soft_delete__with_active_deployment(
         self, create_success_response, test_api_client_persistent, app_container


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR excludes soft-deleted catalog from the catalog namespace so that user is allowed to create a new catalog with the same name.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
