### PR TITLE
[DEV-2801] inherit purpose when creating observation table

### DIFF
--- a/featurebyte/worker/task/target_table.py
+++ b/featurebyte/worker/task/target_table.py
@@ -3,10 +3,10 @@ TargetTable creation task
 """
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 from featurebyte.logging import get_logger
-from featurebyte.models.observation_table import ObservationTableModel
+from featurebyte.models.observation_table import ObservationTableModel, Purpose
 from featurebyte.routes.common.derive_primary_entity_helper import DerivePrimaryEntityHelper
 from featurebyte.schema.target import ComputeTargetRequest
 from featurebyte.schema.worker.task.target_table import TargetTableTaskPayload
@@ -94,6 +94,10 @@ class TargetTableTask(DataWarehouseMixin, BaseTask[TargetTableTaskPayload]):
                 )
             )
 
+            purpose: Optional[Purpose] = None
+            if isinstance(observation_set, ObservationTableModel):
+                purpose = observation_set.purpose
+
             observation_table = ObservationTableModel(
                 _id=payload.output_document_id,
                 user_id=payload.user_id,
@@ -102,6 +106,7 @@ class TargetTableTask(DataWarehouseMixin, BaseTask[TargetTableTaskPayload]):
                 context_id=payload.context_id,
                 request_input=payload.request_input,
                 primary_entity_ids=primary_entity_ids,
+                purpose=purpose,
                 **additional_metadata,
             )
             await self.observation_table_service.create_document(observation_table)


### PR DESCRIPTION
## Description

inherit purpose when creating observation table

## Related Issue

[DEV-2801](https://featurebyte.atlassian.net/browse/DEV-2801)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly


[DEV-2801]: https://featurebyte.atlassian.net/browse/DEV-2801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ