### PR TITLE
[chore] Re-enable test case on enabled_serving_entity_ids

### DIFF
--- a/featurebyte/service/deploy.py
+++ b/featurebyte/service/deploy.py
@@ -381,9 +381,6 @@ class DeployFeatureListManagementService:
         deployment_id: ObjectId
             Deployment ID
         """
-        if feature_list.deployed:
-            return
-
         enabled_serving_entity_ids = await self._get_enabled_serving_entity_ids(
             feature_list_model=feature_list,
             deployment_id=deployment_id,
@@ -398,6 +395,10 @@ class DeployFeatureListManagementService:
             document=feature_list,
             return_document=False,
         )
+
+        if feature_list.deployed:
+            return
+
         await self._update_feature_list_namespace(
             feature_list_namespace_id=feature_list.feature_list_namespace_id,
             feature_list_id=feature_list.id,

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -922,7 +922,6 @@ async def test_multiple_parts_in_same_feature_table(test_dir, persistent, user):
     }
 
 
-@pytest.mark.skip(reason="Skip for now to avoid conflict, to be re-enabled")
 @pytest.mark.asyncio
 async def test_enabled_serving_entity_ids_updated_no_op_deploy(
     app_container,
@@ -935,10 +934,6 @@ async def test_enabled_serving_entity_ids_updated_no_op_deploy(
     """
     Test enabled_serving_entity_ids is updated even for a no-op deployment request (when all the
     underlying features are already online enabled)
-
-    TODO: This is a less common case but still need to be handled. This will likely cause conflict
-     with the on-going deployment flow stabilization work. For now, adding this test case which
-     should be re-enabled later.
     """
     feature_tables = await get_all_feature_tables(document_service)
     assert set(feature_tables.keys()) == {


### PR DESCRIPTION
## Description

Follow up of https://github.com/featurebyte/featurebyte/pull/2149: re-enabling a test case after fixing the handling.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
