### PR TITLE
[DEV-2914] Fix feature service not created in feast registry

### DIFF
--- a/featurebyte/service/deploy.py
+++ b/featurebyte/service/deploy.py
@@ -381,7 +381,7 @@ class DeployService(OpsServiceMixin):
     async def _update_offline_store_feature_tables(
         self, feature_models: List[FeatureModel], is_online_enabling: bool
     ) -> None:
-        if FeastIntegrationSettings().FEATUREBYTE_FEAST_INTEGRATION_ENABLED and feature_models:
+        if FeastIntegrationSettings().FEATUREBYTE_FEAST_INTEGRATION_ENABLED:
             if is_online_enabling:
                 await self.offline_store_feature_table_manager_service.handle_online_enabled_features(
                     feature_models

--- a/featurebyte/service/offline_store_feature_table_manager.py
+++ b/featurebyte/service/offline_store_feature_table_manager.py
@@ -205,6 +205,12 @@ class OfflineStoreFeatureTableManagerService:  # pylint: disable=too-many-instan
                     feature_table_model
                 )
 
+        if not features:
+            # If all the features are already online enabled, i.e. the offline feature store tables
+            # are up-to-date. But registry still needs to be updated because there could be a new
+            # feature service that needs to be created.
+            await self._create_or_update_feast_registry()
+
     async def handle_online_disabled_features(self, features: List[FeatureModel]) -> None:
         """
         Handles the case where a feature is disabled for online serving by updating all affected
@@ -244,7 +250,7 @@ class OfflineStoreFeatureTableManagerService:  # pylint: disable=too-many-instan
                 await self.offline_store_feature_table_service.delete_document(
                     document_id=feature_table_dict["_id"],
                 )
-            await self._create_or_update_feast_registry()
+        await self._create_or_update_feast_registry()
 
     @staticmethod
     def _get_offline_store_feature_table_columns(features: List[FeatureModel]) -> List[str]:

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -129,6 +129,25 @@ async def deployed_item_aggregate_feature(
     return await deploy_feature(app_container, non_time_based_feature)
 
 
+@pytest_asyncio.fixture
+async def deployed_feature_list_when_all_features_already_deployed(
+    app_container,
+    float_feature,
+    deployed_float_feature,
+):
+    """
+    Fixture for a deployment created when all the underlying features are already deployed
+    """
+    _ = deployed_float_feature
+    out = await deploy_feature(
+        app_container,
+        float_feature,
+        feature_list_name_override="my_new_feature_list",
+        return_type="feature_list",
+    )
+    return out
+
+
 @pytest.fixture
 def document_service(app_container):
     """
@@ -622,4 +641,22 @@ async def test_aggregate_asat_feature(
         app_container,
         expected_feature_views={"fb_entity_gender_fjs_86400_0_0"},
         expected_feature_services={"asat_gender_count_list"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_new_deployment_when_all_features_already_deployed(
+    app_container,
+    deployed_feature_list_when_all_features_already_deployed,
+):
+    """
+    Test enabling a new deployment when all the underlying features are already deployed
+    """
+    await check_feast_registry(
+        app_container,
+        expected_feature_views={"fb_entity_cust_id_fjs_1800_300_600_ttl"},
+        expected_feature_services={
+            "sum_1d_list",
+            deployed_feature_list_when_all_features_already_deployed.name,
+        },
     )


### PR DESCRIPTION
## Description

This fixes an issue where required feature services are not created in feast registry in some cases. Specifically, that happens when all the underlying features of a feature list were already online enabled.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
