### PR TITLE
[DEV-2832] Drop columns in offline store feature table after online disabling features

### DIFF
--- a/featurebyte/service/feature_materialize.py
+++ b/featurebyte/service/feature_materialize.py
@@ -317,6 +317,23 @@ class FeatureMaterializeService:  # pylint: disable=too-many-instance-attributes
             )
             await session.execute_query(query)
 
+    async def drop_table(self, feature_table_model: OfflineStoreFeatureTableModel) -> None:
+        """
+        Drop the feature table. This is expected to be called when the feature table is deleted.
+
+        Parameters
+        ----------
+        feature_table_model: OfflineStoreFeatureTableModel
+            OfflineStoreFeatureTableModel object
+        """
+        session = await self._get_session(feature_table_model)
+        await session.drop_table(
+            feature_table_model.name,
+            schema_name=session.schema_name,
+            database_name=session.database_name,
+            if_exists=True,
+        )
+
     async def _get_feast_feature_store(self) -> FeastFeatureStore:
         """
         Get the FeastFeatureStore object

--- a/featurebyte/service/offline_store_feature_table_manager.py
+++ b/featurebyte/service/offline_store_feature_table_manager.py
@@ -224,7 +224,11 @@ class OfflineStoreFeatureTableManagerService:  # pylint: disable=too-many-instan
                     updated_feature_table, self._get_offline_store_feature_table_columns(features)
                 )
             else:
-                # TODO: drop table
+                await self.feature_materialize_service.drop_table(
+                    await self.offline_store_feature_table_service.get_document(
+                        feature_table_dict["_id"],
+                    )
+                )
                 await self.feature_materialize_scheduler_service.stop_job(
                     feature_table_dict["_id"],
                 )
@@ -242,6 +246,7 @@ class OfflineStoreFeatureTableManagerService:  # pylint: disable=too-many-instan
             for ingest_query_graph in info.extract_offline_store_ingest_query_graphs():
                 output_column_names.append(ingest_query_graph.output_column_name)
             return output_column_names
+        return []
 
     async def _get_compatible_existing_feature_table(
         self, table_name: str

--- a/tests/fixtures/feature_materialize/drop_columns.sql
+++ b/tests/fixtures/feature_materialize/drop_columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "fb_entity_cust_id_fjs_1800_300_600_ttl"   DROP COLUMN "a";
+
+ALTER TABLE "fb_entity_cust_id_fjs_1800_300_600_ttl"   DROP COLUMN "b";

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -1016,12 +1016,18 @@ def feature_materialize_service_fixture(app_container):
     return app_container.feature_materialize_service
 
 
-@pytest.fixture(name="mock_initialize_new_columns")
-def mock_initialize_new_columns_fixture():
+@pytest.fixture(name="mock_feature_materialize_service")
+def mock_feature_materialize_service_fixture():
     """
-    Fixture to mock FeatureMaterializeService.initialize_new_columns
+    Fixture to mock FeatureMaterializeService's methods where the actual queries are executed
     """
-    with patch(
-        "featurebyte.service.offline_store_feature_table_manager.FeatureMaterializeService.initialize_new_columns"
-    ) as patched:
-        yield patched
+    patched = {}
+    service_name = (
+        "featurebyte.service.offline_store_feature_table_manager.FeatureMaterializeService"
+    )
+    for method_name in ["initialize_new_columns", "drop_columns"]:
+        patcher = patch(f"{service_name}.{method_name}")
+        patched[method_name] = patcher.start()
+    yield patched
+    for patcher in patched.values():
+        patcher.stop()

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -1025,7 +1025,7 @@ def mock_feature_materialize_service_fixture():
     service_name = (
         "featurebyte.service.offline_store_feature_table_manager.FeatureMaterializeService"
     )
-    for method_name in ["initialize_new_columns", "drop_columns"]:
+    for method_name in ["initialize_new_columns", "drop_columns", "drop_table"]:
         patcher = patch(f"{service_name}.{method_name}")
         patched[method_name] = patcher.start()
     yield patched

--- a/tests/unit/service/test_feature_materialize.py
+++ b/tests/unit/service/test_feature_materialize.py
@@ -350,3 +350,23 @@ async def test_drop_columns(
         "tests/fixtures/feature_materialize/drop_columns.sql",
         update_fixtures,
     )
+
+
+@pytest.mark.usefixtures("mock_get_feature_store_session")
+@pytest.mark.asyncio
+async def test_drop_table(
+    feature_materialize_service,
+    mock_snowflake_session,
+    offline_store_feature_table,
+    update_fixtures,
+):
+    """
+    Test drop_columns
+    """
+    await feature_materialize_service.drop_table(offline_store_feature_table)
+    assert mock_snowflake_session.drop_table.call_args == call(
+        offline_store_feature_table.name,
+        schema_name="sf_schema",
+        database_name="sf_db",
+        if_exists=True,
+    )

--- a/tests/unit/service/test_feature_materialize.py
+++ b/tests/unit/service/test_feature_materialize.py
@@ -358,7 +358,6 @@ async def test_drop_table(
     feature_materialize_service,
     mock_snowflake_session,
     offline_store_feature_table,
-    update_fixtures,
 ):
     """
     Test drop_columns

--- a/tests/unit/service/test_feature_materialize.py
+++ b/tests/unit/service/test_feature_materialize.py
@@ -330,3 +330,23 @@ async def test_initialize_new_columns__table_exists(
     feature_view = kwargs.pop("feature_view")
     assert feature_view.name == "fb_entity_cust_id_fjs_1800_300_600_ttl"
     assert kwargs == {"columns": ["sum_30m"], "end_date": datetime(2022, 10, 15, 10, 0, 0)}
+
+
+@pytest.mark.usefixtures("mock_get_feature_store_session")
+@pytest.mark.asyncio
+async def test_drop_columns(
+    feature_materialize_service,
+    mock_snowflake_session,
+    offline_store_feature_table,
+    update_fixtures,
+):
+    """
+    Test drop_columns
+    """
+    await feature_materialize_service.drop_columns(offline_store_feature_table, ["a", "b"])
+    queries = extract_session_executed_queries(mock_snowflake_session, "execute_query")
+    assert_equal_with_expected_fixture(
+        queries,
+        "tests/fixtures/feature_materialize/drop_columns.sql",
+        update_fixtures,
+    )

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -22,14 +22,14 @@ def always_enable_feast_integration_fixture(enable_feast_integration):
 
 @pytest_asyncio.fixture
 async def deployed_float_feature(
-    app_container, float_feature, mock_update_data_warehouse, mock_initialize_new_columns
+    app_container, float_feature, mock_update_data_warehouse, mock_feature_materialize_service
 ):
     """
     Fixture for deployed float feature
     """
     _ = mock_update_data_warehouse
     out = await deploy_feature(app_container, float_feature)
-    assert mock_initialize_new_columns.call_count == 1
+    assert mock_feature_materialize_service["initialize_new_columns"].call_count == 1
     return out
 
 
@@ -225,6 +225,7 @@ async def test_feature_table_undeploy(
     periodic_task_service,
     deployed_float_feature,
     deployed_float_feature_post_processed,
+    mock_feature_materialize_service,
     update_fixtures,
 ):
     """
@@ -272,6 +273,11 @@ async def test_feature_table_undeploy(
         "tests/fixtures/offline_store_feature_table/feature_cluster_disabled_one_feature.json",
         update_fixtures,
     )
+
+    # Check drop_columns called
+    args, _ = mock_feature_materialize_service["drop_columns"].call_args
+    assert args[0].name == "fb_entity_cust_id_fjs_1800_300_600_ttl"
+    assert args[1] == ["sum_1d"]
 
     # Check online disabling the last feature deletes the feature table
     undeploy_feature(deployed_float_feature_post_processed)

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -285,6 +285,8 @@ async def test_feature_table_undeploy(
     assert len(feature_tables) == 0
     assert not await has_scheduled_task(periodic_task_service, feature_table)
 
+    args, _ = mock_feature_materialize_service["drop_table"].call_args
+    assert args[0].name == "fb_entity_cust_id_fjs_1800_300_600_ttl"
     await check_feast_registry(
         app_container,
         expected_feature_views=set(),

--- a/tests/unit/service/test_online_serving_feast.py
+++ b/tests/unit/service/test_online_serving_feast.py
@@ -21,25 +21,25 @@ def always_enable_feast_integration_fixture(enable_feast_integration):
 async def deployed_feature_list_with_float_feature(
     app_container,
     float_feature,
-    mock_initialize_new_columns,
+    mock_feature_materialize_service,
     mock_update_data_warehouse,
 ):
     """
     Fixture for deployed float feature
     """
-    _ = mock_initialize_new_columns
+    _ = mock_feature_materialize_service
     _ = mock_update_data_warehouse
     return await deploy_feature(app_container, float_feature, return_type="feature_list")
 
 
 @pytest_asyncio.fixture
 async def deployed_feature_list_with_point_in_time_request_column_feature(
-    app_container, float_feature, mock_initialize_new_columns, mock_update_data_warehouse
+    app_container, float_feature, mock_feature_materialize_service, mock_update_data_warehouse
 ):
     """
     Fixture for deployed point in time request column feature
     """
-    _ = mock_initialize_new_columns
+    _ = mock_feature_materialize_service
     _ = mock_update_data_warehouse
     new_feature = float_feature * fb.RequestColumn.point_in_time().dt.day
     new_feature.name = "feature_with_point_in_time_request_column"


### PR DESCRIPTION
## Description

This updates offline store feature table manager to drop corresponding columns in the feature table after features are online disabled. Feature table is dropped if all features are online disabled.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
