### PR TITLE
[DEV-3042] Fix bug with view column shape

### DIFF
--- a/tests/unit/api/test_event_view.py
+++ b/tests/unit/api/test_event_view.py
@@ -956,7 +956,7 @@ def test_shape(snowflake_event_table, snowflake_query_map):
     Test creating ObservationTable from an EventView
     """
     view = snowflake_event_table.get_view()
-    expected_call = textwrap.dedent(
+    expected_call_view = textwrap.dedent(
         """
         WITH data AS (
           SELECT
@@ -968,6 +968,18 @@ def test_shape(snowflake_event_table, snowflake_query_map):
             "col_boolean" AS "col_boolean",
             "event_timestamp" AS "event_timestamp",
             "cust_id" AS "cust_id"
+          FROM "sf_database"."sf_schema"."sf_table"
+        )
+        SELECT
+          COUNT(*) AS "count"
+        FROM data
+        """
+    ).strip()
+    expected_call_view_column = textwrap.dedent(
+        """
+        WITH data AS (
+          SELECT
+            "col_int" AS "col_int"
           FROM "sf_database"."sf_schema"."sf_table"
         )
         SELECT
@@ -989,9 +1001,11 @@ def test_shape(snowflake_event_table, snowflake_query_map):
         mock_execute_query.side_effect = side_effect
         assert view.shape() == (1000, 8)
         # Check that the correct query was executed
-        assert mock_execute_query.call_args[0][0] == expected_call
+        assert mock_execute_query.call_args[0][0] == expected_call_view
         # test view colum shape
         assert view["col_int"].shape() == (1000, 1)
+        # Check that the correct query was executed
+        assert mock_execute_query.call_args[0][0] == expected_call_view_column
 
 
 @pytest.mark.flaky(reruns=3)


### PR DESCRIPTION
## Description
Fix failure when getting the shape of a view column with
```
view["column_name"].shape()
```
Traceback
```
[PARSE_SYNTAX_ERROR] Syntax error at or near '`GroceryInvoiceGuid`'. SQLSTATE: 42601 (line 2, pos 2)

== SQL ==
WITH data AS (
  `GroceryInvoiceGuid`
--^^^
)
SELECT
  COUNT(*) AS `count`
FROM data
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
