### PR TITLE
[DEV-2902] Support non-window aggregate features in feast integration

### DIFF
--- a/featurebyte/models/entity_universe.py
+++ b/featurebyte/models/entity_universe.py
@@ -1,0 +1,327 @@
+"""
+This module contains the logic to construct the entity universe for a given node
+"""
+from __future__ import annotations
+
+from typing import List, Optional, Tuple, cast
+
+from abc import abstractmethod
+from datetime import datetime
+
+from sqlglot import expressions
+from sqlglot.expressions import Expression, Select, select
+
+from featurebyte.enum import SourceType
+from featurebyte.models.base import FeatureByteBaseModel
+from featurebyte.models.offline_store_ingest_query import OfflineStoreIngestQueryGraph
+from featurebyte.models.sqlglot_expression import SqlglotExpressionModel
+from featurebyte.query_graph.enum import NodeType
+from featurebyte.query_graph.model.graph import QueryGraphModel
+from featurebyte.query_graph.node import Node
+from featurebyte.query_graph.node.generic import AggregateAsAtNode, LookupNode
+from featurebyte.query_graph.sql.ast.literal import make_literal_value
+from featurebyte.query_graph.sql.builder import SQLOperationGraph
+from featurebyte.query_graph.sql.common import SQLType, quoted_identifier
+from featurebyte.query_graph.sql.template import SqlExpressionTemplate
+from featurebyte.query_graph.transform.flattening import GraphFlatteningTransformer
+
+CURRENT_FEATURE_TIMESTAMP_PLACEHOLDER = "__fb_current_feature_timestamp"
+LAST_MATERIALIZED_TIMESTAMP_PLACEHOLDER = "__fb_last_materialized_timestamp"
+
+
+class BaseEntityUniverseConstructor:
+    """
+    Base class for entity universe constructor.
+
+    Prepares the context of what is commonly required when determining the entity universe for a
+    given aggregation node: the node parameters the SQL expression for the input of the aggregation
+    node.
+    """
+
+    def __init__(self, graph: QueryGraphModel, node: Node):
+        flat_graph, node_name_map = GraphFlatteningTransformer(graph=graph).transform()
+        flat_node = flat_graph.get_node_by_name(node_name_map[node.name])
+        self.graph = flat_graph
+        self.node = flat_node
+
+        sql_graph = SQLOperationGraph(
+            self.graph, SQLType.AGGREGATION, source_type=SourceType.SNOWFLAKE
+        )
+        sql_node = sql_graph.build(self.node)
+        self.aggregate_input_expr = sql_node.sql
+
+    @abstractmethod
+    def get_entity_universe_template(self) -> Expression:
+        """
+        Returns a SQL expression for the universe of the entity with placeholders for current
+        feature timestamp and last materialization timestamp
+        """
+
+
+class LookupNodeEntityUniverseConstructor(BaseEntityUniverseConstructor):
+    """
+    Construct the entity universe expression for lookup node
+    """
+
+    def get_entity_universe_template(self) -> Expression:
+        node = cast(LookupNode, self.node)
+
+        if node.parameters.scd_parameters is not None:
+            ts_col = node.parameters.scd_parameters.effective_timestamp_column
+        elif node.parameters.event_parameters is not None:
+            ts_col = node.parameters.event_parameters.event_timestamp_column
+        else:
+            ts_col = None
+
+        if ts_col:
+            aggregate_input_expr = self.aggregate_input_expr.where(
+                expressions.and_(
+                    expressions.GTE(
+                        this=quoted_identifier(ts_col),
+                        expression=LAST_MATERIALIZED_TIMESTAMP_PLACEHOLDER,
+                    ),
+                    expressions.LT(
+                        this=quoted_identifier(ts_col),
+                        expression=CURRENT_FEATURE_TIMESTAMP_PLACEHOLDER,
+                    ),
+                )
+            )
+        else:
+            aggregate_input_expr = self.aggregate_input_expr
+
+        universe_expr = (
+            select(
+                expressions.alias_(
+                    quoted_identifier(node.parameters.entity_column),
+                    alias=node.parameters.serving_name,
+                    quoted=True,
+                )
+            )
+            .distinct()
+            .from_(aggregate_input_expr.subquery())
+        )
+        return universe_expr
+
+
+class AggregateAsAtNodeEntityUniverseConstructor(BaseEntityUniverseConstructor):
+    """
+    Construct the entity universe expression for aggregate as at node
+    """
+
+    def get_entity_universe_template(self) -> Expression:
+        node = cast(AggregateAsAtNode, self.node)
+
+        ts_col = node.parameters.effective_timestamp_column
+        filtered_aggregate_input_expr = self.aggregate_input_expr.where(
+            expressions.and_(
+                expressions.GTE(
+                    this=quoted_identifier(ts_col),
+                    expression=LAST_MATERIALIZED_TIMESTAMP_PLACEHOLDER,
+                ),
+                expressions.LT(
+                    this=quoted_identifier(ts_col), expression=CURRENT_FEATURE_TIMESTAMP_PLACEHOLDER
+                ),
+            )
+        )
+        universe_expr = (
+            select(
+                *[
+                    expressions.alias_(quoted_identifier(key), alias=serving_name, quoted=True)
+                    for key, serving_name in zip(
+                        node.parameters.keys, node.parameters.serving_names
+                    )
+                ]
+            )
+            .distinct()
+            .from_(filtered_aggregate_input_expr.subquery())
+        )
+        return universe_expr
+
+
+def get_entity_universe_constructor(
+    graph: QueryGraphModel, node: Node
+) -> BaseEntityUniverseConstructor:
+    """
+    Returns the entity universe constructor for the given node
+
+    Parameters
+    ----------
+    graph: QueryGraphModel
+        The query graph
+    node: Node
+        The node for which the entity universe constructor is to be returned
+
+    Returns
+    -------
+    BaseEntityUniverseConstructor
+
+    Raises
+    ------
+    NotImplementedError
+        If the node type is not supported
+    """
+    if node.type == NodeType.LOOKUP:
+        return LookupNodeEntityUniverseConstructor(graph, node)
+    if node.type == NodeType.AGGREGATE_AS_AT:
+        return AggregateAsAtNodeEntityUniverseConstructor(graph, node)
+    raise NotImplementedError(f"Unsupported node type: {node.type}")
+
+
+def get_combined_universe(graph_and_node_pairs: List[Tuple[QueryGraphModel, Node]]) -> Expression:
+    """
+    Returns the combined entity universe expression
+
+    Parameters
+    ----------
+    graph_and_node_pairs: List[Tuple[QueryGraphModel, Node]]
+        List of (graph, node) pairs for which the entity universe is to be constructed
+
+    Returns
+    -------
+    Expression
+    """
+    combined_universe_expr: Optional[Expression] = None
+    processed_universe_exprs = set()
+
+    for graph, node in graph_and_node_pairs:
+        entity_universe_constructor = get_entity_universe_constructor(graph, node)
+        current_universe_expr = entity_universe_constructor.get_entity_universe_template()
+        if combined_universe_expr is None:
+            combined_universe_expr = current_universe_expr
+        elif current_universe_expr not in processed_universe_exprs:
+            combined_universe_expr = expressions.Union(
+                this=current_universe_expr,
+                distinct=True,
+                expression=combined_universe_expr,
+            )
+        processed_universe_exprs.add(current_universe_expr)
+
+    assert combined_universe_expr is not None
+    return combined_universe_expr
+
+
+def construct_window_aggregates_universe(
+    serving_names: List[str],
+    aggregate_result_table_names: List[str],
+) -> Expression:
+    """
+    Construct the entity universe expression for window aggregate
+
+    Parameters
+    ----------
+    serving_names: List[str]
+        The serving names of the entities
+    aggregate_result_table_names: List[str]
+        The names of the aggregate result tables
+
+    Returns
+    -------
+    Expression
+    """
+    if not serving_names:
+        return expressions.select(
+            expressions.alias_(make_literal_value(1), "dummy_entity", quoted=True)
+        )
+
+    assert len(aggregate_result_table_names) > 0
+
+    # select distinct serving names across all aggregation result tables
+    distinct_serving_names_from_tables = [
+        select(*[quoted_identifier(serving_name) for serving_name in serving_names])
+        .distinct()
+        .from_(table_name)
+        for table_name in aggregate_result_table_names
+    ]
+
+    union_expr = distinct_serving_names_from_tables[0]
+    for expr in distinct_serving_names_from_tables[1:]:
+        union_expr = expressions.Union(this=expr, distinct=True, expression=union_expr)  # type: ignore
+
+    return union_expr
+
+
+class EntityUniverseModel(FeatureByteBaseModel):
+    """
+    EntityUniverseModel class
+    """
+
+    # query_template is a SQL expression template with placeholders __fb_current_feature_timestamp,
+    # __fb_last_materialized_timestamp which will be replaced with actual values when entity
+    # universe needs to be generated.
+    query_template: SqlglotExpressionModel
+
+    @classmethod
+    def create(
+        cls,
+        serving_names: List[str],
+        aggregate_result_table_names: List[str],
+        offline_ingest_graphs: List[OfflineStoreIngestQueryGraph],
+    ) -> EntityUniverseModel:
+        """
+        Create a new EntityUniverseModel object
+
+        Parameters
+        ----------
+        serving_names: List[str]
+            The serving names of the entities
+        aggregate_result_table_names: List[str]
+            The names of the aggregate result tables for window aggregates
+        offline_ingest_graphs: List[OfflineStoreIngestQueryGraph]
+            The offline ingest graphs that the entity universe is to be constructed from
+
+        Returns
+        -------
+        EntityUniverse
+        """
+        if aggregate_result_table_names:
+            universe_expr = construct_window_aggregates_universe(
+                serving_names=serving_names,
+                aggregate_result_table_names=aggregate_result_table_names,
+            )
+        else:
+            graph_and_node_pairs = []
+            for offline_ingest_graph in offline_ingest_graphs:
+                for info in offline_ingest_graph.aggregation_nodes_info:
+                    node = offline_ingest_graph.graph.get_node_by_name(info.node_name)
+                    graph_and_node_pairs.append((offline_ingest_graph.graph, node))
+            universe_expr = get_combined_universe(graph_and_node_pairs)
+
+        return EntityUniverseModel(query_template=SqlglotExpressionModel.create(universe_expr))
+
+    def get_entity_universe_expr(
+        self,
+        current_feature_timestamp: datetime,
+        last_materialized_timestamp: Optional[datetime],
+    ) -> Select:
+        """
+        Get a concrete SQL expression for the entity universe for the given feature timestamp and
+        optionally the last materialized timestamp.
+
+        Parameters
+        ----------
+        current_feature_timestamp : datetime
+            Current feature timestamp
+        last_materialized_timestamp : Optional[datetime]
+            Last materialized timestamp
+
+        Returns
+        -------
+        Expression
+        """
+        params = {
+            CURRENT_FEATURE_TIMESTAMP_PLACEHOLDER: make_literal_value(
+                current_feature_timestamp, cast_as_timestamp=True
+            ),
+        }
+        if last_materialized_timestamp is not None:
+            params[LAST_MATERIALIZED_TIMESTAMP_PLACEHOLDER] = make_literal_value(
+                last_materialized_timestamp, cast_as_timestamp=True
+            )
+        else:
+            params[LAST_MATERIALIZED_TIMESTAMP_PLACEHOLDER] = make_literal_value(
+                "1970-01-01 00:00:00", cast_as_timestamp=True
+            )
+        return cast(
+            Select,
+            SqlExpressionTemplate(self.query_template.expr).render(data=params, as_str=False),
+        )

--- a/featurebyte/models/feature.py
+++ b/featurebyte/models/feature.py
@@ -29,6 +29,7 @@ from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.query_graph.model.common_table import TabularSource
 from featurebyte.query_graph.model.entity_relationship_info import EntityRelationshipInfo
 from featurebyte.query_graph.model.feature_job_setting import (
+    FeatureJobSetting,
     TableFeatureJobSetting,
     TableIdFeatureJobSetting,
 )
@@ -462,9 +463,15 @@ class BaseFeatureModel(QueryGraphMixin, FeatureByteCatalogBaseDocumentModel):
         else:
             decomposed_graph = self.graph
             output_node_name = self.node.name
-            feature_job_setting = None
             if self.table_id_feature_job_settings:
                 feature_job_setting = self.table_id_feature_job_settings[0].feature_job_setting
+            else:
+                # TODO: Remove this once the default are specified in the graph
+                feature_job_setting = FeatureJobSetting(
+                    frequency="1d",
+                    time_modulo_frequency="0s",
+                    blind_spot="0s",
+                )
 
             has_ttl = bool(
                 next(

--- a/featurebyte/models/offline_store_feature_table.py
+++ b/featurebyte/models/offline_store_feature_table.py
@@ -10,7 +10,7 @@ from datetime import datetime
 
 import pymongo
 
-from featurebyte.enum import DBVarType
+from featurebyte.enum import DBVarType, SourceType
 from featurebyte.models.base import (
     FeatureByteCatalogBaseDocumentModel,
     PydanticObjectId,
@@ -177,6 +177,7 @@ def get_offline_store_feature_table_model(
     primary_entities: List[EntityModel],
     has_ttl: bool,
     feature_job_setting: Optional[FeatureJobSetting],
+    source_type: SourceType,
 ) -> OfflineStoreFeatureTableModel:
     """
     Returns a OfflineStoreFeatureTableModel for a feature table
@@ -195,6 +196,8 @@ def get_offline_store_feature_table_model(
         Whether the feature table has TTL
     feature_job_setting : Optional[FeatureJobSetting]
         Feature job setting of the feature table
+    source_type : SourceType
+        Source type information
 
     Returns
     -------
@@ -211,6 +214,7 @@ def get_offline_store_feature_table_model(
         serving_names=[entity.serving_names[0] for entity in primary_entities],
         aggregate_result_table_names=aggregate_result_table_names,
         offline_ingest_graphs=ingest_graph_metadata.offline_ingest_graphs,
+        source_type=source_type,
     )
 
     return OfflineStoreFeatureTableModel(

--- a/featurebyte/models/offline_store_feature_table.py
+++ b/featurebyte/models/offline_store_feature_table.py
@@ -1,80 +1,29 @@
 """
 OfflineStoreFeatureTableModel class
 """
-from typing import List, Literal, Optional, Union
+from __future__ import annotations
+
+from typing import List, Optional, Union
 
 from dataclasses import dataclass
 from datetime import datetime
 
 import pymongo
-from pydantic import Field
-from sqlglot import expressions
-from sqlglot.expressions import Select, select
 
-from featurebyte.enum import DBVarType, StrEnum
+from featurebyte.enum import DBVarType
 from featurebyte.models.base import (
-    FeatureByteBaseModel,
     FeatureByteCatalogBaseDocumentModel,
     PydanticObjectId,
     UniqueValuesConstraint,
 )
 from featurebyte.models.entity import EntityModel
+from featurebyte.models.entity_universe import EntityUniverseModel
 from featurebyte.models.feature import FeatureModel
 from featurebyte.models.feature_list import FeatureCluster
+from featurebyte.models.offline_store_ingest_query import OfflineStoreIngestQueryGraph
 from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
-from featurebyte.query_graph.sql.ast.literal import make_literal_value
-from featurebyte.query_graph.sql.common import quoted_identifier
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema
-
-
-class EntityUniverseType(StrEnum):
-    """
-    EntityUniverseType enum
-    """
-
-    WINDOW_AGGREGATE = "window_aggregate"
-
-
-class WindowAggregateEntityUniverse(FeatureByteBaseModel):
-    """
-    WindowAggregateEntityUniverse class
-    """
-
-    serving_names: List[str]
-    aggregate_result_table_names: List[str] = Field(min_length=1)
-    type: Literal[EntityUniverseType.WINDOW_AGGREGATE] = Field(
-        EntityUniverseType.WINDOW_AGGREGATE, const=True
-    )
-
-    def get_entity_universe_expr(self) -> Select:
-        """
-        Get the SQL expression for the entity universe
-
-        Returns
-        -------
-        Select
-        """
-        if not self.serving_names:
-            return expressions.select(
-                expressions.alias_(make_literal_value(1), "dummy_entity", quoted=True)
-            )
-
-        assert len(self.aggregate_result_table_names) > 0
-
-        # select distinct serving names across all aggregation result tables
-        distinct_serving_names_from_tables = [
-            select(*[quoted_identifier(serving_name) for serving_name in self.serving_names])
-            .distinct()
-            .from_(table_name)
-            for table_name in self.aggregate_result_table_names
-        ]
-
-        union_expr = distinct_serving_names_from_tables[0]
-        for expr in distinct_serving_names_from_tables[1:]:
-            union_expr = expressions.Union(this=expr, distinct=True, expression=union_expr)  # type: ignore
-
-        return union_expr
 
 
 class OfflineStoreFeatureTableModel(FeatureByteCatalogBaseDocumentModel):
@@ -93,7 +42,7 @@ class OfflineStoreFeatureTableModel(FeatureByteCatalogBaseDocumentModel):
     feature_cluster: FeatureCluster
     output_column_names: List[str]
     output_dtypes: List[DBVarType]
-    entity_universe: WindowAggregateEntityUniverse
+    entity_universe: EntityUniverseModel
 
     class Settings(FeatureByteCatalogBaseDocumentModel.Settings):
         """
@@ -127,7 +76,7 @@ class FeaturesUpdate(BaseDocumentServiceUpdateSchema):
     feature_cluster: FeatureCluster
     output_column_names: List[str]
     output_dtypes: List[DBVarType]
-    entity_universe: WindowAggregateEntityUniverse
+    entity_universe: EntityUniverseModel
 
 
 class LastMaterializedAtUpdate(BaseDocumentServiceUpdateSchema):
@@ -150,6 +99,7 @@ class OfflineIngestGraphMetadata:
     feature_cluster: FeatureCluster
     output_column_names: List[str]
     output_dtypes: List[DBVarType]
+    offline_ingest_graphs: List[OfflineStoreIngestQueryGraph]
 
 
 def get_combined_ingest_graph(
@@ -181,6 +131,7 @@ def get_combined_ingest_graph(
     output_nodes = []
     output_column_names = []
     output_dtypes = []
+    all_offline_ingest_graphs = []
 
     primary_entity_ids = sorted([entity.id for entity in primary_entities])
     for feature in features:
@@ -203,6 +154,7 @@ def get_combined_ingest_graph(
             output_nodes.append(local_query_graph.get_node_by_name(local_name_map[node.name]))
             output_column_names.append(offline_ingest_graph.output_column_name)
             output_dtypes.append(offline_ingest_graph.output_dtype)
+            all_offline_ingest_graphs.append(offline_ingest_graph)
 
     feature_cluster = FeatureCluster(
         feature_store_id=features[0].tabular_source.feature_store_id,
@@ -214,6 +166,7 @@ def get_combined_ingest_graph(
         feature_cluster=feature_cluster,
         output_column_names=output_column_names,
         output_dtypes=output_dtypes,
+        offline_ingest_graphs=all_offline_ingest_graphs,
     )
 
 
@@ -254,12 +207,10 @@ def get_offline_store_feature_table_model(
         feature_job_setting=feature_job_setting,
     )
 
-    # TODO: handle feature types that are currently not being precomputed, e.g. lookup
-    #  features, asat aggregates, etc.
-    assert len(aggregate_result_table_names) > 0
-    entity_universe = WindowAggregateEntityUniverse(
+    entity_universe = EntityUniverseModel.create(
         serving_names=[entity.serving_names[0] for entity in primary_entities],
         aggregate_result_table_names=aggregate_result_table_names,
+        offline_ingest_graphs=ingest_graph_metadata.offline_ingest_graphs,
     )
 
     return OfflineStoreFeatureTableModel(

--- a/featurebyte/models/sqlglot_expression.py
+++ b/featurebyte/models/sqlglot_expression.py
@@ -1,0 +1,54 @@
+"""
+SqlglotExpressionModel class
+"""
+from __future__ import annotations
+
+from typing import cast
+
+import sqlglot
+from sqlglot.expressions import Expression
+
+from featurebyte.models.base import FeatureByteBaseModel
+
+
+class SqlglotExpressionModel(FeatureByteBaseModel):
+    """
+    SqlglotExpressionModel class
+    """
+
+    formatted_expression: str
+
+    # The sqlglot expression will be serialized as a string using this format. Upon deserialization,
+    # the string will be parsed using the same format. But this model can be used for different
+    # dialects not necessarily the same as this.
+    _DIALECT_FORMAT = "snowflake"
+
+    @classmethod
+    def create(cls, expr: Expression) -> SqlglotExpressionModel:
+        """
+        Create a SqlglotExpressionModel from a sqlglot expression
+
+        Parameters
+        ----------
+        expr : Expression
+            Sqlglot expression
+
+        Returns
+        -------
+        SqlglotExpressionModel
+        """
+        formatted_expression = expr.sql(dialect=cls._DIALECT_FORMAT, pretty=True)
+        return cls(formatted_expression=formatted_expression)
+
+    @property
+    def expr(self) -> Expression:
+        """
+        Get the underlying SQL expression
+
+        Returns
+        -------
+        Expression
+        """
+        return cast(
+            Expression, sqlglot.parse_one(self.formatted_expression, read=self._DIALECT_FORMAT)
+        )

--- a/featurebyte/query_graph/sql/template.py
+++ b/featurebyte/query_graph/sql/template.py
@@ -3,7 +3,7 @@ Module for constructs to work with template SQL code with placeholders
 """
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 from sqlglot import expressions
 from sqlglot.expressions import Expression
@@ -25,7 +25,7 @@ class SqlExpressionTemplate:
         Source type information
     """
 
-    def __init__(self, sql_expr: Expression, source_type: SourceType):
+    def __init__(self, sql_expr: Expression, source_type: Optional[SourceType] = None):
         self.sql_expr = sql_expr
         self.source_type = source_type
 
@@ -54,6 +54,7 @@ class SqlExpressionTemplate:
                 )
             )
         if as_str:
+            assert self.source_type is not None
             return sql_to_string(rendered_expr, source_type=self.source_type)
         return rendered_expr
 

--- a/featurebyte/service/offline_store_feature_table_manager.py
+++ b/featurebyte/service/offline_store_feature_table_manager.py
@@ -190,6 +190,9 @@ class OfflineStoreFeatureTableManagerService:  # pylint: disable=too-many-instan
                 await self.offline_store_feature_table_service.create_document(feature_table_model)
 
             if feature_table_model is not None:
+                # Note: might need to defer updating feast registry till initialization is done to
+                # prevent concurrency issues (scheduled job started while new column's
+                # initialization is still in progress)
                 await self._create_or_update_feast_registry()
                 await self.feature_materialize_service.initialize_new_columns(feature_table_model)
                 await self.feature_materialize_scheduler_service.start_job_if_not_exist(

--- a/tests/fixtures/offline_store_feature_table/aggregate_asat_feature_universe.sql
+++ b/tests/fixtures/offline_store_feature_table/aggregate_asat_feature_universe.sql
@@ -1,0 +1,19 @@
+SELECT DISTINCT
+  "col_boolean" AS "gender"
+FROM (
+  SELECT
+    "col_int" AS "col_int",
+    "col_float" AS "col_float",
+    "col_text" AS "col_text",
+    "col_binary" AS "col_binary",
+    "col_boolean" AS "col_boolean",
+    "effective_timestamp" AS "effective_timestamp",
+    "end_timestamp" AS "end_timestamp",
+    "date_of_birth" AS "date_of_birth",
+    "created_at" AS "created_at",
+    "cust_id" AS "cust_id"
+  FROM "sf_database"."sf_schema"."scd_table"
+  WHERE
+    "effective_timestamp" >= __fb_last_materialized_timestamp
+    AND "effective_timestamp" < __fb_current_feature_timestamp
+)

--- a/tests/fixtures/offline_store_feature_table/lookup_feature_universe.sql
+++ b/tests/fixtures/offline_store_feature_table/lookup_feature_universe.sql
@@ -1,0 +1,19 @@
+SELECT DISTINCT
+  "col_text" AS "cust_id"
+FROM (
+  SELECT
+    "col_int" AS "col_int",
+    "col_float" AS "col_float",
+    "col_text" AS "col_text",
+    "col_binary" AS "col_binary",
+    "col_boolean" AS "col_boolean",
+    "effective_timestamp" AS "effective_timestamp",
+    "end_timestamp" AS "end_timestamp",
+    "date_of_birth" AS "date_of_birth",
+    "created_at" AS "created_at",
+    "cust_id" AS "cust_id"
+  FROM "sf_database"."sf_schema"."scd_table"
+  WHERE
+    "effective_timestamp" >= __fb_last_materialized_timestamp
+    AND "effective_timestamp" < __fb_current_feature_timestamp
+)

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -31,7 +31,7 @@ def always_enable_feast_integration_fixture():
 
 
 @pytest.fixture(name="features", scope="module")
-def features_fixture(event_table):
+def features_fixture(event_table, scd_table):
     """
     Fixture for feature
     """
@@ -118,6 +118,15 @@ def features_fixture(event_table):
     feature_9 = feature_8.vec.cosine_similarity(vec_agg_feature2)
     feature_9.name = "EXTERNAL_FS_COSINE_SIMILARITY_VEC"
 
+    scd_view = scd_table.get_view()
+    feature_10 = scd_view["User Status"].as_feature("User Status Feature")
+    feature_11 = (
+        scd_view.groupby("User Status")
+        .aggregate_asat(method="count", feature_name="Current Number of Users With This Status")
+        .astype(float)
+    )
+    feature_11.name = "Current Number of Users With This Status"
+
     # Save all features to be deployed
     features = [
         feature_1,
@@ -129,6 +138,8 @@ def features_fixture(event_table):
         feature_7,
         feature_8,
         feature_9,
+        feature_10,
+        feature_11,
     ]
     for feature in features:
         feature.save()
@@ -196,6 +207,8 @@ async def check_feast_registry(app_container):
         "fb_entity_product_action_fjs_3600_1800_1800_ttl",
         "fb_entity_cust_id_fjs_3600_1800_1800_ttl",
         "fb_entity_üserid_fjs_3600_1800_1800_ttl",
+        "fb_entity_üserid_fjs_86400_0_0",
+        "fb_entity_user_status_fjs_86400_0_0",
     }
     assert {fs.name for fs in feature_store.list_feature_services()} == {"EXTERNAL_FS_FEATURE_LIST"}
 
@@ -207,6 +220,7 @@ async def check_feast_registry(app_container):
             {
                 "üser id": 1,
                 "cust_id": 761,
+                "user_status": "STÀTUS_CODE_39",
                 "PRODUCT_ACTION": "detail",
                 "POINT_IN_TIME": pd.Timestamp("2001-01-02 12:00:00"),
             }
@@ -222,6 +236,9 @@ async def check_feast_registry(app_container):
         "üser id": ["1"],
         "cust_id": ["761"],
         "PRODUCT_ACTION": ["detail"],
+        "user_status": ["STÀTUS_CODE_39"],
+        "User Status Feature": ["STÀTUS_CODE_39"],
+        "Current Number of Users With This Status": [1.0],
         "EXTERNAL_FS_COUNT_OVERALL_7d": [149.0],
         "EXTERNAL_FS_COUNT_BY_PRODUCT_ACTION_7d": [43.0],
         "EXTERNAL_FS_AMOUNT_SUM_BY_USER_ID_24h": [475.38],
@@ -263,7 +280,16 @@ def check_online_features(deployment, config):
     """
     client = config.get_client()
 
-    entity_serving_names = [{"üser id": 1, "cust_id": 761, "PRODUCT_ACTION": "detail"}]
+    entity_serving_names = [
+        {
+            "üser id": 1,
+            "cust_id": 761,
+            "PRODUCT_ACTION": "detail",
+            # Note: shouldn't have to provide this once parent entity lookup is supported (via child
+            # entity üser id)
+            "user_status": "STÀTUS_CODE_39",
+        }
+    ]
     data = OnlineFeaturesRequestPayload(entity_serving_names=entity_serving_names)
 
     tic = time.time()
@@ -285,6 +311,9 @@ def check_online_features(deployment, config):
         "üser id": "1",
         "cust_id": "761",
         "PRODUCT_ACTION": "detail",
+        "user_status": "STÀTUS_CODE_39",
+        "User Status Feature": "STÀTUS_CODE_39",
+        "Current Number of Users With This Status": 1.0,
         "EXTERNAL_FS_COUNT_OVERALL_7d": 149.0,
         "EXTERNAL_FS_COUNT_BY_PRODUCT_ACTION_7d": 43.0,
         "EXTERNAL_FS_AMOUNT_SUM_BY_USER_ID_24h": 475.38,
@@ -323,6 +352,7 @@ async def test_feature_materialize_service(
     user_entity,
     customer_entity,
     product_action_entity,
+    status_entity,
     deployed_feature_list,
     config,
 ):
@@ -344,6 +374,7 @@ async def test_feature_materialize_service(
         (user_entity.id,),
         (customer_entity.id,),
         (product_action_entity.id,),
+        (status_entity.id,),
     }
 
     await check_feature_tables_populated(session, primary_entity_to_feature_table.values())

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -31,7 +31,7 @@ def always_enable_feast_integration_fixture():
 
 
 @pytest.fixture(name="features", scope="module")
-def features_fixture(event_table, scd_table):
+def features_fixture(event_table, scd_table):  # pylint: disable=too-many-locals
     """
     Fixture for feature
     """

--- a/tests/unit/api/test_offline_ingest_query_graph.py
+++ b/tests/unit/api/test_offline_ingest_query_graph.py
@@ -224,7 +224,9 @@ def test_feature__multiple_non_ttl_components(
     ingest_query_graphs = offline_store_info.extract_offline_store_ingest_query_graphs()
     assert len(ingest_query_graphs) == 1
     non_ttl_component_graph = ingest_query_graphs[0]
-    assert non_ttl_component_graph.feature_job_setting is None
+    assert non_ttl_component_graph.feature_job_setting == FeatureJobSetting(
+        blind_spot="0s", frequency="1d", time_modulo_frequency="0s"
+    )
     assert non_ttl_component_graph.node_name == "alias_1"
     assert non_ttl_component_graph.has_ttl is False
     assert non_ttl_component_graph.aggregation_nodes_info == [

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -925,6 +925,17 @@ def transaction_entity_fixture(transaction_entity_id, catalog):
     yield entity
 
 
+@pytest.fixture(name="gender_entity")
+def gender_entity_fixture(catalog):
+    """
+    Gender entity fixture
+    """
+    _ = catalog
+    entity = Entity(name="gender", serving_names=["gender"])
+    entity.save()
+    yield entity
+
+
 @pytest.fixture(name="snowflake_event_table_with_entity")
 def snowflake_event_table_with_entity_fixture(
     snowflake_event_table,
@@ -1572,6 +1583,31 @@ def feature_without_entity_fixture(snowflake_event_table):
         feature_names=["count_1d"],
     )
     yield feature_group["count_1d"]
+
+
+@pytest.fixture(name="scd_lookup_feature")
+def scd_lookup_feature_fixture(snowflake_scd_table_with_entity):
+    """
+    Fixture to get a lookup feature from SCD table
+    """
+    scd_view = snowflake_scd_table_with_entity.get_view()
+    feature = scd_view["col_boolean"].as_feature("some_lookup_feature")
+    return feature
+
+
+@pytest.fixture(name="aggregate_asat_feature")
+def aggregate_asat_feature_fixture(snowflake_scd_table_with_entity, gender_entity):
+    """
+    Fixture to get a lookup feature from SCD table
+    """
+    snowflake_scd_table_with_entity["col_boolean"].as_entity(gender_entity.name)
+    scd_view = snowflake_scd_table_with_entity.get_view()
+    feature = scd_view.groupby("col_boolean").aggregate_asat(
+        value_column=None,
+        method="count",
+        feature_name="asat_gender_count",
+    )
+    return feature
 
 
 @pytest.fixture(name="session_manager")

--- a/tests/unit/feast/service/test_registry.py
+++ b/tests/unit/feast/service/test_registry.py
@@ -85,11 +85,14 @@ async def test_get_feast_feature_store(feast_feature_store_service, feast_regist
     data_src_names = [data_source.name for data_source in feast_fs.list_data_sources()]
     assert set(data_src_names) == {
         "fb_entity_cust_id_fjs_1800_300_600_ttl",
-        "fb_entity_transaction_id",
+        "fb_entity_transaction_id_fjs_86400_0_0",
     }
     entity_names = [entity.name for entity in feast_fs.list_entities()]
     assert set(entity_names) == {"cust_id", "transaction_id"}
     fv_names = [feature_view.name for feature_view in feast_fs.list_feature_views()]
-    assert set(fv_names) == {"fb_entity_cust_id_fjs_1800_300_600_ttl", "fb_entity_transaction_id"}
+    assert set(fv_names) == {
+        "fb_entity_cust_id_fjs_1800_300_600_ttl",
+        "fb_entity_transaction_id_fjs_86400_0_0",
+    }
     fs_names = [feature_service.name for feature_service in feast_fs.list_feature_services()]
     assert fs_names == ["test_feature_list"]

--- a/tests/unit/feast/utils/test_register_construction.py
+++ b/tests/unit/feast/utils/test_register_construction.py
@@ -127,12 +127,12 @@ def test_feast_registry_construction(feast_registry_proto):
             },
             {
                 "dataSourceClassType": "feast.infra.offline_stores.snowflake_source.SnowflakeSource",
-                "name": "fb_entity_transaction_id",
+                "name": "fb_entity_transaction_id_fjs_86400_0_0",
                 "project": "featurebyte_project",
                 "snowflakeOptions": {
                     "database": "sf_database",
                     "schema": "sf_schema",
-                    "table": "fb_entity_transaction_id",
+                    "table": "fb_entity_transaction_id_fjs_86400_0_0",
                 },
                 "timestampField": "__feature_timestamp",
                 "type": "BATCH_SNOWFLAKE",
@@ -180,7 +180,7 @@ def test_feast_registry_construction(feast_registry_proto):
                             "featureColumns": [
                                 {"name": "non_time_time_sum_amount_feature", "valueType": "DOUBLE"}
                             ],
-                            "featureViewName": "fb_entity_transaction_id",
+                            "featureViewName": "fb_entity_transaction_id_fjs_86400_0_0",
                         },
                     ],
                     "name": "test_feature_list",
@@ -223,11 +223,11 @@ def test_feast_registry_construction(feast_registry_proto):
                 "spec": {
                     "batchSource": {
                         "dataSourceClassType": "feast.infra.offline_stores.snowflake_source.SnowflakeSource",
-                        "name": "fb_entity_transaction_id",
+                        "name": "fb_entity_transaction_id_fjs_86400_0_0",
                         "snowflakeOptions": {
                             "database": "sf_database",
                             "schema": "sf_schema",
-                            "table": "fb_entity_transaction_id",
+                            "table": "fb_entity_transaction_id_fjs_86400_0_0",
                         },
                         "timestampField": "__feature_timestamp",
                         "type": "BATCH_SNOWFLAKE",
@@ -237,7 +237,7 @@ def test_feast_registry_construction(feast_registry_proto):
                     "features": [
                         {"name": "non_time_time_sum_amount_feature", "valueType": "DOUBLE"}
                     ],
-                    "name": "fb_entity_transaction_id",
+                    "name": "fb_entity_transaction_id_fjs_86400_0_0",
                     "online": True,
                     "project": "featurebyte_project",
                 },

--- a/tests/unit/models/test_entity_universe.py
+++ b/tests/unit/models/test_entity_universe.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 import pytest
 
+from featurebyte import SourceType
 from featurebyte.models.entity_universe import (
     EntityUniverseModel,
     get_combined_universe,
@@ -60,7 +61,7 @@ def test_lookup_feature(catalog, lookup_graph_and_node):
     """
     _ = catalog
     graph, node = lookup_graph_and_node
-    constructor = get_entity_universe_constructor(graph, node)
+    constructor = get_entity_universe_constructor(graph, node, SourceType.SNOWFLAKE)
     expected = textwrap.dedent(
         """
         SELECT DISTINCT
@@ -93,7 +94,7 @@ def test_aggregate_asat_universe(catalog, aggregate_asat_graph_and_node):
     """
     _ = catalog
     graph, node = aggregate_asat_graph_and_node
-    constructor = get_entity_universe_constructor(graph, node)
+    constructor = get_entity_universe_constructor(graph, node, SourceType.SNOWFLAKE)
     expected = textwrap.dedent(
         """
         SELECT DISTINCT
@@ -128,7 +129,7 @@ def test_combined_universe(catalog, lookup_graph_and_node, aggregate_asat_graph_
     # Note: in practice the two universes should have the same serving name, though that is not the
     # case in this test.
     universe = get_combined_universe(
-        [lookup_graph_and_node, aggregate_asat_graph_and_node],
+        [lookup_graph_and_node, aggregate_asat_graph_and_node], SourceType.SNOWFLAKE
     )
     expected = textwrap.dedent(
         """
@@ -184,7 +185,7 @@ def test_combined_universe_deduplicate(
     """
     _ = catalog
     universe = get_combined_universe(
-        [lookup_graph_and_node, lookup_graph_and_node_same_input],
+        [lookup_graph_and_node, lookup_graph_and_node_same_input], SourceType.SNOWFLAKE
     )
     expected = textwrap.dedent(
         """
@@ -218,7 +219,7 @@ def test_entity_universe_model_get_entity_universe_expr(catalog, lookup_graph_an
     """
     _ = catalog
     graph, node = lookup_graph_and_node
-    constructor = get_entity_universe_constructor(graph, node)
+    constructor = get_entity_universe_constructor(graph, node, SourceType.SNOWFLAKE)
     query_template = constructor.get_entity_universe_template()
     entity_universe_model = EntityUniverseModel(
         query_template=SqlglotExpressionModel.create(query_template)

--- a/tests/unit/models/test_entity_universe.py
+++ b/tests/unit/models/test_entity_universe.py
@@ -1,0 +1,253 @@
+"""
+Tests for entity_universe.py
+"""
+import textwrap
+from datetime import datetime
+
+import pytest
+
+from featurebyte.models.entity_universe import (
+    EntityUniverseModel,
+    get_combined_universe,
+    get_entity_universe_constructor,
+)
+from featurebyte.models.sqlglot_expression import SqlglotExpressionModel
+from featurebyte.query_graph.enum import NodeType
+
+
+def get_node_from_feature(feature, node_type):
+    """
+    Get node from feature
+    """
+    return next(feature.graph.iterate_nodes(feature.node, node_type))
+
+
+@pytest.fixture
+def lookup_graph_and_node(scd_lookup_feature):
+    """
+    Fixture for a lookup aggregate node
+    """
+    graph = scd_lookup_feature.graph
+    lookup_node = get_node_from_feature(scd_lookup_feature, NodeType.LOOKUP)
+    return graph, lookup_node
+
+
+@pytest.fixture
+def aggregate_asat_graph_and_node(aggregate_asat_feature):
+    """
+    Fixture for an aggregate_asat aggregate node
+    """
+    graph = aggregate_asat_feature.graph
+    aggregate_asat_node = get_node_from_feature(aggregate_asat_feature, NodeType.AGGREGATE_AS_AT)
+    return graph, aggregate_asat_node
+
+
+@pytest.fixture
+def lookup_graph_and_node_same_input(scd_lookup_feature):
+    """
+    Fixture for a new lookup feature that has the same input as the original lookup feature
+    """
+    new_feature = scd_lookup_feature.notnull()
+    new_feature.name = "new_lookup_feature"
+    graph = new_feature.graph
+    lookup_node = get_node_from_feature(new_feature, NodeType.LOOKUP)
+    return graph, lookup_node
+
+
+def test_lookup_feature(catalog, lookup_graph_and_node):
+    """
+    Test lookup feature's universe
+    """
+    _ = catalog
+    graph, node = lookup_graph_and_node
+    constructor = get_entity_universe_constructor(graph, node)
+    expected = textwrap.dedent(
+        """
+        SELECT DISTINCT
+          "col_text" AS "cust_id"
+        FROM (
+          SELECT
+            "col_int" AS "col_int",
+            "col_float" AS "col_float",
+            "col_text" AS "col_text",
+            "col_binary" AS "col_binary",
+            "col_boolean" AS "col_boolean",
+            "effective_timestamp" AS "effective_timestamp",
+            "end_timestamp" AS "end_timestamp",
+            "date_of_birth" AS "date_of_birth",
+            "created_at" AS "created_at",
+            "cust_id" AS "cust_id"
+          FROM "sf_database"."sf_schema"."scd_table"
+          WHERE
+            "effective_timestamp" >= __fb_last_materialized_timestamp
+            AND "effective_timestamp" < __fb_current_feature_timestamp
+        )
+        """
+    ).strip()
+    assert constructor.get_entity_universe_template().sql(pretty=True) == expected
+
+
+def test_aggregate_asat_universe(catalog, aggregate_asat_graph_and_node):
+    """
+    Test lookup feature's universe
+    """
+    _ = catalog
+    graph, node = aggregate_asat_graph_and_node
+    constructor = get_entity_universe_constructor(graph, node)
+    expected = textwrap.dedent(
+        """
+        SELECT DISTINCT
+          "col_boolean" AS "gender"
+        FROM (
+          SELECT
+            "col_int" AS "col_int",
+            "col_float" AS "col_float",
+            "col_text" AS "col_text",
+            "col_binary" AS "col_binary",
+            "col_boolean" AS "col_boolean",
+            "effective_timestamp" AS "effective_timestamp",
+            "end_timestamp" AS "end_timestamp",
+            "date_of_birth" AS "date_of_birth",
+            "created_at" AS "created_at",
+            "cust_id" AS "cust_id"
+          FROM "sf_database"."sf_schema"."scd_table"
+          WHERE
+            "effective_timestamp" >= __fb_last_materialized_timestamp
+            AND "effective_timestamp" < __fb_current_feature_timestamp
+        )
+        """
+    ).strip()
+    assert constructor.get_entity_universe_template().sql(pretty=True) == expected
+
+
+def test_combined_universe(catalog, lookup_graph_and_node, aggregate_asat_graph_and_node):
+    """
+    Test combined universe
+    """
+    _ = catalog
+    # Note: in practice the two universes should have the same serving name, though that is not the
+    # case in this test.
+    universe = get_combined_universe(
+        [lookup_graph_and_node, aggregate_asat_graph_and_node],
+    )
+    expected = textwrap.dedent(
+        """
+        SELECT DISTINCT
+          "col_boolean" AS "gender"
+        FROM (
+          SELECT
+            "col_int" AS "col_int",
+            "col_float" AS "col_float",
+            "col_text" AS "col_text",
+            "col_binary" AS "col_binary",
+            "col_boolean" AS "col_boolean",
+            "effective_timestamp" AS "effective_timestamp",
+            "end_timestamp" AS "end_timestamp",
+            "date_of_birth" AS "date_of_birth",
+            "created_at" AS "created_at",
+            "cust_id" AS "cust_id"
+          FROM "sf_database"."sf_schema"."scd_table"
+          WHERE
+            "effective_timestamp" >= __fb_last_materialized_timestamp
+            AND "effective_timestamp" < __fb_current_feature_timestamp
+        )
+        UNION
+        SELECT DISTINCT
+          "col_text" AS "cust_id"
+        FROM (
+          SELECT
+            "col_int" AS "col_int",
+            "col_float" AS "col_float",
+            "col_text" AS "col_text",
+            "col_binary" AS "col_binary",
+            "col_boolean" AS "col_boolean",
+            "effective_timestamp" AS "effective_timestamp",
+            "end_timestamp" AS "end_timestamp",
+            "date_of_birth" AS "date_of_birth",
+            "created_at" AS "created_at",
+            "cust_id" AS "cust_id"
+          FROM "sf_database"."sf_schema"."scd_table"
+          WHERE
+            "effective_timestamp" >= __fb_last_materialized_timestamp
+            AND "effective_timestamp" < __fb_current_feature_timestamp
+        )
+        """
+    ).strip()
+    assert universe.sql(pretty=True) == expected
+
+
+def test_combined_universe_deduplicate(
+    catalog, lookup_graph_and_node, lookup_graph_and_node_same_input
+):
+    """
+    Test combined universe doesn't duplicate the same universe
+    """
+    _ = catalog
+    universe = get_combined_universe(
+        [lookup_graph_and_node, lookup_graph_and_node_same_input],
+    )
+    expected = textwrap.dedent(
+        """
+        SELECT DISTINCT
+          "col_text" AS "cust_id"
+        FROM (
+          SELECT
+            "col_int" AS "col_int",
+            "col_float" AS "col_float",
+            "col_text" AS "col_text",
+            "col_binary" AS "col_binary",
+            "col_boolean" AS "col_boolean",
+            "effective_timestamp" AS "effective_timestamp",
+            "end_timestamp" AS "end_timestamp",
+            "date_of_birth" AS "date_of_birth",
+            "created_at" AS "created_at",
+            "cust_id" AS "cust_id"
+          FROM "sf_database"."sf_schema"."scd_table"
+          WHERE
+            "effective_timestamp" >= __fb_last_materialized_timestamp
+            AND "effective_timestamp" < __fb_current_feature_timestamp
+        )
+        """
+    ).strip()
+    assert universe.sql(pretty=True) == expected
+
+
+def test_entity_universe_model_get_entity_universe_expr(catalog, lookup_graph_and_node):
+    """
+    Test EntityUniverseModel get_entity_universe_expr() method
+    """
+    _ = catalog
+    graph, node = lookup_graph_and_node
+    constructor = get_entity_universe_constructor(graph, node)
+    query_template = constructor.get_entity_universe_template()
+    entity_universe_model = EntityUniverseModel(
+        query_template=SqlglotExpressionModel.create(query_template)
+    )
+    expected = textwrap.dedent(
+        """
+        SELECT DISTINCT
+          "col_text" AS "cust_id"
+        FROM (
+          SELECT
+            "col_int" AS "col_int",
+            "col_float" AS "col_float",
+            "col_text" AS "col_text",
+            "col_binary" AS "col_binary",
+            "col_boolean" AS "col_boolean",
+            "effective_timestamp" AS "effective_timestamp",
+            "end_timestamp" AS "end_timestamp",
+            "date_of_birth" AS "date_of_birth",
+            "created_at" AS "created_at",
+            "cust_id" AS "cust_id"
+          FROM "sf_database"."sf_schema"."scd_table"
+          WHERE
+            "effective_timestamp" >= CAST('2022-10-15 09:00:00' AS TIMESTAMP)
+            AND "effective_timestamp" < CAST('2022-10-15 10:00:00' AS TIMESTAMP)
+        )
+        """
+    ).strip()
+    actual = entity_universe_model.get_entity_universe_expr(
+        current_feature_timestamp=datetime(2022, 10, 15, 10, 0, 0),
+        last_materialized_timestamp=datetime(2022, 10, 15, 9, 0, 0),
+    ).sql(pretty=True)
+    assert actual == expected

--- a/tests/unit/models/test_sqlglot_expression.py
+++ b/tests/unit/models/test_sqlglot_expression.py
@@ -1,0 +1,17 @@
+"""
+Tests for SqlglotExpressionModel
+"""
+from sqlglot.expressions import select
+
+from featurebyte.models.sqlglot_expression import SqlglotExpressionModel
+
+
+def test_sqlglot_expression_model():
+    """
+    Test SqlglotExpressionModel
+    """
+    expr = select("a", "b", "c").from_("my_table")
+    model = SqlglotExpressionModel.create(expr=expr)
+    assert model.dict() == {"formatted_expression": "SELECT\n  a,\n  b,\n  c\nFROM my_table"}
+    assert model.expr == expr
+    assert SqlglotExpressionModel(**model.dict()).expr == expr

--- a/tests/unit/service/test_feature_materialize_scheduler.py
+++ b/tests/unit/service/test_feature_materialize_scheduler.py
@@ -6,12 +6,11 @@ import pytest_asyncio
 from bson import ObjectId
 
 from featurebyte import FeatureJobSetting
+from featurebyte.models.entity_universe import EntityUniverseModel
 from featurebyte.models.feature_list import FeatureCluster
-from featurebyte.models.offline_store_feature_table import (
-    OfflineStoreFeatureTableModel,
-    WindowAggregateEntityUniverse,
-)
+from featurebyte.models.offline_store_feature_table import OfflineStoreFeatureTableModel
 from featurebyte.models.periodic_task import Interval
+from featurebyte.models.sqlglot_expression import SqlglotExpressionModel
 from featurebyte.query_graph.graph import QueryGraph
 
 
@@ -32,9 +31,10 @@ async def fixture_offline_store_feature_table(app_container, feature_job_setting
         ),
         output_column_names=["col1", "col2"],
         output_dtypes=["VARCHAR", "FLOAT"],
-        entity_universe=WindowAggregateEntityUniverse(
-            serving_names=["cust_id"],
-            aggregate_result_table_names=["my_agg_result_table"],
+        entity_universe=EntityUniverseModel(
+            query_template=SqlglotExpressionModel(
+                formatted_expression="SELECT DISTINCT cust_id FROM my_table",
+            )
         ),
     )
     await app_container.offline_store_feature_table_service.create_document(feature_table)

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -9,7 +9,12 @@ from bson import ObjectId
 
 from featurebyte.models.feature import FeatureModel
 from featurebyte.models.offline_store_feature_table import OfflineStoreFeatureTableModel
-from tests.util.helper import assert_equal_json_fixture, deploy_feature, undeploy_feature
+from tests.util.helper import (
+    assert_equal_json_fixture,
+    assert_equal_with_expected_fixture,
+    deploy_feature,
+    undeploy_feature,
+)
 
 
 @pytest.fixture(name="always_enable_feast_integration", autouse=True)
@@ -66,6 +71,51 @@ async def deployed_feature_without_entity(
     _ = mock_update_data_warehouse
     _ = mock_feature_materialize_service
     return await deploy_feature(app_container, feature_without_entity)
+
+
+@pytest_asyncio.fixture
+async def deployed_scd_lookup_feature(
+    app_container,
+    scd_lookup_feature,
+    mock_update_data_warehouse,
+    mock_feature_materialize_service,
+):
+    """
+    Fixture for deployed scd lookup feature
+    """
+    _ = mock_update_data_warehouse
+    _ = mock_feature_materialize_service
+    return await deploy_feature(app_container, scd_lookup_feature)
+
+
+@pytest_asyncio.fixture
+async def deployed_aggregate_asat_feature(
+    app_container,
+    aggregate_asat_feature,
+    mock_update_data_warehouse,
+    mock_feature_materialize_service,
+):
+    """
+    Fixture for deployed aggregate asat feature
+    """
+    _ = mock_update_data_warehouse
+    _ = mock_feature_materialize_service
+    return await deploy_feature(app_container, aggregate_asat_feature)
+
+
+@pytest_asyncio.fixture
+async def deployed_item_aggregate_feature(
+    app_container,
+    non_time_based_feature,
+    mock_update_data_warehouse,
+    mock_feature_materialize_service,
+):
+    """
+    Fixture for deployed item aggregate feature
+    """
+    _ = mock_update_data_warehouse
+    _ = mock_feature_materialize_service
+    return await deploy_feature(app_container, non_time_based_feature)
 
 
 @pytest.fixture
@@ -136,11 +186,13 @@ async def test_feature_table_one_feature_deployed(
         "catalog_id": ObjectId("646f6c1c0ed28a5271fb02db"),
         "description": None,
         "entity_universe": {
-            "aggregate_result_table_names": [
+            "query_template": {
+                "formatted_expression": "SELECT "
+                "DISTINCT\n"
+                '  "cust_id"\n'
+                "FROM "
                 "online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c"
-            ],
-            "serving_names": ["cust_id"],
-            "type": "window_aggregate",
+            }
         },
         "feature_ids": [deployed_float_feature.id],
         "feature_job_setting": {
@@ -197,11 +249,13 @@ async def test_feature_table_two_features_deployed(
         "catalog_id": ObjectId("646f6c1c0ed28a5271fb02db"),
         "description": None,
         "entity_universe": {
-            "aggregate_result_table_names": [
+            "query_template": {
+                "formatted_expression": "SELECT "
+                "DISTINCT\n"
+                '  "cust_id"\n'
+                "FROM "
                 "online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c"
-            ],
-            "serving_names": ["cust_id"],
-            "type": "window_aggregate",
+            }
         },
         "feature_ids": [deployed_float_feature.id, deployed_float_feature_post_processed.id],
         "feature_job_setting": {
@@ -262,11 +316,13 @@ async def test_feature_table_undeploy(
         "catalog_id": ObjectId("646f6c1c0ed28a5271fb02db"),
         "description": None,
         "entity_universe": {
-            "aggregate_result_table_names": [
+            "query_template": {
+                "formatted_expression": "SELECT "
+                "DISTINCT\n"
+                '  "cust_id"\n'
+                "FROM "
                 "online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c"
-            ],
-            "serving_names": ["cust_id"],
-            "type": "window_aggregate",
+            }
         },
         "feature_ids": [deployed_float_feature_post_processed.id],
         "feature_job_setting": {
@@ -334,11 +390,13 @@ async def test_feature_table_two_features_different_feature_job_settings_deploye
         "catalog_id": ObjectId("646f6c1c0ed28a5271fb02db"),
         "description": None,
         "entity_universe": {
-            "aggregate_result_table_names": [
+            "query_template": {
+                "formatted_expression": "SELECT "
+                "DISTINCT\n"
+                '  "cust_id"\n'
+                "FROM "
                 "online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c"
-            ],
-            "serving_names": ["cust_id"],
-            "type": "window_aggregate",
+            }
         },
         "feature_ids": [deployed_float_feature.id],
         "feature_job_setting": {
@@ -368,11 +426,13 @@ async def test_feature_table_two_features_different_feature_job_settings_deploye
         "catalog_id": ObjectId("646f6c1c0ed28a5271fb02db"),
         "description": None,
         "entity_universe": {
-            "aggregate_result_table_names": [
+            "query_template": {
+                "formatted_expression": "SELECT "
+                "DISTINCT\n"
+                '  "cust_id"\n'
+                "FROM "
                 "online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c"
-            ],
-            "serving_names": ["cust_id"],
-            "type": "window_aggregate",
+            }
         },
         "feature_ids": [deployed_float_feature_different_job_setting.id],
         "feature_job_setting": {
@@ -424,11 +484,7 @@ async def test_feature_table_without_entity(
         "catalog_id": ObjectId("646f6c1c0ed28a5271fb02db"),
         "description": None,
         "entity_universe": {
-            "aggregate_result_table_names": [
-                "online_store_e4d5f4dff76dea2d344a4cc284d7881e0b183981"
-            ],
-            "serving_names": [],
-            "type": "window_aggregate",
+            "query_template": {"formatted_expression": "SELECT\n" "  1 AS " '"dummy_entity"'}
         },
         "feature_ids": [deployed_feature_without_entity.id],
         "feature_job_setting": {
@@ -450,4 +506,109 @@ async def test_feature_table_without_entity(
         app_container,
         expected_feature_views={"fb_entity_overall_fjs_86400_3600_7200_ttl"},
         expected_feature_services={"count_1d_list"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_lookup_feature(
+    app_container,
+    document_service,
+    periodic_task_service,
+    deployed_scd_lookup_feature,
+    update_fixtures,
+):
+    """
+    Test feature table creation with lookup feature
+    """
+    feature_tables = await get_all_feature_tables(document_service)
+    assert len(feature_tables) == 1
+    feature_table = feature_tables["fb_entity_cust_id_fjs_86400_0_0"]
+
+    feature_table_dict = feature_table.dict(
+        by_alias=True, exclude={"created_at", "updated_at", "id"}
+    )
+    _ = feature_table_dict.pop("feature_cluster")
+    entity_universe = feature_table_dict.pop("entity_universe")
+    assert_equal_with_expected_fixture(
+        entity_universe["query_template"]["formatted_expression"],
+        "tests/fixtures/offline_store_feature_table/lookup_feature_universe.sql",
+        update_fixtures,
+    )
+    assert feature_table_dict == {
+        "block_modification_by": [],
+        "catalog_id": ObjectId("646f6c1c0ed28a5271fb02db"),
+        "description": None,
+        "feature_ids": [deployed_scd_lookup_feature.id],
+        "feature_job_setting": {
+            "blind_spot": "0s",
+            "frequency": "1d",
+            "time_modulo_frequency": "0s",
+        },
+        "has_ttl": False,
+        "last_materialized_at": None,
+        "name": "fb_entity_cust_id_fjs_86400_0_0",
+        "output_column_names": ["some_lookup_feature"],
+        "output_dtypes": ["BOOL"],
+        "primary_entity_ids": [ObjectId("63f94ed6ea1f050131379214")],
+        "serving_names": ["cust_id"],
+        "user_id": ObjectId("63f9506dd478b94127123456"),
+    }
+    assert await has_scheduled_task(periodic_task_service, feature_table)
+    await check_feast_registry(
+        app_container,
+        expected_feature_views={"fb_entity_cust_id_fjs_86400_0_0"},
+        expected_feature_services={"some_lookup_feature_list"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_aggregate_asat_feature(
+    app_container,
+    document_service,
+    periodic_task_service,
+    deployed_aggregate_asat_feature,
+    update_fixtures,
+):
+    """
+    Test feature table creation with aggregate asat feature
+    """
+    feature_tables = await get_all_feature_tables(document_service)
+    assert len(feature_tables) == 1
+    feature_table = feature_tables["fb_entity_gender_fjs_86400_0_0"]
+
+    feature_table_dict = feature_table.dict(
+        by_alias=True, exclude={"created_at", "updated_at", "id"}
+    )
+    _ = feature_table_dict.pop("feature_cluster")
+    entity_universe = feature_table_dict.pop("entity_universe")
+    assert_equal_with_expected_fixture(
+        entity_universe["query_template"]["formatted_expression"],
+        "tests/fixtures/offline_store_feature_table/aggregate_asat_feature_universe.sql",
+        update_fixtures,
+    )
+
+    assert feature_table_dict == {
+        "block_modification_by": [],
+        "catalog_id": ObjectId("646f6c1c0ed28a5271fb02db"),
+        "description": None,
+        "feature_ids": [deployed_aggregate_asat_feature.id],
+        "feature_job_setting": {
+            "blind_spot": "0s",
+            "frequency": "1d",
+            "time_modulo_frequency": "0s",
+        },
+        "has_ttl": False,
+        "last_materialized_at": None,
+        "name": "fb_entity_gender_fjs_86400_0_0",
+        "output_column_names": ["asat_gender_count"],
+        "output_dtypes": ["FLOAT"],
+        "primary_entity_ids": deployed_aggregate_asat_feature.primary_entity_ids,
+        "serving_names": ["gender"],
+        "user_id": ObjectId("63f9506dd478b94127123456"),
+    }
+    assert await has_scheduled_task(periodic_task_service, feature_table)
+    await check_feast_registry(
+        app_container,
+        expected_feature_views={"fb_entity_gender_fjs_86400_0_0"},
+        expected_feature_services={"asat_gender_count_list"},
     )


### PR DESCRIPTION
## Description

This adds support for non-window aggregate features in feast integration: lookup features and aggregate as-at features. The main change is a generalised entity universe model which determines the entities for features computation. It will be used when materialising new features and existing features in scheduled tasks.

Support for item aggregates will be added in a follow up PR.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
