### PR TITLE
[DEV-2929] Fix snowflake session role specification

### DIFF
--- a/featurebyte/feast/model/feature_store.py
+++ b/featurebyte/feast/model/feature_store.py
@@ -118,7 +118,7 @@ class FeastSnowflakeDetails(AbstractDatabaseDetailsForFeast, BaseSnowflakeDetail
             account=self.account,
             user=username,
             password=password,
-            role=None,
+            role=self.role_name,
             warehouse=self.warehouse,
             database=self.database_name,
             schema_=self.schema_name,

--- a/featurebyte/session/snowflake.py
+++ b/featurebyte/session/snowflake.py
@@ -79,13 +79,12 @@ class SnowflakeSession(BaseSession):
         # If the featurebyte schema does not exist, the self._connection can still be created
         # without errors. Below checks whether the schema actually exists. If not, it will be
         # created and initialized with custom functions and procedures.
+        await self.execute_query(f'USE ROLE "{self.role_name}"')
         await super().initialize()
         # set timezone to UTC
         await self.execute_query(
             "ALTER SESSION SET TIMEZONE='UTC', TIMESTAMP_OUTPUT_FORMAT='YYYY-MM-DD HH24:MI:SS.FF9 TZHTZM'"
         )
-        # specify role to use
-        await self.execute_query(f'USE ROLE "{self.role_name}"')
 
     def initializer(self) -> BaseSchemaInitializer:
         return SnowflakeSchemaInitializer(self)

--- a/tests/unit/session/test_snowflake_session.py
+++ b/tests/unit/session/test_snowflake_session.py
@@ -60,10 +60,10 @@ async def test_snowflake_session__credential_from_config(
     await session.initialize()
 
     # check session initialization includes timezone and role specification
-    assert snowflake_execute_query.call_args_list[-2][0] == (
+    assert snowflake_execute_query.call_args_list[0][0] == ('USE ROLE "TESTING"',)
+    assert snowflake_execute_query.call_args_list[-1][0] == (
         "ALTER SESSION SET TIMEZONE='UTC', TIMESTAMP_OUTPUT_FORMAT='YYYY-MM-DD HH24:MI:SS.FF9 TZHTZM'",
     )
-    assert snowflake_execute_query.call_args_list[-1][0] == ('USE ROLE "TESTING"',)
 
     assert session.database_credential.username == "username"
     assert session.database_credential.password == "password"


### PR DESCRIPTION
## Description

This fixes issues related to role specification when creating a Snowflake session:

- `USE ROLE` should be issued before working schema initialization where we create internal assets
- Feast offline store config for Snowflake should specify the same role

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
