### PR TITLE
[DEV-2877] Replace OBJECT_AGG hive udf with built-in functions in spark and databricks

### DIFF
--- a/featurebyte/query_graph/sql/adapter/databricks.py
+++ b/featurebyte/query_graph/sql/adapter/databricks.py
@@ -37,7 +37,11 @@ class DatabricksAdapter(BaseAdapter):
 
     @classmethod
     def object_agg(cls, key_column: str | Expression, value_column: str | Expression) -> Expression:
-        return expressions.Anonymous(this="OBJECT_AGG", expressions=[key_column, value_column])
+        struct_expr = expressions.Anonymous(this="struct", expressions=[key_column, value_column])
+        return expressions.Anonymous(
+            this="map_from_entries",
+            expressions=[expressions.Anonymous(this="collect_list", expressions=[struct_expr])],
+        )
 
     @classmethod
     def to_epoch_seconds(cls, timestamp_expr: Expression) -> Expression:

--- a/featurebyte/query_graph/sql/interpreter/preview.py
+++ b/featurebyte/query_graph/sql/interpreter/preview.py
@@ -15,7 +15,6 @@ from sqlglot import expressions, parse_one
 from featurebyte.enum import DBVarType
 from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.query_graph.node.metadata.operation import ViewDataColumn
-from featurebyte.query_graph.sql.adapter import get_sql_adapter
 from featurebyte.query_graph.sql.ast.base import ExpressionNode, TableNode
 from featurebyte.query_graph.sql.ast.literal import make_literal_value
 from featurebyte.query_graph.sql.builder import SQLOperationGraph

--- a/featurebyte/query_graph/sql/interpreter/preview.py
+++ b/featurebyte/query_graph/sql/interpreter/preview.py
@@ -15,10 +15,12 @@ from sqlglot import expressions, parse_one
 from featurebyte.enum import DBVarType
 from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.query_graph.node.metadata.operation import ViewDataColumn
+from featurebyte.query_graph.sql.adapter import get_sql_adapter
 from featurebyte.query_graph.sql.ast.base import ExpressionNode, TableNode
 from featurebyte.query_graph.sql.ast.literal import make_literal_value
 from featurebyte.query_graph.sql.builder import SQLOperationGraph
 from featurebyte.query_graph.sql.common import (
+    MISSING_VALUE_REPLACEMENT,
     CteStatement,
     SQLType,
     construct_cte_sql,
@@ -551,15 +553,21 @@ class PreviewMixin(BaseGraphInterpreter):
         expressions.Select
         """
         cat_counts = self._get_cat_counts(col_expr)
+        col_expr_filled_null = expressions.Case(
+            ifs=[
+                expressions.If(
+                    this=expressions.Is(this=col_expr, expression=expressions.Null()),
+                    true=make_literal_value(MISSING_VALUE_REPLACEMENT),
+                )
+            ],
+            default=col_expr,
+        )
+        object_agg_expr = self.adapter.object_agg(
+            col_expr_filled_null, quoted_identifier(CATEGORY_COUNT_COLUMN_NAME)
+        )
         cat_count_dict = expressions.select(
             expressions.alias_(
-                expression=expressions.Anonymous(
-                    this="object_agg",
-                    expressions=[
-                        col_expr,
-                        quoted_identifier(CATEGORY_COUNT_COLUMN_NAME),
-                    ],
-                ),
+                expression=object_agg_expr,
                 alias="COUNT_DICT",
                 quoted=True,
             )

--- a/featurebyte/session/databricks.py
+++ b/featurebyte/session/databricks.py
@@ -166,6 +166,7 @@ class DatabricksSession(BaseSparkSession):
                 arrow_table = pa.Table.from_pandas(dataframe)
                 if arrow_table.num_rows == 0:
                     if counter == 0:
+                        # return empty dataframe with correct schema
                         yield pa_table_to_record_batches(arrow_table)[0]
                     break
                 for record_batch in arrow_table.to_batches():

--- a/tests/fixtures/expected_describe_request.sql
+++ b/tests/fixtures/expected_describe_request.sql
@@ -17,7 +17,10 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__0"
   FROM (
     SELECT
-      OBJECT_AGG("col_float", "__FB_COUNTS") AS "COUNT_DICT"
+      OBJECT_AGG(
+        CASE WHEN "col_float" IS NULL THEN '__MISSING__' ELSE "col_float" END,
+        TO_VARIANT("__FB_COUNTS")
+      ) AS "COUNT_DICT"
     FROM (
       SELECT
         "col_float",
@@ -37,7 +40,10 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__1"
   FROM (
     SELECT
-      OBJECT_AGG("col_text", "__FB_COUNTS") AS "COUNT_DICT"
+      OBJECT_AGG(
+        CASE WHEN "col_text" IS NULL THEN '__MISSING__' ELSE "col_text" END,
+        TO_VARIANT("__FB_COUNTS")
+      ) AS "COUNT_DICT"
     FROM (
       SELECT
         "col_text",

--- a/tests/fixtures/query_graph/expected_describe_count_based_stats_only.sql
+++ b/tests/fixtures/query_graph/expected_describe_count_based_stats_only.sql
@@ -24,7 +24,10 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__1"
   FROM (
     SELECT
-      OBJECT_AGG("cust_id", "__FB_COUNTS") AS "COUNT_DICT"
+      OBJECT_AGG(
+        CASE WHEN "cust_id" IS NULL THEN '__MISSING__' ELSE "cust_id" END,
+        TO_VARIANT("__FB_COUNTS")
+      ) AS "COUNT_DICT"
     FROM (
       SELECT
         "cust_id",

--- a/tests/fixtures/query_graph/expected_describe_databricks.sql
+++ b/tests/fixtures/query_graph/expected_describe_databricks.sql
@@ -1,0 +1,302 @@
+WITH data AS (
+  SELECT
+    `ts` AS `ts`,
+    `cust_id` AS `cust_id`,
+    `a` AS `a`,
+    `b` AS `b`,
+    `a` AS `a_copy`
+  FROM `db`.`public`.`event_table`
+  ORDER BY
+    RANDOM(1234)
+  LIMIT 10
+), casted_data AS (
+  SELECT
+    CAST(`ts` AS STRING) AS `ts`,
+    CAST(`cust_id` AS STRING) AS `cust_id`,
+    CAST(`a` AS STRING) AS `a`,
+    CAST(`b` AS STRING) AS `b`,
+    CAST(`a_copy` AS STRING) AS `a_copy`
+  FROM data
+), counts__0 AS (
+  SELECT
+    F_COUNT_DICT_MOST_FREQUENT(count_dict.`COUNT_DICT`) AS `top__0`,
+    F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict.`COUNT_DICT`) AS `freq__0`
+  FROM (
+    SELECT
+      MAP_FROM_ENTRIES(
+        COLLECT_LIST(STRUCT(CASE WHEN `ts` IS NULL THEN '__MISSING__' ELSE `ts` END, `__FB_COUNTS`))
+      ) AS `COUNT_DICT`
+    FROM (
+      SELECT
+        `ts`,
+        COUNT(*) AS `__FB_COUNTS`
+      FROM casted_data
+      GROUP BY
+        `ts`
+      ORDER BY
+        `__FB_COUNTS` DESC
+      LIMIT 500
+    ) AS cat_counts
+  ) AS count_dict
+), counts__1 AS (
+  SELECT
+    F_COUNT_DICT_ENTROPY(count_dict.`COUNT_DICT`) AS `entropy__1`,
+    F_COUNT_DICT_MOST_FREQUENT(count_dict.`COUNT_DICT`) AS `top__1`,
+    F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict.`COUNT_DICT`) AS `freq__1`
+  FROM (
+    SELECT
+      MAP_FROM_ENTRIES(
+        COLLECT_LIST(
+          STRUCT(CASE WHEN `cust_id` IS NULL THEN '__MISSING__' ELSE `cust_id` END, `__FB_COUNTS`)
+        )
+      ) AS `COUNT_DICT`
+    FROM (
+      SELECT
+        `cust_id`,
+        COUNT(*) AS `__FB_COUNTS`
+      FROM casted_data
+      GROUP BY
+        `cust_id`
+      ORDER BY
+        `__FB_COUNTS` DESC
+      LIMIT 500
+    ) AS cat_counts
+  ) AS count_dict
+), counts__2 AS (
+  SELECT
+    F_COUNT_DICT_MOST_FREQUENT(count_dict.`COUNT_DICT`) AS `top__2`,
+    F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict.`COUNT_DICT`) AS `freq__2`
+  FROM (
+    SELECT
+      MAP_FROM_ENTRIES(
+        COLLECT_LIST(STRUCT(CASE WHEN `a` IS NULL THEN '__MISSING__' ELSE `a` END, `__FB_COUNTS`))
+      ) AS `COUNT_DICT`
+    FROM (
+      SELECT
+        `a`,
+        COUNT(*) AS `__FB_COUNTS`
+      FROM casted_data
+      GROUP BY
+        `a`
+      ORDER BY
+        `__FB_COUNTS` DESC
+      LIMIT 500
+    ) AS cat_counts
+  ) AS count_dict
+), counts__3 AS (
+  SELECT
+    F_COUNT_DICT_MOST_FREQUENT(count_dict.`COUNT_DICT`) AS `top__3`,
+    F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict.`COUNT_DICT`) AS `freq__3`
+  FROM (
+    SELECT
+      MAP_FROM_ENTRIES(
+        COLLECT_LIST(STRUCT(CASE WHEN `b` IS NULL THEN '__MISSING__' ELSE `b` END, `__FB_COUNTS`))
+      ) AS `COUNT_DICT`
+    FROM (
+      SELECT
+        `b`,
+        COUNT(*) AS `__FB_COUNTS`
+      FROM casted_data
+      GROUP BY
+        `b`
+      ORDER BY
+        `__FB_COUNTS` DESC
+      LIMIT 500
+    ) AS cat_counts
+  ) AS count_dict
+), counts__4 AS (
+  SELECT
+    F_COUNT_DICT_MOST_FREQUENT(count_dict.`COUNT_DICT`) AS `top__4`,
+    F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict.`COUNT_DICT`) AS `freq__4`
+  FROM (
+    SELECT
+      MAP_FROM_ENTRIES(
+        COLLECT_LIST(
+          STRUCT(CASE WHEN `a_copy` IS NULL THEN '__MISSING__' ELSE `a_copy` END, `__FB_COUNTS`)
+        )
+      ) AS `COUNT_DICT`
+    FROM (
+      SELECT
+        `a_copy`,
+        COUNT(*) AS `__FB_COUNTS`
+      FROM casted_data
+      GROUP BY
+        `a_copy`
+      ORDER BY
+        `__FB_COUNTS` DESC
+      LIMIT 500
+    ) AS cat_counts
+  ) AS count_dict
+), stats AS (
+  SELECT
+    COUNT(DISTINCT `ts`) AS `unique__0`,
+    (
+      1.0 - COUNT(`ts`) / NULLIF(COUNT(*), 0)
+    ) * 100 AS `%missing__0`,
+    NULL AS `%empty__0`,
+    NULL AS `mean__0`,
+    NULL AS `std__0`,
+    MIN(`ts`) AS `min__0`,
+    NULL AS `25%__0`,
+    NULL AS `50%__0`,
+    NULL AS `75%__0`,
+    MAX(`ts`) AS `max__0`,
+    NULL AS `min TZ offset__0`,
+    NULL AS `max TZ offset__0`,
+    COUNT(DISTINCT `cust_id`) AS `unique__1`,
+    (
+      1.0 - COUNT(`cust_id`) / NULLIF(COUNT(*), 0)
+    ) * 100 AS `%missing__1`,
+    COUNT_IF(`cust_id` = '') AS `%empty__1`,
+    NULL AS `mean__1`,
+    NULL AS `std__1`,
+    NULL AS `min__1`,
+    NULL AS `25%__1`,
+    NULL AS `50%__1`,
+    NULL AS `75%__1`,
+    NULL AS `max__1`,
+    NULL AS `min TZ offset__1`,
+    NULL AS `max TZ offset__1`,
+    COUNT(DISTINCT `a`) AS `unique__2`,
+    (
+      1.0 - COUNT(`a`) / NULLIF(COUNT(*), 0)
+    ) * 100 AS `%missing__2`,
+    NULL AS `%empty__2`,
+    AVG(CAST(`a` AS DOUBLE)) AS `mean__2`,
+    STDDEV(CAST(`a` AS DOUBLE)) AS `std__2`,
+    MIN(`a`) AS `min__2`,
+    PERCENTILE(`a`, 0.25) AS `25%__2`,
+    PERCENTILE(`a`, 0.5) AS `50%__2`,
+    PERCENTILE(`a`, 0.75) AS `75%__2`,
+    MAX(`a`) AS `max__2`,
+    NULL AS `min TZ offset__2`,
+    NULL AS `max TZ offset__2`,
+    COUNT(DISTINCT `b`) AS `unique__3`,
+    (
+      1.0 - COUNT(`b`) / NULLIF(COUNT(*), 0)
+    ) * 100 AS `%missing__3`,
+    NULL AS `%empty__3`,
+    AVG(CAST(`b` AS DOUBLE)) AS `mean__3`,
+    STDDEV(CAST(`b` AS DOUBLE)) AS `std__3`,
+    MIN(`b`) AS `min__3`,
+    PERCENTILE(`b`, 0.25) AS `25%__3`,
+    PERCENTILE(`b`, 0.5) AS `50%__3`,
+    PERCENTILE(`b`, 0.75) AS `75%__3`,
+    MAX(`b`) AS `max__3`,
+    NULL AS `min TZ offset__3`,
+    NULL AS `max TZ offset__3`,
+    COUNT(DISTINCT `a_copy`) AS `unique__4`,
+    (
+      1.0 - COUNT(`a_copy`) / NULLIF(COUNT(*), 0)
+    ) * 100 AS `%missing__4`,
+    NULL AS `%empty__4`,
+    AVG(CAST(`a_copy` AS DOUBLE)) AS `mean__4`,
+    STDDEV(CAST(`a_copy` AS DOUBLE)) AS `std__4`,
+    MIN(`a_copy`) AS `min__4`,
+    PERCENTILE(`a_copy`, 0.25) AS `25%__4`,
+    PERCENTILE(`a_copy`, 0.5) AS `50%__4`,
+    PERCENTILE(`a_copy`, 0.75) AS `75%__4`,
+    MAX(`a_copy`) AS `max__4`,
+    NULL AS `min TZ offset__4`,
+    NULL AS `max TZ offset__4`
+  FROM data
+), joined_tables_0 AS (
+  SELECT
+    *
+  FROM stats
+  LEFT JOIN counts__0
+), joined_tables_1 AS (
+  SELECT
+    *
+  FROM counts__1
+  LEFT JOIN counts__2
+), joined_tables_2 AS (
+  SELECT
+    *
+  FROM counts__3
+  LEFT JOIN counts__4
+)
+SELECT
+  'TIMESTAMP' AS `dtype__0`,
+  `unique__0`,
+  `%missing__0`,
+  `%empty__0`,
+  NULL AS `entropy__0`,
+  `top__0`,
+  `freq__0`,
+  `mean__0`,
+  `std__0`,
+  `min__0`,
+  `25%__0`,
+  `50%__0`,
+  `75%__0`,
+  `max__0`,
+  `min TZ offset__0`,
+  `max TZ offset__0`,
+  'VARCHAR' AS `dtype__1`,
+  `unique__1`,
+  `%missing__1`,
+  `%empty__1`,
+  `entropy__1`,
+  `top__1`,
+  `freq__1`,
+  `mean__1`,
+  `std__1`,
+  `min__1`,
+  `25%__1`,
+  `50%__1`,
+  `75%__1`,
+  `max__1`,
+  `min TZ offset__1`,
+  `max TZ offset__1`,
+  'FLOAT' AS `dtype__2`,
+  `unique__2`,
+  `%missing__2`,
+  `%empty__2`,
+  NULL AS `entropy__2`,
+  `top__2`,
+  `freq__2`,
+  `mean__2`,
+  `std__2`,
+  `min__2`,
+  `25%__2`,
+  `50%__2`,
+  `75%__2`,
+  `max__2`,
+  `min TZ offset__2`,
+  `max TZ offset__2`,
+  'INT' AS `dtype__3`,
+  `unique__3`,
+  `%missing__3`,
+  `%empty__3`,
+  NULL AS `entropy__3`,
+  `top__3`,
+  `freq__3`,
+  `mean__3`,
+  `std__3`,
+  `min__3`,
+  `25%__3`,
+  `50%__3`,
+  `75%__3`,
+  `max__3`,
+  `min TZ offset__3`,
+  `max TZ offset__3`,
+  'FLOAT' AS `dtype__4`,
+  `unique__4`,
+  `%missing__4`,
+  `%empty__4`,
+  NULL AS `entropy__4`,
+  `top__4`,
+  `freq__4`,
+  `mean__4`,
+  `std__4`,
+  `min__4`,
+  `25%__4`,
+  `50%__4`,
+  `75%__4`,
+  `max__4`,
+  `min TZ offset__4`,
+  `max TZ offset__4`
+FROM joined_tables_0
+LEFT JOIN joined_tables_1
+LEFT JOIN joined_tables_2

--- a/tests/fixtures/query_graph/expected_describe_snowflake.sql
+++ b/tests/fixtures/query_graph/expected_describe_snowflake.sql
@@ -23,7 +23,7 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__0"
   FROM (
     SELECT
-      OBJECT_AGG("ts", "__FB_COUNTS") AS "COUNT_DICT"
+      OBJECT_AGG(CASE WHEN "ts" IS NULL THEN '__MISSING__' ELSE "ts" END, TO_VARIANT("__FB_COUNTS")) AS "COUNT_DICT"
     FROM (
       SELECT
         "ts",
@@ -43,7 +43,10 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__1"
   FROM (
     SELECT
-      OBJECT_AGG("cust_id", "__FB_COUNTS") AS "COUNT_DICT"
+      OBJECT_AGG(
+        CASE WHEN "cust_id" IS NULL THEN '__MISSING__' ELSE "cust_id" END,
+        TO_VARIANT("__FB_COUNTS")
+      ) AS "COUNT_DICT"
     FROM (
       SELECT
         "cust_id",
@@ -62,7 +65,7 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__2"
   FROM (
     SELECT
-      OBJECT_AGG("a", "__FB_COUNTS") AS "COUNT_DICT"
+      OBJECT_AGG(CASE WHEN "a" IS NULL THEN '__MISSING__' ELSE "a" END, TO_VARIANT("__FB_COUNTS")) AS "COUNT_DICT"
     FROM (
       SELECT
         "a",
@@ -81,7 +84,7 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__3"
   FROM (
     SELECT
-      OBJECT_AGG("b", "__FB_COUNTS") AS "COUNT_DICT"
+      OBJECT_AGG(CASE WHEN "b" IS NULL THEN '__MISSING__' ELSE "b" END, TO_VARIANT("__FB_COUNTS")) AS "COUNT_DICT"
     FROM (
       SELECT
         "b",
@@ -100,7 +103,10 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict."COUNT_DICT") AS "freq__4"
   FROM (
     SELECT
-      OBJECT_AGG("a_copy", "__FB_COUNTS") AS "COUNT_DICT"
+      OBJECT_AGG(
+        CASE WHEN "a_copy" IS NULL THEN '__MISSING__' ELSE "a_copy" END,
+        TO_VARIANT("__FB_COUNTS")
+      ) AS "COUNT_DICT"
     FROM (
       SELECT
         "a_copy",

--- a/tests/fixtures/query_graph/expected_describe_spark.sql
+++ b/tests/fixtures/query_graph/expected_describe_spark.sql
@@ -23,7 +23,9 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict.`COUNT_DICT`) AS `freq__0`
   FROM (
     SELECT
-      OBJECT_AGG(`ts`, `__FB_COUNTS`) AS `COUNT_DICT`
+      MAP_FROM_ENTRIES(
+        COLLECT_LIST(STRUCT(CASE WHEN `ts` IS NULL THEN '__MISSING__' ELSE `ts` END, `__FB_COUNTS`))
+      ) AS `COUNT_DICT`
     FROM (
       SELECT
         `ts`,
@@ -43,7 +45,11 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict.`COUNT_DICT`) AS `freq__1`
   FROM (
     SELECT
-      OBJECT_AGG(`cust_id`, `__FB_COUNTS`) AS `COUNT_DICT`
+      MAP_FROM_ENTRIES(
+        COLLECT_LIST(
+          STRUCT(CASE WHEN `cust_id` IS NULL THEN '__MISSING__' ELSE `cust_id` END, `__FB_COUNTS`)
+        )
+      ) AS `COUNT_DICT`
     FROM (
       SELECT
         `cust_id`,
@@ -62,7 +68,9 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict.`COUNT_DICT`) AS `freq__2`
   FROM (
     SELECT
-      OBJECT_AGG(`a`, `__FB_COUNTS`) AS `COUNT_DICT`
+      MAP_FROM_ENTRIES(
+        COLLECT_LIST(STRUCT(CASE WHEN `a` IS NULL THEN '__MISSING__' ELSE `a` END, `__FB_COUNTS`))
+      ) AS `COUNT_DICT`
     FROM (
       SELECT
         `a`,
@@ -81,7 +89,9 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict.`COUNT_DICT`) AS `freq__3`
   FROM (
     SELECT
-      OBJECT_AGG(`b`, `__FB_COUNTS`) AS `COUNT_DICT`
+      MAP_FROM_ENTRIES(
+        COLLECT_LIST(STRUCT(CASE WHEN `b` IS NULL THEN '__MISSING__' ELSE `b` END, `__FB_COUNTS`))
+      ) AS `COUNT_DICT`
     FROM (
       SELECT
         `b`,
@@ -100,7 +110,11 @@ WITH data AS (
     F_COUNT_DICT_MOST_FREQUENT_VALUE(count_dict.`COUNT_DICT`) AS `freq__4`
   FROM (
     SELECT
-      OBJECT_AGG(`a_copy`, `__FB_COUNTS`) AS `COUNT_DICT`
+      MAP_FROM_ENTRIES(
+        COLLECT_LIST(
+          STRUCT(CASE WHEN `a_copy` IS NULL THEN '__MISSING__' ELSE `a_copy` END, `__FB_COUNTS`)
+        )
+      ) AS `COUNT_DICT`
     FROM (
       SELECT
         `a_copy`,

--- a/tests/integration/api/test_view_describe.py
+++ b/tests/integration/api/test_view_describe.py
@@ -2,7 +2,10 @@
 Test API View objects describe function
 """
 import pandas as pd
+import pytest
 from pandas.testing import assert_series_equal
+
+from tests.source_types import SNOWFLAKE_SPARK_DATABRICKS
 
 
 def _to_utc_no_offset(date):
@@ -12,6 +15,7 @@ def _to_utc_no_offset(date):
     return pd.to_datetime(date, utc=True).tz_localize(None)
 
 
+@pytest.mark.parametrize("source_type", SNOWFLAKE_SPARK_DATABRICKS, indirect=True)
 def test_event_view_describe(event_table):
     """
     Test describe for EventView
@@ -66,6 +70,7 @@ def test_event_view_describe(event_table):
     assert _to_utc_no_offset(describe_df["ËVENT_TIMESTAMP"]["max"]) == expected_max_timestamp
 
 
+@pytest.mark.parametrize("source_type", SNOWFLAKE_SPARK_DATABRICKS, indirect=True)
 def test_event_view_describe_with_date_range(event_table):
     """
     Test describe for EventView with date range
@@ -120,6 +125,7 @@ def test_event_view_describe_with_date_range(event_table):
     )
 
 
+@pytest.mark.parametrize("source_type", SNOWFLAKE_SPARK_DATABRICKS, indirect=True)
 def test_item_view_describe(item_table):
     """
     Test describe for ItemView
@@ -168,6 +174,7 @@ def test_item_view_describe(item_table):
     assert _to_utc_no_offset(describe_df["ËVENT_TIMESTAMP"]["max"]) == expected_max_timestamp
 
 
+@pytest.mark.parametrize("source_type", SNOWFLAKE_SPARK_DATABRICKS, indirect=True)
 def test_dimension_view_describe(dimension_table):
     """
     Test sample for DimensionView
@@ -194,6 +201,7 @@ def test_dimension_view_describe(dimension_table):
     assert describe_df.shape == (9, 4)
 
 
+@pytest.mark.parametrize("source_type", SNOWFLAKE_SPARK_DATABRICKS, indirect=True)
 def test_scd_view_describe(scd_table):
     """
     Test sample for DimensionView
@@ -237,6 +245,7 @@ def test_scd_view_describe(scd_table):
     assert _to_utc_no_offset(describe_df["Effective Timestamp"]["max"]) == expected_max_timestamp
 
 
+@pytest.mark.parametrize("source_type", SNOWFLAKE_SPARK_DATABRICKS, indirect=True)
 def test_describe_empty_view(event_table):
     """
     Test describe for an empty view

--- a/tests/unit/query_graph/interpreter/test_preview.py
+++ b/tests/unit/query_graph/interpreter/test_preview.py
@@ -7,6 +7,7 @@ import pytest
 
 from featurebyte.enum import SourceType
 from featurebyte.query_graph.sql.interpreter import GraphInterpreter
+from tests.source_types import SNOWFLAKE_SPARK_DATABRICKS
 from tests.util.helper import assert_equal_with_expected_fixture
 
 
@@ -19,7 +20,7 @@ def patch_num_tables_per_join():
         yield
 
 
-@pytest.mark.parametrize("source_type", [SourceType.SNOWFLAKE, SourceType.SPARK])
+@pytest.mark.parametrize("source_type", SNOWFLAKE_SPARK_DATABRICKS)
 def test_graph_interpreter_describe(simple_graph, source_type, update_fixtures):
     """Test graph sample"""
     graph, node = simple_graph


### PR DESCRIPTION
## Description

This replaces the usage of `OBJECT_AGG` hive udf with spark's built-in functions. This allows us to transition to databricks with unity catalog.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
