### PR TITLE
[DEV-2973] Replace None with np.nan in on-demand feature view's output

### DIFF
--- a/featurebyte/query_graph/transform/on_demand_view.py
+++ b/featurebyte/query_graph/transform/on_demand_view.py
@@ -154,6 +154,7 @@ class OnDemandFeatureViewExtractor(
             {mask_var_name} = ({feat_time_name} >= {cutoff_var_name}) & ({feat_time_name} <= {req_time_var_name})
             {input_column_expr}[~{mask_var_name}] = np.nan
             {subset_output_column_expr} = {input_column_expr}
+            {output_df_name}.fillna(np.nan, inplace=True)
             """
             ).strip()
         )

--- a/tests/unit/api/test_offline_ingest_query_graph.py
+++ b/tests/unit/api/test_offline_ingest_query_graph.py
@@ -238,6 +238,7 @@ def test_feature__request_column_ttl_and_non_ttl_components(
         mask = (feature_timestamp >= cutoff) & (feature_timestamp <= request_time)
         feat_2[~mask] = np.nan
         df["feature_V231227"] = feat_2
+        df.fillna(np.nan, inplace=True)
         return df
     """
     assert offline_store_info.odfv_info.codes.strip() == textwrap.dedent(expected).strip()
@@ -341,6 +342,7 @@ def test_feature__ttl_item_aggregate_request_column(
         mask = (feature_timestamp >= cutoff) & (feature_timestamp <= request_time)
         feat_3[~mask] = np.nan
         df["composite_feature_V231227"] = feat_3
+        df.fillna(np.nan, inplace=True)
         return df
     """
     assert offline_store_info.odfv_info.codes.strip() == textwrap.dedent(expected).strip()
@@ -422,6 +424,7 @@ def test_feature__input_has_mixed_ingest_graph_node_flags(
         mask = (feature_timestamp >= cutoff) & (feature_timestamp <= request_time)
         feat_1[~mask] = np.nan
         df["feature_zscore_V231227"] = feat_1
+        df.fillna(np.nan, inplace=True)
         return df
     """
     assert offline_store_info.odfv_info.codes.strip() == textwrap.dedent(expected).strip()
@@ -495,6 +498,7 @@ def test_feature__with_ttl_handling(float_feature):
         mask = (feature_timestamp >= cutoff) & (feature_timestamp <= request_time)
         inputs["sum_1d_V231227"][~mask] = np.nan
         df["sum_1d_V231227"] = inputs["sum_1d_V231227"]
+        df.fillna(np.nan, inplace=True)
         return df
     """
     assert offline_store_info.odfv_info.codes.strip() == textwrap.dedent(expected).strip()
@@ -668,6 +672,7 @@ def test_on_demand_feature_view_code_generation__card_transaction_description_fe
         df[
             "TXN_CardTransactionDescription_Representation_in_CARD_Txn_Count_90d_V240105"
         ] = feat_4
+        df.fillna(np.nan, inplace=True)
         return df
     """
     assert feature.offline_store_info.odfv_info.codes.strip() == textwrap.dedent(expected).strip()

--- a/tests/unit/feast/utils/test_registry_construction.py
+++ b/tests/unit/feast/utils/test_registry_construction.py
@@ -349,6 +349,7 @@ def test_feast_registry_construction(
         mask = (feature_timestamp >= cutoff) & (feature_timestamp <= request_time)
         inputs["sum_1d_{get_version()}"][~mask] = np.nan
         df["sum_1d_{get_version()}"] = inputs["sum_1d_{get_version()}"]
+        df.fillna(np.nan, inplace=True)
         return df
     """
     assert udf_definition.strip() == textwrap.dedent(expected).strip()


### PR DESCRIPTION
## Description

This adds a final step in on-demand feature views transformations to convert any `None` values in the output to `np.nan`. Without this, `get_online_features()` can sometimes raise a "Couldn't infer value type from empty value" error.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
