### PR TITLE
[chore] Fix hanging tests due to interactions between alive_bar and logging

### DIFF
--- a/featurebyte/api/api_object_util.py
+++ b/featurebyte/api/api_object_util.py
@@ -63,7 +63,6 @@ class ProgressThread(threading.Thread):
         with Configurations().get_websocket_client(task_id=self.task_id) as websocket_client:
             try:
                 while True:
-                    logger.debug("Waiting for websocket message")
                     message = websocket_client.receive_json()
                     # socket closed
                     if not message:
@@ -79,7 +78,7 @@ class ProgressThread(threading.Thread):
                             break
                         self.progress_bar(percent / 100)  # pylint: disable=not-callable
             finally:
-                logger.debug("Progress tracking ended.")
+                pass
 
     def get_id(self) -> Optional[int]:
         """

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -269,7 +269,6 @@ async def test_feature_table_two_features_deployed(
     )
 
 
-@pytest.mark.skip(reason="This test sometimes hangs. Skip for now to unblock CI.")
 @pytest.mark.asyncio
 async def test_feature_table_undeploy(
     app_container,

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -269,6 +269,7 @@ async def test_feature_table_two_features_deployed(
     )
 
 
+@pytest.mark.skip(reason="This test sometimes hangs. Skip for now to unblock CI.")
 @pytest.mark.asyncio
 async def test_feature_table_undeploy(
     app_container,


### PR DESCRIPTION
## Description

Calling logging in `ProgressThread` appears to cause some tests to hang due to interactions between alive_bar and logging.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
