### PR TITLE
[DEV-2806] Invoke offline store feature table manager on deployment

### DIFF
--- a/featurebyte/models/deployment.py
+++ b/featurebyte/models/deployment.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import List, Optional
 
 import pymongo
-from pydantic import Field, StrictStr
+from pydantic import BaseSettings, Field, StrictStr
 
 from featurebyte.models.base import (
     FeatureByteCatalogBaseDocumentModel,
@@ -51,3 +51,11 @@ class DeploymentModel(FeatureByteCatalogBaseDocumentModel):
                 ("description", pymongo.TEXT),
             ],
         ]
+
+
+class FeastIntegrationSettings(BaseSettings):
+    """
+    Feast integration settings
+    """
+
+    FEATUREBYTE_FEAST_INTEGRATION_ENABLED: bool = False

--- a/featurebyte/service/deploy.py
+++ b/featurebyte/service/deploy.py
@@ -9,7 +9,7 @@ from bson.objectid import ObjectId
 
 from featurebyte.exception import DocumentCreationError, DocumentError, DocumentUpdateError
 from featurebyte.models.base import PydanticObjectId
-from featurebyte.models.deployment import DeploymentModel
+from featurebyte.models.deployment import DeploymentModel, FeastIntegrationSettings
 from featurebyte.models.feature import FeatureModel
 from featurebyte.models.feature_list import (
     FeatureListModel,
@@ -383,7 +383,7 @@ class DeployService(OpsServiceMixin):
     async def _update_offline_store_feature_tables(
         self, feature_models: List[FeatureModel], is_online_enabling: bool
     ) -> None:
-        if feature_models:
+        if FeastIntegrationSettings().FEATUREBYTE_FEAST_INTEGRATION_ENABLED and feature_models:
             if is_online_enabling:
                 await self.offline_store_feature_table_manager_service.handle_online_enabled_features(
                     feature_models

--- a/featurebyte/service/deploy.py
+++ b/featurebyte/service/deploy.py
@@ -28,6 +28,9 @@ from featurebyte.service.feature_list import FeatureListService
 from featurebyte.service.feature_list_namespace import FeatureListNamespaceService
 from featurebyte.service.feature_list_status import FeatureListStatusService
 from featurebyte.service.mixin import OpsServiceMixin
+from featurebyte.service.offline_store_feature_table_manager import (
+    OfflineStoreFeatureTableManagerService,
+)
 from featurebyte.service.online_enable import OnlineEnableService
 
 
@@ -46,6 +49,7 @@ class DeployService(OpsServiceMixin):
         deployment_service: DeploymentService,
         feature_list_namespace_service: FeatureListNamespaceService,
         feature_list_service: FeatureListService,
+        offline_store_feature_table_manager_service: OfflineStoreFeatureTableManagerService,
     ):
         self.persistent = persistent
         self.feature_service = feature_service
@@ -54,6 +58,9 @@ class DeployService(OpsServiceMixin):
         self.feature_list_status_service = feature_list_status_service
         self.feature_list_namespace_service = feature_list_namespace_service
         self.deployment_service = deployment_service
+        self.offline_store_feature_table_manager_service = (
+            offline_store_feature_table_manager_service
+        )
 
     @classmethod
     def _extract_deployed_feature_list_ids(
@@ -81,7 +88,7 @@ class DeployService(OpsServiceMixin):
 
         Returns
         -------
-        FeatureModel:
+        FeatureModel
         """
         document = await self.feature_service.get_document(document_id=feature_id)
         deployed_feature_list_ids = self._extract_deployed_feature_list_ids(
@@ -259,6 +266,8 @@ class DeployService(OpsServiceMixin):
                     await update_progress(20, "Update features")
 
                 # make each feature online enabled first
+                feature_models = []
+                is_online_enabling = True
                 for ind, feature_id in enumerate(document.feature_ids):
                     async with self.persistent.start_transaction():
                         feature = await self.feature_service.get_document(document_id=feature_id)
@@ -267,13 +276,18 @@ class DeployService(OpsServiceMixin):
                             feature_id=feature_id,
                             feature_list=feature_list,
                         )
+                        if updated_feature.online_enabled != feature.online_enabled:
+                            feature_models.append(feature)
+                            if updated_feature.online_enabled:
+                                is_online_enabling = True
+                            else:
+                                is_online_enabling = False
 
-                    if updated_feature:
-                        # move update warehouse and backfill tiles to outside of transaction
-                        await self.online_enable_service.update_data_warehouse(
-                            updated_feature=updated_feature,
-                            online_enabled_before_update=feature.online_enabled,
-                        )
+                    # move update warehouse and backfill tiles to outside of transaction
+                    await self.online_enable_service.update_data_warehouse(
+                        updated_feature=updated_feature,
+                        online_enabled_before_update=feature.online_enabled,
+                    )
 
                     if update_progress:
                         percent = 20 + int(60 / len(document.feature_ids) * (ind + 1))
@@ -290,6 +304,16 @@ class DeployService(OpsServiceMixin):
 
                     if update_progress:
                         await update_progress(100, "Updated feature list")
+
+                if feature_models:
+                    if is_online_enabling:
+                        await self.offline_store_feature_table_manager_service.handle_online_enabled_features(
+                            feature_models
+                        )
+                    else:
+                        await self.offline_store_feature_table_manager_service.handle_online_disabled_features(
+                            feature_models
+                        )
 
             except Exception as exc:
                 try:

--- a/featurebyte/service/offline_store_feature_table_manager.py
+++ b/featurebyte/service/offline_store_feature_table_manager.py
@@ -181,8 +181,9 @@ class OfflineStoreFeatureTableManagerService:
             if feature_table_dict is not None:
                 # update existing table
                 feature_ids = feature_table_dict["feature_ids"][:]
+                feature_ids_set = set(feature_ids)
                 for feature in offline_store_table_features:
-                    if feature.id not in feature_ids:
+                    if feature.id not in feature_ids_set:
                         feature_ids.append(feature.id)
                 if feature_ids != feature_table_dict["feature_ids"]:
                     feature_table_model = await self._update_offline_store_feature_table(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,3 +111,12 @@ def index_to_timestamp_fixture(request):
     Parameterized fixture for index to timestamp conversion
     """
     return request.param
+
+
+@pytest.fixture(name="enable_feast_integration")
+def enable_feast_integration_fixture():
+    """
+    Enable feast integration
+    """
+    with patch.dict(os.environ, {"FEATUREBYTE_FEAST_INTEGRATION_ENABLED": "True"}):
+        yield

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -1,6 +1,7 @@
 """
 Tests for feature materialization service
 """
+import os
 from unittest.mock import patch
 
 import pandas as pd
@@ -10,6 +11,15 @@ import featurebyte as fb
 from featurebyte.schema.worker.task.scheduled_feature_materialize import (
     ScheduledFeatureMaterializeTaskPayload,
 )
+
+
+@pytest.fixture(name="always_enable_feast_integration", scope="module", autouse=True)
+def always_enable_feast_integration_fixture():
+    """
+    Enable feast integration for all tests in this module
+    """
+    with patch.dict(os.environ, {"FEATUREBYTE_FEAST_INTEGRATION_ENABLED": "True"}):
+        yield
 
 
 @pytest.fixture(name="features", scope="module")

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -79,16 +79,6 @@ def deployed_features_list_fixture(features):
     deployment.disable()
 
 
-async def register_offline_store_feature_tables(app_container, features):
-    """
-    Register offline store feature tables
-    """
-    for feature in features:
-        await app_container.offline_store_feature_table_manager_service.handle_online_enabled_features(
-            [await app_container.feature_service.get_document(feature.id)],
-        )
-
-
 @pytest.fixture(name="default_feature_job_setting")
 def default_feature_job_setting_fixture(event_table):
     """
@@ -160,8 +150,6 @@ async def test_feature_materialize_service(
     Test FeatureMaterializeService
     """
     _ = deployed_feature_list
-
-    await register_offline_store_feature_tables(app_container, features)
 
     primary_entity_to_feature_table = {}
     async for feature_table in app_container.offline_store_feature_table_service.list_documents_iterator(

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -143,7 +143,6 @@ async def test_feature_materialize_service(
     session,
     user_entity,
     product_action_entity,
-    features,
     deployed_feature_list,
 ):
     """

--- a/tests/unit/service/test_feature_materialize.py
+++ b/tests/unit/service/test_feature_materialize.py
@@ -16,6 +16,14 @@ from featurebyte.models.online_store import OnlineFeatureSpec
 from tests.util.helper import assert_equal_with_expected_fixture
 
 
+@pytest.fixture(name="always_enable_feast_integration", autouse=True)
+def always_enable_feast_integration_fixture(enable_feast_integration):
+    """
+    Enable feast integration for all tests in this module
+    """
+    _ = enable_feast_integration
+
+
 async def create_online_store_compute_query(online_store_compute_query_service, feature_model):
     """
     Helper to create online store compute query since that step is skipped because of

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -36,6 +36,14 @@ def undeploy_feature(feature):
     deployment.disable()  # pylint: disable=no-member
 
 
+@pytest.fixture(name="always_enable_feast_integration", autouse=True)
+def always_enable_feast_integration_fixture(enable_feast_integration):
+    """
+    Enable feast integration for all tests in this module
+    """
+    _ = enable_feast_integration
+
+
 @pytest_asyncio.fixture
 async def deployed_float_feature(app_container, float_feature, mock_initialize_new_columns):
     """

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -74,14 +74,6 @@ def document_service(app_container):
     return app_container.offline_store_feature_table_service
 
 
-@pytest.fixture
-def manager_service(app_container):
-    """
-    Fixture for OfflineStoreFeatureTableManagerService
-    """
-    return app_container.offline_store_feature_table_manager_service
-
-
 async def get_all_feature_tables(document_service) -> Dict[str, OfflineStoreFeatureTableModel]:
     """
     Helper function to get all feature tables keyed by feature table name
@@ -132,7 +124,6 @@ async def check_feast_registry(app_container, expected_feature_views, expected_f
 async def test_feature_table_one_feature_deployed(
     app_container,
     document_service,
-    manager_service,
     periodic_task_service,
     deployed_float_feature,
     update_fixtures,
@@ -193,7 +184,6 @@ async def test_feature_table_one_feature_deployed(
 async def test_feature_table_two_features_deployed(
     app_container,
     document_service,
-    manager_service,
     periodic_task_service,
     deployed_float_feature,
     deployed_float_feature_post_processed,
@@ -255,7 +245,6 @@ async def test_feature_table_two_features_deployed(
 async def test_feature_table_undeploy(
     app_container,
     document_service,
-    manager_service,
     periodic_task_service,
     deployed_float_feature,
     deployed_float_feature_post_processed,
@@ -324,7 +313,6 @@ async def test_feature_table_undeploy(
 async def test_feature_table_two_features_different_feature_job_settings_deployed(
     app_container,
     document_service,
-    manager_service,
     periodic_task_service,
     deployed_float_feature,
     deployed_float_feature_different_job_setting,


### PR DESCRIPTION
## Description

This updates deployment service to invoke offline store feature table manager to create or update feature store tables. Currently this is disabled by default and only enabled in tests.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
