### PR TITLE
[DEV-2784] Fix SDK code generation bug when the column name contains quote

### DIFF
--- a/.changelog/DEV-2784.yaml
+++ b/.changelog/DEV-2784.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fixes a bug where the feature saving would fail if the feature or colum name contains quotes."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/query_graph/node/utils.py
+++ b/featurebyte/query_graph/node/utils.py
@@ -1,0 +1,61 @@
+"""
+Utility functions for query graph node module
+"""
+from typing import List
+
+
+def subset_frame_column_expr(frame_name: str, column_name: str) -> str:
+    """
+    Subset frame column expression
+
+    Parameters
+    ----------
+    frame_name: str
+        Frame name
+    column_name: str
+        Column name
+
+    Returns
+    -------
+    str
+        Subset frame column expression
+    """
+    return f"{frame_name}[{repr(column_name)}]"
+
+
+def subset_frame_columns_expr(frame_name: str, column_names: List[str]) -> str:
+    """
+    Subset frame columns expression
+
+    Parameters
+    ----------
+    frame_name: str
+        Frame column
+    column_names: List[str]
+        Column names
+
+    Returns
+    -------
+    str
+        Subset frame columns expression
+    """
+    return f"{frame_name}[{repr(column_names)}]"
+
+
+def filter_series_or_frame_expr(series_or_frame_name: str, filter_expression: str) -> str:
+    """
+    Filter series or frame expression
+
+    Parameters
+    ----------
+    series_or_frame_name: str
+        Series or frame name
+    filter_expression: str
+        Filter expression
+
+    Returns
+    -------
+    str
+        Filter series or frame expression
+    """
+    return f"{series_or_frame_name}[{filter_expression}]"

--- a/tests/unit/query_graph/test_node_utils.py
+++ b/tests/unit/query_graph/test_node_utils.py
@@ -1,0 +1,74 @@
+"""
+Unit tests for the node/utils module.
+"""
+import pandas as pd
+import pytest
+
+from featurebyte.query_graph.node.utils import (
+    filter_series_or_frame_expr,
+    subset_frame_column_expr,
+    subset_frame_columns_expr,
+)
+
+
+@pytest.mark.parametrize(
+    "frame_name, column_name, expected_expression",
+    [
+        ("df", "col", "df['col']"),
+        ("df", "col name", "df['col name']"),
+        ("df", "col's name", 'df["col\'s name"]'),
+        ("df", 'col"s name', "df['col\"s name']"),
+    ],
+)
+def test_subset_frame_column_expression(frame_name, column_name, expected_expression):
+    """Test subset_frame_column_expression function"""
+    df = pd.DataFrame()
+    df[column_name] = [1, 2, 3]
+    expr = subset_frame_column_expr(frame_name, column_name)
+    assert expr == expected_expression
+
+    # evaluate the expression to get the column
+    col = eval(expr)
+    assert col.tolist() == [1, 2, 3]
+
+
+@pytest.mark.parametrize(
+    "frame_name, column_names, expected_expression",
+    [
+        ("df", ["col1", "col2"], "df[['col1', 'col2']]"),
+        ("df", ["col1 name", "col2 name"], "df[['col1 name', 'col2 name']]"),
+        ("df", ["col1's name", "col2's name"], 'df[["col1\'s name", "col2\'s name"]]'),
+        ("df", ['col1"s name', 'col2"s name'], "df[['col1\"s name', 'col2\"s name']]"),
+    ],
+)
+def test_subset_frame_columns_expression(frame_name, column_names, expected_expression):
+    """Test subset_frame_columns_expression function"""
+    df = pd.DataFrame()
+    for col_name in column_names:
+        df[col_name] = [1, 2, 3]
+    expr = subset_frame_columns_expr(frame_name, column_names)
+    assert expr == expected_expression
+
+    # evaluate the expression to get the columns
+    cols = eval(expr)
+    pd.testing.assert_frame_equal(cols, df[column_names])
+
+
+@pytest.mark.parametrize(
+    "frame_name, filter_expression, expected_expression",
+    [
+        ("df", "mask", "df[mask]"),
+        ("df", 'df["col"] > 0', 'df[df["col"] > 0]'),
+        ("df", '(df["col"] > 0) & (df["col"] < 10)', 'df[(df["col"] > 0) & (df["col"] < 10)]'),
+    ],
+)
+def test_filter_series_or_frame_expression(frame_name, filter_expression, expected_expression):
+    """Test filter_series_or_frame_expression function"""
+    df = pd.DataFrame({"col": [1, 2, 3]})
+    mask = pd.Series([True, False, True])
+    expr = filter_series_or_frame_expr(frame_name, filter_expression)
+    assert expr == expected_expression
+    _ = df, mask
+
+    # check that the expression can be evaluated
+    _ = eval(expr)


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
This PR fixes SDK code generation bug due to SDK expression not constructed properly when the column or feature name contains quote.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
