### PR TITLE
[DEV-2964] target table cache conflicting columns

### DIFF
--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -551,7 +551,7 @@ class FeatureTableCacheService:
         sql = sql_to_string(select_expr, source_type=db_session.source_type)
         return await db_session.execute_query(sql)
 
-    async def create_view_from_cache(
+    async def create_view_from_cache(  # pylint: disable=R0914
         self,
         feature_store: FeatureStoreModel,
         observation_table: ObservationTableModel,
@@ -616,6 +616,12 @@ class FeatureTableCacheService:
         )
 
         request_column_names = sorted({col.name for col in observation_table.columns_info})
+        node_feature_names = [
+            graph.get_node_output_column_name(node.name) for node in hashes.values()
+        ]
+        request_column_names = [
+            col for col in request_column_names if col not in node_feature_names
+        ]
         request_columns = [quoted_identifier(col) for col in request_column_names]
         columns_expr = self._get_column_expr(graph, hashes, cast(Dict[str, str], cached_features))
         select_expr = (

--- a/featurebyte/service/historical_features_and_target.py
+++ b/featurebyte/service/historical_features_and_target.py
@@ -298,6 +298,10 @@ async def get_target(
     request_table_name = f"{REQUEST_TABLE_NAME}_{request_id}"
     request_table_columns = observation_set.columns
 
+    # filter request columns if nodes request them as well
+    nodes_columns = [graph.get_node_output_column_name(node.name) for node in nodes]
+    request_table_columns = [col for col in request_table_columns if col not in nodes_columns]
+
     # Execute feature SQL code
     await observation_set.register_as_request_table(
         session,


### PR DESCRIPTION
## Description

Observation table with target added has identical column name to the target node in the graph. 
This leads to `get_target` function failing generating SQL with two columns having same name. 

Assuming that they are identical, not adding target column to the cache as it will be added via caching.  

## Related Issue

https://featurebyte.atlassian.net/browse/DEV-2964

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
