### PR TITLE
[DEV-2831] Fix periodic tasks not disabled when reverting failed deployment

### DIFF
--- a/.changelog/DEV-2831.yaml
+++ b/.changelog/DEV-2831.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: deployment
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix an issue where periodic tasks were not disabled when reverting a failed deployment"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/service/deploy.py
+++ b/featurebyte/service/deploy.py
@@ -196,14 +196,16 @@ class DeployService(OpsServiceMixin):
         # revert all online enabled status back before raising exception
         for feature_id, online_enabled in feature_online_enabled_map.items():
             async with self.persistent.start_transaction():
+                document_before_update = await self.feature_service.get_document(
+                    document_id=feature_id,
+                )
                 document = await self.online_enable_service.update_feature(
                     feature_id=feature_id,
                     online_enabled=online_enabled,
                 )
-            # move update warehouse and backfill tiles to outside of transaction
             await self.online_enable_service.update_data_warehouse(
                 updated_feature=document,
-                online_enabled_before_update=online_enabled,
+                online_enabled_before_update=document_before_update.online_enabled,
             )
 
         # update feature list namespace again

--- a/tests/unit/service/test_deploy.py
+++ b/tests/unit/service/test_deploy.py
@@ -254,6 +254,19 @@ async def test_update_deployment_error__state_is_reverted_when_update_feature_li
     assert feature_list.online_enabled_feature_ids == []
     assert feature_list_namespace.deployed_feature_list_ids == []
 
+    # check update_data_warehouse is provided with the right parameters during revert
+    assert mock_update_data_warehouse.call_count == 2
+
+    # check the first call (enabling)
+    args, kwargs = mock_update_data_warehouse.call_args_list[0]
+    assert kwargs["updated_feature"].online_enabled is True
+    assert kwargs["online_enabled_before_update"] is False
+
+    # check the second call (disabling during revert)
+    args, kwargs = mock_update_data_warehouse.call_args_list[1]
+    assert kwargs["updated_feature"].online_enabled is False
+    assert kwargs["online_enabled_before_update"] is True
+
 
 @pytest.mark.asyncio
 async def test_update_deployment_error__state_is_reverted_when_update_feature_is_failed(

--- a/tests/unit/service/test_deploy.py
+++ b/tests/unit/service/test_deploy.py
@@ -258,12 +258,12 @@ async def test_update_deployment_error__state_is_reverted_when_update_feature_li
     assert mock_update_data_warehouse.call_count == 2
 
     # check the first call (enabling)
-    args, kwargs = mock_update_data_warehouse.call_args_list[0]
+    _, kwargs = mock_update_data_warehouse.call_args_list[0]
     assert kwargs["updated_feature"].online_enabled is True
     assert kwargs["online_enabled_before_update"] is False
 
     # check the second call (disabling during revert)
-    args, kwargs = mock_update_data_warehouse.call_args_list[1]
+    _, kwargs = mock_update_data_warehouse.call_args_list[1]
     assert kwargs["updated_feature"].online_enabled is False
     assert kwargs["online_enabled_before_update"] is True
 


### PR DESCRIPTION
## Description

This fixes an issue where periodic tasks were not disabled when reverting a failed deployment.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
