### PR TITLE
[DEV-2807] Add primary key constraints for feature tables on databricks unity

### DIFF
--- a/featurebyte/common/string.py
+++ b/featurebyte/common/string.py
@@ -1,6 +1,7 @@
 """
 String utilities.
 """
+import unicodedata
 
 
 def sanitize_identifier(string: str) -> str:
@@ -17,6 +18,9 @@ def sanitize_identifier(string: str) -> str:
     str
         A sanitized version of the string suitable as a database identifier.
     """
+    # Normalize unicode characters if any
+    string = unicodedata.normalize("NFKD", string)
+
     # Remove invalid characters
     sanitized = "".join(char for char in string if char.isalnum() or char == "_")
 

--- a/featurebyte/feast/service/registry.py
+++ b/featurebyte/feast/service/registry.py
@@ -167,6 +167,7 @@ class FeastRegistryService(
         -------
         bool
         """
+        assert self.catalog_id is not None
         catalog = await self.catalog_service.get_document(document_id=self.catalog_id)
         assert len(catalog.default_feature_store_ids) > 0
         feature_store_id = catalog.default_feature_store_ids[0]

--- a/featurebyte/feast/service/registry.py
+++ b/featurebyte/feast/service/registry.py
@@ -4,7 +4,9 @@ Feast registry service
 from typing import Any, Optional, cast
 
 from bson import ObjectId
+from pydantic import ValidationError
 
+from featurebyte.feast.model.feature_store import FeatureStoreDetailsWithFeastConfiguration
 from featurebyte.feast.model.registry import FeastRegistryModel
 from featurebyte.feast.schema.registry import FeastRegistryCreate, FeastRegistryUpdate
 from featurebyte.feast.utils.registry_construction import FeastRegistryConstructor
@@ -156,3 +158,22 @@ class FeastRegistryService(
         ):
             return feast_registry_model
         return None
+
+    async def is_source_type_supported(self) -> bool:
+        """
+        Check if source type of the current catalog is supported
+
+        Returns
+        -------
+        bool
+        """
+        catalog = await self.catalog_service.get_document(document_id=self.catalog_id)
+        assert len(catalog.default_feature_store_ids) > 0
+        feature_store_id = catalog.default_feature_store_ids[0]
+        feature_store = await self.feature_store_service.get_document(document_id=feature_store_id)
+        feature_store_details_dict = feature_store.get_feature_store_details().dict()
+        try:
+            _ = FeatureStoreDetailsWithFeastConfiguration(**feature_store_details_dict)
+        except ValidationError:
+            return False
+        return True

--- a/featurebyte/service/feature_materialize.py
+++ b/featurebyte/service/feature_materialize.py
@@ -425,7 +425,7 @@ class FeatureMaterializeService:  # pylint: disable=too-many-instance-attributes
         # Table constraint syntax is only supported in newer versions of sqlglot, so the queries are
         # formatted manually here
         quoted_primary_key_columns = [
-            "`{}`".format(column_name)
+            f"`{column_name}`"
             for column_name in [InternalName.FEATURE_TIMESTAMP_COLUMN.value]
             + feature_table_model.serving_names
         ]

--- a/featurebyte/service/offline_store_feature_table_manager.py
+++ b/featurebyte/service/offline_store_feature_table_manager.py
@@ -357,7 +357,7 @@ class OfflineStoreFeatureTableManagerService:  # pylint: disable=too-many-instan
 
         return sorted(set(filtered_table_names))
 
-    async def _create_or_update_feast_registry(self):
+    async def _create_or_update_feast_registry(self) -> None:
         if not await self.feast_registry_service.is_source_type_supported():
             return
 

--- a/featurebyte/service/offline_store_feature_table_manager.py
+++ b/featurebyte/service/offline_store_feature_table_manager.py
@@ -357,7 +357,10 @@ class OfflineStoreFeatureTableManagerService:  # pylint: disable=too-many-instan
 
         return sorted(set(filtered_table_names))
 
-    async def _create_or_update_feast_registry(self) -> None:
+    async def _create_or_update_feast_registry(self):
+        if not await self.feast_registry_service.is_source_type_supported():
+            return
+
         feature_lists = []
         async for feature_list_dict in self.feature_list_service.iterate_online_enabled_feature_lists_as_dict():
             feature_lists.append(FeatureListModel(**feature_list_dict))

--- a/tests/fixtures/feature_materialize/initialize_new_columns_new_table_databricks.sql
+++ b/tests/fixtures/feature_materialize/initialize_new_columns_new_table_databricks.sql
@@ -1,0 +1,24 @@
+SELECT
+  *
+FROM `fb_entity_cust_id_fjs_1800_300_600_ttl`
+LIMIT 1;
+
+CREATE TABLE `sf_db`.`sf_schema`.`fb_entity_cust_id_fjs_1800_300_600_ttl`
+USING DELTA
+TBLPROPERTIES (
+  'delta.columnMapping.mode'='name',
+  'delta.minReaderVersion'='2',
+  'delta.minWriterVersion'='5'
+) AS
+SELECT
+  CAST('2022-01-01T00:00:00' AS TIMESTAMP) AS `__feature_timestamp`,
+  `cust_id`,
+  `sum_30m`
+FROM `TEMP_FEATURE_TABLE_000000000000000000000000`;
+
+ALTER TABLE `fb_entity_cust_id_fjs_1800_300_600_ttl` ALTER COLUMN `__feature_timestamp` SET NOT NULL;
+
+ALTER TABLE `fb_entity_cust_id_fjs_1800_300_600_ttl` ALTER COLUMN `cust_id` SET NOT NULL;
+
+ALTER TABLE `fb_entity_cust_id_fjs_1800_300_600_ttl` ADD CONSTRAINT `pk_fb_entity_cust_id_fjs_1800_300_600_ttl`
+PRIMARY KEY(`__feature_timestamp`, `cust_id`);

--- a/tests/fixtures/feature_materialize/initialize_new_columns_new_table_databricks.sql
+++ b/tests/fixtures/feature_materialize/initialize_new_columns_new_table_databricks.sql
@@ -13,7 +13,7 @@ TBLPROPERTIES (
 SELECT
   CAST('2022-01-01T00:00:00' AS TIMESTAMP) AS `__feature_timestamp`,
   `cust_id`,
-  `sum_30m`
+  `sum_30m_V220101`
 FROM `TEMP_FEATURE_TABLE_000000000000000000000000`;
 
 ALTER TABLE `fb_entity_cust_id_fjs_1800_300_600_ttl` ALTER COLUMN `__feature_timestamp` SET NOT NULL;

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1471,7 +1471,7 @@ def task_manager_fixture(persistent, user, catalog):
     return task_manager
 
 
-@pytest.fixture(name="app_container", scope="session")
+@pytest.fixture(name="app_container")
 def app_container_fixture(persistent, user, catalog):
     """
     Return an app container used in tests. This will allow us to easily retrieve instances of the right type.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1471,7 +1471,7 @@ def task_manager_fixture(persistent, user, catalog):
     return task_manager
 
 
-@pytest.fixture(name="app_container")
+@pytest.fixture(name="app_container", scope="session")
 def app_container_fixture(persistent, user, catalog):
     """
     Return an app container used in tests. This will allow us to easily retrieve instances of the right type.

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -188,6 +188,7 @@ async def offline_store_feature_tables_fixture(app_container, deployed_feature_l
     """
     Fixture for offline store feature tables based on the deployed features
     """
+    _ = deployed_feature_list
     primary_entity_to_feature_table = {}
     async for feature_table in app_container.offline_store_feature_table_service.list_documents_iterator(
         query_filter={},
@@ -245,7 +246,7 @@ async def test_feature_tables_populated(session, offline_store_feature_tables):
 
 @pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
 @pytest.mark.asyncio
-async def test_feast_registry(source_type, app_container):
+async def test_feast_registry(app_container):
     """
     Check feast registry is populated correctly
     """
@@ -367,7 +368,7 @@ async def test_feast_registry(source_type, app_container):
 
 @pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
 @freezegun.freeze_time("2001-01-02 12:00:00")
-def test_online_features(config, source_type, deployed_feature_list):
+def test_online_features(config, deployed_feature_list):
     """
     Check online features are populated correctly
     """


### PR DESCRIPTION
## Description

This updates feature materialize service to add primary key constraints for offline store feature tables created in databricks with unity catalog. The feast integration test is also refactored into smaller tests since it's getting too long.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
