### PR TITLE
[DEV-2828] Update online serving route to use feast when enabled

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -232,7 +232,9 @@ tasks:
       - featurebyte/**/*
       - tests/**/*
     cmds:
+      - task: test-setup
       - poetry run pytest --reruns=3 --timeout=240 --junitxml=pytest.xml.0 -n auto --cov=featurebyte tests/unit
+      - task: test-teardown
 
   generate-unit-test-fixtures:
     desc: Generate unit test fixtures

--- a/featurebyte/feast/service/feature_store.py
+++ b/featurebyte/feast/service/feature_store.py
@@ -1,7 +1,7 @@
 """
 This module contains classes for constructing feast repository config
 """
-from typing import Any, cast
+from typing import Any, Optional, cast
 
 import tempfile
 
@@ -88,3 +88,16 @@ class FeastFeatureStoreService:
                 online_store=RedisOnlineStoreConfig(connection_string="localhost:6379"),
             )
             return cast(FeatureStore, FeatureStore(config=repo_config))
+
+    async def get_feast_feature_store_for_catalog(self) -> Optional[FeatureStore]:
+        """
+        Retrieve a FeatureStore object for the current catalog
+
+        Returns
+        -------
+        Optional[FeatureStore]
+        """
+        feast_registry = await self.feast_registry_service.get_feast_registry_for_catalog()
+        if feast_registry is None:
+            return None
+        return await self.get_feast_feature_store(feast_registry_id=feast_registry.id)

--- a/featurebyte/feast/utils/on_demand_view.py
+++ b/featurebyte/feast/utils/on_demand_view.py
@@ -53,10 +53,7 @@ def create_feast_on_demand_feature_view(
         file_handle.write(definition)
 
     module = importlib.import_module(module_name)
-    try:
-        func = getattr(module, function_name)
-    except:
-        raise
+    func = getattr(module, function_name)
     try:
         output = on_demand_feature_view(sources=sources, schema=schema)(func)
     except IOError:

--- a/featurebyte/feast/utils/on_demand_view.py
+++ b/featurebyte/feast/utils/on_demand_view.py
@@ -7,6 +7,7 @@ import importlib
 import os
 from unittest.mock import patch
 
+from bson import ObjectId
 from feast import FeatureView, Field, RequestSource
 from feast.feature_view_projection import FeatureViewProjection
 from feast.on_demand_feature_view import OnDemandFeatureView, on_demand_feature_view
@@ -45,14 +46,17 @@ def create_feast_on_demand_feature_view(
     OnDemandFeatureView
         The created OnDemandFeatureView
     """
-    module_name = "on_demand_feature_view"
+    module_name = f"on_demand_feature_view_{ObjectId()}"
     with open(
         os.path.join(on_demand_feature_view_dir, f"{module_name}.py"), "w", encoding="utf-8"
     ) as file_handle:
         file_handle.write(definition)
 
     module = importlib.import_module(module_name)
-    func = getattr(module, function_name)
+    try:
+        func = getattr(module, function_name)
+    except:
+        raise
     try:
         output = on_demand_feature_view(sources=sources, schema=schema)(func)
     except IOError:

--- a/tests/fixtures/offline_store_feature_table/feature_cluster_disabled_one_feature.json
+++ b/tests/fixtures/offline_store_feature_table/feature_cluster_disabled_one_feature.json
@@ -140,7 +140,7 @@
                         "table_id": {
                             "$oid": "6337f9651050ee7d5980660d"
                         },
-                        "view_mode": "manual"
+                        "view_mode": "auto"
                     },
                     "output_node_name": "project_1",
                     "type": "event_view"

--- a/tests/fixtures/offline_store_feature_table/feature_cluster_one_feature.json
+++ b/tests/fixtures/offline_store_feature_table/feature_cluster_one_feature.json
@@ -132,7 +132,7 @@
                         "table_id": {
                             "$oid": "6337f9651050ee7d5980660d"
                         },
-                        "view_mode": "manual"
+                        "view_mode": "auto"
                     },
                     "output_node_name": "project_1",
                     "type": "event_view"

--- a/tests/fixtures/offline_store_feature_table/feature_cluster_two_features.json
+++ b/tests/fixtures/offline_store_feature_table/feature_cluster_two_features.json
@@ -140,7 +140,7 @@
                         "table_id": {
                             "$oid": "6337f9651050ee7d5980660d"
                         },
-                        "view_mode": "manual"
+                        "view_mode": "auto"
                     },
                     "output_node_name": "project_1",
                     "type": "event_view"

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -995,8 +995,7 @@ def mock_update_data_warehouse(app_container):
     """Mock update data warehouse method"""
 
     async def mock_func(updated_feature, online_enabled_before_update):
-        if updated_feature.online_enabled == online_enabled_before_update:
-            return
+        _ = online_enabled_before_update
         extended_feature_model = ExtendedFeatureModel(**updated_feature.dict(by_alias=True))
         online_feature_spec = OnlineFeatureSpec(feature=extended_feature_model)
         for query in online_feature_spec.precompute_queries:

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -1003,3 +1003,14 @@ def feature_materialize_service_fixture(app_container):
     Fixture for FeatureMaterializeService
     """
     return app_container.feature_materialize_service
+
+
+@pytest.fixture(name="mock_initialize_new_columns")
+def mock_initialize_new_columns_fixture():
+    """
+    Fixture to mock FeatureMaterializeService.initialize_new_columns
+    """
+    with patch(
+        "featurebyte.service.offline_store_feature_table_manager.FeatureMaterializeService.initialize_new_columns"
+    ) as patched:
+        yield patched

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -17,9 +17,11 @@ from bson.objectid import ObjectId
 
 from featurebyte import Catalog
 from featurebyte.enum import SemanticType, SourceType
+from featurebyte.feature_manager.model import ExtendedFeatureModel
 from featurebyte.models.base import DEFAULT_CATALOG_ID
 from featurebyte.models.entity import ParentEntity
 from featurebyte.models.entity_validation import EntityInfo
+from featurebyte.models.online_store import OnlineFeatureSpec
 from featurebyte.routes.block_modification_handler import BlockModificationHandler
 from featurebyte.routes.lazy_app_container import LazyAppContainer
 from featurebyte.routes.registry import app_container_config
@@ -989,10 +991,20 @@ def relationships(b_is_parent_of_a, c_is_parent_of_b):
 
 
 @pytest.fixture(name="mock_update_data_warehouse")
-def mock_update_data_warehouse():
+def mock_update_data_warehouse(app_container):
     """Mock update data warehouse method"""
+
+    async def mock_func(updated_feature, online_enabled_before_update):
+        if updated_feature.online_enabled == online_enabled_before_update:
+            return
+        extended_feature_model = ExtendedFeatureModel(**updated_feature.dict(by_alias=True))
+        online_feature_spec = OnlineFeatureSpec(feature=extended_feature_model)
+        for query in online_feature_spec.precompute_queries:
+            await app_container.online_store_compute_query_service.create_document(query)
+
     with patch(
-        "featurebyte.service.deploy.OnlineEnableService.update_data_warehouse"
+        "featurebyte.service.deploy.OnlineEnableService.update_data_warehouse",
+        side_effect=mock_func,
     ) as mock_update_data_warehouse:
         yield mock_update_data_warehouse
 

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -3,37 +3,13 @@ Tests for OfflineStoreFeatureTableManagerService
 """
 from typing import Dict
 
-from unittest.mock import patch
-
 import pytest
 import pytest_asyncio
 from bson import ObjectId
 
-import featurebyte as fb
 from featurebyte.models.feature import FeatureModel
 from featurebyte.models.offline_store_feature_table import OfflineStoreFeatureTableModel
-from tests.util.helper import assert_equal_json_fixture
-
-
-async def deploy_feature(app_container, feature) -> FeatureModel:
-    """
-    Helper function to create deploy a single feature
-    """
-    feature_list = fb.FeatureList([feature], name=f"{feature.name}_list")
-    feature_list.save()
-    deployment = feature_list.deploy(
-        deployment_name=feature_list.name, make_production_ready=True, ignore_guardrails=True
-    )
-    deployment.enable()
-    return await app_container.feature_service.get_document(feature.id)
-
-
-def undeploy_feature(feature):
-    """
-    Helper function to undeploy a single feature
-    """
-    deployment: fb.Deployment = fb.Deployment.get(f"{feature.name}_list")
-    deployment.disable()  # pylint: disable=no-member
+from tests.util.helper import assert_equal_json_fixture, deploy_feature, undeploy_feature
 
 
 @pytest.fixture(name="always_enable_feast_integration", autouse=True)
@@ -90,17 +66,6 @@ async def get_all_feature_tables(document_service) -> Dict[str, OfflineStoreFeat
     async for feature_table in document_service.list_documents_iterator(query_filter={}):
         feature_tables[feature_table.name] = feature_table
     return feature_tables
-
-
-@pytest.fixture(name="mock_initialize_new_columns")
-def mock_initialize_new_columns_fixture():
-    """
-    Fixture to mock FeatureMaterializeService.initialize_new_columns
-    """
-    with patch(
-        "featurebyte.service.offline_store_feature_table_manager.FeatureMaterializeService.initialize_new_columns"
-    ) as patched:
-        yield patched
 
 
 async def has_scheduled_task(periodic_task_service, feature_table):

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -21,10 +21,13 @@ def always_enable_feast_integration_fixture(enable_feast_integration):
 
 
 @pytest_asyncio.fixture
-async def deployed_float_feature(app_container, float_feature, mock_initialize_new_columns):
+async def deployed_float_feature(
+    app_container, float_feature, mock_update_data_warehouse, mock_initialize_new_columns
+):
     """
     Fixture for deployed float feature
     """
+    _ = mock_update_data_warehouse
     out = await deploy_feature(app_container, float_feature)
     assert mock_initialize_new_columns.call_count == 1
     return out
@@ -136,7 +139,7 @@ async def test_feature_table_one_feature_deployed(
         "output_dtypes": ["FLOAT"],
         "primary_entity_ids": [ObjectId("63f94ed6ea1f050131379214")],
         "serving_names": ["cust_id"],
-        "user_id": None,
+        "user_id": ObjectId("63f9506dd478b94127123456"),
     }
     assert_equal_json_fixture(
         feature_cluster,
@@ -197,7 +200,7 @@ async def test_feature_table_two_features_deployed(
         "output_dtypes": ["FLOAT", "FLOAT"],
         "primary_entity_ids": [ObjectId("63f94ed6ea1f050131379214")],
         "serving_names": ["cust_id"],
-        "user_id": None,
+        "user_id": ObjectId("63f9506dd478b94127123456"),
     }
     assert_equal_json_fixture(
         feature_cluster,
@@ -261,7 +264,7 @@ async def test_feature_table_undeploy(
         "output_dtypes": ["FLOAT"],
         "primary_entity_ids": [ObjectId("63f94ed6ea1f050131379214")],
         "serving_names": ["cust_id"],
-        "user_id": None,
+        "user_id": ObjectId("63f9506dd478b94127123456"),
     }
     assert_equal_json_fixture(
         feature_cluster,
@@ -326,7 +329,7 @@ async def test_feature_table_two_features_different_feature_job_settings_deploye
         "output_dtypes": ["FLOAT"],
         "primary_entity_ids": [ObjectId("63f94ed6ea1f050131379214")],
         "serving_names": ["cust_id"],
-        "user_id": None,
+        "user_id": ObjectId("63f9506dd478b94127123456"),
     }
     assert await has_scheduled_task(periodic_task_service, feature_table)
 
@@ -360,7 +363,7 @@ async def test_feature_table_two_features_different_feature_job_settings_deploye
         "output_dtypes": ["FLOAT"],
         "primary_entity_ids": [ObjectId("63f94ed6ea1f050131379214")],
         "serving_names": ["cust_id"],
-        "user_id": None,
+        "user_id": ObjectId("63f9506dd478b94127123456"),
     }
     assert await has_scheduled_task(periodic_task_service, feature_table)
 

--- a/tests/unit/service/test_online_serving_feast.py
+++ b/tests/unit/service/test_online_serving_feast.py
@@ -1,0 +1,91 @@
+"""
+Tests for OnlineServingService feast implementation
+"""
+import pytest
+import pytest_asyncio
+
+import featurebyte as fb
+from featurebyte.exception import RequiredEntityNotProvidedError
+from tests.util.helper import deploy_feature
+
+
+@pytest.fixture(name="always_enable_feast_integration", autouse=True)
+def always_enable_feast_integration_fixture(enable_feast_integration):
+    """
+    Enable feast integration for all tests in this module
+    """
+    _ = enable_feast_integration
+
+
+@pytest_asyncio.fixture
+async def deployed_feature_list_with_float_feature(
+    app_container, float_feature, mock_initialize_new_columns
+):
+    """
+    Fixture for deployed float feature
+    """
+    _ = mock_initialize_new_columns
+    return await deploy_feature(app_container, float_feature, return_type="feature_list")
+
+
+@pytest_asyncio.fixture
+async def deployed_feature_list_with_point_in_time_request_column_feature(
+    app_container, float_feature, mock_initialize_new_columns
+):
+    """
+    Fixture for deployed point in time request column feature
+    """
+    _ = mock_initialize_new_columns
+    new_feature = float_feature * fb.RequestColumn.point_in_time().dt.day
+    new_feature.name = "feature_with_point_in_time_request_column"
+    return await deploy_feature(app_container, new_feature, return_type="feature_list")
+
+
+@pytest.mark.asyncio
+async def test_feature_no_point_in_time(
+    online_serving_service, deployed_feature_list_with_float_feature
+):
+    """
+    Test online serving feast without point in time
+    """
+    request_data = [{"cust_id": "a"}]
+    result = await online_serving_service.get_online_features_by_feast(
+        deployed_feature_list_with_float_feature, request_data
+    )
+    assert result.dict() == {"features": [{"cust_id": "a", "sum_1d": None}]}
+
+
+@pytest.mark.asyncio
+async def test_feature_with_point_in_time(
+    online_serving_service,
+    deployed_feature_list_with_point_in_time_request_column_feature,
+):
+    """
+    Test online serving feast without point in time
+    """
+    request_data = [{"cust_id": "a"}]
+    result = await online_serving_service.get_online_features_by_feast(
+        deployed_feature_list_with_point_in_time_request_column_feature, request_data
+    )
+    assert result.dict() == {
+        "features": [{"cust_id": "a", "feature_with_point_in_time_request_column": None}]
+    }
+
+
+@pytest.mark.asyncio
+async def test_validate_required_serving_names(
+    online_serving_service,
+    deployed_feature_list_with_float_feature,
+):
+    """
+    Test online serving feast without point in time
+    """
+    request_data = [{"cust_idz": "a"}]
+    with pytest.raises(RequiredEntityNotProvidedError) as exc_info:
+        await online_serving_service.get_online_features_by_feast(
+            deployed_feature_list_with_float_feature, request_data
+        )
+    assert (
+        str(exc_info.value)
+        == 'Required entities are not provided in the request: customer (serving name: "cust_id")'
+    )

--- a/tests/unit/service/test_online_serving_feast.py
+++ b/tests/unit/service/test_online_serving_feast.py
@@ -19,23 +19,28 @@ def always_enable_feast_integration_fixture(enable_feast_integration):
 
 @pytest_asyncio.fixture
 async def deployed_feature_list_with_float_feature(
-    app_container, float_feature, mock_initialize_new_columns
+    app_container,
+    float_feature,
+    mock_initialize_new_columns,
+    mock_update_data_warehouse,
 ):
     """
     Fixture for deployed float feature
     """
     _ = mock_initialize_new_columns
+    _ = mock_update_data_warehouse
     return await deploy_feature(app_container, float_feature, return_type="feature_list")
 
 
 @pytest_asyncio.fixture
 async def deployed_feature_list_with_point_in_time_request_column_feature(
-    app_container, float_feature, mock_initialize_new_columns
+    app_container, float_feature, mock_initialize_new_columns, mock_update_data_warehouse
 ):
     """
     Fixture for deployed point in time request column feature
     """
     _ = mock_initialize_new_columns
+    _ = mock_update_data_warehouse
     new_feature = float_feature * fb.RequestColumn.point_in_time().dt.day
     new_feature.name = "feature_with_point_in_time_request_column"
     return await deploy_feature(app_container, new_feature, return_type="feature_list")
@@ -61,7 +66,7 @@ async def test_feature_with_point_in_time(
     deployed_feature_list_with_point_in_time_request_column_feature,
 ):
     """
-    Test online serving feast without point in time
+    Test online serving feast with point in time
     """
     request_data = [{"cust_id": "a"}]
     result = await online_serving_service.get_online_features_by_feast(
@@ -78,7 +83,7 @@ async def test_validate_required_serving_names(
     deployed_feature_list_with_float_feature,
 ):
     """
-    Test online serving feast without point in time
+    Test validation for missing required serving names
     """
     request_data = [{"cust_idz": "a"}]
     with pytest.raises(RequiredEntityNotProvidedError) as exc_info:

--- a/tests/unit/service/test_online_serving_feast.py
+++ b/tests/unit/service/test_online_serving_feast.py
@@ -80,7 +80,7 @@ async def test_feature_with_point_in_time(
 @pytest.mark.asyncio
 async def test_validate_required_serving_names(
     online_serving_service,
-    deployed_feature_list_with_float_feature,
+    deployed_feature_list_with_point_in_time_request_column_feature,
 ):
     """
     Test validation for missing required serving names
@@ -88,7 +88,7 @@ async def test_validate_required_serving_names(
     request_data = [{"cust_idz": "a"}]
     with pytest.raises(RequiredEntityNotProvidedError) as exc_info:
         await online_serving_service.get_online_features_by_feast(
-            deployed_feature_list_with_float_feature, request_data
+            deployed_feature_list_with_point_in_time_request_column_feature, request_data
         )
     assert (
         str(exc_info.value)

--- a/tests/util/helper.py
+++ b/tests/util/helper.py
@@ -634,7 +634,7 @@ async def deploy_feature(app_container, feature, return_type="feature"):
     )
     deployment.enable()
     if return_type == "feature":
-        return await app_container.feature_service.get_feature(feature.name)
+        return await app_container.feature_service.get_document(feature.id)
     return await app_container.feature_list_service.get_document(feature_list.id)
 
 

--- a/tests/util/helper.py
+++ b/tests/util/helper.py
@@ -10,7 +10,7 @@ import tempfile
 import textwrap
 from contextlib import contextmanager
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import numpy as np
 import pandas as pd
@@ -20,7 +20,6 @@ from sqlglot import expressions
 
 from featurebyte import get_version
 from featurebyte.api.deployment import Deployment
-from featurebyte.api.feature_list import FeatureList
 from featurebyte.api.source_table import AbstractTableData
 from featurebyte.common.env_util import add_sys_path
 from featurebyte.core.generic import QueryObject


### PR DESCRIPTION
## Description

This updates online serving route to use feast to retrieve online features when enabled.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
