### PR TITLE
[chore] Patch Feast feature store's `augment_response_with_on_demand_transforms` method

### DIFF
--- a/featurebyte/feast/patch.py
+++ b/featurebyte/feast/patch.py
@@ -12,7 +12,7 @@ from feast import OnDemandFeatureView
 from feast.online_response import OnlineResponse
 from feast.protos.feast.serving.ServingService_pb2 import FieldStatus, GetOnlineFeaturesResponse
 from feast.type_map import python_values_to_proto_values
-from google.protobuf.timestamp_pb2 import Timestamp
+from google.protobuf.timestamp_pb2 import Timestamp  # type: ignore[import]
 
 
 def augment_response_with_on_demand_transforms(
@@ -20,7 +20,7 @@ def augment_response_with_on_demand_transforms(
     feature_refs: List[str],
     requested_on_demand_feature_views: List[OnDemandFeatureView],
     full_feature_names: bool,
-):
+) -> None:
     """Computes on demand feature values and adds them to the result rows.
 
     Assumes that 'online_features_response' already contains the necessary request data and input feature

--- a/featurebyte/feast/patch.py
+++ b/featurebyte/feast/patch.py
@@ -1,0 +1,92 @@
+"""
+This module functions used to patch the Feast library.
+"""
+from __future__ import annotations
+
+from typing import List
+
+from collections import defaultdict
+
+# pylint: disable=no-name-in-module
+from feast import OnDemandFeatureView
+from feast.online_response import OnlineResponse
+from feast.protos.feast.serving.ServingService_pb2 import FieldStatus, GetOnlineFeaturesResponse
+from feast.type_map import python_values_to_proto_values
+from google.protobuf.timestamp_pb2 import Timestamp
+
+
+def augment_response_with_on_demand_transforms(
+    online_features_response: GetOnlineFeaturesResponse,
+    feature_refs: List[str],
+    requested_on_demand_feature_views: List[OnDemandFeatureView],
+    full_feature_names: bool,
+):
+    """Computes on demand feature values and adds them to the result rows.
+
+    Assumes that 'online_features_response' already contains the necessary request data and input feature
+    views for the on demand feature views. Unneeded feature values such as request data and
+    unrequested input feature views will be removed from 'online_features_response'.
+
+    # noqa: DAR101
+    Args:
+        online_features_response: Protobuf object to populate
+        feature_refs: List of all feature references to be returned.
+        requested_on_demand_feature_views: List of all odfvs that have been requested.
+        full_feature_names: A boolean that provides the option to add the feature view prefixes to the feature names,
+            changing them from the format "feature" to "feature_view__feature" (e.g., "daily_transactions" changes to
+            "customer_fv__daily_transactions").
+    """
+    # pylint: disable=too-many-locals
+    requested_odfv_map = {odfv.name: odfv for odfv in requested_on_demand_feature_views}
+    requested_odfv_feature_names = requested_odfv_map.keys()
+
+    odfv_feature_refs = defaultdict(list)
+    for feature_ref in feature_refs:
+        view_name, feature_name = feature_ref.split(":")
+        if view_name in requested_odfv_feature_names:
+            odfv_feature_refs[view_name].append(
+                f"{requested_odfv_map[view_name].projection.name_to_use()}__{feature_name}"
+                if full_feature_names
+                else feature_name
+            )
+
+    initial_response = OnlineResponse(online_features_response)
+    initial_response_df = initial_response.to_df()
+
+    # Apply on demand transformations and augment the result rows
+    odfv_result_names = set()
+    for odfv_name, _feature_refs in odfv_feature_refs.items():
+        odfv = requested_odfv_map[odfv_name]
+        transformed_features_df = odfv.get_transformed_features_df(
+            initial_response_df,
+            full_feature_names,
+        )
+        selected_subset = [f for f in transformed_features_df.columns if f in _feature_refs]
+        # this is an additional step introduced to extract the correct dtypes for the transformed features
+        odfv_dtype_map = {
+            f"{odfv.projection.name_to_use()}__{feature.name}"
+            if full_feature_names
+            else feature.name: feature.dtype.to_value_type()
+            for feature in odfv.features
+        }
+
+        # pass the expected dtypes to the proto_values_to_proto_values function
+        # (original implementation pass UNKNOWN as the dtype and let the function infer the dtype)
+        proto_values = [
+            python_values_to_proto_values(
+                transformed_features_df[feature].values, odfv_dtype_map[feature]
+            )
+            for feature in selected_subset
+        ]
+
+        odfv_result_names |= set(selected_subset)
+
+        online_features_response.metadata.feature_names.val.extend(selected_subset)
+        for feature_idx in range(len(selected_subset)):
+            online_features_response.results.append(
+                GetOnlineFeaturesResponse.FeatureVector(
+                    values=proto_values[feature_idx],
+                    statuses=[FieldStatus.PRESENT] * len(proto_values[feature_idx]),
+                    event_timestamps=[Timestamp()] * len(proto_values[feature_idx]),
+                )
+            )

--- a/featurebyte/service/online_serving.py
+++ b/featurebyte/service/online_serving.py
@@ -22,6 +22,7 @@ from featurebyte.exception import (
     RequiredEntityNotProvidedError,
     UnsupportedRequestCodeTemplateLanguage,
 )
+from featurebyte.feast.patch import augment_response_with_on_demand_transforms
 from featurebyte.logging import get_logger
 from featurebyte.models.base import PydanticObjectId, VersionIdentifier
 from featurebyte.models.batch_request_table import BatchRequestTableModel
@@ -446,6 +447,12 @@ class OnlineServingService:  # pylint: disable=too-many-instance-attributes
             feature_id_to_versioned_name[feature_id]
             for feature_id in feature_id_to_versioned_name.keys()
         ]
+
+        # FIXME: This is a temporary fix to avoid the bug in feast 0.35.0
+        feast_store._augment_response_with_on_demand_transforms = (  # pylint: disable=protected-access
+            augment_response_with_on_demand_transforms
+        )
+
         df_feast_online_features = feast_store.get_online_features(
             feast_store.get_feature_service(feast_service_name),
             updated_request_data,

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -515,13 +515,12 @@ async def test_feast_registry(app_container, expected_feature_table_names, sourc
 
     # set point in time > 2001-01-02 12:00:00 +  2 hours (frequency is 1 hour) &
     # expect all ttl features to be null
-    entity_row_ttl_expired = entity_row.copy()
-    entity_row_ttl_expired["POINT_IN_TIME"] = pd.Timestamp("2001-01-02 14:00:01")
+    entity_row["POINT_IN_TIME"] = pd.Timestamp("2001-01-02 14:00:01")
     online_features = feature_store.get_online_features(
         features=feature_service,
-        entity_rows=[entity_row_ttl_expired],
+        entity_rows=[entity_row],
     ).to_dict()
-    expected_ttl_expired = {
+    expected = {
         "üser id": ["5"],
         "cust_id": ["761"],
         "PRODUCT_ACTION": ["detail"],
@@ -546,16 +545,16 @@ async def test_feast_registry(app_container, expected_feature_table_names, sourc
     if source_type == SourceType.DATABRICKS_UNITY:
         expected.pop(f"EXTERNAL_FS_ARRAY_AVG_BY_USER_ID_24h_{version}")
         expected.pop(f"EXTERNAL_FS_COSINE_SIMILARITY_VEC_{version}")
-    assert_dict_approx_equal(online_features, expected_ttl_expired)
+    assert_dict_approx_equal(online_features, expected)
 
     # set the point in time earlier than the 2001-01-02 12:00:00
     # expect all ttl features to be null
-    entity_row_ttl_expired["POINT_IN_TIME"] = pd.Timestamp("2001-01-02 11:59:59")
+    entity_row["POINT_IN_TIME"] = pd.Timestamp("2001-01-02 11:59:59")
     online_features = feature_store.get_online_features(
         features=feature_service,
-        entity_rows=[entity_row_ttl_expired],
+        entity_rows=[entity_row],
     ).to_dict()
-    assert_dict_approx_equal(online_features, expected_ttl_expired)
+    assert_dict_approx_equal(online_features, expected)
 
 
 @pytest.mark.order(5)

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -16,6 +16,7 @@ from sqlglot import parse_one
 import featurebyte as fb
 from featurebyte.common.model_util import get_version
 from featurebyte.enum import InternalName, SourceType
+from featurebyte.feast.patch import augment_response_with_on_demand_transforms
 from featurebyte.logging import get_logger
 from featurebyte.query_graph.sql.common import sql_to_string
 from featurebyte.query_graph.sql.entity import DUMMY_ENTITY_COLUMN_NAME, DUMMY_ENTITY_VALUE
@@ -515,12 +516,13 @@ async def test_feast_registry(app_container, expected_feature_table_names, sourc
 
     # set point in time > 2001-01-02 12:00:00 +  2 hours (frequency is 1 hour) &
     # expect all ttl features to be null
-    entity_row["POINT_IN_TIME"] = pd.Timestamp("2001-01-02 14:00:01")
+    entity_row_ttl_expired = entity_row.copy()
+    entity_row_ttl_expired["POINT_IN_TIME"] = pd.Timestamp("2001-01-02 14:00:01")
     online_features = feature_store.get_online_features(
         features=feature_service,
-        entity_rows=[entity_row],
+        entity_rows=[entity_row_ttl_expired],
     ).to_dict()
-    expected = {
+    expected_ttl_expired = {
         "üser id": ["5"],
         "cust_id": ["761"],
         "PRODUCT_ACTION": ["detail"],
@@ -545,16 +547,37 @@ async def test_feast_registry(app_container, expected_feature_table_names, sourc
     if source_type == SourceType.DATABRICKS_UNITY:
         expected.pop(f"EXTERNAL_FS_ARRAY_AVG_BY_USER_ID_24h_{version}")
         expected.pop(f"EXTERNAL_FS_COSINE_SIMILARITY_VEC_{version}")
-    assert_dict_approx_equal(online_features, expected)
+    assert_dict_approx_equal(online_features, expected_ttl_expired)
 
     # set the point in time earlier than the 2001-01-02 12:00:00
     # expect all ttl features to be null
-    entity_row["POINT_IN_TIME"] = pd.Timestamp("2001-01-02 11:59:59")
+    entity_row_ttl_expired["POINT_IN_TIME"] = pd.Timestamp("2001-01-02 11:59:59")
     online_features = feature_store.get_online_features(
         features=feature_service,
-        entity_rows=[entity_row],
+        entity_rows=[entity_row_ttl_expired],
     ).to_dict()
-    assert_dict_approx_equal(online_features, expected)
+    assert_dict_approx_equal(online_features, expected_ttl_expired)
+
+    # test patching of augment_response_with_on_demand_transforms
+    feature_store._augment_response_with_on_demand_transforms = (  # pylint: disable=protected-access
+        augment_response_with_on_demand_transforms
+    )
+    online_features = feature_store.get_online_features(
+        features=feature_service,
+        entity_rows=[entity_row_ttl_expired, entity_row],
+    ).to_dict()
+
+    assert_dict_approx_equal(
+        {key: val[:1] for key, val in online_features.items()}, expected_ttl_expired
+    )
+    second_row = {key: val[1:] for key, val in online_features.items()}
+    for key in [
+        f"EXTERNAL_CATEGORY_AMOUNT_SUM_BY_USER_ID_7d_{version}",
+        f"EXTERNAL_FS_ARRAY_AVG_BY_USER_ID_24h_{version}",
+    ]:
+        if key in second_row:
+            second_row[key][0] = json.loads(second_row[key][0])
+    assert_dict_approx_equal(second_row, expected)
 
 
 @pytest.mark.order(5)

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -947,3 +947,49 @@ async def test_feature_tables_have_primary_key_constraints(session, offline_stor
             ).strip()
         )
         assert df.shape[0] == 1
+
+
+@pytest.mark.order(10)
+@pytest.mark.parametrize("source_type", SNOWFLAKE_SPARK_DATABRICKS_UNITY, indirect=True)
+def test_online_features__patch_feast(config, deployed_feature_list, source_type):
+    """Test feast online features with patching works without error"""
+    client = config.get_client()
+    deployment = deployed_feature_list
+
+    entity_serving_name = {
+        "üser id": 5,
+        "cust_id": 761,
+        "PRODUCT_ACTION": "detail",
+        "user_status": "STÀTUS_CODE_37",
+        "order_id": "T1230",
+    }
+    entity_serving_name_non_exist = {
+        "üser id": "non_existing_user_id",
+        "cust_id": 123456,
+        "PRODUCT_ACTION": "non_existing_product_action",
+        "user_status": "non_existing_user_status",
+        "order_id": "non_existing_order_id",
+    }
+    with patch("featurebyte.service.online_serving.datetime", autospec=True) as mock_datetime:
+        mock_datetime.utcnow.return_value = datetime(2001, 1, 2, 12)
+
+        data = OnlineFeaturesRequestPayload(entity_serving_names=[entity_serving_name])
+        res1 = client.post(
+            f"/deployment/{deployment.id}/online_features",
+            json=data.json_dict(),
+        ).json()
+
+        data = OnlineFeaturesRequestPayload(entity_serving_names=[entity_serving_name_non_exist])
+        res2 = client.post(
+            f"/deployment/{deployment.id}/online_features",
+            json=data.json_dict(),
+        ).json()
+
+        data = OnlineFeaturesRequestPayload(
+            entity_serving_names=[entity_serving_name_non_exist, entity_serving_name]
+        )
+        res3 = client.post(
+            f"/deployment/{deployment.id}/online_features",
+            json=data.json_dict(),
+        ).json()
+        assert res3 == {"features": res2["features"] + res1["features"]}

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -951,7 +951,7 @@ async def test_feature_tables_have_primary_key_constraints(session, offline_stor
 
 @pytest.mark.order(10)
 @pytest.mark.parametrize("source_type", SNOWFLAKE_SPARK_DATABRICKS_UNITY, indirect=True)
-def test_online_features__patch_feast(config, deployed_feature_list, source_type):
+def test_online_features__patch_feast(config, deployed_feature_list):
     """Test feast online features with patching works without error"""
     client = config.get_client()
     deployment = deployed_feature_list


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
This PR fix Feast's `augment_response_with_on_demand_transforms` method by casting the result to expected type (rather than inferring the type from the response).

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
