### PR TITLE
[chore] Add xdist scheduler

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,8 @@ from unittest.mock import patch
 import pytest
 import pytest_asyncio
 from mongomock_motor import AsyncMongoMockClient
+from sortedcontainers import SortedDict
+from xdist.scheduler import LoadScopeScheduling
 
 from featurebyte.persistent.mongo import MongoDB
 
@@ -120,3 +122,33 @@ def enable_feast_integration_fixture():
     """
     with patch.dict(os.environ, {"FEATUREBYTE_FEAST_INTEGRATION_ENABLED": "True"}):
         yield
+
+
+def pytest_xdist_make_scheduler(config, log):
+    """Group tests from the same module together"""
+
+    class GroupByModuleScheduler(LoadScopeScheduling):
+        """Group tests from the same module together and sort the test cases by module & test names"""
+
+        def _assign_work_unit(self, node):
+            """Assign a work unit to a node."""
+            assert self.workqueue
+
+            # Grab a unit of work
+            scope, work_unit = self.workqueue.popitem(last=False)
+
+            # Change the default from OrderedDict() to SortedDict()
+            assigned_to_node = self.assigned_work.setdefault(node, default=SortedDict())
+            assigned_to_node[scope] = work_unit
+
+            # Ask the node to execute the workload
+            worker_collection = self.registered_collections[node]
+            nodeids_indexes = [
+                worker_collection.index(nodeid)
+                for nodeid, completed in work_unit.items()
+                if not completed
+            ]
+
+            node.send_runtest_some(nodeids_indexes)
+
+    return GroupByModuleScheduler(config, log)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,4 +151,7 @@ def pytest_xdist_make_scheduler(config, log):
 
             node.send_runtest_some(nodeids_indexes)
 
+        def mark_test_pending(self, item):
+            raise NotImplementedError()
+
     return GroupByModuleScheduler(config, log)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -19,6 +19,7 @@ from bson.objectid import ObjectId
 from cachetools import TTLCache
 from fastapi.testclient import TestClient
 from snowflake.connector.constants import QueryStatus
+from xdist.scheduler import LoadScopeScheduling
 
 from featurebyte import (
     FeatureJobSetting,
@@ -72,6 +73,11 @@ pytest.register_assert_rewrite("tests.unit.routes.base")
 # "Registering" fixtures so that they'll be available for use as if they were defined here.
 # We keep the definition in a separate file for readability
 _ = [config_file_fixture, config_fixture, mock_config_path_env_fixture]
+
+
+def pytest_xdist_make_scheduler(config, log):
+    """Group tests from the same module together"""
+    return LoadScopeScheduling(config, log)
 
 
 @pytest.fixture(name="mock_api_object_cache")

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -1065,12 +1065,14 @@ def mock_offline_store_feature_manager_dependencies_fixture():
             "apply_comments",
         ],
     }
+    started_patchers = []
     for service_name, method_names in patch_targets.items():
         for method_name in method_names:
             patcher = patch(f"{service_name}.{method_name}")
             patched[method_name] = patcher.start()
+            started_patchers.append(patcher)
     yield patched
-    for patcher in patched.values():
+    for patcher in started_patchers:
         patcher.stop()
 
 

--- a/tests/unit/worker/task/conftest.py
+++ b/tests/unit/worker/task/conftest.py
@@ -41,12 +41,13 @@ def mock_event_dataset():
         ),
     ]
     mock_patches = {}
+    started_patches = []
     for target, side_effect in mock_targets:
         mock_patch = patch(target, side_effect=side_effect, new_callable=AsyncMock)
-        mock_patch.start()
-        mock_patches[target] = mock_patch
+        mock_patches[target] = mock_patch.start()
+        started_patches.append(mock_patch)
 
     yield
 
-    for mock_patch in mock_patches.values():
+    for mock_patch in started_patches:
         mock_patch.stop()


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR adds `xdist` scheduler so that the tests are split by module name (tests of same module will be grouped into the same split) and the tests are run in order sorted by test's module & name.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
