### PR TITLE
[DEV-3044] Update deployment `enabled` status only when task almost finished

### DIFF
--- a/featurebyte/service/deploy.py
+++ b/featurebyte/service/deploy.py
@@ -238,6 +238,8 @@ class DeployService(OpsServiceMixin):
     async def _update_feature_list(
         self,
         feature_list_id: ObjectId,
+        deployment_id: ObjectId,
+        to_enable_deployment: bool,
         update_progress: Optional[Callable[[int, str | None], Coroutine[Any, Any, None]]] = None,
     ) -> FeatureListModel:
         """
@@ -247,6 +249,10 @@ class DeployService(OpsServiceMixin):
         ----------
         feature_list_id: ObjectId
             Target feature list ID
+        deployment_id: ObjectId
+            Deployment ID
+        to_enable_deployment: bool
+            Flag to indicate whether the call is from enable/disable deployment
         update_progress: Callable[[int, str | None], Coroutine[Any, Any, None]]
             Update progress handler function
 
@@ -262,12 +268,19 @@ class DeployService(OpsServiceMixin):
         if update_progress:
             await update_progress(0, "Start updating feature list")
 
-        list_deployment_results = await self.deployment_service.list_documents_as_dict(
-            query_filter={"feature_list_id": feature_list_id, "enabled": True}
-        )
-        target_deployed = list_deployment_results["total"] > 0
-        document = await self.feature_list_service.get_document(document_id=feature_list_id)
+        target_deployed = to_enable_deployment
+        if not to_enable_deployment:
+            # check whether other deployment are using this feature list
+            list_deployment_results = await self.deployment_service.list_documents_as_dict(
+                query_filter={
+                    "feature_list_id": feature_list_id,
+                    "enabled": True,
+                    "_id": {"$ne": deployment_id},
+                }
+            )
+            target_deployed = list_deployment_results["total"] > 0
 
+        document = await self.feature_list_service.get_document(document_id=feature_list_id)
         if document.deployed != target_deployed:
             await self._validate_deployed_operation(document, target_deployed)
 
@@ -415,15 +428,21 @@ class DeployService(OpsServiceMixin):
                     _id=deployment_id,
                     name=deployment_name or default_deployment_name,
                     feature_list_id=feature_list_id,
-                    enabled=to_enable_deployment,
+                    enabled=False,
                     use_case_id=use_case_id,
                     context_id=context_id,
                 )
             )
             await self._update_feature_list(
                 feature_list_id=feature_list_id,
+                deployment_id=deployment_id,
+                to_enable_deployment=to_enable_deployment,
                 update_progress=update_progress,
             )
+            if to_enable_deployment:
+                await self.deployment_service.update_document(
+                    document_id=deployment_id, data=DeploymentUpdate(enabled=to_enable_deployment)
+                )
         except Exception as exc:
             try:
                 await self.deployment_service.delete_document(document_id=deployment_id)
@@ -452,7 +471,7 @@ class DeployService(OpsServiceMixin):
     async def update_deployment(
         self,
         deployment_id: ObjectId,
-        enabled: bool,
+        to_enable_deployment: bool,
         update_progress: Optional[Callable[[int, str | None], Coroutine[Any, Any, None]]] = None,
     ) -> None:
         """
@@ -462,7 +481,7 @@ class DeployService(OpsServiceMixin):
         ----------
         deployment_id: ObjectId
             Deployment ID
-        enabled: bool
+        to_enable_deployment: bool
             Enabled status
         update_progress: Callable[[int, str | None], Coroutine[Any, Any, None]]
             Update progress handler function
@@ -474,15 +493,17 @@ class DeployService(OpsServiceMixin):
         """
         deployment = await self.deployment_service.get_document(document_id=deployment_id)
         original_enabled = deployment.enabled
-        if original_enabled != enabled:
+        if original_enabled != to_enable_deployment:
             try:
-                await self.deployment_service.update_document(
-                    document_id=deployment_id,
-                    data=DeploymentUpdate(enabled=enabled),
-                )
                 await self._update_feature_list(
                     feature_list_id=deployment.feature_list_id,
+                    deployment_id=deployment_id,
+                    to_enable_deployment=to_enable_deployment,
                     update_progress=update_progress,
+                )
+                await self.deployment_service.update_document(
+                    document_id=deployment_id,
+                    data=DeploymentUpdate(enabled=to_enable_deployment),
                 )
             except Exception as exc:
                 try:

--- a/featurebyte/worker/task/deployment_create_update.py
+++ b/featurebyte/worker/task/deployment_create_update.py
@@ -93,6 +93,6 @@ class DeploymentCreateUpdateTask(BaseLockTask[DeploymentCreateUpdateTaskPayload]
             update_deployment_payload = cast(UpdateDeploymentPayload, payload.deployment_payload)
             await self.deploy_service.update_deployment(
                 deployment_id=payload.output_document_id,
-                enabled=update_deployment_payload.enabled,
+                to_enable_deployment=update_deployment_payload.enabled,
                 update_progress=self.task_progress_updater.update_progress,
             )

--- a/tests/unit/service/test_deploy.py
+++ b/tests/unit/service/test_deploy.py
@@ -65,7 +65,7 @@ async def test_update_deployment__not_all_features_are_online_enabled(
     """Test update deployment (not all features are online enabled validation error)"""
     with pytest.raises(DocumentError) as exc:
         await app_container.deploy_service.update_deployment(
-            deployment_id=disabled_deployment.id, enabled=True
+            deployment_id=disabled_deployment.id, to_enable_deployment=True
         )
 
     expected_msg = "Only FeatureList object of all production ready features can be deployed."
@@ -82,7 +82,7 @@ async def test_update_deployment__not_all_features_are_online_enabled(
 async def test_update_deployment__no_update(app_container, disabled_deployment):
     """Test update feature list when deployed status is the same"""
     await app_container.deploy_service.update_deployment(
-        deployment_id=disabled_deployment.id, enabled=False
+        deployment_id=disabled_deployment.id, to_enable_deployment=False
     )
 
     # check that deployment is not updated
@@ -177,7 +177,7 @@ async def test_update_deployment(
 
     await app_container.deploy_service.update_deployment(
         deployment_id=deployment_id,
-        enabled=False,
+        to_enable_deployment=False,
     )
     deployed_disabled_feature_list = await app_container.feature_list_service.get_document(
         document_id=deployment.feature_list_id
@@ -209,7 +209,7 @@ async def test_update_deployment(
     with pytest.raises(DocumentUpdateError) as exc:
         await app_container.deploy_service.update_deployment(
             deployment_id=deployment.id,
-            enabled=True,
+            to_enable_deployment=True,
         )
 
     expected_msg = "Deprecated feature list cannot be deployed."
@@ -233,7 +233,7 @@ async def test_update_deployment_error__state_is_reverted_when_update_feature_li
         with pytest.raises(DocumentError) as exc:
             _ = await app_container.deploy_service.update_deployment(
                 deployment_id=disabled_deployment_with_production_ready_features.id,
-                enabled=True,
+                to_enable_deployment=True,
             )
 
         # check exception message
@@ -285,7 +285,7 @@ async def test_update_deployment_error__state_is_reverted_when_update_feature_is
         with pytest.raises(DocumentError) as exc:
             _ = await app_container.deploy_service.update_deployment(
                 deployment_id=disabled_deployment_with_production_ready_features.id,
-                enabled=True,
+                to_enable_deployment=True,
             )
 
         # check exception message
@@ -339,6 +339,8 @@ async def test_update_feature_list_error__state_is_reverted_after_feature_list_n
     with pytest.raises(ValueError) as exc:
         _ = await deploy_service._update_feature_list(
             feature_list_id=feature_list.id,
+            deployment_id=ObjectId(),
+            to_enable_deployment=False,
             update_progress=fake_update_progress,
         )
 
@@ -361,6 +363,8 @@ async def test_update_feature_list_error__state_is_reverted_after_feature_list_n
             mock_update_feature.side_effect = Exception("Error during revert changes")
             _ = await deploy_service._update_feature_list(
                 feature_list_id=feature_list.id,
+                deployment_id=ObjectId(),
+                to_enable_deployment=False,
                 update_progress=fake_update_progress,
             )
 

--- a/tests/unit/service/test_feature_list_status.py
+++ b/tests/unit/service/test_feature_list_status.py
@@ -150,7 +150,7 @@ async def test_feature_list_status__deployed_feature_namespace_transit_to_public
     ):
         await deploy_service.update_deployment(
             deployment_id=deployment["_id"],
-            enabled=False,
+            to_enable_deployment=False,
         )
 
     namespace = await feature_list_namespace_service.get_document(


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

Current deployment object `enabled` status is updated first before running other operations. This behaviour gives users wrong impression that the deployment create/update task has completed. This PR revises existing deployment enabled status update logic.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
