### PR TITLE
[chore] Add expiry to celery tasks documents

### DIFF
--- a/featurebyte/models/task.py
+++ b/featurebyte/models/task.py
@@ -40,7 +40,7 @@ class Task(FeatureByteBaseDocumentModel):
         collection_name = "celery_taskmeta"
         indexes = [
             pymongo.operations.IndexModel("name"),
-            pymongo.operations.IndexModel("start_time"),
+            pymongo.operations.IndexModel("start_time", expireAfterSeconds=3600 * 24 * 30),
             pymongo.operations.IndexModel("kwargs.is_scheduled_task"),
             pymongo.operations.IndexModel("date_done"),
             [


### PR DESCRIPTION
## Description

Add 30-day expiry to celery tasks documents to clean up mongo storage

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
