### PR TITLE
[chore] Use catalog id as feast project name

### DIFF
--- a/featurebyte/feast/service/feature_store.py
+++ b/featurebyte/feast/service/feature_store.py
@@ -8,12 +8,13 @@ import tempfile
 from bson import ObjectId
 from feast import FeatureStore, RepoConfig
 from feast.infra.online_stores.redis import RedisOnlineStoreConfig
-from feast.repo_config import RegistryConfig
+from feast.repo_config import FeastConfigBaseModel, RegistryConfig
 
 from featurebyte.feast.model.feature_store import FeatureStoreDetailsWithFeastConfiguration
 from featurebyte.feast.service.registry import FeastRegistryService
 from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.utils.credential import MongoBackedCredentialProvider
+from featurebyte.utils.messaging import REDIS_URI
 
 
 class FeastFeatureStoreService:
@@ -85,7 +86,7 @@ class FeastFeatureStoreService:
                 offline_store=feature_store_details.details.get_offline_store_config(
                     credential=database_credential
                 ),
-                online_store=RedisOnlineStoreConfig(connection_string="localhost:6379"),
+                online_store=self.get_default_online_store(),
             )
             return cast(FeatureStore, FeatureStore(config=repo_config))
 
@@ -101,3 +102,13 @@ class FeastFeatureStoreService:
         if feast_registry is None:
             return None
         return await self.get_feast_feature_store(feast_registry_id=feast_registry.id)
+
+    def get_default_online_store(self) -> FeastConfigBaseModel:
+        """
+        Get default online store configuration
+
+        Returns
+        -------
+        FeastConfigBaseModel
+        """
+        return RedisOnlineStoreConfig(connection_string=REDIS_URI.replace("redis://", ""))

--- a/featurebyte/service/offline_store_feature_table_manager.py
+++ b/featurebyte/service/offline_store_feature_table_manager.py
@@ -115,7 +115,7 @@ class OfflineIngestGraphContainer:
             yield table_name, features
 
 
-class OfflineStoreFeatureTableManagerService:
+class OfflineStoreFeatureTableManagerService:  # pylint: disable=too-many-instance-attributes
     """
     OfflineStoreFeatureTableManagerService class
     """

--- a/featurebyte/service/offline_store_feature_table_manager.py
+++ b/featurebyte/service/offline_store_feature_table_manager.py
@@ -122,6 +122,7 @@ class OfflineStoreFeatureTableManagerService:
 
     def __init__(
         self,
+        catalog_id: ObjectId,
         offline_store_feature_table_service: OfflineStoreFeatureTableService,
         feature_service: FeatureService,
         online_store_compute_query_service: OnlineStoreComputeQueryService,
@@ -131,6 +132,7 @@ class OfflineStoreFeatureTableManagerService:
         feast_registry_service: FeastRegistryService,
         feature_list_service: FeatureListService,
     ):
+        self.catalog_id = catalog_id
         self.offline_store_feature_table_service = offline_store_feature_table_service
         self.feature_service = feature_service
         self.online_store_compute_query_service = online_store_compute_query_service
@@ -323,7 +325,7 @@ class OfflineStoreFeatureTableManagerService:
         feast_registry = await self.feast_registry_service.get_feast_registry_for_catalog()
         if feast_registry is None:
             await self.feast_registry_service.create_document(
-                FeastRegistryCreate(project_name="featurebyte", feature_lists=feature_lists)
+                FeastRegistryCreate(project_name=str(self.catalog_id), feature_lists=feature_lists)
             )
         else:
             await self.feast_registry_service.update_document(

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -92,6 +92,7 @@ async def check_feast_registry(app_container, expected_feature_views, expected_f
     feature_store = await app_container.feast_feature_store_service.get_feast_feature_store(
         feast_registry.id
     )
+    assert feature_store.project == str(app_container.catalog_id)
     assert {fv.name for fv in feature_store.list_feature_views()} == expected_feature_views
     assert {fs.name for fs in feature_store.list_feature_services()} == expected_feature_services
 


### PR DESCRIPTION
## Description

This updates feast registry creation to use catalog id as project name to ensure uniqueness of keys in the online store.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
