### PR TITLE
[DEV-2734] Add fb.UserDefinedFunction.get to docs

### DIFF
--- a/featurebyte/api/user_defined_function.py
+++ b/featurebyte/api/user_defined_function.py
@@ -347,7 +347,7 @@ class UserDefinedFunction(DeletableApiObject, SavableApiObject):
     @classmethod
     def get(cls, name: str) -> UserDefinedFunction:
         """
-        Gets a UserDefinedFunction object by its name.
+        Get a UserDefinedFunction object by its name.
 
         Parameters
         ----------

--- a/featurebyte/api/user_defined_function.py
+++ b/featurebyte/api/user_defined_function.py
@@ -344,6 +344,29 @@ class UserDefinedFunction(DeletableApiObject, SavableApiObject):
         user_defined_function.save()
         return user_defined_function
 
+    @classmethod
+    def get(cls, name: str) -> UserDefinedFunction:
+        """
+        Gets a UserDefinedFunction object by its name.
+
+        Parameters
+        ----------
+        name: str
+            Name of the UserDefinedFunction to retrieve.
+
+        Returns
+        -------
+        UserDefinedFunction
+            UserDefinedFunction object.
+
+        Examples
+        --------
+        Get a UserDefinedFunction object that is already created.
+
+        >>> udf = fb.UserDefinedFunction.get("cos")  # doctest: +SKIP
+        """
+        return super().get(name)
+
     @typechecked
     def update_sql_function_name(self, sql_function_name: str) -> None:
         """

--- a/featurebyte/common/documentation/documentation_layout.py
+++ b/featurebyte/common/documentation/documentation_layout.py
@@ -1023,6 +1023,7 @@ def _get_user_defined_function_layout() -> List[DocLayoutItem]:
     return [
         DocLayoutItem([USER_DEFINED_FUNCTION]),
         DocLayoutItem([USER_DEFINED_FUNCTION, CLASS_METHODS, "UserDefinedFunction.create"]),
+        DocLayoutItem([USER_DEFINED_FUNCTION, CLASS_METHODS, "UserDefinedFunction.get"]),
         DocLayoutItem([USER_DEFINED_FUNCTION, INFO, "UserDefinedFunction.created_at"]),
         DocLayoutItem([USER_DEFINED_FUNCTION, INFO, "UserDefinedFunction.info"]),
         DocLayoutItem([USER_DEFINED_FUNCTION, INFO, "UserDefinedFunction.name"]),


### PR DESCRIPTION
## Description

Add fb.UserDefinedFunction.get to docs

## Related Issue

[DEV-2734](https://featurebyte.atlassian.net/browse/DEV-2734)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly


[DEV-2734]: https://featurebyte.atlassian.net/browse/DEV-2734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ