### PR TITLE
[DEV-2913] Use online store configuration specified in catalog

### DIFF
--- a/featurebyte/feast/model/online_store.py
+++ b/featurebyte/feast/model/online_store.py
@@ -1,0 +1,90 @@
+"""
+Models to construct feast online store config from featurebyte BaseOnlineStoreDetails
+"""
+from __future__ import annotations
+
+from typing import Union
+from typing_extensions import Annotated
+
+from abc import abstractmethod  # pylint: disable=wrong-import-order
+
+from feast.infra.online_stores.contrib.mysql_online_store.mysql import MySQLOnlineStoreConfig
+from feast.infra.online_stores.redis import RedisOnlineStoreConfig
+from feast.repo_config import FeastConfigBaseModel
+from pydantic import Field, parse_obj_as
+
+from featurebyte.models.online_store import (
+    BaseOnlineStoreDetails,
+    MySQLOnlineStoreDetails,
+    RedisOnlineStoreDetails,
+)
+
+
+class BaseOnlineStoreDetailsForFeast:
+    """
+    Base class for online store details for feast
+    """
+
+    @abstractmethod
+    def to_feast_online_store_config(self) -> FeastConfigBaseModel:
+        """
+        Returns a corresponding online store configuration instance in feast
+        """
+
+
+class FeastRedisOnlineStoreDetails(BaseOnlineStoreDetailsForFeast, RedisOnlineStoreDetails):
+    """
+    Redis online store details
+    """
+
+    def to_feast_online_store_config(self) -> FeastConfigBaseModel:
+        connection_string = self.connection_string
+        if self.credential is not None:
+            if self.credential.username:
+                connection_string += f",username={self.credential.username}"
+            if self.credential.password:
+                connection_string += f",password={self.credential.password}"
+        return RedisOnlineStoreConfig(connection_string=connection_string)
+
+
+class FeastMySQLOnlineStoreDetails(BaseOnlineStoreDetailsForFeast, MySQLOnlineStoreDetails):
+    """
+    MySQL online store details
+    """
+
+    def to_feast_online_store_config(self) -> FeastConfigBaseModel:
+        if self.credential is not None:
+            user, password = self.credential.username, self.credential.password
+        else:
+            user, password = None, None
+        return MySQLOnlineStoreConfig(
+            host=self.host,
+            user=user,
+            password=password,
+            database=self.database,
+            port=self.port,
+        )
+
+
+FeastOnlineStoreDetails = Annotated[
+    Union[FeastRedisOnlineStoreDetails, FeastMySQLOnlineStoreDetails],
+    Field(discriminator="type"),
+]
+
+
+def get_feast_online_store_details(
+    online_store_details: BaseOnlineStoreDetails,
+) -> FeastOnlineStoreDetails:
+    """
+    Create a FeastOnlineStoreDetails object given an instance of BaseOnlineStoreDetails
+
+    Parameters
+    ----------
+    online_store_details: BaseOnlineStoreDetails
+        Instance of BaseOnlineStoreDetails
+
+    Returns
+    -------
+    FeastOnlineStoreDetails
+    """
+    return parse_obj_as(FeastOnlineStoreDetails, online_store_details.dict())  # type: ignore

--- a/featurebyte/feast/service/feature_store.py
+++ b/featurebyte/feast/service/feature_store.py
@@ -7,14 +7,15 @@ import tempfile
 
 from bson import ObjectId
 from feast import FeatureStore, RepoConfig
-from feast.infra.online_stores.redis import RedisOnlineStoreConfig
-from feast.repo_config import FeastConfigBaseModel, RegistryConfig
+from feast.repo_config import RegistryConfig
 
 from featurebyte.feast.model.feature_store import FeatureStoreDetailsWithFeastConfiguration
+from featurebyte.feast.model.online_store import get_feast_online_store_details
 from featurebyte.feast.service.registry import FeastRegistryService
+from featurebyte.service.catalog import CatalogService
 from featurebyte.service.feature_store import FeatureStoreService
+from featurebyte.service.online_store import OnlineStoreService
 from featurebyte.utils.credential import MongoBackedCredentialProvider
-from featurebyte.utils.messaging import REDIS_URI
 
 
 class FeastFeatureStoreService:
@@ -26,11 +27,15 @@ class FeastFeatureStoreService:
         feast_registry_service: FeastRegistryService,
         mongo_backed_credential_provider: MongoBackedCredentialProvider,
         feature_store_service: FeatureStoreService,
+        catalog_service: CatalogService,
+        online_store_service: OnlineStoreService,
     ):
         self.user = user
         self.feast_registry_service = feast_registry_service
         self.credential_provider = mongo_backed_credential_provider
         self.feature_store_service = feature_store_service
+        self.catalog_service = catalog_service
+        self.online_store_service = online_store_service
 
     async def get_feast_feature_store(
         self,
@@ -58,6 +63,19 @@ class FeastFeatureStoreService:
         credentials = await self.credential_provider.get_credential(
             user_id=self.user.id, feature_store_name=feature_store.name
         )
+
+        # Get online store feast config
+        catalog = await self.catalog_service.get_document(feast_registry.catalog_id)
+        if catalog.online_store_id is not None:
+            online_store_details = (
+                await self.online_store_service.get_document(catalog.online_store_id)
+            ).details
+            online_store = get_feast_online_store_details(
+                online_store_details
+            ).to_feast_online_store_config()
+        else:
+            online_store = None
+
         with tempfile.NamedTemporaryFile() as temp_file:
             # Use temp file to pass the registry proto to the feature store. Once the
             # feature store is created, the temp file is no longer needed.
@@ -86,7 +104,7 @@ class FeastFeatureStoreService:
                 offline_store=feature_store_details.details.get_offline_store_config(
                     credential=database_credential
                 ),
-                online_store=self.get_default_online_store(),
+                online_store=online_store,
             )
             return cast(FeatureStore, FeatureStore(config=repo_config))
 
@@ -102,13 +120,3 @@ class FeastFeatureStoreService:
         if feast_registry is None:
             return None
         return await self.get_feast_feature_store(feast_registry_id=feast_registry.id)
-
-    def get_default_online_store(self) -> FeastConfigBaseModel:
-        """
-        Get default online store configuration
-
-        Returns
-        -------
-        FeastConfigBaseModel
-        """
-        return RedisOnlineStoreConfig(connection_string=REDIS_URI.replace("redis://", ""))

--- a/featurebyte/models/online_store.py
+++ b/featurebyte/models/online_store.py
@@ -1,8 +1,10 @@
 """
 This module contains Online Store related models
 """
-from typing import List, Literal, Optional, Union
+from typing import Any, List, Literal, Optional, Union
 from typing_extensions import Annotated
+
+from abc import abstractmethod
 
 import pymongo
 from pydantic import Field, StrictStr
@@ -26,6 +28,15 @@ class BaseOnlineStoreDetails(FeatureByteBaseModel):
     # Online store type selector
     type: OnlineStoreType
     credential: Optional[BaseDatabaseCredential]
+
+    @abstractmethod
+    def to_feast_online_store_config(self) -> Any:
+        """
+        Returns a corresponding online store configuration instance in feast
+
+        TODO: make sure to import inline since this model is imported by client at top level, or
+        don't implement this here.
+        """
 
 
 class RedisOnlineStoreDetails(BaseOnlineStoreDetails):

--- a/featurebyte/models/online_store.py
+++ b/featurebyte/models/online_store.py
@@ -1,10 +1,8 @@
 """
 This module contains Online Store related models
 """
-from typing import Any, List, Literal, Optional, Union
+from typing import List, Literal, Optional, Union
 from typing_extensions import Annotated
-
-from abc import abstractmethod
 
 import pymongo
 from pydantic import Field, StrictStr
@@ -28,15 +26,6 @@ class BaseOnlineStoreDetails(FeatureByteBaseModel):
     # Online store type selector
     type: OnlineStoreType
     credential: Optional[BaseDatabaseCredential]
-
-    @abstractmethod
-    def to_feast_online_store_config(self) -> Any:
-        """
-        Returns a corresponding online store configuration instance in feast
-
-        TODO: make sure to import inline since this model is imported by client at top level, or
-        don't implement this here.
-        """
 
 
 class RedisOnlineStoreDetails(BaseOnlineStoreDetails):

--- a/featurebyte/routes/deployment/controller.py
+++ b/featurebyte/routes/deployment/controller.py
@@ -218,9 +218,13 @@ class DeploymentController(
         document = await self.service.get_document(deployment_id)
 
         feature_list = await self.feature_list_service.get_document(document.feature_list_id)
+        catalog = await self.catalog_service.get_document(feature_list.catalog_id)
         try:
             result: Optional[OnlineFeaturesResponseModel]
-            if FeastIntegrationSettings().FEATUREBYTE_FEAST_INTEGRATION_ENABLED:
+            if (
+                FeastIntegrationSettings().FEATUREBYTE_FEAST_INTEGRATION_ENABLED
+                and catalog.online_store_id is not None
+            ):
                 result = await self.online_serving_service.get_online_features_by_feast(
                     feature_list=feature_list,
                     request_data=data.entity_serving_names,

--- a/featurebyte/service/feature_materialize.py
+++ b/featurebyte/service/feature_materialize.py
@@ -233,7 +233,7 @@ class FeatureMaterializeService:  # pylint: disable=too-many-instance-attributes
 
         # Feast online materialize
         feature_store = await self._get_feast_feature_store()
-        if feature_store is not None:
+        if feature_store is not None and feature_store.config.online_store is not None:
             materialize_partial(
                 feature_store=feature_store,
                 feature_view=feature_store.get_feature_view(feature_table_model.name),
@@ -303,7 +303,7 @@ class FeatureMaterializeService:  # pylint: disable=too-many-instance-attributes
 
         # Feast online materialize. Start date is not set because these are new columns.
         feature_store = await self._get_feast_feature_store()
-        if feature_store is not None:
+        if feature_store is not None and feature_store.config.online_store is not None:
             materialize_partial(
                 feature_store=feature_store,
                 feature_view=feature_store.get_feature_view(feature_table_model.name),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -37,6 +37,8 @@ from featurebyte import (
     Configurations,
     DatabricksDetails,
     FeatureJobSetting,
+    OnlineStore,
+    RedisOnlineStoreDetails,
     SnowflakeDetails,
 )
 from featurebyte.api.entity import Entity
@@ -63,6 +65,7 @@ from featurebyte.service.online_store_table_version import OnlineStoreTableVersi
 from featurebyte.service.task_manager import TaskManager
 from featurebyte.session.manager import SessionManager
 from featurebyte.storage import LocalStorage, LocalTempStorage
+from featurebyte.utils.messaging import REDIS_URI
 from featurebyte.worker import get_celery
 from featurebyte.worker.registry import TASK_REGISTRY_MAP
 
@@ -475,11 +478,15 @@ def data_source_fixture(catalog):
 
 
 @pytest.fixture(name="catalog", scope="session")
-def catalog_fixture(feature_store):
+def catalog_fixture(feature_store, online_store):
     """
     Catalog fixture
     """
-    return Catalog.create(name="default", feature_store_name=feature_store.name)
+    return Catalog.create(
+        name="default",
+        feature_store_name=feature_store.name,
+        online_store_name=online_store.name,
+    )
 
 
 @pytest.fixture(name="mock_config_path_env", scope="session")
@@ -1516,3 +1523,17 @@ def online_store_compute_query_service_fixture(app_container) -> OnlineStoreComp
     Online store compute query service fixture
     """
     return app_container.online_store_compute_query_service
+
+
+@pytest.fixture(name="online_store", scope="session")
+def online_store_fixture():
+    """
+    Fixture for an OnlineStore
+    """
+    return OnlineStore.create(
+        name="My Online Store",
+        details=RedisOnlineStoreDetails(
+            redis_type="redis",
+            connection_string=REDIS_URI.replace("redis://", ""),
+        ),
+    )

--- a/tests/unit/feast/model/test_online_store.py
+++ b/tests/unit/feast/model/test_online_store.py
@@ -1,0 +1,46 @@
+"""
+Test for feast online store models
+"""
+from feast.infra.online_stores.contrib.mysql_online_store.mysql import MySQLOnlineStoreConfig
+from feast.infra.online_stores.redis import RedisOnlineStoreConfig
+
+from featurebyte import MySQLOnlineStoreDetails, RedisOnlineStoreDetails
+from featurebyte.feast.model.online_store import get_feast_online_store_details
+
+
+def test_redis_details():
+    """
+    Test converting redis online store details to feast config
+    """
+    online_store_details = RedisOnlineStoreDetails(
+        redis_type="redis",
+        connection_string="localhost:6379",
+        credential={"username": "user", "password": "my_pw"},
+    )
+    feast_config = get_feast_online_store_details(
+        online_store_details
+    ).to_feast_online_store_config()
+    assert feast_config == RedisOnlineStoreConfig(
+        type="redis",
+        redis_type="redis",
+        connection_string="localhost:6379,username=user,password=my_pw",
+        key_ttl_seconds=None,
+    )
+
+
+def test_mysql_details():
+    """
+    Test converting mysql online store details to feast config
+    """
+    online_store_details = MySQLOnlineStoreDetails(
+        host="1.2.3.4",
+        database="my_db",
+        port=3306,
+        credential={"username": "user", "password": "my_pw"},
+    )
+    feast_config = get_feast_online_store_details(
+        online_store_details
+    ).to_feast_online_store_config()
+    assert feast_config == MySQLOnlineStoreConfig(
+        host="1.2.3.4", user="user", password="my_pw", database="my_db", port=3306, type="mysql"
+    )

--- a/tests/unit/service/test_feature_materialize.py
+++ b/tests/unit/service/test_feature_materialize.py
@@ -12,7 +12,6 @@ from bson import ObjectId
 from freezegun import freeze_time
 
 from featurebyte.common.model_util import get_version
-from featurebyte.models.online_store import OnlineStoreModel, RedisOnlineStoreDetails
 from featurebyte.schema.catalog import CatalogOnlineStoreUpdate
 from tests.util.helper import assert_equal_with_expected_fixture
 
@@ -57,6 +56,7 @@ def is_online_store_registered_for_catalog_fixture():
 async def deployed_feature_list_fixture(
     app_container,
     production_ready_feature_list,
+    online_store,
     mock_update_data_warehouse,
     is_source_type_supported_by_feast,
     is_online_store_registered_for_catalog,
@@ -67,15 +67,7 @@ async def deployed_feature_list_fixture(
     _ = mock_update_data_warehouse
 
     if is_online_store_registered_for_catalog:
-        online_store_model = await app_container.online_store_service.create_document(
-            OnlineStoreModel(
-                name="redis_online_store",
-                details=RedisOnlineStoreDetails(
-                    redis_type="redis",
-                ),
-            )
-        )
-        catalog_update = CatalogOnlineStoreUpdate(online_store_id=online_store_model.id)
+        catalog_update = CatalogOnlineStoreUpdate(online_store_id=online_store.id)
         await app_container.catalog_service.update_document(
             document_id=production_ready_feature_list.catalog_id, data=catalog_update
         )

--- a/tests/unit/service/test_feature_materialize.py
+++ b/tests/unit/service/test_feature_materialize.py
@@ -12,6 +12,8 @@ from bson import ObjectId
 from freezegun import freeze_time
 
 from featurebyte.common.model_util import get_version
+from featurebyte.models.online_store import OnlineStoreModel, RedisOnlineStoreDetails
+from featurebyte.schema.catalog import CatalogOnlineStoreUpdate
 from tests.util.helper import assert_equal_with_expected_fixture
 
 
@@ -43,17 +45,40 @@ def is_source_type_supported_by_feast_fixture():
     return True
 
 
+@pytest.fixture(name="is_online_store_registered_for_catalog")
+def is_online_store_registered_for_catalog_fixture():
+    """
+    Fixture to determine if catalog is configured with an online store
+    """
+    return True
+
+
 @pytest_asyncio.fixture(name="deployed_feature_list")
 async def deployed_feature_list_fixture(
     app_container,
     production_ready_feature_list,
     mock_update_data_warehouse,
     is_source_type_supported_by_feast,
+    is_online_store_registered_for_catalog,
 ):
     """
     Fixture for FeatureMaterializeService
     """
     _ = mock_update_data_warehouse
+
+    if is_online_store_registered_for_catalog:
+        online_store_model = await app_container.online_store_service.create_document(
+            OnlineStoreModel(
+                name="redis_online_store",
+                details=RedisOnlineStoreDetails(
+                    redis_type="redis",
+                ),
+            )
+        )
+        catalog_update = CatalogOnlineStoreUpdate(online_store_id=online_store_model.id)
+        await app_container.catalog_service.update_document(
+            document_id=production_ready_feature_list.catalog_id, data=catalog_update
+        )
 
     # TODO: use deploy_feature() helper
     deployment_id = ObjectId()
@@ -70,6 +95,7 @@ async def deployed_feature_list_fixture(
                 deployment_name=None,
                 to_enable_deployment=True,
             )
+
     deployment = await app_container.deployment_service.get_document(document_id=deployment_id)
     deployed_feature_list = await app_container.feature_list_service.get_document(
         document_id=deployment.feature_list_id
@@ -193,6 +219,7 @@ async def test_materialize_features(
     ]
 
 
+@pytest.mark.parametrize("is_online_store_registered_for_catalog", [True, False])
 @pytest.mark.usefixtures("mock_get_feature_store_session")
 @pytest.mark.asyncio
 async def test_scheduled_materialize_features(
@@ -201,6 +228,7 @@ async def test_scheduled_materialize_features(
     mock_snowflake_session,
     offline_store_feature_table,
     mock_materialize_partial,
+    is_online_store_registered_for_catalog,
     update_fixtures,
 ):
     """
@@ -215,17 +243,20 @@ async def test_scheduled_materialize_features(
         update_fixtures,
     )
 
-    # Check online materialization called
-    _, kwargs = mock_materialize_partial.call_args
-    _ = kwargs.pop("feature_store")
-    feature_view = kwargs.pop("feature_view")
-    assert feature_view.name == "fb_entity_cust_id_fjs_1800_300_600_ttl"
-    assert kwargs == {
-        "columns": [f"sum_30m_{get_version()}"],
-        "start_date": None,
-        "end_date": datetime(2022, 1, 1, 0, 0),
-        "with_feature_timestamp": True,
-    }
+    # Check online materialization called if there is a registered online store
+    if is_online_store_registered_for_catalog:
+        _, kwargs = mock_materialize_partial.call_args
+        _ = kwargs.pop("feature_store")
+        feature_view = kwargs.pop("feature_view")
+        assert feature_view.name == "fb_entity_cust_id_fjs_1800_300_600_ttl"
+        assert kwargs == {
+            "columns": [f"sum_30m_{get_version()}"],
+            "start_date": None,
+            "end_date": datetime(2022, 1, 1, 0, 0),
+            "with_feature_timestamp": True,
+        }
+    else:
+        assert mock_materialize_partial.call_count == 0
 
     # Check last materialization timestamp updated
     updated_feature_table = await app_container.offline_store_feature_table_service.get_document(
@@ -273,6 +304,7 @@ async def test_scheduled_materialize_features_if_materialized_before(
     assert updated_feature_table.last_materialized_at == datetime(2022, 1, 2, 0, 0)
 
 
+@pytest.mark.parametrize("is_online_store_registered_for_catalog", [True, False])
 @pytest.mark.usefixtures("mock_get_feature_store_session")
 @pytest.mark.asyncio
 async def test_initialize_new_columns__table_does_not_exist(
@@ -280,6 +312,7 @@ async def test_initialize_new_columns__table_does_not_exist(
     mock_snowflake_session,
     offline_store_feature_table,
     mock_materialize_partial,
+    is_online_store_registered_for_catalog,
     update_fixtures,
 ):
     """
@@ -301,15 +334,18 @@ async def test_initialize_new_columns__table_does_not_exist(
         update_fixtures,
     )
 
-    _, kwargs = mock_materialize_partial.call_args
-    _ = kwargs.pop("feature_store")
-    feature_view = kwargs.pop("feature_view")
-    assert feature_view.name == "fb_entity_cust_id_fjs_1800_300_600_ttl"
-    assert kwargs == {
-        "columns": [f"sum_30m_{get_version()}"],
-        "end_date": datetime(2022, 1, 1, 0, 0),
-        "with_feature_timestamp": True,
-    }
+    if is_online_store_registered_for_catalog:
+        _, kwargs = mock_materialize_partial.call_args
+        _ = kwargs.pop("feature_store")
+        feature_view = kwargs.pop("feature_view")
+        assert feature_view.name == "fb_entity_cust_id_fjs_1800_300_600_ttl"
+        assert kwargs == {
+            "columns": [f"sum_30m_{get_version()}"],
+            "end_date": datetime(2022, 1, 1, 0, 0),
+            "with_feature_timestamp": True,
+        }
+    else:
+        assert mock_materialize_partial.call_count == 0
 
 
 @pytest.mark.usefixtures("mock_get_feature_store_session")

--- a/tests/unit/service/test_online_serving_feast.py
+++ b/tests/unit/service/test_online_serving_feast.py
@@ -10,11 +10,12 @@ from tests.util.helper import deploy_feature
 
 
 @pytest.fixture(name="always_enable_feast_integration", autouse=True)
-def always_enable_feast_integration_fixture(enable_feast_integration):
+def always_enable_feast_integration_fixture(enable_feast_integration, catalog_with_online_store):
     """
     Enable feast integration for all tests in this module
     """
     _ = enable_feast_integration
+    _ = catalog_with_online_store
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
## Description

This updates external feature store integration to respect the online store configuration specified in the catalog.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
