### PR TITLE
[DEV-2714] Add dtype information in OfflineStoreIngestQueryGraph

### DIFF
--- a/featurebyte/service/feature_materialize.py
+++ b/featurebyte/service/feature_materialize.py
@@ -157,7 +157,7 @@ class MaterializedFeatures:
 
     materialized_table_name: str
     names: List[str]
-    physical_types: List[str]
+    data_types: List[str]
     serving_names: List[str]
 
 
@@ -261,7 +261,7 @@ class FeatureMaterializeService:
         return MaterializedFeatures(
             materialized_table_name=output_table_details.table_name,
             names=online_enabled_features_metadata.output_column_names,
-            physical_types=[
+            data_types=[
                 adapter.get_physical_type_from_dtype(dtype)
                 for dtype in online_enabled_features_metadata.output_dtypes
             ],

--- a/featurebyte/service/feature_materialize.py
+++ b/featurebyte/service/feature_materialize.py
@@ -11,6 +11,7 @@ from bson import ObjectId
 from sqlglot import expressions
 from sqlglot.expressions import Select, select
 
+from featurebyte.enum import DBVarType
 from featurebyte.models.entity import EntityModel
 from featurebyte.models.feature import FeatureModel
 from featurebyte.query_graph.graph import QueryGraph
@@ -38,6 +39,7 @@ class OfflineIngestGraphMetadata:
     graph: QueryGraph
     node_names: List[str]
     output_column_names: List[str]
+    output_dtypes: List[DBVarType]
 
 
 @dataclass
@@ -52,6 +54,7 @@ class OnlineEnabledFeaturesMetadata:
     primary_entities: List[EntityModel]
     ingest_graph_and_node_names: Tuple[QueryGraph, List[str]] = field(init=False)
     output_column_names: List[str] = field(init=False)
+    output_dtypes: List[DBVarType] = field(init=False)
 
     def __post_init__(self) -> None:
         ingest_graph_metadata = self._get_combined_ingest_graph()
@@ -60,6 +63,7 @@ class OnlineEnabledFeaturesMetadata:
             ingest_graph_metadata.node_names,
         )
         self.output_column_names = ingest_graph_metadata.output_column_names
+        self.output_dtypes = ingest_graph_metadata.output_dtypes
 
     @property
     def serving_names(self) -> List[str]:
@@ -121,6 +125,7 @@ class OnlineEnabledFeaturesMetadata:
         local_query_graph = QueryGraph()
         output_nodes = []
         output_column_names = []
+        output_dtypes = []
 
         for feature in self.features:
             offline_ingest_graphs = feature.extract_offline_store_ingest_query_graphs()
@@ -134,11 +139,13 @@ class OnlineEnabledFeaturesMetadata:
                 local_query_graph, local_name_map = local_query_graph.load(graph)
                 output_nodes.append(local_query_graph.get_node_by_name(local_name_map[node.name]))
                 output_column_names.append(offline_ingest_graph.output_column_name)
+                output_dtypes.append(offline_ingest_graph.output_dtype)
 
         return OfflineIngestGraphMetadata(
             graph=local_query_graph,
             node_names=[node.name for node in output_nodes],
             output_column_names=output_column_names,
+            output_dtypes=output_dtypes,
         )
 
 
@@ -150,6 +157,7 @@ class MaterializedFeatures:
 
     materialized_table_name: str
     names: List[str]
+    physical_types: List[str]
     serving_names: List[str]
 
 
@@ -253,6 +261,10 @@ class FeatureMaterializeService:
         return MaterializedFeatures(
             materialized_table_name=output_table_details.table_name,
             names=online_enabled_features_metadata.output_column_names,
+            physical_types=[
+                adapter.get_physical_type_from_dtype(dtype)
+                for dtype in online_enabled_features_metadata.output_dtypes
+            ],
             serving_names=online_enabled_features_metadata.serving_names,
         )
 

--- a/tests/unit/service/test_feature_materialize.py
+++ b/tests/unit/service/test_feature_materialize.py
@@ -83,6 +83,7 @@ async def test_materialize_features(
     assert materialized_features_dict == {
         "materialized_table_name": "TEMP_FEATURE_TABLE",
         "names": ["sum_30m"],
+        "physical_types": ["FLOAT"],
         "serving_names": ["cust_id"],
     }
 

--- a/tests/unit/service/test_feature_materialize.py
+++ b/tests/unit/service/test_feature_materialize.py
@@ -83,7 +83,7 @@ async def test_materialize_features(
     assert materialized_features_dict == {
         "materialized_table_name": "TEMP_FEATURE_TABLE",
         "names": ["sum_30m"],
-        "physical_types": ["FLOAT"],
+        "data_types": ["FLOAT"],
         "serving_names": ["cust_id"],
     }
 


### PR DESCRIPTION
## Description

This updates OfflineStoreIngestQueryGraph to include dtype information of the output column.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
