### PR TITLE
[chore] Fix mock_offline_store_feature_manager_dependencies fixture improper teardown

### DIFF
--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -1065,12 +1065,14 @@ def mock_offline_store_feature_manager_dependencies_fixture():
             "apply_comments",
         ],
     }
+    started_patchers = []
     for service_name, method_names in patch_targets.items():
         for method_name in method_names:
             patcher = patch(f"{service_name}.{method_name}")
             patched[method_name] = patcher.start()
+            started_patchers.append(patcher)
     yield patched
-    for patcher in patched.values():
+    for patcher in started_patchers:
         patcher.stop()
 
 


### PR DESCRIPTION
## Description

This fixes the `mock_offline_store_feature_manager_dependencies` fixture to disable the mocks properly on teardown. Without this, it can affect other tests.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
