### PR TITLE
[DEV-2665] Ban SCD surrogate keys from entity tagging

### DIFF
--- a/featurebyte/exception.py
+++ b/featurebyte/exception.py
@@ -466,3 +466,10 @@ class UnsupportedObservationTableUploadFileFormat(BaseUnprocessableEntityError):
     """
     Raise when the file format for observation table upload is not supported
     """
+
+
+class EntityTaggingIsNotAllowedError(BaseUnprocessableEntityError):
+    """ "
+    Raise when entity tagging is not allowed for a specific columns,
+    for example scd surrogate key
+    """

--- a/featurebyte/routes/common/base_table.py
+++ b/featurebyte/routes/common/base_table.py
@@ -8,7 +8,7 @@ from typing import Any, List, Optional, Tuple, Type, TypeVar, cast
 from bson.objectid import ObjectId
 
 from featurebyte.enum import SemanticType
-from featurebyte.exception import ColumnNotFoundError
+from featurebyte.exception import ColumnNotFoundError, EntityTaggingIsNotAllowedError
 from featurebyte.models.dimension_table import DimensionTableModel
 from featurebyte.models.event_table import EventTableModel
 from featurebyte.models.item_table import ItemTableModel
@@ -258,6 +258,16 @@ class BaseTableDocumentController(
         TableDocumentT
             Table object with updated entity
         """
+        document = await self.service.get_document(document_id=document_id)
+
+        col_info = [col for col in document.columns_info if col.name == column_name]
+        if col_info and col_info[0].semantic_id:
+            semantic = await self.semantic_service.get_document(document_id=col_info[0].semantic_id)
+            if semantic and semantic.name == SemanticType.SCD_SURROGATE_KEY_ID.value:
+                raise EntityTaggingIsNotAllowedError(
+                    f"Column {column_name} cannot be tagged with entity {entity_id}"
+                )
+
         return await self.update_table_columns_info(
             document_id=document_id,
             column_name=column_name,

--- a/featurebyte/routes/common/base_table.py
+++ b/featurebyte/routes/common/base_table.py
@@ -265,7 +265,7 @@ class BaseTableDocumentController(
             semantic = await self.semantic_service.get_document(document_id=col_info[0].semantic_id)
             if semantic and semantic.name == SemanticType.SCD_SURROGATE_KEY_ID.value:
                 raise EntityTaggingIsNotAllowedError(
-                    f"Column {column_name} cannot be tagged with entity {entity_id}"
+                    f"Surrogate key column {column_name} cannot be tagged as entity"
                 )
 
         return await self.update_table_columns_info(

--- a/tests/fixtures/sdk_code/scd_view_aggregate_asat.py
+++ b/tests/fixtures/sdk_code/scd_view_aggregate_asat.py
@@ -8,7 +8,7 @@ scd_view = scd_table.get_view(
     drop_column_names=["is_active"],
     column_cleaning_operations=[],
 )
-feat = scd_view.groupby(by_keys=["col_int"], category=None).aggregate_asat(
+feat = scd_view.groupby(by_keys=["cust_id"], category=None).aggregate_asat(
     value_column="col_float",
     method="max",
     feature_name="col_float_max",

--- a/tests/unit/api/test_aggregate_asat.py
+++ b/tests/unit/api/test_aggregate_asat.py
@@ -22,7 +22,7 @@ def scd_view_with_entity(snowflake_scd_table, entity_col_int):
     """
     Entity(name="col_text_entity", serving_names=["col_text"]).save()
     snowflake_scd_table["col_text"].as_entity("col_text_entity")
-    snowflake_scd_table["col_int"].as_entity("col_int_entity")
+    snowflake_scd_table["cust_id"].as_entity("col_int_entity")
     return snowflake_scd_table.get_view()
 
 
@@ -30,7 +30,7 @@ def test_aggregate_asat__valid(scd_view_with_entity, snowflake_scd_table, entity
     """
     Test valid usage of aggregate_asat
     """
-    feature = scd_view_with_entity.groupby("col_int").aggregate_asat(
+    feature = scd_view_with_entity.groupby("cust_id").aggregate_asat(
         value_column="col_float", method="sum", feature_name="asat_feature"
     )
     assert isinstance(feature, Feature)
@@ -48,23 +48,23 @@ def test_aggregate_asat__valid(scd_view_with_entity, snowflake_scd_table, entity
     asat_node_dict = get_node(graph_dict, "aggregate_as_at_1")
     assert asat_node_dict == {
         "name": "aggregate_as_at_1",
-        "type": "aggregate_as_at",
         "output_type": "frame",
         "parameters": {
-            "effective_timestamp_column": "effective_timestamp",
-            "natural_key_column": "col_text",
-            "current_flag_column": "is_active",
-            "end_timestamp_column": "end_timestamp",
-            "keys": ["col_int"],
-            "parent": "col_float",
             "agg_func": "sum",
-            "value_by": None,
-            "serving_names": ["col_int"],
-            "entity_ids": [entity_col_int.id],
-            "name": "asat_feature",
-            "offset": None,
             "backward": True,
+            "current_flag_column": "is_active",
+            "effective_timestamp_column": "effective_timestamp",
+            "end_timestamp_column": "end_timestamp",
+            "entity_ids": [entity_col_int.id],
+            "keys": ["cust_id"],
+            "name": "asat_feature",
+            "natural_key_column": "col_text",
+            "offset": None,
+            "parent": "col_float",
+            "serving_names": ["col_int"],
+            "value_by": None,
         },
+        "type": "aggregate_as_at",
     }
     assert graph_dict["edges"] == [
         {"source": "input_1", "target": "graph_1"},
@@ -94,7 +94,7 @@ def test_aggregate_asat__method_required(scd_view_with_entity):
     Test method parameter is required
     """
     with pytest.raises(ValueError) as exc:
-        scd_view_with_entity.groupby("col_int").aggregate_asat(
+        scd_view_with_entity.groupby("cust_id").aggregate_asat(
             value_column="col_float", feature_name="asat_feature"
         )
     assert str(exc.value) == "method is required"
@@ -105,7 +105,7 @@ def test_aggregate_asat__feature_name_required(scd_view_with_entity):
     Test feature_name parameter is required
     """
     with pytest.raises(ValueError) as exc:
-        scd_view_with_entity.groupby("col_int").aggregate_asat(
+        scd_view_with_entity.groupby("cust_id").aggregate_asat(
             value_column="col_float", feature_name="asat_feature"
         )
     assert str(exc.value) == "method is required"
@@ -116,7 +116,7 @@ def test_aggregate_asat__latest_not_supported(scd_view_with_entity):
     Test using "latest" method is not supported
     """
     with pytest.raises(ValueError) as exc:
-        scd_view_with_entity.groupby("col_int").aggregate_asat(
+        scd_view_with_entity.groupby("cust_id").aggregate_asat(
             value_column="col_float", method="latest", feature_name="asat_feature"
         )
     assert str(exc.value) == "latest aggregation method is not supported for aggregated_asat"
@@ -138,7 +138,7 @@ def test_aggregate_asat__invalid_offset_string(scd_view_with_entity):
     Test offset string is validated
     """
     with pytest.raises(ValueError) as exc:
-        scd_view_with_entity.groupby("col_int").aggregate_asat(
+        scd_view_with_entity.groupby("cust_id").aggregate_asat(
             value_column="col_float", method="sum", feature_name="asat_feature", offset="yesterday"
         )
     assert "Failed to parse the offset parameter" in str(exc.value)
@@ -149,7 +149,7 @@ def test_aggregate_asat__offset_not_implemented(scd_view_with_entity):
     Test offset support not yet implemented
     """
     with pytest.raises(NotImplementedError) as exc:
-        scd_view_with_entity.groupby("col_int").aggregate_asat(
+        scd_view_with_entity.groupby("cust_id").aggregate_asat(
             value_column="col_float", method="sum", feature_name="asat_feature", offset="7d"
         )
     assert str(exc.value) == "offset support is not yet implemented"

--- a/tests/unit/api/test_change_view.py
+++ b/tests/unit/api/test_change_view.py
@@ -327,51 +327,51 @@ def test_get_change_view__check_entity_id(snowflake_scd_table):
 
     snowflake_scd_table[snowflake_scd_table.natural_key_column].as_entity("key_column")
     snowflake_scd_table[snowflake_scd_table.effective_timestamp_column].as_entity("eff_timestamp")
-    snowflake_scd_table.col_int.as_entity("change")
+    snowflake_scd_table.col_float.as_entity("change")
 
     # create change view
-    change_view = snowflake_scd_table.get_change_view("col_int")
+    change_view = snowflake_scd_table.get_change_view("col_float")
     columns_info_dict = change_view.dict()["columns_info"]
     assert columns_info_dict == [
         {
             "critical_data_info": None,
+            "description": None,
             "dtype": "VARCHAR",
             "entity_id": entity_key.id,
             "name": "col_text",
             "semantic_id": columns_info_dict[0]["semantic_id"],
-            "description": None,
         },
         {
             "critical_data_info": None,
+            "description": None,
             "dtype": "TIMESTAMP_TZ",
             "entity_id": entity_eff_ts.id,
             "name": "new_effective_timestamp",
             "semantic_id": columns_info_dict[1]["semantic_id"],
-            "description": None,
         },
         {
             "critical_data_info": None,
+            "description": None,
             "dtype": "TIMESTAMP_TZ",
             "entity_id": None,
             "name": "past_effective_timestamp",
             "semantic_id": None,
-            "description": None,
         },
         {
             "critical_data_info": None,
-            "dtype": "INT",
+            "description": None,
+            "dtype": "FLOAT",
             "entity_id": entity_change.id,
-            "name": "new_col_int",
+            "name": "new_col_float",
             "semantic_id": columns_info_dict[3]["semantic_id"],
-            "description": None,
         },
         {
             "critical_data_info": None,
-            "dtype": "INT",
-            "entity_id": None,
-            "name": "past_col_int",
-            "semantic_id": None,
             "description": None,
+            "dtype": "FLOAT",
+            "entity_id": None,
+            "name": "past_col_float",
+            "semantic_id": None,
         },
     ]
 

--- a/tests/unit/api/test_scd_view.py
+++ b/tests/unit/api/test_scd_view.py
@@ -280,9 +280,9 @@ def test_sdk_code_generation(saved_scd_table, update_fixtures):
 
 def test_aggregate_asat_sdk_code_generation(saved_scd_table, transaction_entity, update_fixtures):
     """Test SDK code generation for aggregate asat"""
-    saved_scd_table.col_int.as_entity(transaction_entity.name)
+    saved_scd_table.cust_id.as_entity(transaction_entity.name)
     snowflake_scd_view = saved_scd_table.get_view()
-    feature = snowflake_scd_view.groupby(by_keys=["col_int"]).aggregate_asat(
+    feature = snowflake_scd_view.groupby(by_keys=["cust_id"]).aggregate_asat(
         value_column="col_float", method="max", feature_name="col_float_max"
     )
     check_sdk_code_generation(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1399,13 +1399,11 @@ def multiple_scd_joined_feature_fixture(
     snowflake_event_table_with_entity,
     snowflake_scd_table,
     snowflake_scd_table_state_map,
-    cust_id_entity,
 ):
     """
     Feature that is built from multiple SCD tables joined with event table
     """
     col_boolean_entity = Entity.create("col_boolean", serving_names=["col_boolean"])
-    snowflake_scd_table.col_int.as_entity(cust_id_entity.name)
     snowflake_scd_table.col_boolean.as_entity(col_boolean_entity.name)
 
     state_code_entity = Entity.create("state_code", serving_names=["state_code"])

--- a/tests/unit/routes/test_scd_table.py
+++ b/tests/unit/routes/test_scd_table.py
@@ -131,6 +131,27 @@ class TestSCDTableApi(BaseTableApiTestSuite):
         }
 
     @pytest.mark.asyncio
+    async def test_surrogate_key_cannot_be_tagged_as_entity(
+        self, test_api_client_persistent, create_success_response
+    ):
+        """test tag surrogate key as entity"""
+        test_api_client, _ = test_api_client_persistent
+        create_response_dict = create_success_response.json()
+        assert create_response_dict["surrogate_key_column"] == "col_int"
+
+        entity_payload = self.load_payload("tests/fixtures/request_payloads/entity.json")
+        table_id = create_response_dict["_id"]
+
+        response = test_api_client.patch(
+            f"{self.base_route}/{table_id}/column_entity",
+            json={
+                "column_name": "col_int",
+                "entity_id": entity_payload["_id"],
+            },
+        )
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.text
+
+    @pytest.mark.asyncio
     async def test_get_info_200(self, test_api_client_persistent, create_success_response):
         """Test retrieve info"""
         test_api_client, _ = test_api_client_persistent


### PR DESCRIPTION
## Description

Ban SCD surrogate keys from entity tagging

## Related Issue

[DEV-2665](https://featurebyte.atlassian.net/browse/DEV-2665)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly


[DEV-2665]: https://featurebyte.atlassian.net/browse/DEV-2665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ