### PR TITLE
[DEV-2791] Support features without entity in feast integration

### DIFF
--- a/featurebyte/models/offline_store_feature_table.py
+++ b/featurebyte/models/offline_store_feature_table.py
@@ -23,6 +23,7 @@ from featurebyte.models.feature import FeatureModel
 from featurebyte.models.feature_list import FeatureCluster
 from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
+from featurebyte.query_graph.sql.ast.literal import make_literal_value
 from featurebyte.query_graph.sql.common import quoted_identifier
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema
 
@@ -54,6 +55,11 @@ class WindowAggregateEntityUniverse(FeatureByteBaseModel):
         -------
         Select
         """
+        if not self.serving_names:
+            return expressions.select(
+                expressions.alias_(make_literal_value(1), "dummy_entity", quoted=True)
+            )
+
         assert len(self.aggregate_result_table_names) > 0
 
         # select distinct serving names across all aggregation result tables

--- a/featurebyte/query_graph/transform/offline_store_ingest.py
+++ b/featurebyte/query_graph/transform/offline_store_ingest.py
@@ -50,8 +50,12 @@ def get_offline_store_table_name(
     str
         Offline store table name
     """
-    entity_part = "_".join(primary_entity_serving_names)
-    table_name = sanitize_identifier(f"fb_entity_{entity_part}")
+    if primary_entity_serving_names:
+        entity_part = "_".join(primary_entity_serving_names)
+        table_name = sanitize_identifier(f"fb_entity_{entity_part}")
+    else:
+        table_name = "fb_entity_overall"
+
     if feature_job_setting:
         fjs = feature_job_setting.to_seconds()
         frequency = fjs["frequency"]

--- a/featurebyte/service/offline_store_feature_table_manager.py
+++ b/featurebyte/service/offline_store_feature_table_manager.py
@@ -322,13 +322,19 @@ class OfflineStoreFeatureTableManagerService:  # pylint: disable=too-many-instan
 
         # Get aggregate result tables
         filtered_table_names = []
-        query_filter = {
-            "table_name": {"$in": aggregate_result_table_names},
-            "serving_names": {
-                "$all": primary_entity_serving_names,
-                "$size": len(primary_entity_serving_names),
-            },
-        }
+        if primary_entity_serving_names:
+            query_filter = {
+                "table_name": {"$in": aggregate_result_table_names},
+                "serving_names": {
+                    "$all": primary_entity_serving_names,
+                    "$size": len(primary_entity_serving_names),
+                },
+            }
+        else:
+            query_filter = {
+                "table_name": {"$in": aggregate_result_table_names},
+            }
+
         async for online_store_compute_query_model in self.online_store_compute_query_service.list_documents_iterator(
             query_filter=query_filter
         ):

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -65,7 +65,7 @@ def features_fixture(event_table):
         feature_names=["EXTERNAL_FS_COUNT_BY_PRODUCT_ACTION_7d"],
     )["EXTERNAL_FS_COUNT_BY_PRODUCT_ACTION_7d"]
 
-    # Feature with two entities (not supported yet)
+    # Complex feature with multiple unrelated entities and request column
     feature_4 = feature_1 + feature_3 + fb.RequestColumn.point_in_time().dt.day.sin()
     feature_4.name = "EXTERNAL_FS_COMPLEX_USER_X_PRODUCTION_ACTION_FEATURE"
 
@@ -141,6 +141,7 @@ async def check_feast_registry(app_container):
 
     # Check feature views and feature services
     assert {fv.name for fv in feature_store.list_feature_views()} == {
+        "fb_entity_overall_fjs_3600_1800_1800_ttl",
         "fb_entity_product_action_fjs_3600_1800_1800_ttl",
         "fb_entity_üserid_fjs_3600_1800_1800_ttl",
     }
@@ -161,6 +162,7 @@ async def check_feast_registry(app_container):
     assert online_features == {
         "üser id": ["1"],
         "PRODUCT_ACTION": ["detail"],
+        "EXTERNAL_FS_COUNT_OVERALL_7d": [149.0],
         "EXTERNAL_FS_COUNT_BY_PRODUCT_ACTION_7d": [43.0],
         "EXTERNAL_FS_AMOUNT_SUM_BY_USER_ID_24h": [475.38],
         "EXTERNAL_FS_AMOUNT_SUM_BY_USER_ID_24h_TIMES_100": [47538.0],
@@ -191,6 +193,7 @@ def check_online_features(deployment, config):
             {
                 "üser id": "1",
                 "PRODUCT_ACTION": "detail",
+                "EXTERNAL_FS_COUNT_OVERALL_7d": 149.0,
                 "EXTERNAL_FS_COUNT_BY_PRODUCT_ACTION_7d": 43.0,
                 "EXTERNAL_FS_AMOUNT_SUM_BY_USER_ID_24h": 475.38,
                 "EXTERNAL_FS_AMOUNT_SUM_BY_USER_ID_24h_TIMES_100": 47538.0,
@@ -224,6 +227,7 @@ async def test_feature_materialize_service(
         ] = feature_table
 
     assert set(primary_entity_to_feature_table.keys()) == {
+        (),
         (user_entity.id,),
         (product_action_entity.id,),
     }

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -69,8 +69,16 @@ def features_fixture(event_table):
     feature_4 = feature_1 + feature_3 + fb.RequestColumn.point_in_time().dt.day.sin()
     feature_4.name = "EXTERNAL_FS_COMPLEX_USER_X_PRODUCTION_ACTION_FEATURE"
 
+    # Feature without entity
+    feature_5 = filtered_event_view.groupby([]).aggregate_over(
+        None,
+        method="count",
+        windows=["7d"],
+        feature_names=["EXTERNAL_FS_COUNT_OVERALL_7d"],
+    )["EXTERNAL_FS_COUNT_OVERALL_7d"]
+
     # Save all features to be deployed
-    features = [feature_1, feature_2, feature_3, feature_4]
+    features = [feature_1, feature_2, feature_3, feature_4, feature_5]
     for feature in features:
         feature.save()
         feature.update_readiness("PRODUCTION_READY")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1556,6 +1556,24 @@ def multiple_scd_joined_feature_fixture(
     yield feature
 
 
+@pytest.fixture(name="feature_without_entity")
+def feature_without_entity_fixture(snowflake_event_table):
+    """
+    Fixture to get a feature without entity
+    """
+    event_view = snowflake_event_table.get_view()
+    feature_group = event_view.groupby([]).aggregate_over(
+        value_column=None,
+        method="count",
+        windows=["1d"],
+        feature_job_setting=FeatureJobSetting(
+            frequency="24h", time_modulo_frequency="1h", blind_spot="2h"
+        ),
+        feature_names=["count_1d"],
+    )
+    yield feature_group["count_1d"]
+
+
 @pytest.fixture(name="session_manager")
 def session_manager_fixture(credentials, snowflake_connector):
     """

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -407,7 +407,6 @@ async def test_feature_table_without_entity(
     document_service,
     periodic_task_service,
     deployed_feature_without_entity,
-    update_fixtures,
 ):
     """
     Test feature table creation when feature has no entity


### PR DESCRIPTION
## Description

This adds support for features without entity in feast integration. When constructing the feast registry, a special entity recognised by feast will be used for such features.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
