### PR TITLE
[DEV-3037] Fix ambiguous column name error for SCD lookup features with offset

### DIFF
--- a/.changelog/DEV-3037.yaml
+++ b/.changelog/DEV-3037.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix ambiguous column name error when using SCD lookup features with different offsets"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/query_graph/sql/specifications/base_lookup.py
+++ b/featurebyte/query_graph/sql/specifications/base_lookup.py
@@ -37,7 +37,14 @@ class BaseLookupSpec(NonTileBasedAggregationSpec, ABC):
     def agg_result_name(self) -> str:
         if self.is_parent_lookup:
             return self.feature_name
-        return self.construct_agg_result_name(self.input_column_name)
+        args = self._get_additional_agg_result_name_params()
+        return self.construct_agg_result_name(self.input_column_name, *args)
+
+    def _get_additional_agg_result_name_params(self) -> list[Any]:
+        args = []
+        if self.scd_parameters is not None and self.scd_parameters.offset is not None:
+            args.append(self.scd_parameters.offset)
+        return args
 
     def get_source_hash_parameters(self) -> dict[str, Any]:
         params: dict[str, Any] = {

--- a/tests/fixtures/expected_preview_sql_scd_lookup_with_offset.sql
+++ b/tests/fixtures/expected_preview_sql_scd_lookup_with_offset.sql
@@ -6,12 +6,12 @@ WITH REQUEST_TABLE AS (
   SELECT
     REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
     REQ."CUSTOMER_ID" AS "CUSTOMER_ID",
-    REQ."_fb_internal_lookup_membership_status_input_1" AS "_fb_internal_lookup_membership_status_input_1"
+    REQ."_fb_internal_lookup_membership_status_14d_input_1" AS "_fb_internal_lookup_membership_status_14d_input_1"
   FROM (
     SELECT
       L."POINT_IN_TIME" AS "POINT_IN_TIME",
       L."CUSTOMER_ID" AS "CUSTOMER_ID",
-      R."membership_status" AS "_fb_internal_lookup_membership_status_input_1"
+      R."membership_status" AS "_fb_internal_lookup_membership_status_14d_input_1"
     FROM (
       SELECT
         "__FB_KEY_COL_0",
@@ -72,5 +72,5 @@ WITH REQUEST_TABLE AS (
 SELECT
   AGG."POINT_IN_TIME",
   AGG."CUSTOMER_ID",
-  "_fb_internal_lookup_membership_status_input_1" AS "Current Membership Status"
+  "_fb_internal_lookup_membership_status_14d_input_1" AS "Current Membership Status"
 FROM _FB_AGGREGATED AS AGG


### PR DESCRIPTION
## Description

This fixes a bug that causes ambiguous column name error in the generated queries. The error is triggered when a feature list contains SCD lookup features from the same source table but with different offsets.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
