### PR TITLE
[chore] Use longer TTL (`APIObject` cache) for batch feature & feature list saving

### DIFF
--- a/featurebyte/worker/task/batch_feature_create.py
+++ b/featurebyte/worker/task/batch_feature_create.py
@@ -8,7 +8,10 @@ from typing import Any
 from featurebyte.logging import get_logger
 from featurebyte.schema.worker.task.batch_feature_create import BatchFeatureCreateTaskPayload
 from featurebyte.worker.task.base import BaseTask
-from featurebyte.worker.util.batch_feature_creator import BatchFeatureCreator
+from featurebyte.worker.util.batch_feature_creator import (
+    BatchFeatureCreator,
+    patch_api_object_cache,
+)
 
 logger = get_logger(__name__)
 
@@ -30,6 +33,7 @@ class BatchFeatureCreateTask(BaseTask[BatchFeatureCreateTaskPayload]):
     async def get_task_description(self, payload: BatchFeatureCreateTaskPayload) -> str:
         return f"Save {len(payload.features)} features"
 
+    @patch_api_object_cache()
     async def execute(self, payload: BatchFeatureCreateTaskPayload) -> Any:
         await self.batch_feature_creator.batch_feature_create(
             payload=payload, start_percentage=0, end_percentage=100

--- a/featurebyte/worker/task/feature_list_batch_feature_create.py
+++ b/featurebyte/worker/task/feature_list_batch_feature_create.py
@@ -11,7 +11,10 @@ from featurebyte.schema.worker.task.feature_list_batch_feature_create import (
     FeatureListCreateWithBatchFeatureCreationTaskPayload,
 )
 from featurebyte.worker.task.base import BaseTask
-from featurebyte.worker.util.batch_feature_creator import BatchFeatureCreator
+from featurebyte.worker.util.batch_feature_creator import (
+    BatchFeatureCreator,
+    patch_api_object_cache,
+)
 from featurebyte.worker.util.task_progress_updater import TaskProgressUpdater
 
 
@@ -40,6 +43,7 @@ class FeatureListCreateWithBatchFeatureCreationTask(
     ) -> str:
         return f'Save feature list "{payload.name}"'
 
+    @patch_api_object_cache()
     async def execute(self, payload: FeatureListCreateWithBatchFeatureCreationTaskPayload) -> Any:
         # create list of features
         feature_ids = await self.batch_feature_creator.batch_feature_create(

--- a/tests/unit/worker/task/test_batch_creator.py
+++ b/tests/unit/worker/task/test_batch_creator.py
@@ -23,5 +23,9 @@ async def test_patch_api_object_cache__async_func(snowflake_event_table):
     # make the first call to the function to populate the cache during the execution of the function
     await check_api_object_cache()
 
+    # check that the cache after the execution of the function
+    assert ApiObject._cache.maxsize == 1024
+    assert ApiObject._cache.ttl == 1
+
     # check that the cache is cleared after the execution of the function
     await check_api_object_cache()

--- a/tests/unit/worker/task/test_batch_creator.py
+++ b/tests/unit/worker/task/test_batch_creator.py
@@ -1,0 +1,27 @@
+"""This module contains unit tests for the batch creator module."""
+import pytest
+
+from featurebyte.api.api_object import ApiObject
+from featurebyte.api.event_table import EventTable
+from featurebyte.worker.util.batch_feature_creator import patch_api_object_cache
+
+
+@pytest.mark.asyncio
+async def test_patch_api_object_cache__async_func(snowflake_event_table):
+    """Test patch_api_object_cache."""
+
+    @patch_api_object_cache()
+    async def check_api_object_cache():
+        api_cache = ApiObject._cache
+        assert len(api_cache) == 0
+        assert api_cache.maxsize == 1024
+        assert api_cache.ttl == 7200
+
+        _ = EventTable.get_by_id(snowflake_event_table.id)
+        assert len(api_cache) > 0  # check that the cache is populated
+
+    # make the first call to the function to populate the cache during the execution of the function
+    await check_api_object_cache()
+
+    # check that the cache is cleared after the execution of the function
+    await check_api_object_cache()


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
This PR uses much longer API cache when task executing SDK code to reduce number of API calls.


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
