### PR TITLE
[DEV-2714] Implement FeatureMaterializeService to prepare features for publishing

### DIFF
--- a/.changelog/DEV-2714.yaml
+++ b/.changelog/DEV-2714.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Implement service to materialize features to be published to external feature store"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -82,6 +82,7 @@ from featurebyte.service.feature_list_facade import FeatureListFacadeService
 from featurebyte.service.feature_list_namespace import FeatureListNamespaceService
 from featurebyte.service.feature_list_status import FeatureListStatusService
 from featurebyte.service.feature_manager import FeatureManagerService
+from featurebyte.service.feature_materialize import FeatureMaterializeService
 from featurebyte.service.feature_namespace import FeatureNamespaceService
 from featurebyte.service.feature_preview import FeaturePreviewService
 from featurebyte.service.feature_readiness import FeatureReadinessService
@@ -223,6 +224,7 @@ app_container_config.register_class(FeatureListNamespaceController)
 app_container_config.register_class(FeatureListNamespaceService)
 app_container_config.register_class(FeatureListStatusService)
 app_container_config.register_class(FeatureManagerService)
+app_container_config.register_class(FeatureMaterializeService)
 app_container_config.register_class(FeatureOrTargetHelper)
 app_container_config.register_class(FeatureOrTargetMetadataExtractor)
 app_container_config.register_class(FeatureNamespaceController)

--- a/featurebyte/service/feature_materialize.py
+++ b/featurebyte/service/feature_materialize.py
@@ -113,6 +113,10 @@ class OnlineEnabledFeaturesMetadata:
     def _get_combined_ingest_graph(self) -> OfflineIngestGraphMetadata:
         """
         Returns a combined ingest graph and related information for all features
+
+        Returns
+        -------
+        OfflineIngestGraphMetadata
         """
         local_query_graph = QueryGraph()
         output_nodes = []

--- a/featurebyte/service/feature_materialize.py
+++ b/featurebyte/service/feature_materialize.py
@@ -1,0 +1,328 @@
+"""
+FeatureMaterializeService class
+"""
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+from dataclasses import dataclass, field
+
+from bson import ObjectId
+from sqlglot import expressions
+from sqlglot.expressions import Select, select
+
+from featurebyte.models.entity import EntityModel
+from featurebyte.models.feature import FeatureModel
+from featurebyte.query_graph.graph import QueryGraph
+from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
+from featurebyte.query_graph.node.schema import TableDetails
+from featurebyte.query_graph.sql.adapter import get_sql_adapter
+from featurebyte.query_graph.sql.common import quoted_identifier, sql_to_string
+from featurebyte.query_graph.sql.online_serving import (
+    TemporaryBatchRequestTable,
+    get_online_features,
+)
+from featurebyte.service.entity import EntityService
+from featurebyte.service.feature import FeatureService
+from featurebyte.service.online_store_compute_query_service import OnlineStoreComputeQueryService
+from featurebyte.service.online_store_table_version import OnlineStoreTableVersionService
+from featurebyte.session.base import BaseSession
+
+
+@dataclass
+class OfflineIngestGraphMetadata:
+    """
+    Information about offline ingest graph combined for all features
+    """
+
+    graph: QueryGraph
+    node_names: List[str]
+    output_column_names: List[str]
+
+
+@dataclass
+class OnlineEnabledFeaturesMetadata:
+    """
+    Information about online enabled features having the same primary entity that should be
+    published together
+    """
+
+    features: List[FeatureModel]
+    online_store_table_names: List[str]
+    primary_entities: List[EntityModel]
+    ingest_graph_and_node_names: Tuple[QueryGraph, List[str]] = field(init=False)
+    output_column_names: List[str] = field(init=False)
+
+    def __post_init__(self) -> None:
+        ingest_graph_metadata = self._get_combined_ingest_graph()
+        self.ingest_graph_and_node_names = (
+            ingest_graph_metadata.graph,
+            ingest_graph_metadata.node_names,
+        )
+        self.output_column_names = ingest_graph_metadata.output_column_names
+
+    @property
+    def serving_names(self) -> List[str]:
+        """
+        Returns serving names for the primary entities
+
+        Returns
+        -------
+        List[str]
+        """
+        return sorted([entity.serving_names[0] for entity in self.primary_entities])
+
+    @property
+    def primary_entity_ids(self) -> List[ObjectId]:
+        """
+        Returns primary entity ids
+
+        Returns
+        -------
+        List[ObjectId]
+        """
+        return sorted([entity.id for entity in self.primary_entities])
+
+    @property
+    def entity_universe_expr(self) -> Optional[Select]:
+        """
+        Returns a SQL expression that selects the distinct entity serving names across all online
+        store tables
+
+        Returns
+        -------
+        Optional[Select]
+        """
+        if not self.online_store_table_names:
+            return None
+
+        # select distinct serving names across all online store tables
+        distinct_serving_names_from_tables = [
+            select(*[quoted_identifier(serving_name) for serving_name in self.serving_names])
+            .distinct()
+            .from_(table_name)
+            for table_name in self.online_store_table_names
+        ]
+
+        union_expr = distinct_serving_names_from_tables[0]
+        for expr in distinct_serving_names_from_tables[1:]:
+            union_expr = expressions.Union(this=expr, distinct=True, expression=union_expr)  # type: ignore
+
+        return union_expr
+
+    def _get_combined_ingest_graph(self) -> OfflineIngestGraphMetadata:
+        """
+        Returns a combined ingest graph and related information for all features
+        """
+        local_query_graph = QueryGraph()
+        output_nodes = []
+        output_column_names = []
+
+        for feature in self.features:
+            offline_ingest_graphs = feature.extract_offline_store_ingest_query_graphs()
+            for offline_ingest_graph in offline_ingest_graphs:
+                if offline_ingest_graph.primary_entity_ids != self.primary_entity_ids:
+                    # Feature of a primary entity can be decomposed into ingest graphs with
+                    # different primary entity. Skip if it is not the same as the primary_entity_ids
+                    # of interest now.
+                    continue
+                graph, node = offline_ingest_graph.ingest_graph_and_node()
+                local_query_graph, local_name_map = local_query_graph.load(graph)
+                output_nodes.append(local_query_graph.get_node_by_name(local_name_map[node.name]))
+                output_column_names.append(offline_ingest_graph.output_column_name)
+
+        return OfflineIngestGraphMetadata(
+            graph=local_query_graph,
+            node_names=[node.name for node in output_nodes],
+            output_column_names=output_column_names,
+        )
+
+
+@dataclass
+class MaterializedFeatures:
+    """
+    Information about materialised features ready to be published
+    """
+
+    materialized_table_name: str
+    names: List[str]
+    serving_names: List[str]
+
+
+class FeatureMaterializeService:
+    """
+    FeatureMaterializeService is responsible for materialising a set of currently online enabled
+    features so that they can be published to an external feature store. These features are
+    materialised into a new table in the data warehouse.
+    """
+
+    def __init__(
+        self,
+        feature_service: FeatureService,
+        online_store_compute_query_service: OnlineStoreComputeQueryService,
+        entity_service: EntityService,
+        online_store_table_version_service: OnlineStoreTableVersionService,
+    ):
+        self.feature_service = feature_service
+        self.online_store_compute_query_service = online_store_compute_query_service
+        self.entity_service = entity_service
+        self.online_store_table_version_service = online_store_table_version_service
+
+    async def materialize_features(
+        self,
+        session: BaseSession,
+        primary_entity_ids: List[ObjectId],
+        feature_job_setting: FeatureJobSetting,
+    ) -> Optional[MaterializedFeatures]:
+        """
+        Materialise currently online enabled features matching the given primary entity and feature
+        job settings into a new table in the data warehouse.
+
+        Parameters
+        ----------
+        session: BaseSession
+            Session object
+        primary_entity_ids: List[ObjectId]
+            List of primary entity ids
+        feature_job_setting: FeatureJobSetting
+            Feature job setting
+
+        Returns
+        -------
+        Optional[MaterializedFeatures]
+        """
+        # Collect list of features to be published
+        online_enabled_features_metadata = await self._get_online_enabled_features_metadata(
+            primary_entity_ids, feature_job_setting
+        )
+        if online_enabled_features_metadata.entity_universe_expr is None:
+            # TODO: handle feature types that are currently not being precomputed, e.g. lookup
+            #  features, asat aggregates, etc.
+            return None
+
+        # Create temporary batch request table with the universe of entities
+        unique_id = ObjectId()
+        batch_request_table = TemporaryBatchRequestTable(
+            table_details=TableDetails(
+                database_name=session.database_name,
+                schema_name=session.schema_name,
+                table_name=f"TEMP_REQUEST_TABLE_{unique_id}".upper(),
+            ),
+            column_names=online_enabled_features_metadata.serving_names,
+        )
+        adapter = get_sql_adapter(session.source_type)
+        create_batch_request_table_query = sql_to_string(
+            adapter.create_table_as(
+                table_details=batch_request_table.table_details,
+                select_expr=online_enabled_features_metadata.entity_universe_expr,
+            ),
+            source_type=session.source_type,
+        )
+        await session.execute_query_long_running(create_batch_request_table_query)
+
+        # Materialize features
+        output_table_details = TableDetails(
+            database_name=session.database_name,
+            schema_name=session.schema_name,
+            table_name=f"TEMP_FEATURE_TABLE_{unique_id}".upper(),
+        )
+        graph, node_names = online_enabled_features_metadata.ingest_graph_and_node_names
+        try:
+            await get_online_features(
+                session=session,
+                graph=graph,
+                nodes=[graph.get_node_by_name(node_name) for node_name in node_names],
+                request_data=batch_request_table,
+                source_type=session.source_type,
+                online_store_table_version_service=self.online_store_table_version_service,
+                output_table_details=output_table_details,
+            )
+        finally:
+            # Delete temporary batch request table
+            await session.drop_table(
+                table_name=batch_request_table.table_details.table_name,
+                schema_name=batch_request_table.table_details.schema_name,  # type: ignore
+                database_name=batch_request_table.table_details.database_name,  # type: ignore
+                if_exists=True,
+            )
+
+        return MaterializedFeatures(
+            materialized_table_name=output_table_details.table_name,
+            names=online_enabled_features_metadata.output_column_names,
+            serving_names=online_enabled_features_metadata.serving_names,
+        )
+
+    async def _get_online_enabled_features_metadata(
+        self,
+        primary_entity_ids: List[ObjectId],
+        feature_job_setting: FeatureJobSetting,
+    ) -> OnlineEnabledFeaturesMetadata:
+        """
+        Get current online enabled features corresponding to the primary entity ids
+
+        Parameters
+        ----------
+        primary_entity_ids: List[ObjectId]
+            List of primary entity ids
+        feature_job_setting: FeatureJobSetting
+            Feature job setting
+
+        Returns
+        -------
+        OnlineEnabledFeaturesMetadata
+        """
+        online_store_table_names = set()
+        online_enabled_features = []
+
+        # Note: Use of "$in" for primary_entity_ids field is intentional. For example, if a feature
+        # has primary entity of CUSTOMER X PRODUCT. It could be a CUSTOMER feature combined with
+        # PRODUCT feature, or a CUSTOMER X PRODUCT feature (via composite groupby keys). For the
+        # former case, the feature will be decomposed into two parts - one for CUSTOMER and one for
+        # PRODUCT. One of the parts need to be included in the CUSTOMER offline store table.
+        async for feature_model in self.feature_service.list_documents_iterator(
+            query_filter={
+                "online_enabled": True,
+                "primary_entity_ids": {"$in": primary_entity_ids},
+            }
+        ):
+            # TODO: investigate why filtering directly by
+            #  table_id_feature_job_settings.feature_job_setting doesn't work
+            for table_id_feature_job_setting in feature_model.table_id_feature_job_settings:
+                if table_id_feature_job_setting.feature_job_setting == feature_job_setting:
+                    online_enabled_features.append(feature_model)
+                    online_store_table_names.update(feature_model.online_store_table_names)
+                    break
+
+        online_store_table_names = sorted(online_store_table_names)  # type: ignore[assignment]
+
+        # Get online tables
+        online_store_table_name_to_serving_names = {}
+        async for online_store_compute_query_model in self.online_store_compute_query_service.list_documents_iterator(
+            query_filter={"table_name": {"$in": online_store_table_names}}
+        ):
+            online_store_table_name_to_serving_names[
+                online_store_compute_query_model.table_name
+            ] = online_store_compute_query_model.serving_names
+
+        primary_entities = []
+        async for entity_model in self.entity_service.list_documents_iterator(
+            query_filter={"_id": {"$in": primary_entity_ids}}
+        ):
+            primary_entities.append(entity_model)
+
+        primary_entity_serving_names = sorted(
+            [entity.serving_names[0] for entity in primary_entities]
+        )
+        required_online_store_tables = []
+        for (
+            online_store_table_name,
+            online_store_serving_names,
+        ) in online_store_table_name_to_serving_names.items():
+            if sorted(online_store_serving_names) == primary_entity_serving_names:
+                required_online_store_tables.append(online_store_table_name)
+
+        return OnlineEnabledFeaturesMetadata(
+            features=online_enabled_features,
+            online_store_table_names=required_online_store_tables,
+            primary_entities=primary_entities,
+        )

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -1,0 +1,143 @@
+"""
+Tests for feature materialization service
+"""
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+import featurebyte as fb
+
+
+@pytest.fixture(name="features", scope="module")
+def features_fixture(event_table):
+    """
+    Fixture for feature
+    """
+    event_view = event_table.get_view()
+
+    # Feature saved but not deployed
+    feature_0 = event_view.groupby("ÜSER ID").aggregate_over(
+        "ÀMOUNT",
+        method="sum",
+        windows=["666h"],
+        feature_names=["EXTERNAL_FS_FEATURE_NOT_DEPLOYED"],
+    )
+    feature_0.save()
+
+    # Window aggregate feature
+    feature_1 = event_view.groupby("ÜSER ID").aggregate_over(
+        "ÀMOUNT",
+        method="sum",
+        windows=["24h"],
+        feature_names=["EXTERNAL_FS_AMOUNT_SUM_BY_USER_ID_24h"],
+    )["EXTERNAL_FS_AMOUNT_SUM_BY_USER_ID_24h"]
+
+    # Window aggregate feature with more post-processing
+    feature_2 = feature_1 * 100
+    feature_2.name = feature_1.name + "_TIMES_100"
+
+    # Feature with two entities
+    feature_3 = event_view.groupby("PRODUCT_ACTION").aggregate_over(
+        None,
+        method="count",
+        windows=["7d"],
+        feature_names=["temp"],
+    )["temp"]
+    feature_3 = feature_1 + feature_3
+    feature_3.name = "EXTERNAL_FS_COMPLEX_USER_X_PRODUCTION_ACTION_FEATURE"
+
+    # Save all features to be deployed
+    features = [feature_1, feature_2, feature_3]
+    for feature in features:
+        feature.save()
+        feature.update_readiness("PRODUCTION_READY")
+
+    return features
+
+
+@pytest.fixture(name="deployed_feature_list", scope="module")
+def deployed_features_list_fixture(features):
+    """
+    Fixture for deployed feature list
+    """
+    feature_list = fb.FeatureList(features, name="EXTERNAL_FS_FEATURE_LIST")
+    feature_list.save()
+    with patch(
+        "featurebyte.service.feature_manager.get_next_job_datetime",
+        return_value=pd.Timestamp("2001-01-02 12:00:00").to_pydatetime(),
+    ):
+        deployment = feature_list.deploy()
+        deployment.enable()
+    yield deployment
+    deployment.disable()
+
+
+@pytest.fixture(name="default_feature_job_setting")
+def default_feature_job_setting_fixture(event_table):
+    """
+    Fixture for default feature job setting
+    """
+    return event_table.default_feature_job_setting
+
+
+@pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
+@pytest.mark.asyncio
+async def test_feature_materialize_service(
+    app_container,
+    session,
+    user_entity,
+    product_action_entity,
+    default_feature_job_setting,
+    deployed_feature_list,
+):
+    """
+    Test FeatureMaterializeService
+    """
+    _ = deployed_feature_list
+
+    service = app_container.feature_materialize_service
+    materialized_features = await service.materialize_features(
+        session=session,
+        primary_entity_ids=[user_entity.id],
+        feature_job_setting=default_feature_job_setting,
+    )
+
+    # Check offline store table for user entity
+    df = await session.execute_query(
+        f"SELECT * FROM {materialized_features.materialized_table_name}"
+    )
+    expected = [
+        "üser id",
+        "EXTERNAL_FS_AMOUNT_SUM_BY_USER_ID_24h_TIMES_100",
+        "EXTERNAL_FS_AMOUNT_SUM_BY_USER_ID_24h",
+        "__EXTERNAL_FS_COMPLEX_USER_X_PRODUCTION_ACTION_FEATURE__part0",
+    ]
+    assert set(df.columns.tolist()) == set(expected)
+    assert set(materialized_features.names) == set(expected[1:])
+    assert df.shape[0] == 9
+
+    # Check offline store table for product_action entity
+    materialized_features = await service.materialize_features(
+        session=session,
+        primary_entity_ids=[product_action_entity.id],
+        feature_job_setting=default_feature_job_setting,
+    )
+    df = await session.execute_query(
+        f"SELECT * FROM {materialized_features.materialized_table_name}"
+    )
+    expected = [
+        "PRODUCT_ACTION",
+        "__EXTERNAL_FS_COMPLEX_USER_X_PRODUCTION_ACTION_FEATURE__part1",
+    ]
+    assert set(df.columns.tolist()) == set(expected)
+    assert set(materialized_features.names) == set(expected[1:])
+    assert df.shape[0] == 5
+
+    # Check offline store table for combined entity (nothing to materialise here)
+    materialized_features = await service.materialize_features(
+        session=session,
+        primary_entity_ids=[user_entity.id, product_action_entity.id],
+        feature_job_setting=default_feature_job_setting,
+    )
+    assert materialized_features is None

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -995,3 +995,11 @@ def mock_update_data_warehouse():
         "featurebyte.service.deploy.OnlineEnableService.update_data_warehouse"
     ) as mock_update_data_warehouse:
         yield mock_update_data_warehouse
+
+
+@pytest.fixture(name="feature_materialize_service")
+def feature_materialize_service_fixture(app_container):
+    """
+    Fixture for FeatureMaterializeService
+    """
+    return app_container.feature_materialize_service

--- a/tests/unit/service/test_feature_materialize.py
+++ b/tests/unit/service/test_feature_materialize.py
@@ -1,0 +1,124 @@
+"""
+Test FeatureMaterializeService
+"""
+from dataclasses import asdict
+
+import pytest
+import pytest_asyncio
+from bson import ObjectId
+
+from featurebyte import FeatureJobSetting
+from featurebyte.feature_manager.model import ExtendedFeatureModel
+from featurebyte.models.online_store import OnlineFeatureSpec
+
+
+async def create_online_store_compute_query(online_store_compute_query_service, feature_model):
+    """
+    Helper to create online store compute query since that step is skipped because of
+    mock_update_data_warehouse
+    """
+    extended_feature_model = ExtendedFeatureModel(**feature_model.dict(by_alias=True))
+    online_feature_spec = OnlineFeatureSpec(feature=extended_feature_model)
+    for query in online_feature_spec.precompute_queries:
+        await online_store_compute_query_service.create_document(query)
+
+
+@pytest_asyncio.fixture(name="deployed_feature_list")
+async def deployed_feature_list_fixture(
+    app_container, production_ready_feature_list, mock_update_data_warehouse
+):
+    """
+    Fixture for FeatureMaterializeService
+    """
+    _ = mock_update_data_warehouse
+    deployment_id = ObjectId()
+    await app_container.deploy_service.create_deployment(
+        feature_list_id=production_ready_feature_list.id,
+        deployment_id=deployment_id,
+        deployment_name=None,
+        to_enable_deployment=True,
+    )
+    for feature_id in production_ready_feature_list.feature_ids:
+        feature_model = await app_container.feature_service.get_document(
+            document_id=feature_id,
+        )
+        await create_online_store_compute_query(
+            app_container.online_store_compute_query_service, feature_model
+        )
+    deployment = await app_container.deployment_service.get_document(document_id=deployment_id)
+    deployed_feature_list = await app_container.feature_list_service.get_document(
+        document_id=deployment.feature_list_id
+    )
+    yield deployed_feature_list
+
+
+@pytest_asyncio.fixture(name="deployed_feature")
+async def deployed_feature_fixture(feature_service, deployed_feature_list):
+    """
+    Fixture for a deployed feature
+    """
+    return await feature_service.get_document(deployed_feature_list.feature_ids[0])
+
+
+@pytest.mark.asyncio
+async def test_materialize_features(
+    feature_materialize_service,
+    mock_snowflake_session,
+    deployed_feature,
+):
+    """
+    Test materialize_features
+    """
+    feature_job_setting = deployed_feature.table_id_feature_job_settings[0].feature_job_setting
+    materialized_features = await feature_materialize_service.materialize_features(
+        session=mock_snowflake_session,
+        primary_entity_ids=deployed_feature.primary_entity_ids,
+        feature_job_setting=feature_job_setting,
+    )
+    materialized_features_dict = asdict(materialized_features)
+    materialized_features_dict["materialized_table_name"], suffix = materialized_features_dict[
+        "materialized_table_name"
+    ].rsplit("_", 1)
+    assert suffix != ""
+    assert materialized_features_dict == {
+        "materialized_table_name": "TEMP_FEATURE_TABLE",
+        "names": ["sum_30m"],
+        "serving_names": ["cust_id"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_materialize_features__different_feature_job_setting(
+    feature_materialize_service,
+    mock_snowflake_session,
+    deployed_feature,
+):
+    """
+    Test materialize_features when no matching features are found
+    """
+    materialized_features = await feature_materialize_service.materialize_features(
+        session=mock_snowflake_session,
+        primary_entity_ids=deployed_feature.primary_entity_ids,
+        feature_job_setting=FeatureJobSetting(
+            blind_spot="1h", time_modulo_frequency="2h", frequency="3h"
+        ),
+    )
+    assert materialized_features is None
+
+
+@pytest.mark.asyncio
+async def test_materialize_features__different_primary_entity_ids(
+    feature_materialize_service,
+    mock_snowflake_session,
+    deployed_feature,
+):
+    """
+    Test materialize_features when no matching features are found
+    """
+    feature_job_setting = deployed_feature.table_id_feature_job_settings[0].feature_job_setting
+    materialized_features = await feature_materialize_service.materialize_features(
+        session=mock_snowflake_session,
+        primary_entity_ids=[ObjectId()],
+        feature_job_setting=feature_job_setting,
+    )
+    assert materialized_features is None


### PR DESCRIPTION
## Description

This implements FeatureMaterializeService to prepare features for publishing. It retrieves currently online enabled features that should be materialised together and generates a feature table to be published to offline store. The sql query to generate the feature table is derived from the ingest graphs.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
