### PR TITLE
[chore] Remove `importlib` in on demand feature view creation

### DIFF
--- a/featurebyte/feast/utils/on_demand_view.py
+++ b/featurebyte/feast/utils/on_demand_view.py
@@ -1,13 +1,10 @@
 """
 On demand feature view related classes and functions.
 """
-from typing import Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Union, cast
 
-import importlib
-import os
 from unittest.mock import patch
 
-from bson import ObjectId
 from feast import FeatureView, Field, RequestSource
 from feast.feature_view_projection import FeatureViewProjection
 from feast.on_demand_feature_view import OnDemandFeatureView, on_demand_feature_view
@@ -23,7 +20,6 @@ def create_feast_on_demand_feature_view(
     function_name: str,
     sources: List[Union[FeatureView, RequestSource, FeatureViewProjection]],
     schema: List[Field],
-    on_demand_feature_view_dir: str,
 ) -> OnDemandFeatureView:
     """
     Create a Feast OnDemandFeatureView from a function definition.
@@ -38,29 +34,21 @@ def create_feast_on_demand_feature_view(
         List of FeatureViews and RequestSources to be used as sources for the OnDemandFeatureView
     schema: List[Field]
         List of Fields to be used as schema for the OnDemandFeatureView
-    on_demand_feature_view_dir: str
-        Directory to write the on demand feature view code to
 
     Returns
     -------
     OnDemandFeatureView
         The created OnDemandFeatureView
     """
-    module_name = f"on_demand_feature_view_{ObjectId()}"
-    with open(
-        os.path.join(on_demand_feature_view_dir, f"{module_name}.py"), "w", encoding="utf-8"
-    ) as file_handle:
-        file_handle.write(definition)
+    # get the function from the definition
+    locals_namespace: Dict[str, Any] = {}
+    exec(definition, locals_namespace)  # pylint: disable=exec-used  # nosec
+    func = locals_namespace[function_name]
 
-    module = importlib.import_module(module_name)
-    func = getattr(module, function_name)
-    try:
+    # dill.source.getsource fails to find the source code of the function
+    # since we already have the source code, we can just use that instead
+    with patch("dill.source.getsource", return_value=definition):
         output = on_demand_feature_view(sources=sources, schema=schema)(func)
-    except IOError:
-        # dill.source.getsource fails to find the source code of the function in some environments
-        # since we already have the source code, we can just use that instead
-        with patch("dill.source.getsource", return_value=definition):
-            output = on_demand_feature_view(sources=sources, schema=schema)(func)
 
     return cast(OnDemandFeatureView, output)
 
@@ -76,7 +64,6 @@ class OnDemandFeatureViewConstructor:
         feature_model: FeatureModel,
         name_to_feast_feature_view: Dict[str, FeatureView],
         name_to_feast_request_source: Dict[str, RequestSource],
-        on_demand_feature_view_dir: str,
     ) -> OnDemandFeatureView:
         """
         Create a Feast OnDemandFeatureView from an offline store info.
@@ -89,8 +76,6 @@ class OnDemandFeatureViewConstructor:
             Dict of FeatureView names to FeatureViews to be used as sources for the OnDemandFeatureView
         name_to_feast_request_source: Dict[str, RequestSource]
             Dict of RequestSource names to RequestSources to be used as sources for the OnDemandFeatureView
-        on_demand_feature_view_dir: str
-            Directory to write the on demand feature view code to
 
         Returns
         -------
@@ -158,6 +143,5 @@ class OnDemandFeatureViewConstructor:
                     dtype=to_feast_primitive_type(DBVarType(feature_model.dtype)),
                 )
             ],
-            on_demand_feature_view_dir=on_demand_feature_view_dir,
         )
         return feature_view

--- a/featurebyte/feast/utils/registry_construction.py
+++ b/featurebyte/feast/utils/registry_construction.py
@@ -21,7 +21,6 @@ from feast.inference import update_feature_views_with_inferred_features_and_enti
 from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
 from feast.repo_config import RegistryConfig, RepoConfig
 
-from featurebyte.common.env_util import add_sys_path
 from featurebyte.enum import DBVarType, InternalName, SpecialColumnName
 from featurebyte.feast.enum import to_feast_primitive_type
 from featurebyte.feast.model.feature_store import (
@@ -321,7 +320,6 @@ class FeastRegistryConstructor:
         features: List[FeatureModel],
         name_to_feast_feature_view: Dict[str, FeastFeatureView],
         name_to_feast_request_source: Dict[str, FeastRequestSource],
-        on_demand_feature_view_dir: str,
     ) -> List[FeastOnDemandFeatureView]:
         """
         Create feast on demand feature views based on the features
@@ -334,8 +332,6 @@ class FeastRegistryConstructor:
             Mapping from feast feature view name to feast feature view
         name_to_feast_request_source: Dict[str, FeastRequestSource]
             Mapping from feast request source name to feast request source
-        on_demand_feature_view_dir: str
-            Directory to store the on demand feature view
 
         Returns
         -------
@@ -353,7 +349,6 @@ class FeastRegistryConstructor:
                 feature_model=feature,
                 name_to_feast_feature_view=name_to_feast_feature_view,
                 name_to_feast_request_source=name_to_feast_request_source,
-                on_demand_feature_view_dir=on_demand_feature_view_dir,
             )
             on_demand_feature_views.append(on_demand_feature_view)
         return on_demand_feature_views
@@ -526,28 +521,25 @@ class FeastRegistryConstructor:
             name_to_feast_feature_view[offline_store_table.table_name] = feast_feature_view
 
         name_to_feast_request_source = cls.create_feast_name_to_request_source(features)
-        with tempfile.TemporaryDirectory() as temp_dir:
-            with add_sys_path(temp_dir):
-                on_demand_feature_views = cls.create_feast_on_demand_feature_views(
-                    features=features,
-                    name_to_feast_feature_view=name_to_feast_feature_view,
-                    name_to_feast_request_source=name_to_feast_request_source,
-                    on_demand_feature_view_dir=temp_dir,
-                )
-                feast_feature_services = cls.create_feast_feature_services(
-                    feature_lists=feature_lists,
-                    features=features,
-                    feast_feature_views=list(name_to_feast_feature_view.values()),
-                    feast_on_demand_feature_views=on_demand_feature_views,
-                )
+        on_demand_feature_views = cls.create_feast_on_demand_feature_views(
+            features=features,
+            name_to_feast_feature_view=name_to_feast_feature_view,
+            name_to_feast_request_source=name_to_feast_request_source,
+        )
+        feast_feature_services = cls.create_feast_feature_services(
+            feature_lists=feature_lists,
+            features=features,
+            feast_feature_views=list(name_to_feast_feature_view.values()),
+            feast_on_demand_feature_views=on_demand_feature_views,
+        )
 
-                # construct feast registry by constructing a feast feature store and extracting the registry
-                return cls._create_feast_registry_proto(
-                    project_name=project_name,
-                    feast_data_sources=feast_data_sources,
-                    primary_entity_ids_to_feast_entity=primary_entity_ids_to_feast_entity,
-                    feast_request_sources=list(name_to_feast_request_source.values()),
-                    feast_feature_views=list(name_to_feast_feature_view.values()),
-                    feast_on_demand_feature_views=on_demand_feature_views,
-                    feast_feature_services=feast_feature_services,
-                )
+        # construct feast registry by constructing a feast feature store and extracting the registry
+        return cls._create_feast_registry_proto(
+            project_name=project_name,
+            feast_data_sources=feast_data_sources,
+            primary_entity_ids_to_feast_entity=primary_entity_ids_to_feast_entity,
+            feast_request_sources=list(name_to_feast_request_source.values()),
+            feast_feature_views=list(name_to_feast_feature_view.values()),
+            feast_on_demand_feature_views=on_demand_feature_views,
+            feast_feature_services=feast_feature_services,
+        )

--- a/tests/unit/feast/utils/test_register_construction.py
+++ b/tests/unit/feast/utils/test_register_construction.py
@@ -2,7 +2,6 @@
 Test the construction of the feast register.
 """
 import textwrap
-from unittest.mock import patch
 
 import pytest
 from google.protobuf.json_format import MessageToDict
@@ -91,20 +90,7 @@ def test_feast_registry_construction__with_post_processing_features(
 
     # dill's getsource() does not include the import statements
     udf = feast_registry_proto.on_demand_feature_views[0].spec.user_defined_function
-    assert udf.body_text.startswith("def compute_feature_feature_")
-
-    with patch("dill.source.getsource") as getsource_mock:
-        getsource_mock.side_effect = IOError
-        feast_registry_proto = FeastRegistryConstructor.create(
-            feature_store=snowflake_feature_store.cached_model,
-            entities=[cust_id_entity.cached_model, transaction_entity.cached_model],
-            features=[feature_requires_post_processing.cached_model],
-            feature_lists=[feature_list.cached_model],  # type: ignore
-        )
-
-        # patch version of getsource() contains the import statements
-        udf = feast_registry_proto.on_demand_feature_views[0].spec.user_defined_function
-        assert udf.body_text.startswith("import json\nimport numpy as np\nimport pandas as pd\n")
+    assert udf.body_text.startswith("import json\nimport numpy as np\nimport pandas as pd\n")
 
 
 def test_feast_registry_construction(feast_registry_proto):
@@ -120,6 +106,12 @@ def test_feast_registry_construction(feast_registry_proto):
     assert len(on_demand_feature_views) == 1
     udf_definition = on_demand_feature_views[0]["spec"]["userDefinedFunction"]["bodyText"]
     expected = f"""
+    import json
+    import numpy as np
+    import pandas as pd
+    import scipy as sp
+
+
     def {feat_view_name}(
         inputs: pd.DataFrame,
     ) -> pd.DataFrame:


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

Current `importlib` used in on demand feature view may cause integration test failures due to not detecting the existence of the module. To bypass this issue, we change the `importlib` to `exec`.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
