### PR TITLE
[DEV-2643] Fix observation table sampling not uniform

### DIFF
--- a/.changelog/DEV-2643.yaml
+++ b/.changelog/DEV-2643.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix observation table sampling so that it is always uniform over the input"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/tests/unit/api/test_event_view.py
+++ b/tests/unit/api/test_event_view.py
@@ -887,6 +887,8 @@ def test_create_observation_table_from_event_view__with_sample(
             FROM "sf_database"."sf_schema"."sf_table"
           )
         ) TABLESAMPLE(14)
+        ORDER BY
+          RANDOM()
         LIMIT 100
         """,
     )

--- a/tests/unit/api/test_source_table.py
+++ b/tests/unit/api/test_source_table.py
@@ -284,6 +284,8 @@ def test_create_observation_table_with_sample_rows(
             *
           FROM "sf_database"."sf_schema"."sf_table"
         ) TABLESAMPLE(14)
+        ORDER BY
+          RANDOM()
         LIMIT 100
         """,
     )


### PR DESCRIPTION
## Description

This fixes an issue in observation table creation where the sampling is not uniform over the full available time range. 

Previously in the sampling query, the tablesample clause can potentially return ordered data and cause some rows to be prematurely truncated by the limit clause. To prevent that issue, this shuffles the output of tabesample so that rows are randomly selected before truncation.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
