### PR TITLE
[DEV-2904] Add support to convert query graph to DataBricks UDF (part-2)

### DIFF
--- a/featurebyte/query_graph/node/base.py
+++ b/featurebyte/query_graph/node/base.py
@@ -1240,6 +1240,9 @@ class BaseSeriesOutputWithSingleOperandNode(BaseSeriesOutputNode, ABC):
             self.generate_expression(var_name_expression.as_input())
         )
 
+    def _generate_odfv_expression_with_null_value_handling(self, operand: str) -> str:
+        return self.generate_odfv_expression(operand)
+
     def _derive_on_demand_view_code(
         self,
         node_inputs: List[VarNameExpressionInfo],
@@ -1248,7 +1251,10 @@ class BaseSeriesOutputWithSingleOperandNode(BaseSeriesOutputNode, ABC):
     ) -> Tuple[List[StatementT], VarNameExpressionInfo]:
         input_var_name_expressions = self._assert_no_info_dict(node_inputs)
         var_name_expression = input_var_name_expressions[0]
-        return [], ExpressionStr(self.generate_odfv_expression(var_name_expression.as_input()))
+        expr = self._generate_odfv_expression_with_null_value_handling(
+            var_name_expression.as_input()
+        )
+        return [], ExpressionStr(expr)
 
     def _generate_udf_expression_with_null_value_handling(self, operand: str) -> str:
         expr = self.generate_udf_expression(operand)

--- a/featurebyte/query_graph/node/distance.py
+++ b/featurebyte/query_graph/node/distance.py
@@ -10,7 +10,11 @@ from pydantic import BaseModel, Field
 from featurebyte.enum import DBVarType
 from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.node.base import BaseSeriesOutputNode
-from featurebyte.query_graph.node.metadata.config import OnDemandViewCodeGenConfig, SDKCodeGenConfig
+from featurebyte.query_graph.node.metadata.config import (
+    OnDemandFunctionCodeGenConfig,
+    OnDemandViewCodeGenConfig,
+    SDKCodeGenConfig,
+)
 from featurebyte.query_graph.node.metadata.operation import OperationStructure
 from featurebyte.query_graph.node.metadata.sdk_code import (
     ClassEnum,
@@ -68,11 +72,10 @@ class HaversineNode(BaseSeriesOutputNode):
         statements.append((var_name, obj))
         return statements, var_name
 
-    def _derive_on_demand_view_code(
+    def _derive_on_demand_view_or_function_code_helper(
         self,
         node_inputs: List[VarNameExpressionInfo],
         var_name_generator: VariableNameGenerator,
-        config: OnDemandViewCodeGenConfig,
     ) -> Tuple[List[StatementT], VarNameExpressionInfo]:
         statements: List[StatementT] = []
         input_var_name_expressions = self._assert_no_info_dict(node_inputs)
@@ -100,5 +103,25 @@ class HaversineNode(BaseSeriesOutputNode):
         lon_1 = input_var_name_expressions[1]
         lat_2 = input_var_name_expressions[2]
         lon_2 = input_var_name_expressions[3]
-        dist_expr = ExpressionStr(f"haversine_distance({lat_1}, {lon_1}, {lat_2}, {lon_2})")
+        dist_expr = ExpressionStr(f"{func_name}({lat_1}, {lon_1}, {lat_2}, {lon_2})")
         return statements, dist_expr
+
+    def _derive_on_demand_view_code(
+        self,
+        node_inputs: List[VarNameExpressionInfo],
+        var_name_generator: VariableNameGenerator,
+        config: OnDemandViewCodeGenConfig,
+    ) -> Tuple[List[StatementT], VarNameExpressionInfo]:
+        return self._derive_on_demand_view_or_function_code_helper(
+            node_inputs=node_inputs, var_name_generator=var_name_generator
+        )
+
+    def _derive_user_defined_function_code(
+        self,
+        node_inputs: List[VarNameExpressionInfo],
+        var_name_generator: VariableNameGenerator,
+        config: OnDemandFunctionCodeGenConfig,
+    ) -> Tuple[List[StatementT], VarNameExpressionInfo]:
+        return self._derive_on_demand_view_or_function_code_helper(
+            node_inputs=node_inputs, var_name_generator=var_name_generator
+        )

--- a/featurebyte/query_graph/node/nested.py
+++ b/featurebyte/query_graph/node/nested.py
@@ -625,7 +625,7 @@ class BaseGraphNode(BasePrunableNode):
             node_name=self.name,
         )
 
-    def _derive_on_demand_view_or_function_code_helper(
+    def _derive_on_demand_view_or_user_defined_function_helper(
         self,
         var_name_generator: VariableNameGenerator,
         input_var_name_expr: VarNameExpressionInfo,
@@ -667,7 +667,7 @@ class BaseGraphNode(BasePrunableNode):
         input_var_name_expr = VariableNameStr(
             subset_frame_column_expr(frame_name=input_df_name, column_name=column_name)
         )
-        return self._derive_on_demand_view_or_function_code_helper(
+        return self._derive_on_demand_view_or_user_defined_function_helper(
             var_name_generator=var_name_generator,
             input_var_name_expr=input_var_name_expr,
             json_conversion_func=_json_conversion_func,
@@ -693,7 +693,7 @@ class BaseGraphNode(BasePrunableNode):
         input_var_name = var_name_generator.convert_to_variable_name(
             variable_name_prefix=config.input_var_prefix, node_name=associated_node_name
         )
-        return self._derive_on_demand_view_or_function_code_helper(
+        return self._derive_on_demand_view_or_user_defined_function_helper(
             var_name_generator=var_name_generator,
             input_var_name_expr=input_var_name,
             json_conversion_func=lambda expr: ExpressionStr(

--- a/featurebyte/query_graph/node/request.py
+++ b/featurebyte/query_graph/node/request.py
@@ -101,7 +101,7 @@ class RequestColumnNode(BaseNode):
         statements.append((var_name, obj))
         return statements, var_name
 
-    def _derive_on_demand_view_or_function_code_helper(
+    def _derive_on_demand_view_or_user_defined_function_helper(
         self,
         var_name_generator: VariableNameGenerator,
         input_var_name_expr: VarNameExpressionInfo,
@@ -124,7 +124,7 @@ class RequestColumnNode(BaseNode):
         input_df_name = config.input_df_name
         column_name = self.parameters.column_name
         expr = VariableNameStr(subset_frame_column_expr(input_df_name, column_name))
-        return self._derive_on_demand_view_or_function_code_helper(
+        return self._derive_on_demand_view_or_user_defined_function_helper(
             var_name_generator=var_name_generator,
             input_var_name_expr=expr,
             var_name_prefix="request_col",
@@ -143,7 +143,7 @@ class RequestColumnNode(BaseNode):
         request_input_var_name = var_name_generator.convert_to_variable_name(
             variable_name_prefix=config.request_input_var_prefix, node_name=associated_node_name
         )
-        return self._derive_on_demand_view_or_function_code_helper(
+        return self._derive_on_demand_view_or_user_defined_function_helper(
             var_name_generator=var_name_generator,
             input_var_name_expr=request_input_var_name,
             var_name_prefix="feat",

--- a/featurebyte/query_graph/node/string.py
+++ b/featurebyte/query_graph/node/string.py
@@ -2,7 +2,10 @@
 This module contains string operation related node classes
 """
 # DO NOT include "from __future__ import annotations" as it will trigger issue for pydantic model nested definition
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Tuple
+
+import textwrap
+from abc import ABC
 
 from pydantic import BaseModel, Field
 
@@ -13,14 +16,32 @@ from featurebyte.query_graph.node.base import (
     BinaryArithmeticOpNode,
     ValueWithRightOpNodeParameters,
 )
+from featurebyte.query_graph.node.metadata.config import OnDemandFunctionCodeGenConfig
 from featurebyte.query_graph.node.metadata.operation import OperationStructure
-from featurebyte.query_graph.node.metadata.sdk_code import ValueStr
+from featurebyte.query_graph.node.metadata.sdk_code import (
+    ExpressionStr,
+    StatementStr,
+    StatementT,
+    ValueStr,
+    VariableNameGenerator,
+    VarNameExpressionInfo,
+)
 
 Side = Literal["left", "right", "both"]
 Case = Literal["upper", "lower"]
 
 
-class LengthNode(BaseSeriesOutputWithSingleOperandNode):
+class BaseStringAccessorOpNode(BaseSeriesOutputWithSingleOperandNode, ABC):
+    """BaseStringAccessorOpNode class"""
+
+    def _generate_odfv_expression_with_null_value_handling(self, operand: str) -> str:
+        # to simulate SQL behavior, we need to handle null value by make it null after operation
+        expr = self.generate_odfv_expression(operand)
+        where_expr = f"np.where(pd.isna({operand}), np.nan, {expr})"
+        return f"pd.Series({where_expr}, index={operand}.index)"
+
+
+class LengthNode(BaseStringAccessorOpNode):
     """LengthNode class"""
 
     type: Literal[NodeType.LENGTH] = Field(NodeType.LENGTH, const=True)
@@ -32,8 +53,11 @@ class LengthNode(BaseSeriesOutputWithSingleOperandNode):
     def generate_expression(self, operand: str) -> str:
         return f"{operand}.str.len()"
 
+    def generate_udf_expression(self, operand: str) -> str:
+        return f"len({operand})"
 
-class TrimNode(BaseSeriesOutputWithSingleOperandNode):
+
+class TrimNode(BaseStringAccessorOpNode):
     """TrimNode class"""
 
     class Parameters(BaseModel):
@@ -58,8 +82,18 @@ class TrimNode(BaseSeriesOutputWithSingleOperandNode):
             return f"{operand}.str.lstrip(to_strip={value})"
         return f"{operand}.str.rstrip(to_strip={value})"
 
+    def generate_udf_expression(self, operand: str) -> str:
+        value = None
+        if self.parameters.character:
+            value = ValueStr.create(self.parameters.character)
+        if self.parameters.side == "both":
+            return f"{operand}.strip({value})"
+        if self.parameters.side == "left":
+            return f"{operand}.lstrip({value})"
+        return f"{operand}.rstrip({value})"
 
-class ReplaceNode(BaseSeriesOutputWithSingleOperandNode):
+
+class ReplaceNode(BaseStringAccessorOpNode):
     """ReplaceNode class"""
 
     class Parameters(BaseModel):
@@ -79,8 +113,13 @@ class ReplaceNode(BaseSeriesOutputWithSingleOperandNode):
         replacement = ValueStr.create(self.parameters.replacement)
         return f"{operand}.str.replace(pat={pattern}, repl={replacement})"
 
+    def generate_udf_expression(self, operand: str) -> str:
+        pattern = ValueStr.create(self.parameters.pattern)
+        replacement = ValueStr.create(self.parameters.replacement)
+        return f"{operand}.replace({pattern}, {replacement})"
 
-class PadNode(BaseSeriesOutputWithSingleOperandNode):
+
+class PadNode(BaseStringAccessorOpNode):
     """PadNode class"""
 
     class Parameters(BaseModel):
@@ -102,8 +141,53 @@ class PadNode(BaseSeriesOutputWithSingleOperandNode):
         fill_char = ValueStr.create(self.parameters.pad)
         return f"{operand}.str.pad(width={width}, side={side}, fillchar={fill_char})"
 
+    @staticmethod
+    def _get_pad_string_function_name(
+        var_name_generator: VariableNameGenerator,
+    ) -> Tuple[List[StatementT], str]:
+        statements: List[StatementT] = []
+        func_name = "pad_string"
+        if func_name not in var_name_generator.var_name_counter:
+            # add custom function if it doesn't exist
+            func_name = var_name_generator.convert_to_variable_name(
+                variable_name_prefix=func_name, node_name=None
+            )
+            func_string = """
+            def pad_string(input_string: str, side: str, length: int, pad: str) -> str:
+                pad_length = length - len(input_string)
+                if pad_length <= 0:
+                    return input_string  # No padding needed
+                if side == "left":
+                    return pad * pad_length + input_string
+                elif side == "right":
+                    return input_string + pad * pad_length
+                else:
+                    left_pad = (pad_length // 2) * pad
+                    right_pad = (pad_length - len(left_pad)) * pad
+                    return left_pad + input_string + right_pad
+            """
+            statements.append(StatementStr(textwrap.dedent(func_string)))
+        return statements, func_name
 
-class StringCaseNode(BaseSeriesOutputWithSingleOperandNode):
+    def _derive_user_defined_function_code(
+        self,
+        node_inputs: List[VarNameExpressionInfo],
+        var_name_generator: VariableNameGenerator,
+        config: OnDemandFunctionCodeGenConfig,
+    ) -> Tuple[List[StatementT], VarNameExpressionInfo]:
+        statements, func_name = self._get_pad_string_function_name(
+            var_name_generator=var_name_generator
+        )
+        input_var_name_expressions = self._assert_no_info_dict(node_inputs)
+        input_string = input_var_name_expressions[0].as_input()
+        side = ValueStr.create(self.parameters.side)
+        length = self.parameters.length
+        pad = ValueStr.create(self.parameters.pad)
+        expr = f"{func_name}(input_string={input_string}, side={side}, length={length}, pad={pad})"
+        return statements, ExpressionStr(f"np.nan if pd.isna({input_string}) else {expr}")
+
+
+class StringCaseNode(BaseStringAccessorOpNode):
     """StringCaseNode class"""
 
     class Parameters(BaseModel):
@@ -120,8 +204,13 @@ class StringCaseNode(BaseSeriesOutputWithSingleOperandNode):
     def generate_expression(self, operand: str) -> str:
         return f"{operand}.str.{self.parameters.case}()"
 
+    def generate_udf_expression(self, operand: str) -> str:
+        if self.parameters.case == "upper":
+            return f"{operand}.upper()"
+        return f"{operand}.lower()"
 
-class StringContainsNode(BaseSeriesOutputWithSingleOperandNode):
+
+class StringContainsNode(BaseStringAccessorOpNode):
     """StringContainsNode class"""
 
     class Parameters(BaseModel):
@@ -140,8 +229,14 @@ class StringContainsNode(BaseSeriesOutputWithSingleOperandNode):
         pattern = ValueStr.create(self.parameters.pattern)
         return f"{operand}.str.contains(pat={pattern}, case={self.parameters.case})"
 
+    def generate_udf_expression(self, operand: str) -> str:
+        pattern = ValueStr.create(self.parameters.pattern)
+        if self.parameters.case:
+            return f"{pattern} in {operand}"
+        return f"{pattern}.lower() in {operand}.lower()"
 
-class SubStringNode(BaseSeriesOutputWithSingleOperandNode):
+
+class SubStringNode(BaseStringAccessorOpNode):
     """SubStringNode class"""
 
     class Parameters(BaseModel):
@@ -161,6 +256,12 @@ class SubStringNode(BaseSeriesOutputWithSingleOperandNode):
         if self.parameters.length is not None:
             stop = self.parameters.length + (self.parameters.start or 0)
         return f"{operand}.str.slice(start={self.parameters.start}, stop={stop})"
+
+    def generate_udf_expression(self, operand: str) -> str:
+        stop = None
+        if self.parameters.length is not None:
+            stop = self.parameters.length + (self.parameters.start or 0)
+        return f"{operand}[{self.parameters.start}:{stop}]"
 
 
 class ConcatNode(BinaryArithmeticOpNode):

--- a/featurebyte/query_graph/node/unary.py
+++ b/featurebyte/query_graph/node/unary.py
@@ -29,6 +29,12 @@ class NotNode(BaseSeriesOutputWithSingleOperandNode):
     def generate_expression(self, operand: str) -> str:
         return f"~{operand}"
 
+    def generate_odfv_expression(self, operand: str) -> str:
+        return f"{operand}.map(lambda x: not x if pd.notnull(x) else x)"
+
+    def generate_udf_expression(self, operand: str) -> str:
+        return f"not {operand}"
+
 
 class AbsoluteNode(BaseSeriesOutputWithSingleOperandNode):
     """AbsoluteNode class"""
@@ -40,6 +46,9 @@ class AbsoluteNode(BaseSeriesOutputWithSingleOperandNode):
 
     def generate_expression(self, operand: str) -> str:
         return f"{operand}.abs()"
+
+    def generate_udf_expression(self, operand: str) -> str:
+        return f"np.abs({operand})"
 
 
 class SquareRootNode(BaseSeriesOutputWithSingleOperandNode):
@@ -54,6 +63,9 @@ class SquareRootNode(BaseSeriesOutputWithSingleOperandNode):
         return f"{operand}.sqrt()"
 
     def generate_odfv_expression(self, operand: str) -> str:
+        return f"np.sqrt({operand})"
+
+    def generate_udf_expression(self, operand: str) -> str:
         return f"np.sqrt({operand})"
 
 
@@ -71,6 +83,9 @@ class FloorNode(BaseSeriesOutputWithSingleOperandNode):
     def generate_odfv_expression(self, operand: str) -> str:
         return f"np.floor({operand})"
 
+    def generate_udf_expression(self, operand: str) -> str:
+        return f"np.floor({operand})"
+
 
 class CeilNode(BaseSeriesOutputWithSingleOperandNode):
     """CeilNode class"""
@@ -84,6 +99,9 @@ class CeilNode(BaseSeriesOutputWithSingleOperandNode):
         return f"{operand}.ceil()"
 
     def generate_odfv_expression(self, operand: str) -> str:
+        return f"np.ceil({operand})"
+
+    def generate_udf_expression(self, operand: str) -> str:
         return f"np.ceil({operand})"
 
 
@@ -101,6 +119,9 @@ class CosNode(BaseSeriesOutputWithSingleOperandNode):
     def generate_odfv_expression(self, operand: str) -> str:
         return f"np.cos({operand})"
 
+    def generate_udf_expression(self, operand: str) -> str:
+        return f"np.cos({operand})"
+
 
 class SinNode(BaseSeriesOutputWithSingleOperandNode):
     """SinNode class"""
@@ -114,6 +135,9 @@ class SinNode(BaseSeriesOutputWithSingleOperandNode):
         return f"{operand}.sin()"
 
     def generate_odfv_expression(self, operand: str) -> str:
+        return f"np.sin({operand})"
+
+    def generate_udf_expression(self, operand: str) -> str:
         return f"np.sin({operand})"
 
 
@@ -131,6 +155,9 @@ class TanNode(BaseSeriesOutputWithSingleOperandNode):
     def generate_odfv_expression(self, operand: str) -> str:
         return f"np.tan({operand})"
 
+    def generate_udf_expression(self, operand: str) -> str:
+        return f"np.tan({operand})"
+
 
 class AcosNode(BaseSeriesOutputWithSingleOperandNode):
     """AcosNode class"""
@@ -144,6 +171,9 @@ class AcosNode(BaseSeriesOutputWithSingleOperandNode):
         return f"{operand}.acos()"
 
     def generate_odfv_expression(self, operand: str) -> str:
+        return f"np.arccos({operand})"
+
+    def generate_udf_expression(self, operand: str) -> str:
         return f"np.arccos({operand})"
 
 
@@ -161,6 +191,9 @@ class AsinNode(BaseSeriesOutputWithSingleOperandNode):
     def generate_odfv_expression(self, operand: str) -> str:
         return f"np.arcsin({operand})"
 
+    def generate_udf_expression(self, operand: str) -> str:
+        return f"np.arcsin({operand})"
+
 
 class AtanNode(BaseSeriesOutputWithSingleOperandNode):
     """CeilNode class"""
@@ -174,6 +207,9 @@ class AtanNode(BaseSeriesOutputWithSingleOperandNode):
         return f"{operand}.atan()"
 
     def generate_odfv_expression(self, operand: str) -> str:
+        return f"np.arctan({operand})"
+
+    def generate_udf_expression(self, operand: str) -> str:
         return f"np.arctan({operand})"
 
 
@@ -191,6 +227,9 @@ class LogNode(BaseSeriesOutputWithSingleOperandNode):
     def generate_odfv_expression(self, operand: str) -> str:
         return f"np.log({operand})"
 
+    def generate_udf_expression(self, operand: str) -> str:
+        return f"np.log({operand})"
+
 
 class ExponentialNode(BaseSeriesOutputWithSingleOperandNode):
     """ExponentialNode class"""
@@ -206,6 +245,9 @@ class ExponentialNode(BaseSeriesOutputWithSingleOperandNode):
     def generate_odfv_expression(self, operand: str) -> str:
         return f"np.exp({operand})"
 
+    def generate_udf_expression(self, operand: str) -> str:
+        return f"np.exp({operand})"
+
 
 class IsNullNode(BaseSeriesOutputWithSingleOperandNode):
     """IsNullNode class"""
@@ -217,6 +259,12 @@ class IsNullNode(BaseSeriesOutputWithSingleOperandNode):
 
     def generate_expression(self, operand: str) -> str:
         return f"{operand}.isnull()"
+
+    def generate_udf_expression(self, operand: str) -> str:
+        return f"pd.isna({operand})"
+
+    def _generate_udf_expression_with_null_value_handling(self, operand: str) -> str:
+        return self.generate_udf_expression(operand=operand)
 
 
 class CastNode(BaseSeriesOutputWithSingleOperandNode):
@@ -242,6 +290,12 @@ class CastNode(BaseSeriesOutputWithSingleOperandNode):
 
     def generate_expression(self, operand: str) -> str:
         return f"{operand}.astype({self.parameters.type})"
+
+    def generate_odfv_expression(self, operand: str) -> str:
+        return f"{operand}.map(lambda x: {self.parameters.type}(x) if pd.notnull(x) else x)"
+
+    def generate_udf_expression(self, operand: str) -> str:
+        return f"{self.parameters.type}({operand})"
 
 
 class IsStringNode(BaseSeriesOutputWithSingleOperandNode):

--- a/tests/fixtures/on_demand_function/req_col_ttl_and_non_ttl.sql
+++ b/tests/fixtures/on_demand_function/req_col_ttl_and_non_ttl.sql
@@ -1,0 +1,29 @@
+CREATE FUNCTION odf_func(x_1 STRING, x_2 DOUBLE, r_1 STRING)
+RETURNS DOUBLE
+LANGUAGE PYTHON
+COMMENT ''
+AS $$
+import json
+import numpy as np
+import pandas as pd
+import scipy as sp
+
+
+def on_demand_feature_function(
+    col_1: str, col_2: float, request_col_1: str
+) -> float:
+    # col_1: __feature_V231227__part0
+    # col_2: __feature_V231227__part1
+    # request_col_1: POINT_IN_TIME
+    feat_1 = pd.to_datetime(col_1)
+    feat_2 = pd.to_datetime(request_col_1)
+    feat_3 = (
+        np.nan
+        if pd.isna(((feat_2 + (feat_2 - feat_2)) - feat_1))
+        else ((feat_2 + (feat_2 - feat_2)) - feat_1).seconds // 86400
+    )
+    feat_4 = np.nan if pd.isna(feat_3) or pd.isna(col_2) else feat_3 + col_2
+    return feat_4
+
+return on_demand_feature_function(x_1, x_2, r_1)
+$$

--- a/tests/unit/api/test_offline_ingest_query_graph.py
+++ b/tests/unit/api/test_offline_ingest_query_graph.py
@@ -123,6 +123,8 @@ def test_feature__request_column_ttl_and_non_ttl_components(
     non_time_based_feature,
     latest_event_timestamp_feature,
     feature_group_feature_job_setting,
+    test_dir,
+    update_fixtures,
 ):
     """Test that a feature contains request column, ttl and non-ttl components."""
     request_and_ttl_component = (
@@ -170,8 +172,15 @@ def test_feature__request_column_ttl_and_non_ttl_components(
     check_ingest_query_graph(non_ttl_component_graph)
 
     # check consistency of decomposed graph
+    sql_fixture_path = os.path.join(
+        test_dir, "fixtures/on_demand_function/req_col_ttl_and_non_ttl.sql"
+    )
     check_decomposed_graph_output_node_hash(feature_model=feature_model)
-    check_on_demand_feature_code_generation(feature_model=feature_model, skip_udf_check=True)
+    check_on_demand_feature_code_generation(
+        feature_model=feature_model,
+        sql_fixture_path=sql_fixture_path,
+        update_fixtures=update_fixtures,
+    )
 
     # check on-demand view code
     codes = offline_store_info.generate_on_demand_feature_view_code(
@@ -266,7 +275,7 @@ def test_feature__ttl_item_aggregate_request_column(
     # check offline ingest query graph
     feature_model = composite_feature.cached_model
     check_decomposed_graph_output_node_hash(feature_model=feature_model)
-    check_on_demand_feature_code_generation(feature_model=feature_model, skip_udf_check=True)
+    check_on_demand_feature_code_generation(feature_model=feature_model)
 
     # check on-demand view code
     offline_store_info = feature_model.offline_store_info
@@ -415,7 +424,7 @@ def test_feature__composite_count_dict(
     feature_model = feature.cached_model
     assert feature_model.offline_store_info.is_decomposed is True
     check_decomposed_graph_output_node_hash(feature_model=feature_model)
-    check_on_demand_feature_code_generation(feature_model=feature_model, skip_udf_check=True)
+    check_on_demand_feature_code_generation(feature_model=feature_model)
 
 
 def test_feature__input_has_ingest_query_graph_node(test_dir):

--- a/tests/unit/api/test_request_column.py
+++ b/tests/unit/api/test_request_column.py
@@ -90,7 +90,7 @@ def test_point_in_time_minus_timestamp_feature(
         feature_model=new_feature_model,
         output=output,
     )
-    check_on_demand_feature_code_generation(feature_model=new_feature_model, skip_udf_check=True)
+    check_on_demand_feature_code_generation(feature_model=new_feature_model)
 
 
 def test_request_column_non_point_in_time_blocked():

--- a/tests/unit/query_graph/on_demand_function/conftest.py
+++ b/tests/unit/query_graph/on_demand_function/conftest.py
@@ -1,0 +1,24 @@
+"""
+This module contains common fixtures for on-demand function tests
+"""
+import pytest
+
+from featurebyte.enum import DBVarType
+from featurebyte.query_graph.node.metadata.config import (
+    OnDemandFunctionCodeGenConfig,
+    OnDemandViewCodeGenConfig,
+)
+
+
+@pytest.fixture(name="odfv_config")
+def fixture_odfv_config():
+    """Fixture for the ODFV config"""
+    # set a high limit to avoid the expression being split into multiple statements
+    return OnDemandViewCodeGenConfig(max_expression_length=180)
+
+
+@pytest.fixture(name="udf_config")
+def fixture_udf_config():
+    """Fixture for the UDF config"""
+    # set a high limit to avoid the expression being split into multiple statements
+    return OnDemandFunctionCodeGenConfig(output_dtype=DBVarType.FLOAT, max_expression_length=180)

--- a/tests/unit/query_graph/on_demand_function/test_binary.py
+++ b/tests/unit/query_graph/on_demand_function/test_binary.py
@@ -5,7 +5,6 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from featurebyte.enum import DBVarType
 from featurebyte.query_graph.node.base import BinaryOpWithBoolOutputNode
 from featurebyte.query_graph.node.binary import (
     AddNode,
@@ -24,29 +23,10 @@ from featurebyte.query_graph.node.binary import (
     PowerNode,
     SubtractNode,
 )
-from featurebyte.query_graph.node.metadata.config import (
-    OnDemandFunctionCodeGenConfig,
-    OnDemandViewCodeGenConfig,
-)
 from featurebyte.query_graph.node.metadata.sdk_code import VariableNameGenerator, VariableNameStr
+from tests.unit.query_graph.util import evaluate_and_compare_odfv_and_udf_results
 
 NODE_PARAMS = {"name": "node_name", "parameters": {"value": None}}
-
-
-def evaluate_and_compare_result(feat1, feat2, odfv_expr, udf_expr):
-    """Evaluate the odfv & udf expressions & compare the results"""
-    # check the odfv expression can be evaluated
-    out_odfv = eval(odfv_expr)
-
-    # check the udf expression can be evaluated
-    out_vals = []
-    for feat1, feat2 in zip(feat1, feat2):
-        _ = feat1, feat2
-        out_vals.append(eval(udf_expr))
-    out_udf = pd.Series(out_vals)
-
-    # check the consistency between two expressions
-    pd.testing.assert_series_equal(out_odfv, out_udf)
 
 
 @pytest.mark.parametrize(
@@ -68,40 +48,22 @@ def evaluate_and_compare_result(feat1, feat2, odfv_expr, udf_expr):
         (PowerNode(**NODE_PARAMS), "feat1.pow(feat2)", "np.power(feat1, feat2)"),
     ],
 )
-def test_derive_on_demand_function(node, expected_odfv_expr, expected_udf_expr):
+def test_derive_on_demand_function(
+    node, odfv_config, udf_config, expected_odfv_expr, expected_udf_expr
+):
     """Test derive_on_demand_view_code"""
     node_inputs = [VariableNameStr("feat1"), VariableNameStr("feat2")]
-    # set a high limit to avoid the expression being split into multiple statements
-    max_expr_length = 180
-
     odfv_stats, odfv_expr = node.derive_on_demand_view_code(
         node_inputs=node_inputs,
         var_name_generator=VariableNameGenerator(),
-        config=OnDemandViewCodeGenConfig(max_expression_length=max_expr_length),
+        config=odfv_config,
     )
 
     udf_stats, udf_expr = node.derive_user_defined_function_code(
-        node_inputs=[VariableNameStr("feat1"), VariableNameStr("feat2")],
+        node_inputs=node_inputs,
         var_name_generator=VariableNameGenerator(),
-        config=OnDemandFunctionCodeGenConfig(
-            output_dtype=DBVarType.FLOAT, max_expression_length=max_expr_length
-        ),
+        config=udf_config,
     )
-
-    expected_udf_expr = f"np.nan if pd.isna(feat1) or pd.isna(feat2) else {expected_udf_expr}"
-    expected_odfv_expr = (
-        "pd.Series(np.where(pd.isna(feat1) | pd.isna(feat2), np.nan, "
-        f"{expected_odfv_expr}), index=feat1.index)"
-    )
-    if isinstance(node, BinaryOpWithBoolOutputNode):
-        expected_odfv_expr = (
-            f"{expected_odfv_expr}.apply(lambda x: np.nan if pd.isna(x) else bool(x))"
-        )
-
-    assert odfv_expr == expected_odfv_expr
-    assert udf_expr == expected_udf_expr
-    assert udf_stats == []
-    assert odfv_stats == []
 
     # check odfv statements & expression
     if isinstance(node, BinaryOpWithBoolOutputNode):
@@ -112,22 +74,24 @@ def test_derive_on_demand_function(node, expected_odfv_expr, expected_udf_expr):
         feat2 = pd.Series([1, 2, 3, 4, np.nan])
 
     # evaluate expression
-    evaluate_and_compare_result(
-        feat1=feat1, feat2=feat2, odfv_expr=expected_odfv_expr, udf_expr=expected_udf_expr
+    evaluate_and_compare_odfv_and_udf_results(
+        input_map={"feat1": feat1, "feat2": feat2},
+        odfv_expr=odfv_expr,
+        udf_expr=udf_expr,
+        odfv_stats=odfv_stats,
+        udf_stats=udf_stats,
     )
 
 
-def test_derive_on_demand_function__isin_node():
+def test_derive_on_demand_function__isin_node(odfv_config, udf_config):
     """Test derive_on_demand_view_code (isin node)"""
     node = IsInNode(**NODE_PARAMS)
     node_inputs = [VariableNameStr("feat1"), VariableNameStr("feat2")]
-    # set a high limit to avoid the expression being split into multiple statements
-    max_expr_length = 180
 
     odfv_stats, odfv_expr = node.derive_on_demand_view_code(
         node_inputs=node_inputs,
         var_name_generator=VariableNameGenerator(),
-        config=OnDemandViewCodeGenConfig(max_expression_length=max_expr_length),
+        config=odfv_config,
     )
     expected_odfv_expr = (
         "feat1.combine(feat2, "
@@ -139,9 +103,7 @@ def test_derive_on_demand_function__isin_node():
     udf_stats, udf_expr = node.derive_user_defined_function_code(
         node_inputs=[VariableNameStr("feat1"), VariableNameStr("feat2")],
         var_name_generator=VariableNameGenerator(),
-        config=OnDemandFunctionCodeGenConfig(
-            output_dtype=DBVarType.FLOAT, max_expression_length=max_expr_length
-        ),
+        config=udf_config,
     )
     expected_udf_expr = "False if pd.isna(feat1) or not isinstance(feat2, list) else feat1 in feat2"
     assert udf_stats == []
@@ -152,8 +114,12 @@ def test_derive_on_demand_function__isin_node():
     feat2 = pd.Series([[1], [1, 2], [1], [], np.nan])
 
     # evaluate expression
-    evaluate_and_compare_result(
-        feat1=feat1, feat2=feat2, odfv_expr=expected_odfv_expr, udf_expr=expected_udf_expr
+    evaluate_and_compare_odfv_and_udf_results(
+        input_map={"feat1": feat1, "feat2": feat2},
+        odfv_expr=odfv_expr,
+        udf_expr=udf_expr,
+        odfv_stats=odfv_stats,
+        udf_stats=udf_stats,
     )
 
     # test when the value is a list (single not input)
@@ -161,7 +127,7 @@ def test_derive_on_demand_function__isin_node():
     odfv_stats, odfv_expr = node.derive_on_demand_view_code(
         node_inputs=node_inputs[:1],
         var_name_generator=VariableNameGenerator(),
-        config=OnDemandViewCodeGenConfig(max_expression_length=max_expr_length),
+        config=odfv_config,
     )
     expected_odfv_expr = (
         "pd.Series(np.where(pd.isna(feat1), np.nan, feat1.isin([1, 3])), index=feat1.index)"
@@ -173,12 +139,16 @@ def test_derive_on_demand_function__isin_node():
     udf_stats, udf_expr = node.derive_user_defined_function_code(
         node_inputs=node_inputs[:1],
         var_name_generator=VariableNameGenerator(),
-        config=OnDemandFunctionCodeGenConfig(
-            output_dtype=DBVarType.FLOAT, max_expression_length=max_expr_length
-        ),
+        config=udf_config,
     )
     expected_udf_expr = "np.nan if pd.isna(feat1) else feat1 in [1, 3]"
     assert udf_stats == []
     assert udf_expr == expected_udf_expr
 
-    evaluate_and_compare_result(feat1, feat2, expected_odfv_expr, expected_udf_expr)
+    evaluate_and_compare_odfv_and_udf_results(
+        input_map={"feat1": feat1},
+        odfv_expr=odfv_expr,
+        udf_expr=udf_expr,
+        odfv_stats=odfv_stats,
+        udf_stats=udf_stats,
+    )

--- a/tests/unit/query_graph/on_demand_function/test_date.py
+++ b/tests/unit/query_graph/on_demand_function/test_date.py
@@ -13,145 +13,233 @@ from featurebyte.query_graph.node.date import (
     TimeDeltaExtractNode,
     TimeDeltaNode,
 )
-from featurebyte.query_graph.node.metadata.config import OnDemandViewCodeGenConfig
 from featurebyte.query_graph.node.metadata.sdk_code import (
     CodeGenerator,
     VariableNameGenerator,
     VariableNameStr,
 )
+from tests.unit.query_graph.util import evaluate_and_compare_odfv_and_udf_results
 
 
-@pytest.fixture(name="config")
-def fixture_config():
-    """Fixture for the config"""
-    return OnDemandViewCodeGenConfig(
-        input_df_name="df", output_df_name="df", on_demand_function_name="on_demand"
-    )
-
-
-def test_date_add(config):
+def test_date_add(odfv_config, udf_config):
     """Test DateAddNode derive_on_demand_view_code"""
     node = DateAddNode(name="node_name", parameters={"value": None})
-    statements, expr = node.derive_on_demand_view_code(
-        node_inputs=[VariableNameStr("feat1"), VariableNameStr("feat2")],
+    node_inputs = [VariableNameStr("feat1"), VariableNameStr("feat2")]
+
+    odfv_stats, odfv_expr = node.derive_on_demand_view_code(
+        node_inputs=node_inputs,
         var_name_generator=VariableNameGenerator(),
-        config=config,
+        config=odfv_config,
     )
-    assert statements == []
-    feat1 = pd.date_range("2020-10-01", freq="d", periods=10).to_series()
-    feat2 = pd.Series(pd.Timedelta(seconds=1) * np.random.randint(0, 100, 10))
-    _ = feat1, feat2
+    assert odfv_stats == []
+    assert odfv_expr == "feat1 + feat2"
+
+    udf_stats, udf_expr = node.derive_user_defined_function_code(
+        node_inputs=node_inputs,
+        var_name_generator=VariableNameGenerator(),
+        config=udf_config,
+    )
+    assert odfv_stats == []
+    assert udf_expr == "feat1 + feat2"
+
+    feat1 = pd.Series(pd.date_range("2020-10-01", freq="d", periods=10).to_list() + [np.nan])
+    feat2 = pd.Series([np.nan] + list(pd.Timedelta(seconds=1) * np.random.randint(0, 100, 10)))
 
     # check the expression can be evaluated & matches expected
-    eval(expr)
-    assert expr == "feat1 + feat2"
+    evaluate_and_compare_odfv_and_udf_results(
+        input_map={"feat1": feat1, "feat2": feat2},
+        odfv_expr=odfv_expr,
+        udf_expr=udf_expr,
+        odfv_stats=odfv_stats,
+        udf_stats=udf_stats,
+    )
 
 
-def test_date_difference(config):
+def test_date_difference(odfv_config, udf_config):
     """Test DateDifferenceNode derive_on_demand_view_code"""
     node = DateDifferenceNode(name="node_name", parameters={"value": None})
-    statements, expr = node.derive_on_demand_view_code(
-        node_inputs=[VariableNameStr("feat1"), VariableNameStr("feat2")],
+    node_inputs = [VariableNameStr("feat1"), VariableNameStr("feat2")]
+
+    odfv_stats, odfv_expr = node.derive_on_demand_view_code(
+        node_inputs=node_inputs,
         var_name_generator=VariableNameGenerator(),
-        config=config,
+        config=odfv_config,
     )
-    assert statements == []
-    feat1 = pd.date_range("2020-10-01", freq="d", periods=10).to_series()
-    feat2 = feat1
-    _ = feat1, feat2
+    assert odfv_stats == []
+    assert odfv_expr == "feat1 - feat2"
+
+    udf_stats, udf_expr = node.derive_user_defined_function_code(
+        node_inputs=node_inputs,
+        var_name_generator=VariableNameGenerator(),
+        config=udf_config,
+    )
+    assert odfv_stats == []
+    assert udf_expr == "feat1 - feat2"
+
+    feat1 = pd.Series(pd.date_range("2020-10-01", freq="d", periods=10).to_list() + [np.nan])
+    feat2 = pd.Series([np.nan] + pd.date_range("2020-10-01", freq="d", periods=10).to_list())
 
     # check the expression can be evaluated & matches expected
-    eval(expr)
-    assert expr == "feat1 - feat2"
+    evaluate_and_compare_odfv_and_udf_results(
+        input_map={"feat1": feat1, "feat2": feat2},
+        odfv_expr=odfv_expr,
+        udf_expr=udf_expr,
+        odfv_stats=odfv_stats,
+        udf_stats=udf_stats,
+    )
 
 
 @pytest.mark.parametrize(
-    "property", [property for property in DatetimeSupportedPropertyType.__args__]
+    "dt_property", [property for property in DatetimeSupportedPropertyType.__args__]
 )
-def test_datetime_extract(config, property):
+def test_datetime_extract(odfv_config, udf_config, dt_property):
     """Test DatetimeExtractNode derive_on_demand_view_code"""
     # single input with no timezone offset
     node = DatetimeExtractNode(
-        name="node_name", parameters={"property": property, "timezone_offset": None}
+        name="node_name", parameters={"property": dt_property, "timezone_offset": None}
     )
-    statements, expr = node.derive_on_demand_view_code(
+    node_inputs = [VariableNameStr("feat")]
+
+    odfv_stats, odfv_expr = node.derive_on_demand_view_code(
         node_inputs=[VariableNameStr("feat")],
         var_name_generator=VariableNameGenerator(),
-        config=config,
+        config=odfv_config,
     )
-    assert statements == []
-    feat = pd.date_range("2020-10-01", freq="d", periods=10).to_series()
-    _ = feat
+    assert odfv_stats == []
+    assert odfv_expr == f"feat.dt.{dt_property}"
 
-    # check the expression can be evaluated & matches expected
-    eval(expr)
-    assert expr == f"feat.dt.{property}"
+    udf_stats, udf_expr = node.derive_user_defined_function_code(
+        node_inputs=node_inputs,
+        var_name_generator=VariableNameGenerator(),
+        config=udf_config,
+    )
+    assert udf_stats == []
+    assert udf_expr == f"feat.{dt_property}"
+
+    feat = pd.Series(pd.date_range("2020-10-01", freq="d", periods=10).to_list() + [np.nan])
+    evaluate_and_compare_odfv_and_udf_results(
+        input_map={"feat": feat},
+        odfv_expr=odfv_expr,
+        udf_expr=udf_expr,
+        odfv_stats=odfv_stats,
+        udf_stats=udf_stats,
+    )
 
     # second input as timezone offset
-    statements, expr = node.derive_on_demand_view_code(
+    odfv_stats, odfv_expr = node.derive_on_demand_view_code(
         node_inputs=[VariableNameStr("feat"), VariableNameStr("feat1")],
         var_name_generator=VariableNameGenerator(),
-        config=config,
+        config=odfv_config,
     )
-    assert statements == [("feat_dt", "feat + feat1")]
-    assert expr == f"feat_dt.dt.{property}"
+    assert odfv_stats == [("feat_dt", "feat + feat1")]
+    assert odfv_expr == f"feat_dt.dt.{dt_property}"
+
+    udf_stats, udf_expr = node.derive_user_defined_function_code(
+        node_inputs=[VariableNameStr("feat"), VariableNameStr("feat1")],
+        var_name_generator=VariableNameGenerator(),
+        config=udf_config,
+    )
+    assert udf_stats == [("feat", "feat + feat1")]
+    assert udf_expr == f"feat.{dt_property}"
 
     # offset as a timedelta
     node = DatetimeExtractNode(
-        name="node_name", parameters={"property": property, "timezone_offset": "+06:00"}
+        name="node_name", parameters={"property": dt_property, "timezone_offset": "+06:00"}
     )
-    statements, expr = node.derive_on_demand_view_code(
+    odfv_stats, odfv_expr = node.derive_on_demand_view_code(
         node_inputs=[VariableNameStr("feat")],
         var_name_generator=VariableNameGenerator(),
-        config=config,
+        config=odfv_config,
     )
-    code_gen = CodeGenerator(statements=statements + [(VariableNameStr("output"), expr)])
+    code_gen = CodeGenerator(statements=odfv_stats + [(VariableNameStr("output"), odfv_expr)])
     codes = code_gen.generate().strip()
     assert codes == (
         'tz_offset = pd.to_timedelta("+06:00:00")\n'
         "feat_dt = feat + tz_offset\n"
-        f"output = feat_dt.dt.{property}"
+        f"output = feat_dt.dt.{dt_property}"
+    )
+
+    udf_stats, udf_expr = node.derive_user_defined_function_code(
+        node_inputs=[VariableNameStr("feat")],
+        var_name_generator=VariableNameGenerator(),
+        config=udf_config,
+    )
+    code_gen = CodeGenerator(statements=udf_stats + [(VariableNameStr("output"), udf_expr)])
+    codes = code_gen.generate().strip()
+    assert codes == (
+        'tz_offset = pd.to_timedelta("+06:00:00")\n'
+        "feat = feat + tz_offset\n"
+        f"output = feat.{dt_property}"
     )
 
 
 @pytest.mark.parametrize(
-    "property,expected_expr",
+    "td_property,expected_odfv_expr,expected_udf_expr",
     [
-        ("day", "feat.dt.seconds // 86400"),  # 86400 = 24 * 60 * 60
-        ("hour", "feat.dt.seconds // 3600"),  # 3600 = 60 * 60
-        ("minute", "feat.dt.seconds // 60"),
-        ("second", "feat.dt.seconds"),
-        ("millisecond", "feat.dt.microseconds // 1000"),
-        ("microsecond", "feat.dt.microseconds"),
+        ("day", "feat.dt.seconds // 86400", "feat.seconds // 86400"),  # 86400 = 24 * 60 * 60
+        ("hour", "feat.dt.seconds // 3600", "feat.seconds // 3600"),  # 3600 = 60 * 60
+        ("minute", "feat.dt.seconds // 60", "feat.seconds // 60"),
+        ("second", "feat.dt.seconds", "feat.seconds"),
+        ("millisecond", "feat.dt.microseconds // 1000", "feat.microseconds // 1000"),
+        ("microsecond", "feat.dt.microseconds", "feat.microseconds"),
     ],
 )
-def test_time_delta_extract(config, property, expected_expr):
+def test_time_delta_extract(
+    odfv_config, udf_config, td_property, expected_odfv_expr, expected_udf_expr
+):
     """Test TimeDeltaExtractNode derive_on_demand_view_code"""
     # single input with no timezone offset
-    node = TimeDeltaExtractNode(name="node_name", parameters={"property": property})
-    statements, expr = node.derive_on_demand_view_code(
-        node_inputs=[VariableNameStr("feat")],
+    node = TimeDeltaExtractNode(name="node_name", parameters={"property": td_property})
+    node_inputs = [VariableNameStr("feat")]
+
+    odfv_stats, odfv_expr = node.derive_on_demand_view_code(
+        node_inputs=node_inputs,
         var_name_generator=VariableNameGenerator(),
-        config=config,
+        config=odfv_config,
     )
-    assert statements == []
-    feat = pd.Series(pd.Timedelta(seconds=1) * np.random.randint(0, 100, 10))
-    _ = feat
+    assert odfv_stats == []
+    assert odfv_expr == expected_odfv_expr
+
+    udf_stats, udf_expr = node.derive_user_defined_function_code(
+        node_inputs=node_inputs,
+        var_name_generator=VariableNameGenerator(),
+        config=udf_config,
+    )
+    assert udf_stats == []
+    assert udf_expr == f"np.nan if pd.isna(feat) else {expected_udf_expr}"
+
+    feat = pd.Series([np.nan] + list(pd.Timedelta(seconds=1) * np.random.randint(0, 100, 10)))
 
     # check the expression can be evaluated & matches expected
-    eval(expr)
-    assert expr == expected_expr
+    evaluate_and_compare_odfv_and_udf_results(
+        input_map={"feat": feat},
+        odfv_expr=odfv_expr,
+        udf_expr=udf_expr,
+        odfv_stats=odfv_stats,
+        udf_stats=udf_stats,
+    )
 
 
 @pytest.mark.parametrize("unit", [unit for unit in TimedeltaSupportedUnitType.__args__])
-def test_time_delta(config, unit):
+def test_time_delta(odfv_config, udf_config, unit):
     """Test TimeDeltaNode derive_on_demand_view_code"""
     node = TimeDeltaNode(name="node_name", parameters={"unit": unit})
-    statements, expr = node.derive_on_demand_view_code(
-        node_inputs=[VariableNameStr("val")],
+    node_inputs = [VariableNameStr("val")]
+
+    odfv_stats, odfv_expr = node.derive_on_demand_view_code(
+        node_inputs=node_inputs,
         var_name_generator=VariableNameGenerator(),
-        config=config,
+        config=odfv_config,
     )
-    code_gen = CodeGenerator(statements=statements + [(VariableNameStr("output"), expr)])
+    code_gen = CodeGenerator(statements=odfv_stats + [(VariableNameStr("output"), odfv_expr)])
+    codes = code_gen.generate().strip()
+    assert codes == f'feat = pd.to_timedelta(val, unit="{unit}")\n' "output = feat"
+
+    udf_stats, udf_expr = node.derive_user_defined_function_code(
+        node_inputs=node_inputs,
+        var_name_generator=VariableNameGenerator(),
+        config=udf_config,
+    )
+    code_gen = CodeGenerator(statements=udf_stats + [(VariableNameStr("output"), udf_expr)])
     codes = code_gen.generate().strip()
     assert codes == f'feat = pd.to_timedelta(val, unit="{unit}")\n' "output = feat"

--- a/tests/unit/query_graph/on_demand_function/test_distance.py
+++ b/tests/unit/query_graph/on_demand_function/test_distance.py
@@ -2,18 +2,13 @@
 Test on-demand view code generation of distance related nodes.
 """
 import pandas as pd
-import pytest
 
 from featurebyte.query_graph.node.distance import HaversineNode
-from featurebyte.query_graph.node.metadata.config import OnDemandViewCodeGenConfig
-from featurebyte.query_graph.node.metadata.sdk_code import (
-    CodeGenerator,
-    VariableNameGenerator,
-    VariableNameStr,
-)
+from featurebyte.query_graph.node.metadata.sdk_code import VariableNameGenerator, VariableNameStr
+from tests.unit.query_graph.util import evaluate_and_compare_odfv_and_udf_results
 
 
-def test_derive_on_demand_view_code__haversine_distance():
+def test_derive_on_demand_view_code__haversine_distance(odfv_config, udf_config):
     """Test derive_on_demand_view_code"""
     lat1 = pd.Series([40.7128, 51.5074, None, 40.7128, 40.7128, 40.7128])
     lon1 = pd.Series([-74.0060, -0.1278, 74.0060, None, -74.0060, -74.0060])
@@ -22,34 +17,35 @@ def test_derive_on_demand_view_code__haversine_distance():
     expected_values = pd.Series([3935.746255, 343.556060, None, None, None, None])
 
     node = HaversineNode(name="node_name", parameters={})
-    config = OnDemandViewCodeGenConfig(
-        input_df_name="input_df",
-        output_df_name="output_df",
-        on_demand_function_name="on_demand_func",
-    )
-    statements, expr = node.derive_on_demand_view_code(
-        node_inputs=[
-            VariableNameStr('df["lat1"]'),
-            VariableNameStr('df["lon1"]'),
-            VariableNameStr('df["lat2"]'),
-            VariableNameStr('df["lon2"]'),
-        ],
-        var_name_generator=VariableNameGenerator(),
-        config=config,
-    )
-    code_gen = CodeGenerator(
-        statements=statements + [(VariableNameStr('output_df["feature"]'), expr)],
-        template="on_demand_view.tpl",
-    )
-    codes = code_gen.generate(
-        input_df_name=config.input_df_name,
-        output_df_name=config.output_df_name,
-        function_name=config.on_demand_function_name,
-    ).strip()
+    node_inputs = [
+        VariableNameStr("lat1"),
+        VariableNameStr("lon1"),
+        VariableNameStr("lat2"),
+        VariableNameStr("lon2"),
+    ]
 
-    local_vars = {"df": pd.DataFrame({"lat1": lat1, "lon1": lon1, "lat2": lat2, "lon2": lon2})}
-    exec_codes = codes + "\n\nout_df = on_demand_func(df)"
-    exec(exec_codes, local_vars)
-    out_df = local_vars["out_df"]
-    expected_values.name = "feature"
-    pd.testing.assert_series_equal(out_df["feature"], expected_values)
+    odfv_stats, odfv_expr = node.derive_on_demand_view_code(
+        node_inputs=node_inputs,
+        var_name_generator=VariableNameGenerator(),
+        config=odfv_config,
+    )
+
+    udf_stats, udf_expr = node.derive_user_defined_function_code(
+        node_inputs=node_inputs,
+        var_name_generator=VariableNameGenerator(),
+        config=udf_config,
+    )
+
+    evaluate_and_compare_odfv_and_udf_results(
+        input_map={
+            "lat1": lat1,
+            "lon1": lon1,
+            "lat2": lat2,
+            "lon2": lon2,
+        },
+        odfv_expr=odfv_expr,
+        udf_expr=udf_expr,
+        odfv_stats=odfv_stats,
+        udf_stats=udf_stats,
+        expected_output=expected_values,
+    )

--- a/tests/unit/query_graph/on_demand_function/test_generic.py
+++ b/tests/unit/query_graph/on_demand_function/test_generic.py
@@ -1,16 +1,11 @@
 """
 Test node's demand feature view related methods
 """
-from featurebyte.enum import DBVarType
 from featurebyte.query_graph.node.generic import AliasNode, ConditionalNode
-from featurebyte.query_graph.node.metadata.config import (
-    OnDemandFunctionCodeGenConfig,
-    OnDemandViewCodeGenConfig,
-)
 from featurebyte.query_graph.node.metadata.sdk_code import VariableNameGenerator, VariableNameStr
 
 
-def test_alias_node():
+def test_alias_node(odfv_config, udf_config):
     """Test AliasNode derive_on_demand_view_code"""
     node_inputs = [VariableNameStr("feat")]
     node = AliasNode(name="node_name", parameters={"name": "feat"})
@@ -18,7 +13,7 @@ def test_alias_node():
     odfv_stats, odfv_expr = node.derive_on_demand_view_code(
         node_inputs=node_inputs,
         var_name_generator=VariableNameGenerator(),
-        config=OnDemandViewCodeGenConfig(),
+        config=odfv_config,
     )
     assert odfv_stats == []
     assert odfv_expr == "feat"
@@ -26,13 +21,13 @@ def test_alias_node():
     udf_stats, udf_expr = node.derive_user_defined_function_code(
         node_inputs=node_inputs,
         var_name_generator=VariableNameGenerator(),
-        config=OnDemandFunctionCodeGenConfig(output_dtype=DBVarType.FLOAT),
+        config=udf_config,
     )
     assert udf_stats == []
     assert udf_expr == "feat"
 
 
-def test_conditional_node():
+def test_conditional_node(odfv_config, udf_config):
     """Test ConditionalNode derive_on_demand_view_code"""
     node = ConditionalNode(name="node_name", parameters={"value": 1})
     three_node_inputs = [
@@ -43,7 +38,7 @@ def test_conditional_node():
     odfv_stats, odfv_out_var = node.derive_on_demand_view_code(
         node_inputs=three_node_inputs,
         var_name_generator=VariableNameGenerator(),
-        config=OnDemandViewCodeGenConfig(),
+        config=odfv_config,
     )
     assert odfv_stats == [("feat1[mask]", "feat2[mask]")]
     assert odfv_out_var == "feat1"
@@ -51,7 +46,7 @@ def test_conditional_node():
     udf_stats, udf_out_var = node.derive_user_defined_function_code(
         node_inputs=three_node_inputs,
         var_name_generator=VariableNameGenerator(),
-        config=OnDemandFunctionCodeGenConfig(output_dtype=DBVarType.FLOAT),
+        config=udf_config,
     )
     assert udf_stats == ["feat1 = feat2 if mask else feat1"]
     assert udf_out_var == "feat1"
@@ -61,7 +56,7 @@ def test_conditional_node():
     odfv_stats, odfv_out_var = node.derive_on_demand_view_code(
         node_inputs=two_node_inputs,
         var_name_generator=VariableNameGenerator(),
-        config=OnDemandViewCodeGenConfig(),
+        config=odfv_config,
     )
     assert odfv_stats == [("feat1[mask]", "1")]
     assert odfv_out_var == "feat1"
@@ -69,7 +64,7 @@ def test_conditional_node():
     udf_stats, udf_out_var = node.derive_user_defined_function_code(
         node_inputs=two_node_inputs,
         var_name_generator=VariableNameGenerator(),
-        config=OnDemandFunctionCodeGenConfig(output_dtype=DBVarType.FLOAT),
+        config=udf_config,
     )
     assert udf_stats == ["feat1 = 1 if mask else feat1"]
     assert udf_out_var == "feat1"

--- a/tests/unit/query_graph/on_demand_function/test_unary.py
+++ b/tests/unit/query_graph/on_demand_function/test_unary.py
@@ -1,12 +1,11 @@
 """
 Test the unary nodes in the on-demand view code generation.
 """
-import numpy as np  # this is required for eval
+import numpy as np
 import pandas as pd
 import pytest
 
 from featurebyte.enum import DBVarType
-from featurebyte.query_graph.node.metadata.config import OnDemandViewCodeGenConfig
 from featurebyte.query_graph.node.metadata.sdk_code import VariableNameGenerator, VariableNameStr
 from featurebyte.query_graph.node.unary import (
     AbsoluteNode,
@@ -25,47 +24,78 @@ from featurebyte.query_graph.node.unary import (
     SquareRootNode,
     TanNode,
 )
+from tests.unit.query_graph.util import evaluate_and_compare_odfv_and_udf_results
 
 NODE_PARAMS = {"name": "node_name"}
 
 
 @pytest.mark.parametrize(
-    "node, expected_expr",
+    "node, expected_odfv_expr, expected_udf_expr",
     [
-        (NotNode(**NODE_PARAMS), "~feat"),
-        (AbsoluteNode(**NODE_PARAMS), "feat.abs()"),
-        (SquareRootNode(**NODE_PARAMS), "np.sqrt(feat)"),
-        (FloorNode(**NODE_PARAMS), "np.floor(feat)"),
-        (CeilNode(**NODE_PARAMS), "np.ceil(feat)"),
-        (CosNode(**NODE_PARAMS), "np.cos(feat)"),
-        (SinNode(**NODE_PARAMS), "np.sin(feat)"),
-        (TanNode(**NODE_PARAMS), "np.tan(feat)"),
-        (AcosNode(**NODE_PARAMS), "np.arccos(feat)"),
-        (AsinNode(**NODE_PARAMS), "np.arcsin(feat)"),
-        (AtanNode(**NODE_PARAMS), "np.arctan(feat)"),
-        (LogNode(**NODE_PARAMS), "np.log(feat)"),
-        (ExponentialNode(**NODE_PARAMS), "np.exp(feat)"),
-        (IsNullNode(**NODE_PARAMS), "feat.isnull()"),
+        (NotNode(**NODE_PARAMS), "feat.map(lambda x: not x if pd.notnull(x) else x)", "not feat"),
+        (AbsoluteNode(**NODE_PARAMS), "feat.abs()", "np.abs(feat)"),
+        (SquareRootNode(**NODE_PARAMS), "np.sqrt(feat)", "np.sqrt(feat)"),
+        (FloorNode(**NODE_PARAMS), "np.floor(feat)", "np.floor(feat)"),
+        (CeilNode(**NODE_PARAMS), "np.ceil(feat)", "np.ceil(feat)"),
+        (CosNode(**NODE_PARAMS), "np.cos(feat)", "np.cos(feat)"),
+        (SinNode(**NODE_PARAMS), "np.sin(feat)", "np.sin(feat)"),
+        (TanNode(**NODE_PARAMS), "np.tan(feat)", "np.tan(feat)"),
+        (AcosNode(**NODE_PARAMS), "np.arccos(feat)", "np.arccos(feat)"),
+        (AsinNode(**NODE_PARAMS), "np.arcsin(feat)", "np.arcsin(feat)"),
+        (AtanNode(**NODE_PARAMS), "np.arctan(feat)", "np.arctan(feat)"),
+        (LogNode(**NODE_PARAMS), "np.log(feat)", "np.log(feat)"),
+        (ExponentialNode(**NODE_PARAMS), "np.exp(feat)", "np.exp(feat)"),
+        (IsNullNode(**NODE_PARAMS), "feat.isnull()", "pd.isna(feat)"),
         (
             CastNode(**NODE_PARAMS, parameters={"type": "str", "from_dtype": DBVarType.INT}),
-            "feat.astype(str)",
+            "feat.map(lambda x: str(x) if pd.notnull(x) else x)",
+            "str(feat)",
+        ),
+        (
+            CastNode(**NODE_PARAMS, parameters={"type": "float", "from_dtype": DBVarType.INT}),
+            "feat.map(lambda x: float(x) if pd.notnull(x) else x)",
+            "float(feat)",
+        ),
+        (
+            CastNode(**NODE_PARAMS, parameters={"type": "int", "from_dtype": DBVarType.FLOAT}),
+            "feat.map(lambda x: int(x) if pd.notnull(x) else x)",
+            "int(feat)",
         ),
     ],
 )
-def test_derive_on_demand_view_code(node, expected_expr):
+def test_derive_on_demand_view_code(
+    node, odfv_config, udf_config, expected_odfv_expr, expected_udf_expr
+):
     """Test derive_on_demand_view_code"""
-    config = OnDemandViewCodeGenConfig(
-        input_df_name="df", output_df_name="df", on_demand_function_name="on_demand"
-    )
-    statements, expr = node.derive_on_demand_view_code(
-        node_inputs=[VariableNameStr("feat")],
+    node_inputs = [VariableNameStr("feat")]
+
+    odfv_stats, odfv_out_var = node.derive_on_demand_view_code(
+        node_inputs=node_inputs,
         var_name_generator=VariableNameGenerator(),
-        config=config,
+        config=odfv_config,
     )
-    assert statements == []
-    feat = pd.Series([1, 2, 3])
-    _ = feat
+
+    udf_stats, udf_out_var = node.derive_user_defined_function_code(
+        node_inputs=node_inputs,
+        var_name_generator=VariableNameGenerator(),
+        config=udf_config,
+    )
+
+    if not isinstance(node, IsNullNode):
+        expected_udf_expr = f"np.nan if pd.isna(feat) else {expected_udf_expr}"
+
+    assert udf_stats == []
+    assert udf_out_var == expected_udf_expr
+
+    assert odfv_stats == []
+    assert odfv_out_var == expected_odfv_expr
 
     # check the expression can be evaluated & matches expected
-    eval(expr)
-    assert expr == expected_expr
+    feat = pd.Series([0, 1, 2, 3.1, np.nan])
+    evaluate_and_compare_odfv_and_udf_results(
+        input_map={"feat": feat},
+        odfv_expr=odfv_out_var,
+        udf_expr=udf_out_var,
+        odfv_stats=odfv_stats,
+        udf_stats=udf_stats,
+    )

--- a/tests/unit/query_graph/on_demand_function/test_vector.py
+++ b/tests/unit/query_graph/on_demand_function/test_vector.py
@@ -4,48 +4,40 @@ Test on-demand view code generation of vector related nodes.
 import numpy as np
 import pandas as pd
 
-from featurebyte.query_graph.node.metadata.config import OnDemandViewCodeGenConfig
-from featurebyte.query_graph.node.metadata.sdk_code import (
-    CodeGenerator,
-    VariableNameGenerator,
-    VariableNameStr,
-)
+from featurebyte.query_graph.node.metadata.sdk_code import VariableNameGenerator, VariableNameStr
 from featurebyte.query_graph.node.vector import VectorCosineSimilarityNode
+from tests.unit.query_graph.util import evaluate_and_compare_odfv_and_udf_results
 
 
-def test_derive_on_demand_view_code__haversine_distance():
+def test_derive_on_demand_view_code__haversine_distance(odfv_config):
     """Test derive_on_demand_view_code"""
     vec1 = pd.Series([[1, 0], [0, 1], np.array([]), [], np.nan])
     vec2 = pd.Series([[1, 0], [1, 0], [], np.array([]), [0, 1]])
     expected_values = pd.Series([1.0, 0.0, 0.0, 0.0, 0.0])
 
     node = VectorCosineSimilarityNode(name="node_name", parameters={})
-    config = OnDemandViewCodeGenConfig(
-        input_df_name="input_df",
-        output_df_name="output_df",
-        on_demand_function_name="on_demand_func",
-    )
-    statements, expr = node.derive_on_demand_view_code(
-        node_inputs=[
-            VariableNameStr('df["vec1"]'),
-            VariableNameStr('df["vec2"]'),
-        ],
-        var_name_generator=VariableNameGenerator(),
-        config=config,
-    )
-    code_gen = CodeGenerator(
-        statements=statements + [(VariableNameStr('output_df["feature"]'), expr)],
-        template="on_demand_view.tpl",
-    )
-    codes = code_gen.generate(
-        input_df_name=config.input_df_name,
-        output_df_name=config.output_df_name,
-        function_name=config.on_demand_function_name,
-    ).strip()
+    node_inputs = [VariableNameStr("vec1"), VariableNameStr("vec2")]
 
-    local_vars = {"df": pd.DataFrame({"vec1": vec1, "vec2": vec2})}
-    exec_codes = codes + "\n\nout_df = on_demand_func(df)"
-    exec(exec_codes, local_vars)
-    out_df = local_vars["out_df"]
-    expected_values.name = "feature"
-    pd.testing.assert_series_equal(out_df["feature"], expected_values)
+    odfv_stats, odfv_expr = node.derive_on_demand_view_code(
+        node_inputs=node_inputs,
+        var_name_generator=VariableNameGenerator(),
+        config=odfv_config,
+    )
+
+    udf_stats, udf_expr = node.derive_user_defined_function_code(
+        node_inputs=node_inputs,
+        var_name_generator=VariableNameGenerator(),
+        config=odfv_config,
+    )
+
+    evaluate_and_compare_odfv_and_udf_results(
+        input_map={
+            "vec1": vec1,
+            "vec2": vec2,
+        },
+        odfv_expr=odfv_expr,
+        udf_expr=udf_expr,
+        odfv_stats=odfv_stats,
+        udf_stats=udf_stats,
+        expected_output=expected_values,
+    )

--- a/tests/unit/query_graph/util.py
+++ b/tests/unit/query_graph/util.py
@@ -1,5 +1,9 @@
 from dataclasses import asdict
 
+import numpy as np
+import pandas as pd
+import scipy as sp
+
 from featurebyte.query_graph.node.metadata.operation import (
     AggregationColumn,
     DerivedDataColumn,
@@ -36,3 +40,41 @@ def to_dict(obj, exclude=None, include=None):
     if hasattr(obj, "dict"):
         return to_dict(obj.dict(), exclude=exclude, include=include)
     return obj
+
+
+def evaluate_and_compare_odfv_and_udf_results(
+    input_map, odfv_expr, udf_expr, odfv_stats=None, udf_stats=None, expected_output=None
+):
+    """Evaluate the odfv & udf expressions & compare the results"""
+    # check the odfv expression can be evaluated
+    locals = {"np": np, "pd": pd, "sp": sp, **input_map}
+    if odfv_stats:
+        for stat in odfv_stats:
+            if isinstance(stat, tuple):
+                stat = f"{stat[0]} = {stat[1]}"
+            exec(stat, locals)
+
+    out_odfv = eval(odfv_expr, locals)
+
+    # check the udf expression can be evaluated
+    locals = {"np": np, "pd": pd, "sp": sp}
+    if udf_stats:
+        for stat in udf_stats:
+            if isinstance(stat, tuple):
+                stat = f"{stat[0]} = {stat[1]}"
+            exec(stat, locals)
+
+    out_vals = []
+    input_param_names = list(input_map.keys())
+    for input_vals in zip(*input_map.values()):
+        for param_name, param_val in zip(input_param_names, input_vals):
+            locals[param_name] = param_val
+        out_vals.append(eval(udf_expr, locals))
+    out_udf = pd.Series(out_vals)
+
+    # check the consistency between two expressions
+    pd.testing.assert_series_equal(out_odfv, out_udf)
+
+    # check the expected output
+    if expected_output is not None:
+        pd.testing.assert_series_equal(out_odfv, expected_output)

--- a/tests/util/helper.py
+++ b/tests/util/helper.py
@@ -636,7 +636,7 @@ def check_on_demand_feature_function_code_execution(udf_code_state, df):
 
 
 def check_on_demand_feature_code_generation(
-    feature_model, skip_udf_check=False, sql_fixture_path=None, update_fixtures=False
+    feature_model, sql_fixture_path=None, update_fixtures=False
 ):
     """Check on demand feature view code generation"""
     offline_store_info = feature_model.offline_store_info
@@ -669,9 +669,6 @@ def check_on_demand_feature_code_generation(
     odfv_output = check_on_demand_feature_view_code_execution(odfv_codes, df)
     exp_col_name = feature_model.versioned_name
     assert odfv_output.columns == [exp_col_name]
-
-    if skip_udf_check:
-        return
 
     udf_code_state = offline_store_info._generate_on_demand_feature_function_code_state(
         output_dtype=feature_model.dtype,


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR is a following PR of (https://github.com/featurebyte/featurebyte/pull/2027), it covers the query graph nodes in
* `unary.py`
* `string.py`
* `date.py`
* `count_dict.py`
* `distance.py`
* `vector.py`

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
