### PR TITLE
[DEV-3031] Optimize feature saving runtime

### DIFF
--- a/featurebyte/api/api_object_util.py
+++ b/featurebyte/api/api_object_util.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from typing import Any, Dict, Iterator, List, Optional, Union
 
 import ctypes
-import os
 import threading
 from dataclasses import dataclass
 from http import HTTPStatus
@@ -144,20 +143,6 @@ class NameAttributeUpdatableMixin:
             except RecordRetrievalException:
                 pass
         return super().__getattribute__(item)
-
-
-def is_server_mode() -> bool:
-    """
-    Check if the code is running in server mode. Server mode is used when running the SDK code inside
-    featurebyte worker.
-
-    Returns
-    -------
-    bool
-        True if the code is running in server mode
-    """
-    sdk_execution_mode = os.environ.get("FEATUREBYTE_SDK_EXECUTION_MODE")
-    return sdk_execution_mode == "SERVER"
 
 
 def map_object_id_to_name(

--- a/featurebyte/api/feature.py
+++ b/featurebyte/api/feature.py
@@ -15,7 +15,6 @@ from typeguard import typechecked
 
 from featurebyte.api.api_handler.base import ListHandler
 from featurebyte.api.api_handler.feature import FeatureListHandler
-from featurebyte.api.api_object_util import is_server_mode
 from featurebyte.api.entity import Entity
 from featurebyte.api.feature_job import FeatureJobMixin
 from featurebyte.api.feature_namespace import FeatureNamespace
@@ -43,7 +42,7 @@ from featurebyte.api.templates.series_doc import ISNULL_DOC, NOTNULL_DOC
 from featurebyte.common.descriptor import ClassInstanceMethodDescriptor
 from featurebyte.common.doc_util import FBAutoDoc
 from featurebyte.common.typing import ScalarSequence
-from featurebyte.common.utils import enforce_observation_set_row_order
+from featurebyte.common.utils import enforce_observation_set_row_order, is_server_mode
 from featurebyte.config import Configurations
 from featurebyte.core.accessor.count_dict import CdAccessorMixin
 from featurebyte.core.accessor.feature_datetime import FeatureDtAccessorMixin

--- a/featurebyte/api/savable_api_object.py
+++ b/featurebyte/api/savable_api_object.py
@@ -11,7 +11,8 @@ from bson import ObjectId
 from typeguard import typechecked
 
 from featurebyte.api.api_object import ApiObject, get_api_object_cache_key
-from featurebyte.api.api_object_util import delete_api_object_by_id, is_server_mode
+from featurebyte.api.api_object_util import delete_api_object_by_id
+from featurebyte.common.utils import is_server_mode
 from featurebyte.config import Configurations
 from featurebyte.enum import ConflictResolution
 from featurebyte.exception import (
@@ -87,7 +88,10 @@ class SavableApiObject(ApiObject):
         >>> entity.save()  # doctest: +SKIP
         Entity (id: <entity.id>) has been saved before.
         """
-        self._check_object_not_been_saved(conflict_resolution=conflict_resolution)
+        if not is_server_mode():
+            # skip the check when running the SDK in the server mode (avoid making an API call)
+            self._check_object_not_been_saved(conflict_resolution=conflict_resolution)
+
         client = Configurations().get_client()
         payload = self._get_create_payload()
         if _id is not None:

--- a/featurebyte/common/utils.py
+++ b/featurebyte/common/utils.py
@@ -7,6 +7,7 @@ from typing import Any, Iterator, List, Optional, Union
 
 import ast
 import functools
+import os
 from datetime import datetime
 from decimal import Decimal
 from importlib import metadata as importlib_metadata
@@ -456,3 +457,17 @@ def convert_to_list_of_strings(value: Optional[Union[str, List[str]]]) -> List[s
     if isinstance(value, list):
         output = value
     return output
+
+
+def is_server_mode() -> bool:
+    """
+    Check if the code is running in server mode. Server mode is used when running the SDK code inside
+    featurebyte worker.
+
+    Returns
+    -------
+    bool
+        True if the code is running in server mode
+    """
+    sdk_execution_mode = os.environ.get("FEATUREBYTE_SDK_EXECUTION_MODE")
+    return sdk_execution_mode == "SERVER"

--- a/featurebyte/config.py
+++ b/featurebyte/config.py
@@ -21,7 +21,7 @@ from urllib3.util.retry import Retry
 from websocket import WebSocketConnectionClosedException
 
 from featurebyte.common.doc_util import FBAutoDoc
-from featurebyte.common.utils import get_version
+from featurebyte.common.utils import get_version, is_server_mode
 from featurebyte.enum import StrEnum
 from featurebyte.exception import InvalidSettingsError
 from featurebyte.models.base import get_active_catalog_id
@@ -522,11 +522,13 @@ class Configurations:
         APIClient
             API client
         """
-        # pylint: disable=import-outside-toplevel,cyclic-import
-        from featurebyte.logging import reconfigure_loggers
+        if not is_server_mode():
+            # pylint: disable=import-outside-toplevel,cyclic-import
+            from featurebyte.logging import reconfigure_loggers
 
-        # configure logger
-        reconfigure_loggers(self)
+            # configure logger
+            reconfigure_loggers(self)
+
         return APIClient(
             api_url=self.profile.api_url,
             api_token=self.profile.api_token,


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

Runtime performance of saving a feature by issuing `pytest -vv tests/unit/api/test_feature.py -k test_feature_or_view_column_name_contains_quote -s ` (using this branch: https://github.com/featurebyte/featurebyte/tree/senbong/print-node).
```
----> Reconfiguring loggers in get_client: 0.020622730255126953 seconds
----> Quick prune for payload: 0.001547098159790039 seconds
----> Reconfiguring loggers in get_client: 0.02048182487487793 seconds
----> Prepare task payload (api server): 0.001299142837524414 seconds
----> Quick prune for definition (BatchFeatureCreate.create_feature): 0.0013282299041748047 seconds
------> View construction (prepare_graph_to_store): 0.01244974136352539 seconds
------> Prune graph & node parameters (prepare_graph_to_store): 0.0038080215454101562 seconds
------> Sanitize query graph for definition (prepare_graph_to_store): 0.00115203857421875 seconds
------> Extract derived attributes (service.feature): 0.002209901809692383 seconds
------> Generate definition (namespace_handler.prepare_definition): 0.01884293556213379 seconds
----> Prune for definition (BatchFeatureCreate.create_feature): 0.04477190971374512 seconds
------> Reconfiguring loggers in get_client: 0.020976781845092773 seconds
------> Reconfiguring loggers in get_client: 0.02047896385192871 seconds
------> Reconfiguring loggers in get_client: 0.020095109939575195 seconds
--------> Add GroupBy node to global graph: 0.003368854522705078 seconds
------> Aggregate over operation: 0.0036559104919433594 seconds
----------> Reconfiguring loggers in get_client: 0.020027875900268555 seconds
--------> Check object not been saved (savable_api_object): 0.023073196411132812 seconds
----------> Reconfiguring loggers in get_client: 0.020377159118652344 seconds
--------> Get client (savable_api_object): 0.020481109619140625 seconds
--------> Create payload for feature (api.feature: 0.003451824188232422 seconds
------> Save feature (server mode, api.feature): 0.047338008880615234 seconds
----> Execute SDK code (BatchFeatureCreate.create_feature): 0.1287243366241455 seconds
------> View construction (prepare_graph_to_store): 0.012315034866333008 seconds
------> Prune graph & node parameters (prepare_graph_to_store): 0.003863096237182617 seconds
------> Extract derived attributes (service.feature): 0.0022399425506591797 seconds
------> Generate definition (namespace_handler.prepare_definition): 0.016345977783203125 seconds
------> Generate definition hash (service.feature): 0.001428842544555664 seconds
----> Create feature (controller): 0.08942484855651855 seconds
----> Reconfiguring loggers in get_client: 0.020383119583129883 seconds
----> Reconfiguring loggers in get_client: 0.02598094940185547 seconds
--> Saving feature: 0.511566162109375 seconds
```
After making this change, the runtime of saving a feature is reduce to about 0.46s.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
