### PR TITLE
[DEV-2955] Move table row index handling of materialized tables to backend

### DIFF
--- a/featurebyte/api/materialized_table.py
+++ b/featurebyte/api/materialized_table.py
@@ -15,7 +15,6 @@ from featurebyte.api.feature_store import FeatureStore
 from featurebyte.api.source_table import SourceTable
 from featurebyte.common.utils import parquet_from_arrow_stream
 from featurebyte.config import Configurations
-from featurebyte.enum import InternalName
 from featurebyte.exception import RecordDeletionException, RecordRetrievalException
 from featurebyte.models.materialized_table import MaterializedTableModel
 
@@ -74,7 +73,7 @@ class MaterializedTableMixin(MaterializedTableModel):
         with tempfile.TemporaryDirectory() as temp_dir:
             output_path = os.path.join(temp_dir, "temp.parquet")
             self.download(output_path=output_path)
-            return self._remove_row_index(pd.read_parquet(output_path))
+            return pd.read_parquet(output_path)
 
     def delete(self) -> None:
         """
@@ -91,12 +90,6 @@ class MaterializedTableMixin(MaterializedTableModel):
             raise RecordDeletionException(response)
         self._poll_async_task(task_response=response, retrieve_result=False, has_output_url=False)
 
-    @staticmethod
-    def _remove_row_index(dataframe: pd.DataFrame) -> pd.DataFrame:
-        if InternalName.TABLE_ROW_INDEX in dataframe:
-            dataframe.drop(InternalName.TABLE_ROW_INDEX, axis=1, inplace=True)
-        return dataframe
-
     @typechecked
     def preview(self, limit: int = 10) -> pd.DataFrame:
         """
@@ -112,7 +105,7 @@ class MaterializedTableMixin(MaterializedTableModel):
         pd.DataFrame
             Preview rows of the table.
         """
-        return self._remove_row_index(self._source_table.preview(limit=limit))
+        return self._source_table.preview(limit=limit)
 
     @typechecked
     def sample(self, size: int = 10, seed: int = 1234) -> pd.DataFrame:
@@ -132,7 +125,7 @@ class MaterializedTableMixin(MaterializedTableModel):
         pd.DataFrame
             Sampled rows from the table.
         """
-        return self._remove_row_index(self._source_table.sample(size=size, seed=seed))
+        return self._source_table.sample(size=size, seed=seed)
 
     @typechecked
     def describe(self, size: int = 0, seed: int = 1234) -> pd.DataFrame:
@@ -151,7 +144,7 @@ class MaterializedTableMixin(MaterializedTableModel):
         pd.DataFrame
             Summary of the table.
         """
-        return self._remove_row_index(self._source_table.describe(size=size, seed=seed))
+        return self._source_table.describe(size=size, seed=seed)
 
     def shape(self) -> Tuple[int, int]:
         """

--- a/featurebyte/query_graph/sql/materialisation.py
+++ b/featurebyte/query_graph/sql/materialisation.py
@@ -3,7 +3,7 @@ SQL generation related to materialising tables such as ObservationTable
 """
 from __future__ import annotations
 
-from typing import Optional
+from typing import List, Optional
 
 from sqlglot import expressions
 from sqlglot.expressions import Select, alias_, select
@@ -21,6 +21,7 @@ from featurebyte.query_graph.sql.interpreter import GraphInterpreter
 
 def get_source_expr(
     source: TableDetails,
+    column_names: Optional[List[str]] = None,
 ) -> Select:
     """
     Construct SQL query to materialize a table from a source table
@@ -29,12 +30,19 @@ def get_source_expr(
     ----------
     source: TableDetails
         Source table details
+    column_names: Optional[List[str]]
+        List of column names to select if specified
 
     Returns
     -------
     Select
     """
-    return expressions.select("*").from_(get_fully_qualified_table_name(source.dict()))
+    select_expr = expressions.select().from_(get_fully_qualified_table_name(source.dict()))
+    if column_names:
+        select_expr = select_expr.select(*[quoted_identifier(col) for col in column_names])
+    else:
+        select_expr = select_expr.select("*")
+    return select_expr
 
 
 def get_source_count_expr(

--- a/featurebyte/routes/feature_store/api.py
+++ b/featurebyte/routes/feature_store/api.py
@@ -3,7 +3,7 @@ FeatureStore API routes
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional
 
 from fastapi import Query, Request
 

--- a/featurebyte/routes/feature_store/api.py
+++ b/featurebyte/routes/feature_store/api.py
@@ -112,9 +112,8 @@ class FeatureStoreRouter(
         """
         Create Feature Store
         """
-        controller = request.state.app_container.feature_store_controller
-        feature_store: FeatureStoreModel = await controller.create_feature_store(data=data)
-        return feature_store
+        controller: FeatureStoreController = request.state.app_container.feature_store_controller
+        return await controller.create_feature_store(data=data)
 
     async def get_object(
         self, request: Request, feature_store_id: PydanticObjectId
@@ -149,12 +148,11 @@ class FeatureStoreRouter(
         """
         Retrieve FeatureStore info
         """
-        controller = request.state.app_container.feature_store_controller
-        info = await controller.get_info(
+        controller: FeatureStoreController = request.state.app_container.feature_store_controller
+        return await controller.get_info(
             document_id=feature_store_id,
             verbose=verbose,
         )
-        return cast(FeatureStoreInfo, info)
 
     @staticmethod
     async def try_retrieve_feature_store(
@@ -176,7 +174,7 @@ class FeatureStoreRouter(
         """
         List databases
         """
-        controller = request.state.app_container.feature_store_controller
+        controller: FeatureStoreController = request.state.app_container.feature_store_controller
         feature_store = await FeatureStoreRouter.try_retrieve_feature_store(
             controller, feature_store
         )
@@ -194,7 +192,7 @@ class FeatureStoreRouter(
         """
         List schemas
         """
-        controller = request.state.app_container.feature_store_controller
+        controller: FeatureStoreController = request.state.app_container.feature_store_controller
         feature_store = await FeatureStoreRouter.try_retrieve_feature_store(
             controller, feature_store
         )
@@ -214,7 +212,7 @@ class FeatureStoreRouter(
         """
         List schemas
         """
-        controller = request.state.app_container.feature_store_controller
+        controller: FeatureStoreController = request.state.app_container.feature_store_controller
         feature_store = await FeatureStoreRouter.try_retrieve_feature_store(
             controller, feature_store
         )
@@ -236,7 +234,7 @@ class FeatureStoreRouter(
         """
         List columns
         """
-        controller = request.state.app_container.feature_store_controller
+        controller: FeatureStoreController = request.state.app_container.feature_store_controller
         feature_store = await FeatureStoreRouter.try_retrieve_feature_store(
             controller, feature_store
         )
@@ -256,11 +254,8 @@ class FeatureStoreRouter(
         """
         Retrieve shape for query graph node
         """
-        controller = request.state.app_container.feature_store_controller
-        return cast(
-            FeatureStoreShape,
-            await controller.shape(preview=preview),
-        )
+        controller: FeatureStoreController = request.state.app_container.feature_store_controller
+        return await controller.shape(preview=preview)
 
     @staticmethod
     async def get_data_preview(
@@ -271,11 +266,8 @@ class FeatureStoreRouter(
         """
         Retrieve data preview for query graph node
         """
-        controller = request.state.app_container.feature_store_controller
-        return cast(
-            Dict[str, Any],
-            await controller.preview(preview=preview, limit=limit),
-        )
+        controller: FeatureStoreController = request.state.app_container.feature_store_controller
+        return await controller.preview(preview=preview, limit=limit)
 
     @staticmethod
     async def get_data_sample(
@@ -287,11 +279,8 @@ class FeatureStoreRouter(
         """
         Retrieve data sample for query graph node
         """
-        controller = request.state.app_container.feature_store_controller
-        return cast(
-            Dict[str, Any],
-            await controller.sample(sample=sample, size=size, seed=seed),
-        )
+        controller: FeatureStoreController = request.state.app_container.feature_store_controller
+        return await controller.sample(sample=sample, size=size, seed=seed)
 
     @staticmethod
     async def get_data_description(
@@ -303,15 +292,12 @@ class FeatureStoreRouter(
         """
         Retrieve data description for query graph node
         """
-        controller = request.state.app_container.feature_store_controller
-        return cast(
-            Dict[str, Any],
-            await controller.describe(sample=sample, size=size, seed=seed),
-        )
+        controller: FeatureStoreController = request.state.app_container.feature_store_controller
+        return await controller.describe(sample=sample, size=size, seed=seed)
 
     async def delete_object(
         self, request: Request, feature_store_id: PydanticObjectId
     ) -> DeleteResponse:
-        controller = self.get_controller_for_request(request)
+        controller: FeatureStoreController = self.get_controller_for_request(request)
         await controller.delete(document_id=feature_store_id)
         return DeleteResponse()

--- a/featurebyte/service/feature_store_warehouse.py
+++ b/featurebyte/service/feature_store_warehouse.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from typing import Any, List, Optional
 
+from featurebyte.enum import InternalName
 from featurebyte.exception import DatabaseNotFoundError, SchemaNotFoundError, TableNotFoundError
 from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.models.user_defined_function import UserDefinedFunctionModel
@@ -203,4 +204,9 @@ class FeatureStoreWarehouseService:
         except db_session.no_schema_error as exc:
             raise TableNotFoundError(f"Table {table_name} not found.") from exc
 
+        table_schema = {  # type: ignore[assignment]
+            col_name: v
+            for (col_name, v) in table_schema.items()
+            if col_name != InternalName.TABLE_ROW_INDEX
+        }
         return list(table_schema.values())

--- a/featurebyte/service/preview.py
+++ b/featurebyte/service/preview.py
@@ -11,6 +11,7 @@ import pandas as pd
 from bson import ObjectId
 
 from featurebyte.common.utils import dataframe_to_json
+from featurebyte.enum import InternalName
 from featurebyte.exception import LimitExceededError
 from featurebyte.logging import get_logger
 from featurebyte.models.feature_store import FeatureStoreModel
@@ -311,6 +312,11 @@ class PreviewService:
         result = await db_session.execute_query(sql)
         assert result is not None
         columns = await db_session.list_table_schema(**location.table_details.json_dict())
+        columns = {  # type: ignore[assignment]
+            col_name: v
+            for (col_name, v) in columns.items()
+            if col_name != InternalName.TABLE_ROW_INDEX
+        }
         shape = (result["row_count"].iloc[0], len(columns))
 
         logger.debug(
@@ -324,7 +330,7 @@ class PreviewService:
         if shape[0] * shape[0] > MAX_TABLE_CELLS:
             raise LimitExceededError(f"Table size {shape} exceeds download limit.")
 
-        sql_expr = get_source_expr(source=location.table_details)
+        sql_expr = get_source_expr(source=location.table_details, column_names=list(columns.keys()))
         sql = sql_to_string(
             sql_expr,
             source_type=db_session.source_type,

--- a/tests/integration/api/test_observation_table.py
+++ b/tests/integration/api/test_observation_table.py
@@ -63,6 +63,7 @@ async def test_observation_table_from_source_table(
     expected_max = df["POINT_IN_TIME"].max()
     expected_cust_id_unique_count = df[user_id_entity_col_name].nunique()
     assert observation_table.entity_column_name_to_count["User ID"] == expected_cust_id_unique_count
+    assert df.columns.tolist() == ["POINT_IN_TIME", user_id_entity_col_name]
 
     def _convert_timestamp_for_timezones(timestamp_str):
         current_timestamp = pd.Timestamp(timestamp_str)

--- a/tests/integration/api/test_observation_table.py
+++ b/tests/integration/api/test_observation_table.py
@@ -209,25 +209,3 @@ async def test_observation_table_upload(
     check_materialized_table_preview_methods(
         observation_table, [SpecialColumnName.POINT_IN_TIME, "cust_id"], number_of_rows
     )
-
-
-@pytest.mark.asyncio
-async def test_observation_table_download_consistent_ordering(
-    event_table, scd_table, session, source_type, user_entity
-):
-    """
-    Test downloaded observation table follows a consistent ordering based on table row index
-    """
-    _ = user_entity
-    view = event_table.get_view()
-    scd_view = scd_table.get_view()
-    view = view.join(scd_view, on="ÜSER ID")
-    observation_table = view.create_observation_table(
-        f"{ObjectId()}_{source_type}",
-        columns=[view.timestamp_column, "ÜSER ID"],
-        columns_rename_mapping={view.timestamp_column: "POINT_IN_TIME", "ÜSER ID": "üser id"},
-    )
-
-    df_1 = observation_table.to_pandas()
-    df_2 = observation_table.to_pandas()
-    assert df_1.equals(df_2)

--- a/tests/integration/api/test_observation_table.py
+++ b/tests/integration/api/test_observation_table.py
@@ -5,6 +5,7 @@ import os
 
 import pandas as pd
 import pytest
+from bson import ObjectId
 
 from featurebyte.api.entity import Entity
 from featurebyte.api.observation_table import ObservationTable
@@ -208,3 +209,25 @@ async def test_observation_table_upload(
     check_materialized_table_preview_methods(
         observation_table, [SpecialColumnName.POINT_IN_TIME, "cust_id"], number_of_rows
     )
+
+
+@pytest.mark.asyncio
+async def test_observation_table_download_consistent_ordering(
+    event_table, scd_table, session, source_type, user_entity
+):
+    """
+    Test downloaded observation table follows a consistent ordering based on table row index
+    """
+    _ = user_entity
+    view = event_table.get_view()
+    scd_view = scd_table.get_view()
+    view = view.join(scd_view, on="ÜSER ID")
+    observation_table = view.create_observation_table(
+        f"{ObjectId()}_{source_type}",
+        columns=[view.timestamp_column, "ÜSER ID"],
+        columns_rename_mapping={view.timestamp_column: "POINT_IN_TIME", "ÜSER ID": "üser id"},
+    )
+
+    df_1 = observation_table.to_pandas()
+    df_2 = observation_table.to_pandas()
+    assert df_1.equals(df_2)

--- a/tests/unit/routes/base.py
+++ b/tests/unit/routes/base.py
@@ -1357,7 +1357,7 @@ class BaseMaterializedTableTestSuite(BaseAsyncApiTestSuite):
             == textwrap.dedent(
                 f"""
                 SELECT
-                  *
+                  "colA"
                 FROM "sf_database"."sf_schema"."{table_name}"
                 """
             ).strip()

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -219,7 +219,11 @@ def preview_service_fixture(app_container, feature_store, mock_snowflake_session
     """PreviewService fixture"""
     with patch("featurebyte.service.preview.PreviewService._get_feature_store_session") as mocked:
         mocked.return_value = feature_store, mock_snowflake_session
-        yield app_container.preview_service
+        with patch(
+            "featurebyte.service.online_enable.SessionManagerService.get_feature_store_session"
+        ) as mock_get_feature_store_session:
+            mock_get_feature_store_session.return_value = mock_snowflake_session
+            yield app_container.preview_service
 
 
 @pytest.fixture(name="feature_preview_service")

--- a/tests/unit/service/test_preview.py
+++ b/tests/unit/service/test_preview.py
@@ -1,6 +1,7 @@
 """
 Test preview service module
 """
+import textwrap
 from unittest.mock import patch
 
 import pandas as pd
@@ -11,6 +12,8 @@ from featurebyte import FeatureStore
 from featurebyte.exception import MissingPointInTimeColumnError, RequiredEntityNotProvidedError
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.feature_list import FeatureCluster
+from featurebyte.query_graph.model.common_table import TabularSource
+from featurebyte.query_graph.node.schema import TableDetails
 from featurebyte.schema.feature_list import FeatureListPreview
 from featurebyte.schema.feature_store import FeatureStorePreview
 from featurebyte.schema.preview import FeatureOrTargetPreview
@@ -260,3 +263,69 @@ async def test_value_counts(
         num_categories_limit=500,
     )
     assert result == {"a": 100, "b": 50}
+
+
+@pytest.mark.parametrize("has_row_index", [False, True])
+@pytest.mark.asyncio
+async def test_download_table(
+    preview_service,
+    feature_store,
+    feature_store_preview,
+    mock_snowflake_session,
+    has_row_index,
+):
+    """
+    Test download_table
+    """
+
+    # mock row count query
+    mock_snowflake_session.execute_query.return_value = pd.DataFrame(
+        {
+            "row_count": [100],
+        }
+    )
+
+    # mock list_table_schema query
+    df_list_table_schema = pd.DataFrame(
+        {
+            "col_a": {"name": "col_a"},
+            "col_b": {"name": "col_b"},
+        }
+    )
+    if has_row_index:
+        df_list_table_schema["__FB_TABLE_ROW_INDEX"] = {"name": "__FB_TABLE_ROW_INDEX"}
+    mock_snowflake_session.list_table_schema.return_value = df_list_table_schema
+
+    # check download_table triggers expected queries
+    _ = await preview_service.download_table(
+        location=TabularSource(
+            feature_store_id=feature_store.id,
+            table_details=TableDetails(
+                database_name="my_db",
+                schema_name="my_schema",
+                table_name="my_table",
+            ),
+        ),
+    )
+    if has_row_index:
+        expected_query = textwrap.dedent(
+            """
+            SELECT
+              "col_a",
+              "col_b"
+            FROM "my_db"."my_schema"."my_table"
+            ORDER BY
+              "__FB_TABLE_ROW_INDEX"
+            """
+        ).strip()
+    else:
+        expected_query = textwrap.dedent(
+            """
+            SELECT
+              "col_a",
+              "col_b"
+            FROM "my_db"."my_schema"."my_table"
+            """
+        ).strip()
+    args, _ = mock_snowflake_session.get_async_query_stream.call_args
+    assert args[0] == expected_query

--- a/tests/unit/service/test_preview.py
+++ b/tests/unit/service/test_preview.py
@@ -270,7 +270,6 @@ async def test_value_counts(
 async def test_download_table(
     preview_service,
     feature_store,
-    feature_store_preview,
     mock_snowflake_session,
     has_row_index,
 ):


### PR DESCRIPTION
## Description

Previously, the logic of removing row index column when previewing, sampling and downloading materialized tables is in the SDK client. The downside is that the column is still visible elsewhere such as in the UI.

To fix that, this PR moves such logic to the backend so that the API routes return consistent result. This also adds sorting by row index column when downloading materialised table if such a column is available.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
