### PR TITLE
[chore] Handle databricks describe table output format

### DIFF
--- a/featurebyte/session/base_spark.py
+++ b/featurebyte/session/base_spark.py
@@ -248,7 +248,7 @@ class BaseSparkSession(BaseSession, ABC):
             for _, (column_name, var_info) in schema[["col_name", "data_type"]].iterrows():
                 # Sometimes describe include metadata after column details with and empty row as a separator.
                 # Skip the remaining entries once we run into an empty column name
-                if column_name == "":
+                if column_name == "" or column_name.startswith("# "):
                     break
                 column_name_type_map[column_name] = self._convert_to_internal_variable_type(
                     var_info.upper()

--- a/tests/unit/session/test_databricks_session.py
+++ b/tests/unit/session/test_databricks_session.py
@@ -79,23 +79,28 @@ class MockDatabricksConnection:
                 ["default", "calls"],
             ]
         elif query.startswith("DESCRIBE"):
-            self.description = [["col_name", "STRING"], ["data_type", "STRING"]]
+            self.description = [
+                ["col_name", "STRING"],
+                ["data_type", "STRING"],
+                ["comment", "STRING"],
+            ]
             self.result_rows = [
-                ["col_binary", "BINARY"],
-                ["col_bool", "BOOLEAN"],
-                ["col_date", "DATE"],
-                ["col_decimal", "DECIMAL"],
-                ["col_double", "DOUBLE"],
-                ["col_float", "FLOAT"],
-                ["col_int", "INT"],
-                ["col_interval", "INTERVAL"],
-                ["col_void", "VOID"],
-                ["col_timestamp", "TIMESTAMP"],
-                ["col_array", "ARRAY"],
-                ["col_map", "MAP"],
-                ["col_struct", "STRUCT"],
-                ["col_string", "STRING"],
-                ["col_unknown", "UNKNOWN"],
+                ["col_binary", "BINARY", "Binary Column"],
+                ["col_bool", "BOOLEAN", "Boolean Column"],
+                ["col_date", "DATE", "Date Column"],
+                ["col_decimal", "DECIMAL", "Decimal Column"],
+                ["col_double", "DOUBLE", "Double Column"],
+                ["col_float", "FLOAT", "Float Column"],
+                ["col_int", "INT", "Int Column"],
+                ["col_interval", "INTERVAL", "Interval Column"],
+                ["col_void", "VOID", "Void Column"],
+                ["col_timestamp", "TIMESTAMP", "Timestamp Column"],
+                ["col_array", "ARRAY", "Array Column"],
+                ["col_map", "MAP", "Map Column"],
+                ["col_struct", "STRUCT", "Struct Column"],
+                ["col_string", "STRING", "String Column"],
+                ["col_unknown", "UNKNOWN", "Unknown Column"],
+                ["# Partition Information", ""],
             ]
         else:
             self.description = [["a", "INT"], ["b", "INT"], ["c", "INT"]]


### PR DESCRIPTION
## Description

Unlike in Spark, DESCRIBE TABLE in DataBricks does not include an empty row between column details and table metadata.
This can cause column information to be detected wrongly when table metadata such as partitioning is available.
This PR fixes this.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
