### PR TITLE
[chore] Fix performance issue of `get_entity_ids`

### DIFF
--- a/featurebyte/query_graph/graph.py
+++ b/featurebyte/query_graph/graph.py
@@ -137,6 +137,7 @@ class QueryGraph(QueryGraphModel):
         self,
         node_name: str,
         relationships_info: Optional[List[EntityRelationshipInfo]] = None,
+        extract_primary_entity_ids_only: bool = False,
     ) -> DecomposePointState:
         """
         Get decompose state of the query graph given the target node name
@@ -147,6 +148,8 @@ class QueryGraph(QueryGraphModel):
             Name of the node to get decompose state for
         relationships_info: Optional[List[EntityRelationshipInfo]]
             Entity relationship info
+        extract_primary_entity_ids_only: bool
+            Whether to extract primary entity IDs only to speed up the extraction process
 
         Returns
         -------
@@ -154,7 +157,9 @@ class QueryGraph(QueryGraphModel):
             Decompose state of the query graph
         """
         decompose_state = DecomposePointExtractor(graph=self).extract(
-            node=self.get_node_by_name(node_name=node_name), relationships_info=relationships_info
+            node=self.get_node_by_name(node_name=node_name),
+            relationships_info=relationships_info,
+            extract_primary_entity_ids_only=extract_primary_entity_ids_only,
         )
         return decompose_state
 
@@ -173,7 +178,9 @@ class QueryGraph(QueryGraphModel):
             List of entity IDs in the query graph
         """
         # not passing entity relationship to the extractor, primary entity will be the same as entity
-        decompose_state = self.get_decompose_state(node_name=node_name, relationships_info=None)
+        decompose_state = self.get_decompose_state(
+            node_name=node_name, relationships_info=None, extract_primary_entity_ids_only=True
+        )
         return sorted(decompose_state.primary_entity_ids)
 
     def get_user_defined_function_ids(self, node_name: str) -> List[ObjectId]:

--- a/featurebyte/query_graph/transform/decompose_point.py
+++ b/featurebyte/query_graph/transform/decompose_point.py
@@ -43,14 +43,16 @@ class AggregationInfo:
     feature_job_settings: List[FeatureJobSetting]
     has_request_column: bool
     has_ingest_graph_node: bool
+    extract_primary_entity_ids_only: bool
 
-    def __init__(self) -> None:
+    def __init__(self, extract_primary_entity_ids_only: bool) -> None:
         self.agg_node_types = []
         self.primary_entity_ids = []
         self.primary_entity_dtypes = []
         self.feature_job_settings = []
         self.has_request_column = False
         self.has_ingest_graph_node = False
+        self.extract_primary_entity_ids_only = extract_primary_entity_ids_only
 
     @property
     def primary_entity_id_to_dtype_map(self) -> Dict[PydanticObjectId, DBVarType]:
@@ -80,17 +82,18 @@ class AggregationInfo:
         primary_entity_id_to_dtype_map = self.primary_entity_id_to_dtype_map.copy()
         primary_entity_id_to_dtype_map.update(other.primary_entity_id_to_dtype_map)
 
-        output = AggregationInfo()
-        output.agg_node_types = sorted(set(self.agg_node_types + other.agg_node_types))
+        output = AggregationInfo(self.extract_primary_entity_ids_only)
         output.primary_entity_ids = sorted(set(self.primary_entity_ids + other.primary_entity_ids))
-        output.primary_entity_dtypes = [
-            primary_entity_id_to_dtype_map[entity_id] for entity_id in output.primary_entity_ids
-        ]
-        output.feature_job_settings = list(
-            set(self.feature_job_settings + other.feature_job_settings)
-        )
-        output.has_request_column = self.has_request_column or other.has_request_column
-        output.has_ingest_graph_node = self.has_ingest_graph_node or other.has_ingest_graph_node
+        if not self.extract_primary_entity_ids_only:
+            output.agg_node_types = sorted(set(self.agg_node_types + other.agg_node_types))
+            output.primary_entity_dtypes = [
+                primary_entity_id_to_dtype_map[entity_id] for entity_id in output.primary_entity_ids
+            ]
+            output.feature_job_settings = list(
+                set(self.feature_job_settings + other.feature_job_settings)
+            )
+            output.has_request_column = self.has_request_column or other.has_request_column
+            output.has_ingest_graph_node = self.has_ingest_graph_node or other.has_ingest_graph_node
         return output
 
     @property
@@ -204,6 +207,8 @@ class DecomposePointState:
     ingest_graph_output_node_names: Set[str]
     # operation structure info
     operation_structure_map: Dict[str, OperationStructure]
+    # extract primary entity ids only
+    extract_primary_entity_ids_only: bool
 
     @property
     def should_decompose(self) -> bool:
@@ -250,6 +255,7 @@ class DecomposePointState:
         relationships_info: List[EntityRelationshipInfo],
         aggregation_node_names: Set[str],
         operation_structure_map: Dict[str, OperationStructure],
+        extract_primary_entity_ids_only: bool,
     ) -> "DecomposePointState":
         """
         Create DecomposePointState object
@@ -262,6 +268,8 @@ class DecomposePointState:
             Set of aggregation node names
         operation_structure_map: Dict[str, OperationStructure]
             Operation structure map
+        extract_primary_entity_ids_only: bool
+            Extract primary entity ids only without extracting other information to speed up the process
 
         Returns
         -------
@@ -277,10 +285,15 @@ class DecomposePointState:
             decompose_node_names=set(),
             ingest_graph_output_node_names=set(),
             operation_structure_map=operation_structure_map,
+            extract_primary_entity_ids_only=extract_primary_entity_ids_only,
         )
 
     def update_aggregation_info(
-        self, query_graph: QueryGraphModel, node: Node, input_node_names: List[str]
+        self,
+        query_graph: QueryGraphModel,
+        node: Node,
+        input_node_names: List[str],
+        extract_primary_entity_ids_only: bool,
     ) -> None:
         """
         Update aggregation info of the given node
@@ -293,9 +306,10 @@ class DecomposePointState:
             Node to be processed
         input_node_names: List[str]
             List of input node names
+        extract_primary_entity_ids_only: bool
+            Extract primary entity ids only without extracting other information to speed up the process
         """
-        op_struct = self.operation_structure_map[node.name]
-        aggregation_info = AggregationInfo()
+        aggregation_info = AggregationInfo(extract_primary_entity_ids_only)
         for input_node_name in input_node_names:
             input_aggregation_info = self.node_name_to_aggregation_info.get(input_node_name)
             if input_aggregation_info:
@@ -303,46 +317,53 @@ class DecomposePointState:
                 # as they are skipped in the pre-compute step
                 aggregation_info += input_aggregation_info
 
-        if node.name in self.aggregation_node_names:
-            aggregation_info.agg_node_types = [node.type]
-
         if isinstance(node.parameters, BaseGroupbyParameters):
             # primary entity ids introduced by groupby node family
             aggregation_info.primary_entity_ids = node.parameters.entity_ids or []
-            groupby_keys = node.parameters.keys
-            # check the dtype of the source columns that match the groupby keys to get dtype
-            # of the primary entity ids
-            colname_to_dtype_map = {}
-            for source_column in op_struct.columns:
-                if source_column.name in groupby_keys:
-                    colname_to_dtype_map[source_column.name] = source_column.dtype
-            aggregation_info.primary_entity_dtypes = [
-                colname_to_dtype_map[key] for key in groupby_keys
-            ]
-            assert len(aggregation_info.primary_entity_dtypes) == len(
-                aggregation_info.primary_entity_ids
-            ), "Primary entity dtype not matches"
-
         elif isinstance(node, (LookupNode, LookupTargetNode)):
             # primary entity ids introduced by lookup node family
             aggregation_info.primary_entity_ids = [node.parameters.entity_id]
-            for source_column in op_struct.columns:
-                if source_column.name == node.parameters.entity_column:
-                    aggregation_info.primary_entity_dtypes = [source_column.dtype]
-                    break
-            assert (
-                len(aggregation_info.primary_entity_dtypes) == 1
-            ), "Primary entity dtype not found"
 
-        if isinstance(node, RequestColumnNode):
-            # request columns introduced by request column node
-            aggregation_info.has_request_column = True
+        if not extract_primary_entity_ids_only:
+            op_struct = self.operation_structure_map[node.name]
 
-        feature_job_setting = FeatureJobSettingExtractor(graph=query_graph).extract_from_agg_node(
-            node=node
-        )
-        if feature_job_setting:
-            aggregation_info.feature_job_settings = [feature_job_setting]
+            if node.name in self.aggregation_node_names:
+                aggregation_info.agg_node_types = [node.type]
+
+            if isinstance(node.parameters, BaseGroupbyParameters):
+                groupby_keys = node.parameters.keys
+                # check the dtype of the source columns that match the groupby keys to get dtype
+                # of the primary entity ids
+                colname_to_dtype_map = {}
+                for source_column in op_struct.columns:
+                    if source_column.name in groupby_keys:
+                        colname_to_dtype_map[source_column.name] = source_column.dtype
+                aggregation_info.primary_entity_dtypes = [
+                    colname_to_dtype_map[key] for key in groupby_keys
+                ]
+                assert len(aggregation_info.primary_entity_dtypes) == len(
+                    aggregation_info.primary_entity_ids
+                ), "Primary entity dtype not matches"
+
+            elif isinstance(node, (LookupNode, LookupTargetNode)):
+                # primary entity ids introduced by lookup node family
+                for source_column in op_struct.columns:
+                    if source_column.name == node.parameters.entity_column:
+                        aggregation_info.primary_entity_dtypes = [source_column.dtype]
+                        break
+                assert (
+                    len(aggregation_info.primary_entity_dtypes) == 1
+                ), "Primary entity dtype not found"
+
+            if isinstance(node, RequestColumnNode):
+                # request columns introduced by request column node
+                aggregation_info.has_request_column = True
+
+            feature_job_setting = FeatureJobSettingExtractor(
+                graph=query_graph
+            ).extract_from_agg_node(node=node)
+            if feature_job_setting:
+                aggregation_info.feature_job_settings = [feature_job_setting]
 
         # reduce the primary entity ids based on entity relationship
         aggregation_info.primary_entity_ids = self.entity_ancestor_descendant_mapper.reduce_entity_ids(
@@ -516,33 +537,47 @@ class DecomposePointExtractor(
     ) -> DecomposePointState:
         input_node_names = self.graph.get_input_node_names(node)
         global_state.update_aggregation_info(
-            query_graph=self.graph, node=node, input_node_names=input_node_names
+            query_graph=self.graph,
+            node=node,
+            input_node_names=input_node_names,
+            extract_primary_entity_ids_only=global_state.extract_primary_entity_ids_only,
         )
-        to_decompose = global_state.should_decompose_query_graph(
-            node_name=node.name, input_node_names=input_node_names
-        )
-        if to_decompose:
-            global_state.decompose_node_names.add(node.name)
-            global_state.update_ingest_graph_node_output_names(input_node_names=input_node_names)
-            global_state.node_name_to_aggregation_info[node.name].has_ingest_graph_node = True
+        if not global_state.extract_primary_entity_ids_only:
+            # skip decompose point extraction if the graph is only used to extract primary entity ids
+            # to speed up the process
+            to_decompose = global_state.should_decompose_query_graph(
+                node_name=node.name, input_node_names=input_node_names
+            )
+            if to_decompose:
+                global_state.decompose_node_names.add(node.name)
+                global_state.update_ingest_graph_node_output_names(
+                    input_node_names=input_node_names
+                )
+                global_state.node_name_to_aggregation_info[node.name].has_ingest_graph_node = True
         return global_state
 
     def extract(
         self,
         node: Node,
         relationships_info: Optional[List[EntityRelationshipInfo]] = None,
+        extract_primary_entity_ids_only: bool = False,
         **kwargs: Any,
     ) -> DecomposePointState:
-        # identify aggregation node names in the graph, aggregation node names are used to determine
-        # whether to start decomposing the graph
-        op_struct_state = OperationStructureExtractor(graph=self.graph).extract(node=node)
-        op_struct = op_struct_state.operation_structure_map[node.name]
-        aggregation_node_names = {agg.node_name for agg in op_struct.iterate_aggregations()}
+        aggregation_node_names = set()
+        operation_structure_map = {}
+        if not extract_primary_entity_ids_only:
+            # identify aggregation node names in the graph, aggregation node names are used to determine
+            # whether to start decomposing the graph
+            op_struct_state = OperationStructureExtractor(graph=self.graph).extract(node=node)
+            op_struct = op_struct_state.operation_structure_map[node.name]
+            aggregation_node_names = {agg.node_name for agg in op_struct.iterate_aggregations()}
+            operation_structure_map = op_struct_state.operation_structure_map
 
         global_state = DecomposePointState.create(
             relationships_info=relationships_info or [],
             aggregation_node_names=aggregation_node_names,
-            operation_structure_map=op_struct_state.operation_structure_map,
+            operation_structure_map=operation_structure_map,
+            extract_primary_entity_ids_only=extract_primary_entity_ids_only,
         )
         self._extract(
             node=node,

--- a/tests/unit/query_graph/transform/test_decompose_point.py
+++ b/tests/unit/query_graph/transform/test_decompose_point.py
@@ -8,7 +8,10 @@ from featurebyte.query_graph.transform.decompose_point import AggregationInfo, D
 def decompose_point_global_state_fixture():
     """Fixture for DecomposePointState."""
     return DecomposePointState.create(
-        relationships_info=[], aggregation_node_names=set(), operation_structure_map={}
+        relationships_info=[],
+        aggregation_node_names=set(),
+        operation_structure_map={},
+        extract_primary_entity_ids_only=False,
     )
 
 
@@ -47,16 +50,16 @@ def test_check_input_aggregations(
 ):
     """Test check_input_aggregations."""
     input_node_names = ["input_1", "input_2"]
-    input1_agg_info = AggregationInfo()
+    input1_agg_info = AggregationInfo(extract_primary_entity_ids_only=False)
     input1_agg_info.has_request_column = input1_has_req_col
     input1_agg_info.has_ingest_graph_node = input1_has_graph
-    input2_agg_info = AggregationInfo()
+    input2_agg_info = AggregationInfo(extract_primary_entity_ids_only=False)
     input2_agg_info.has_request_column = input2_has_req_col
     input2_agg_info.has_ingest_graph_node = input2_has_graph
     decompose_point_global_state.node_name_to_aggregation_info["input_1"] = input1_agg_info
     decompose_point_global_state.node_name_to_aggregation_info["input_2"] = input2_agg_info
     output = decompose_point_global_state.check_input_aggregations(
-        agg_info=AggregationInfo(),
+        agg_info=AggregationInfo(extract_primary_entity_ids_only=False),
         input_node_names=input_node_names,
     )
     assert output == expected


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

Previous PR (https://github.com/featurebyte/featurebyte/commit/0ed93eb374164982f66b3602752af1bff0ccb3d3) causes unnecessarily extraction of decompose graph, it causes performance issue when calling `graph.get_entity_ids(...)`.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
