### PR TITLE
[DEV-2721] add feature list id filter to list deployments

### DIFF
--- a/featurebyte/routes/deployment/api.py
+++ b/featurebyte/routes/deployment/api.py
@@ -90,11 +90,15 @@ async def list_deployments(
     sort_dir: Optional[str] = SortDirQuery,
     search: Optional[str] = SearchQuery,
     name: Optional[str] = NameQuery,
+    feature_list_id: Optional[PydanticObjectId] = None,
 ) -> DeploymentList:
     """
     List Deployments
     """
     controller = request.state.app_container.deployment_controller
+    query_filter = None
+    if feature_list_id:
+        query_filter = {"feature_list_id": feature_list_id}
     deployment_list: DeploymentList = await controller.list(
         page=page,
         page_size=page_size,
@@ -102,6 +106,7 @@ async def list_deployments(
         sort_dir=sort_dir,
         search=search,
         name=name,
+        query_filter=query_filter,
     )
     return deployment_list
 

--- a/tests/unit/routes/test_deployment.py
+++ b/tests/unit/routes/test_deployment.py
@@ -140,6 +140,43 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
             "total": 3,
         }
 
+    def test_list_200__filter_by_feature_list_id(
+        self, test_api_client_persistent, create_multiple_success_responses
+    ):
+        """Test list by feature list id"""
+        _ = create_multiple_success_responses
+
+        test_api_client, _ = test_api_client_persistent
+        default_catalog_id = test_api_client.headers["active-catalog-id"]
+
+        response = test_api_client.get("/feature_list")
+        assert response.status_code == HTTPStatus.OK, response.text
+        fl_ids = [obj["_id"] for obj in response.json()["data"]]
+
+        response = test_api_client.get(self.base_route, params={"feature_list_id": fl_ids[0]})
+        response_dict = response.json()
+        assert response_dict == {
+            "data": [
+                {
+                    "_id": response_dict["data"][0]["_id"],
+                    "block_modification_by": [],
+                    "catalog_id": default_catalog_id,
+                    "context_id": None,
+                    "created_at": response_dict["data"][0]["created_at"],
+                    "description": None,
+                    "enabled": False,
+                    "feature_list_id": fl_ids[0],
+                    "name": "my_deployment_2",
+                    "updated_at": response_dict["data"][0]["updated_at"],
+                    "use_case_id": None,
+                    "user_id": response_dict["data"][0]["user_id"],
+                }
+            ],
+            "page": 1,
+            "page_size": 10,
+            "total": 1,
+        }
+
     def test_deployment_summary_200(
         self, test_api_client_persistent, create_success_response, default_catalog_id
     ):


### PR DESCRIPTION
## Description

Add feature list id filter to list deployments

## Related Issue

[DEV-2721](https://featurebyte.atlassian.net/browse/DEV-2721)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly


[DEV-2721]: https://featurebyte.atlassian.net/browse/DEV-2721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ