### PR TITLE
[chore] Remove redundant entries in FeatureListModel features_entity_lookup_info

### DIFF
--- a/featurebyte/service/feature_list.py
+++ b/featurebyte/service/feature_list.py
@@ -251,7 +251,8 @@ class FeatureListService(  # pylint: disable=too-many-instance-attributes
                 feature_list_to_feature_primary_entity_join_steps=feature_list_to_feature_primary_entity_join_steps,
                 feature_internal_entity_join_steps=feature_internal_entity_join_steps,
             )
-            features_entity_lookup_info.append(feature_entity_lookup_info)
+            if feature_entity_lookup_info.join_steps:
+                features_entity_lookup_info.append(feature_entity_lookup_info)
 
         return FeatureListEntityRelationshipData(
             primary_entity_ids=fl_primary_entity_ids,

--- a/tests/unit/service/test_feature_list.py
+++ b/tests/unit/service/test_feature_list.py
@@ -205,6 +205,9 @@ async def test_feature_list__contains_relationships_info(
     # and grand_child_entity is not included in the feature list
     assert new_feature_list.relationships_info == []
 
+    # should contain only features that require additional entity lookups
+    assert new_feature_list.features_entity_lookup_info == []
+
 
 @pytest.mark.asyncio
 async def test_update_readiness_distribution(feature_list_service, feature_list):


### PR DESCRIPTION


## Description

Remove redundant entries in `FeatureListModel`'s  `features_entity_lookup_info` by keeping features that require additional entity lookup steps.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
