### PR TITLE
[chore] Drop column only if exists in FeatureMaterializeService

### DIFF
--- a/featurebyte/service/feature_materialize.py
+++ b/featurebyte/service/feature_materialize.py
@@ -348,7 +348,11 @@ class FeatureMaterializeService:  # pylint: disable=too-many-instance-attributes
             query = sql_to_string(
                 expressions.AlterTable(
                     this=expressions.Table(this=quoted_identifier(feature_table_model.name)),
-                    actions=[expressions.Drop(this=quoted_identifier(column_name), kind="COLUMN")],
+                    actions=[
+                        expressions.Drop(
+                            this=quoted_identifier(column_name), kind="COLUMN", exists=True
+                        )
+                    ],
                 ),
                 source_type=session.source_type,
             )

--- a/tests/fixtures/feature_materialize/drop_columns.sql
+++ b/tests/fixtures/feature_materialize/drop_columns.sql
@@ -1,3 +1,3 @@
-ALTER TABLE "cat1_cust_id_30m"   DROP COLUMN "a";
+ALTER TABLE "cat1_cust_id_30m"   DROP COLUMN IF EXISTS "a";
 
-ALTER TABLE "cat1_cust_id_30m"   DROP COLUMN "b";
+ALTER TABLE "cat1_cust_id_30m"   DROP COLUMN IF EXISTS "b";


### PR DESCRIPTION
## Description

This updates the column dropping query in FeatureMaterializeService to use if exists keyword to make it more robust against bad state.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
