### PR TITLE
[chore] Add missing typechecked decorator

### DIFF
--- a/featurebyte/api/base_table.py
+++ b/featurebyte/api/base_table.py
@@ -1045,6 +1045,7 @@ class TableApiObject(
             ]
         return table_data, column_cleaning_operations
 
+    @typechecked
     def update_column_entity(self, column_name: str, entity_name: Optional[str]) -> None:
         """
         Update column entity
@@ -1072,6 +1073,7 @@ class TableApiObject(
             skip_update_schema_check=True,
         )
 
+    @typechecked
     def update_column_critical_data_info(
         self, column_name: str, critical_data_info: CriticalDataInfo
     ) -> None:
@@ -1095,6 +1097,7 @@ class TableApiObject(
             skip_update_schema_check=True,
         )
 
+    @typechecked
     def update_column_description(self, column_name: str, description: Optional[str]) -> None:
         """
         Update column description

--- a/tests/unit/api/base_table_test.py
+++ b/tests/unit/api/base_table_test.py
@@ -202,8 +202,9 @@ class BaseTableTestSuite:
         expected_error = (
             'type of argument "description" must be one of (str, NoneType); got float instead'
         )
-        with pytest.raises(TypeError, match=expected_error):
+        with pytest.raises(TypeError) as exc:
             table_under_test.update_column_description(self.col, 1.0)
+        assert expected_error in str(exc.value)
 
     def test_delete(self, table_under_test):
         """Test delete table"""

--- a/tests/unit/api/base_table_test.py
+++ b/tests/unit/api/base_table_test.py
@@ -191,6 +191,20 @@ class BaseTableTestSuite:
         assert table_under_test.description is None
         assert table_under_test.info()["description"] is None
 
+    def test_update_column_description(self, table_under_test):
+        """Test table update column description"""
+        table_col = table_under_test[self.col]
+        assert table_col.description is None
+
+        table_under_test.update_column_description(self.col, "new description")
+        assert table_col.description == "new description"
+
+        expected_error = (
+            'type of argument "description" must be one of (str, NoneType); got float instead'
+        )
+        with pytest.raises(TypeError, match=expected_error):
+            table_under_test.update_column_description(self.col, 1.0)
+
     def test_delete(self, table_under_test):
         """Test delete table"""
         assert table_under_test.saved


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
Add missing `typechecked` decorator for several SDK table column update methods.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
