### PR TITLE
[DEV-2770] Trigger feature columns initialization in OfflineStoreFeatureTableManagerService

### DIFF
--- a/featurebyte/service/offline_store_feature_table_manager.py
+++ b/featurebyte/service/offline_store_feature_table_manager.py
@@ -18,8 +18,11 @@ from featurebyte.models.offline_store_feature_table import (
 from featurebyte.models.offline_store_ingest_query import OfflineStoreIngestQueryGraph
 from featurebyte.service.entity import EntityService
 from featurebyte.service.feature import FeatureService
+from featurebyte.service.feature_materialize import FeatureMaterializeService
+from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.service.offline_store_feature_table import OfflineStoreFeatureTableService
 from featurebyte.service.online_store_compute_query_service import OnlineStoreComputeQueryService
+from featurebyte.service.session_manager import SessionManagerService
 
 
 class OfflineStoreFeatureTableManagerService:
@@ -33,11 +36,17 @@ class OfflineStoreFeatureTableManagerService:
         feature_service: FeatureService,
         online_store_compute_query_service: OnlineStoreComputeQueryService,
         entity_service: EntityService,
+        feature_materialize_service: FeatureMaterializeService,
+        feature_store_service: FeatureStoreService,
+        session_manager_service: SessionManagerService,
     ):
         self.offline_store_feature_table_service = offline_store_feature_table_service
         self.feature_service = feature_service
         self.online_store_compute_query_service = online_store_compute_query_service
         self.entity_service = entity_service
+        self.feature_materialize_service = feature_materialize_service
+        self.feature_store_service = feature_store_service
+        self.session_manager_service = session_manager_service
 
     async def handle_online_enabled_feature(self, feature: FeatureModel) -> None:
         """
@@ -65,18 +74,24 @@ class OfflineStoreFeatureTableManagerService:
 
         offline_store_info = feature.offline_store_info
         assert offline_store_info is not None, "Offline store info should not be None"
-
         offline_ingest_graphs = offline_store_info.extract_offline_store_ingest_query_graphs()
+        session = None
+
         for offline_ingest_graph in offline_ingest_graphs:
             feature_table_dict = await self._get_compatible_existing_feature_table(
                 offline_ingest_graph=offline_ingest_graph
             )
+
             if feature_table_dict is not None:
                 # update existing table
                 feature_ids = feature_table_dict["feature_ids"][:]
                 if feature.id not in feature_ids:
                     feature_ids.append(feature.id)
-                    await self._update_offline_store_feature_table(feature_table_dict, feature_ids)
+                    feature_table_model = await self._update_offline_store_feature_table(
+                        feature_table_dict, feature_ids
+                    )
+                else:
+                    feature_table_model = None
             else:
                 # create new table
                 feature_table_model = await self._construct_offline_store_feature_table_model(
@@ -87,6 +102,18 @@ class OfflineStoreFeatureTableManagerService:
                     feature_job_setting=offline_ingest_graph.feature_job_setting,
                 )
                 await self.offline_store_feature_table_service.create_document(feature_table_model)
+
+            if feature_table_model is not None:
+                if session is None:
+                    feature_store = await self.feature_store_service.get_document(
+                        document_id=feature_table_model.feature_cluster.feature_store_id
+                    )
+                    session = await self.session_manager_service.get_feature_store_session(
+                        feature_store
+                    )
+                await self.feature_materialize_service.initialize_new_columns(
+                    session, feature_table_model
+                )
 
     async def handle_online_disabled_feature(self, feature: FeatureModel) -> None:
         """
@@ -131,7 +158,7 @@ class OfflineStoreFeatureTableManagerService:
 
     async def _update_offline_store_feature_table(
         self, feature_table_dict: Dict[str, Any], updated_feature_ids: List[ObjectId]
-    ) -> None:
+    ) -> OfflineStoreFeatureTableModel:
         feature_table_model = await self._construct_offline_store_feature_table_model(
             feature_table_name=feature_table_dict["name"],
             feature_ids=updated_feature_ids,
@@ -140,7 +167,7 @@ class OfflineStoreFeatureTableManagerService:
             feature_job_setting=FeatureJobSetting(**feature_table_dict["feature_job_setting"]),
         )
         update_schema = OfflineStoreFeatureTableUpdate(**feature_table_model.dict())
-        await self.offline_store_feature_table_service.update_document(
+        return await self.offline_store_feature_table_service.update_document(
             document_id=feature_table_dict["_id"], data=update_schema
         )
 

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -144,10 +144,7 @@ async def test_feature_materialize_service(
     # Check offline store table for user entity
     service = app_container.feature_materialize_service
     feature_table_model = primary_entity_to_feature_table[(user_entity.id,)]
-    await service.scheduled_materialize_features(
-        session=session,
-        feature_table_model=feature_table_model,
-    )
+    await service.scheduled_materialize_features(feature_table_model=feature_table_model)
     df = await session.execute_query(f'SELECT * FROM "{feature_table_model.name}"')
     expected = [
         "__feature_timestamp",
@@ -162,10 +159,7 @@ async def test_feature_materialize_service(
     assert df["üser id"].isnull().sum() == 0
 
     # Materialize one more time
-    await service.scheduled_materialize_features(
-        session=session,
-        feature_table_model=feature_table_model,
-    )
+    await service.scheduled_materialize_features(feature_table_model=feature_table_model)
     df = await session.execute_query(f'SELECT * FROM "{feature_table_model.name}"')
     assert df.shape[0] == 27
     assert df["__feature_timestamp"].nunique() == 3

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -73,7 +73,7 @@ def deployed_features_list_fixture(features):
     deployment.disable()
 
 
-async def register_offline_store_feature_tables(app_container, session, features):
+async def register_offline_store_feature_tables(app_container, features):
     """
     Register offline store feature tables
     """
@@ -81,12 +81,6 @@ async def register_offline_store_feature_tables(app_container, session, features
         await app_container.offline_store_feature_table_manager_service.handle_online_enabled_feature(
             await app_container.feature_service.get_document(feature.id)
         )
-        async for feature_table_model in app_container.offline_store_feature_table_service.list_documents_iterator(
-            query_filter={"feature_ids": feature.id},
-        ):
-            await app_container.feature_materialize_service.initialize_new_columns(
-                session=session, feature_table_model=feature_table_model
-            )
 
 
 @pytest.fixture(name="default_feature_job_setting")
@@ -130,7 +124,7 @@ async def test_feature_materialize_service(
     """
     _ = deployed_feature_list
 
-    await register_offline_store_feature_tables(app_container, session, features)
+    await register_offline_store_feature_tables(app_container, features)
 
     primary_entity_to_feature_table = {}
     async for feature_table in app_container.offline_store_feature_table_service.list_documents_iterator(

--- a/tests/unit/service/test_feature_materialize.py
+++ b/tests/unit/service/test_feature_materialize.py
@@ -31,7 +31,7 @@ def mock_get_feature_store_session_fixture(mock_snowflake_session):
     Patch get_feature_store_session to return a mock session
     """
     with patch(
-        "featurebyte.service.offline_store_feature_table_manager.SessionManagerService.get_feature_store_session",
+        "featurebyte.service.feature_materialize.SessionManagerService.get_feature_store_session",
     ) as patched_get_feature_store_session:
         patched_get_feature_store_session.return_value = mock_snowflake_session
         yield patched_get_feature_store_session
@@ -42,13 +42,11 @@ async def deployed_feature_list_fixture(
     app_container,
     production_ready_feature_list,
     mock_update_data_warehouse,
-    mock_get_feature_store_session,
 ):
     """
     Fixture for FeatureMaterializeService
     """
     _ = mock_update_data_warehouse
-    _ = mock_get_feature_store_session
 
     deployment_id = ObjectId()
     await app_container.deploy_service.create_deployment(
@@ -118,6 +116,7 @@ def extract_session_executed_queries(mock_snowflake_session, func="execute_query
     return "\n\n".join(queries)
 
 
+@pytest.mark.usefixtures("mock_get_feature_store_session")
 @pytest.mark.asyncio
 async def test_materialize_features(
     feature_materialize_service,
@@ -129,7 +128,6 @@ async def test_materialize_features(
     Test materialize_features
     """
     async with feature_materialize_service.materialize_features(
-        session=mock_snowflake_session,
         feature_table_model=offline_store_feature_table,
     ) as materialized_features:
         pass
@@ -172,6 +170,7 @@ async def test_materialize_features(
     ]
 
 
+@pytest.mark.usefixtures("mock_get_feature_store_session")
 @pytest.mark.asyncio
 async def test_scheduled_materialize_features(
     feature_materialize_service,
@@ -182,10 +181,7 @@ async def test_scheduled_materialize_features(
     """
     Test scheduled_materialize_features
     """
-    await feature_materialize_service.scheduled_materialize_features(
-        mock_snowflake_session,
-        offline_store_feature_table,
-    )
+    await feature_materialize_service.scheduled_materialize_features(offline_store_feature_table)
 
     executed_queries = extract_session_executed_queries(mock_snowflake_session, "execute_query")
     assert_equal_with_expected_fixture(
@@ -195,6 +191,7 @@ async def test_scheduled_materialize_features(
     )
 
 
+@pytest.mark.usefixtures("mock_get_feature_store_session")
 @pytest.mark.asyncio
 async def test_initialize_new_columns__table_does_not_exist(
     feature_materialize_service,
@@ -213,10 +210,7 @@ async def test_initialize_new_columns__table_does_not_exist(
     mock_snowflake_session.execute_query.side_effect = mock_execute_query
     mock_snowflake_session._no_schema_error = ValueError
 
-    await feature_materialize_service.initialize_new_columns(
-        mock_snowflake_session,
-        offline_store_feature_table,
-    )
+    await feature_materialize_service.initialize_new_columns(offline_store_feature_table)
     queries = extract_session_executed_queries(mock_snowflake_session, "execute_query")
     assert_equal_with_expected_fixture(
         queries,
@@ -225,6 +219,7 @@ async def test_initialize_new_columns__table_does_not_exist(
     )
 
 
+@pytest.mark.usefixtures("mock_get_feature_store_session")
 @pytest.mark.asyncio
 async def test_initialize_new_columns__table_exists(
     feature_materialize_service,
@@ -248,10 +243,7 @@ async def test_initialize_new_columns__table_exists(
     mock_snowflake_session.list_table_schema.side_effect = mock_list_table_schema
     mock_snowflake_session.execute_query.side_effect = mock_execute_query
 
-    await feature_materialize_service.initialize_new_columns(
-        mock_snowflake_session,
-        offline_store_feature_table,
-    )
+    await feature_materialize_service.initialize_new_columns(offline_store_feature_table)
     queries = extract_session_executed_queries(mock_snowflake_session, "execute_query")
     assert_equal_with_expected_fixture(
         queries,


### PR DESCRIPTION
## Description

This updates OfflineStoreFeatureTableManagerService to trigger feature columns initialization using FeatureMaterializeService when handling online enabled features.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
