### PR TITLE
[chore] Switch over remaining databricks integration tests

### DIFF
--- a/.github/workflows/test_gen.yaml
+++ b/.github/workflows/test_gen.yaml
@@ -272,6 +272,7 @@ jobs:
         name: python-${{ matrix.python-version }}-.coverage.2
         path: .coverage.2
   test-integration-databricks:
+    if: false
     needs:
     - build-jar
     runs-on: ubuntu-latest

--- a/tests/integration/session/test_spark.py
+++ b/tests/integration/session/test_spark.py
@@ -112,7 +112,7 @@ async def test_register_table(session):
     assert_frame_equal(df_retrieve, df_training_events, check_dtype=False)
 
 
-@pytest.mark.parametrize("source_type", ["spark", "databricks_unity"], indirect=True)
+@pytest.mark.parametrize("source_type", ["spark"], indirect=True)
 @pytest.mark.asyncio
 async def test_register_udfs(session):
     """

--- a/tests/integration/session/test_spark.py
+++ b/tests/integration/session/test_spark.py
@@ -93,7 +93,7 @@ async def test_session_timezone(session):
     assert result["timezone"].iloc[0] in ["UTC", "Etc/UTC"]
 
 
-@pytest.mark.parametrize("source_type", ["spark"], indirect=True)
+@pytest.mark.parametrize("source_type", ["spark", "databricks_unity"], indirect=True)
 @pytest.mark.asyncio
 async def test_register_table(session):
     """
@@ -112,7 +112,7 @@ async def test_register_table(session):
     assert_frame_equal(df_retrieve, df_training_events, check_dtype=False)
 
 
-@pytest.mark.parametrize("source_type", ["spark"], indirect=True)
+@pytest.mark.parametrize("source_type", ["spark", "databricks_unity"], indirect=True)
 @pytest.mark.asyncio
 async def test_register_udfs(session):
     """

--- a/tests/integration/session/test_spark.py
+++ b/tests/integration/session/test_spark.py
@@ -14,7 +14,7 @@ from featurebyte.session.base_spark import BaseSparkSession
 from featurebyte.session.manager import SessionManager
 
 
-@pytest.mark.parametrize("source_type", ["spark", "databricks"], indirect=True)
+@pytest.mark.parametrize("source_type", ["spark"], indirect=True)
 @pytest.mark.asyncio
 async def test_schema_initializer(config, feature_store, credentials_mapping, session):
     """
@@ -83,7 +83,7 @@ async def test_schema_initializer(config, feature_store, credentials_mapping, se
     )
 
 
-@pytest.mark.parametrize("source_type", ["spark", "databricks"], indirect=True)
+@pytest.mark.parametrize("source_type", ["spark", "databricks_unity"], indirect=True)
 @pytest.mark.asyncio
 async def test_session_timezone(session):
     """
@@ -93,7 +93,7 @@ async def test_session_timezone(session):
     assert result["timezone"].iloc[0] in ["UTC", "Etc/UTC"]
 
 
-@pytest.mark.parametrize("source_type", ["spark", "databricks"], indirect=True)
+@pytest.mark.parametrize("source_type", ["spark"], indirect=True)
 @pytest.mark.asyncio
 async def test_register_table(session):
     """
@@ -112,7 +112,7 @@ async def test_register_table(session):
     assert_frame_equal(df_retrieve, df_training_events, check_dtype=False)
 
 
-@pytest.mark.parametrize("source_type", ["spark", "databricks"], indirect=True)
+@pytest.mark.parametrize("source_type", ["spark"], indirect=True)
 @pytest.mark.asyncio
 async def test_register_udfs(session):
     """

--- a/tests/integration/tile/test_tile_scheduler.py
+++ b/tests/integration/tile/test_tile_scheduler.py
@@ -27,7 +27,6 @@ async def mock_scheduler_fixture(feature, tile_spec, tile_scheduler_service):
     await tile_scheduler_service.stop_job(job_id=job_id)
 
 
-@pytest.mark.parametrize("source_type", ["spark", "snowflake", "databricks"], indirect=True)
 @pytest.mark.asyncio
 async def test_generate_tiles_with_scheduler__verify_scheduling_and_execution(
     feature_store, session, tile_manager_service, scheduler_fixture, app_container
@@ -66,7 +65,6 @@ async def test_generate_tiles_with_scheduler__verify_scheduling_and_execution(
     assert result["TILE_COUNT"].iloc[0] == 100
 
 
-@pytest.mark.parametrize("source_type", ["spark", "snowflake", "databricks"], indirect=True)
 @pytest.mark.asyncio
 async def test_generate_tiles_with_scheduler__avoid_duplicate_tile(
     feature_store, session, tile_manager_service, scheduler_fixture
@@ -82,7 +80,6 @@ async def test_generate_tiles_with_scheduler__avoid_duplicate_tile(
     assert sql is None
 
 
-@pytest.mark.parametrize("source_type", ["spark", "snowflake", "databricks"], indirect=True)
 @pytest.mark.asyncio
 async def test_generate_tiles_with_scheduler__tile_job_exists(
     feature_store, session, tile_manager_service, scheduler_fixture

--- a/tests/integration/udf/test_timestamp_to_index.py
+++ b/tests/integration/udf/test_timestamp_to_index.py
@@ -4,14 +4,8 @@ This module contains integration tests for F_TIMESTAMP_TO_INDEX UDF
 import pytest
 
 from featurebyte.session.base import BaseSession
-from tests.source_types import SNOWFLAKE_SPARK_DATABRICKS_AND_UNITY
 
 
-@pytest.mark.parametrize(
-    "source_type",
-    SNOWFLAKE_SPARK_DATABRICKS_AND_UNITY,
-    indirect=True,
-)
 @pytest.mark.asyncio
 async def test_timestamp_to_index(
     session,
@@ -42,11 +36,6 @@ async def test_timestamp_to_index(
     assert res == tile_index
 
 
-@pytest.mark.parametrize(
-    "source_type",
-    SNOWFLAKE_SPARK_DATABRICKS_AND_UNITY,
-    indirect=True,
-)
 @pytest.mark.asyncio
 async def test_index_to_timestamp(
     session,

--- a/tests/integration/udf/test_timezone_offset_to_second.py
+++ b/tests/integration/udf/test_timezone_offset_to_second.py
@@ -4,14 +4,8 @@ This module contains integration tests for F_TIMEZONE_OFFSET_TO_SECOND
 import pytest
 
 from featurebyte.session.base import BaseSession
-from tests.source_types import SNOWFLAKE_SPARK_DATABRICKS_AND_UNITY
 
 
-@pytest.mark.parametrize(
-    "source_type",
-    SNOWFLAKE_SPARK_DATABRICKS_AND_UNITY,
-    indirect=True,
-)
 @pytest.mark.parametrize(
     "timezone_offset, expected",
     [
@@ -31,11 +25,6 @@ async def test_timezone_offset_to_second__valid(session, timezone_offset, expect
     assert res == expected
 
 
-@pytest.mark.parametrize(
-    "source_type",
-    SNOWFLAKE_SPARK_DATABRICKS_AND_UNITY,
-    indirect=True,
-)
 @pytest.mark.parametrize(
     "timezone_offset",
     [

--- a/tests/integration/udf/test_vector_cosine_similarity.py
+++ b/tests/integration/udf/test_vector_cosine_similarity.py
@@ -4,11 +4,11 @@ Test vector cosine similarity
 import numpy as np
 import pytest
 
-from tests.source_types import SNOWFLAKE_SPARK_DATABRICKS
+from tests.source_types import SNOWFLAKE_AND_SPARK
 
 
 # Note: Currently not applicable to databricks_unity
-@pytest.mark.parametrize("source_type", SNOWFLAKE_SPARK_DATABRICKS, indirect=True)
+@pytest.mark.parametrize("source_type", SNOWFLAKE_AND_SPARK, indirect=True)
 @pytest.mark.parametrize(
     "array1, array2, expected",
     [


### PR DESCRIPTION
## Description

Switch over remaining databricks integration tests to databricks_unity when applicable. `test-integration-databricks` job is now disabled as there is no test to be collected.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
