### PR TITLE
[DEV-2807] Fix primary key constraint for feature timestamp column

### DIFF
--- a/tests/fixtures/feature_materialize/initialize_new_columns_new_table_databricks.sql
+++ b/tests/fixtures/feature_materialize/initialize_new_columns_new_table_databricks.sql
@@ -21,4 +21,4 @@ ALTER TABLE `fb_entity_cust_id_fjs_1800_300_600_ttl` ALTER COLUMN `__feature_tim
 ALTER TABLE `fb_entity_cust_id_fjs_1800_300_600_ttl` ALTER COLUMN `cust_id` SET NOT NULL;
 
 ALTER TABLE `fb_entity_cust_id_fjs_1800_300_600_ttl` ADD CONSTRAINT `pk_fb_entity_cust_id_fjs_1800_300_600_ttl`
-PRIMARY KEY(`__feature_timestamp`, `cust_id`);
+PRIMARY KEY(`__feature_timestamp` TIMESERIES, `cust_id`);


### PR DESCRIPTION
## Description

The primary key constraint for feature timestamp column should be tagged with the `TIMESERIES` keyword.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
