### PR TITLE
[DEV-3056] Make tile cache aware of tile id version

### DIFF
--- a/featurebyte/models/tile.py
+++ b/featurebyte/models/tile.py
@@ -74,9 +74,7 @@ class TileSpec(FeatureByteBaseModel):
     @root_validator(pre=True)
     @classmethod
     def _default_entity_tracker_table_name(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Fill in default entity_tracker_table_name if not provided. For tests.
-        """
+        # Fill in default entity_tracker_table_name if not provided. For tests.
         if values.get("entity_tracker_table_name") is None:
             values["entity_tracker_table_name"] = (
                 values.get("aggregation_id", "") + InternalName.TILE_ENTITY_TRACKER_SUFFIX

--- a/featurebyte/models/tile.py
+++ b/featurebyte/models/tile.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 from bson import ObjectId
 from pydantic import Field, root_validator, validator
 
-from featurebyte.enum import StrEnum
+from featurebyte.enum import InternalName, StrEnum
 from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
 
 
@@ -62,6 +62,7 @@ class TileSpec(FeatureByteBaseModel):
     parent_column_name: Optional[str]
     category_column_name: Optional[str]
     feature_store_id: Optional[ObjectId]
+    entity_tracker_table_name: str
 
     class Config:
         """
@@ -69,6 +70,18 @@ class TileSpec(FeatureByteBaseModel):
         """
 
         arbitrary_types_allowed: bool = True
+
+    @root_validator(pre=True)
+    @classmethod
+    def _default_entity_tracker_table_name(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Fill in default entity_tracker_table_name if not provided. For tests.
+        """
+        if values.get("entity_tracker_table_name") is None:
+            values["entity_tracker_table_name"] = (
+                values.get("aggregation_id", "") + InternalName.TILE_ENTITY_TRACKER_SUFFIX
+            )
+        return values
 
     @validator("tile_id")
     @classmethod

--- a/featurebyte/query_graph/node/generic.py
+++ b/featurebyte/query_graph/node/generic.py
@@ -688,7 +688,7 @@ class GroupByNodeParameters(BaseGroupbyParameters):
     names: List[OutColumnStr]
     tile_id: Optional[str]
     aggregation_id: Optional[str]
-    tile_id_version: Optional[int] = Field(default=1)
+    tile_id_version: int = Field(default=1)
 
 
 class GroupByNode(AggregationOpStructMixin, BaseNode):

--- a/featurebyte/query_graph/sql/interpreter/tile.py
+++ b/featurebyte/query_graph/sql/interpreter/tile.py
@@ -49,6 +49,7 @@ class TileGenSql:
 
     # pylint: disable=too-many-instance-attributes
     tile_table_id: str
+    tile_id_version: int
     aggregation_id: str
     sql_template: SqlExpressionTemplate
     columns: list[str]
@@ -195,6 +196,7 @@ class TileSQLGenerator:
         sql_template = SqlExpressionTemplate(sql_expr=sql, source_type=self.source_type)
         info = TileGenSql(
             tile_table_id=tile_table_id,
+            tile_id_version=groupby_node.parameters.tile_id_version,
             aggregation_id=aggregation_id,
             sql_template=sql_template,
             columns=groupby_sql_node.columns,

--- a/featurebyte/service/tile_manager.py
+++ b/featurebyte/service/tile_manager.py
@@ -222,7 +222,7 @@ class TileManagerService:
 
         tile_entity_tracking_ins = TileGenerateEntityTracking(
             session=session,
-            tile_id=tile_spec.aggregation_id,
+            entity_tracker_table_name=tile_spec.entity_tracker_table_name,
             entity_column_names=entity_column_names,
             entity_table=temp_entity_table,
         )

--- a/featurebyte/sql/tile_generate_entity_tracking.py
+++ b/featurebyte/sql/tile_generate_entity_tracking.py
@@ -18,7 +18,7 @@ class TileGenerateEntityTracking(BaseSqlModel):
     """
 
     entity_column_names: List[str]
-    tile_id: str
+    entity_tracker_table_name: str
     entity_table: str
 
     def __init__(self, session: BaseSession, **kwargs: Any):
@@ -39,7 +39,7 @@ class TileGenerateEntityTracking(BaseSqlModel):
         Execute tile generate entity tracking operation
         """
 
-        tracking_table_name = self.tile_id + "_ENTITY_TRACKER"
+        tracking_table_name = self.entity_tracker_table_name
         tracking_table_exist_flag = await self.table_exists(tracking_table_name)
         logger.debug(f"tracking_table_exist_flag: {tracking_table_exist_flag}")
 

--- a/featurebyte/tile/tile_cache.py
+++ b/featurebyte/tile/tile_cache.py
@@ -3,7 +3,7 @@ Module for TileCache and its implementors
 """
 from __future__ import annotations
 
-from typing import Any, Callable, Coroutine, Optional, Tuple, cast
+from typing import Any, Callable, Coroutine, Optional, cast
 
 import time
 from dataclasses import dataclass

--- a/featurebyte/tile/tile_cache.py
+++ b/featurebyte/tile/tile_cache.py
@@ -58,7 +58,7 @@ class TileInfoKey:
 
         Returns
         -------
-        TileInfoRefType
+        TileInfoKey
         """
         return cls(
             aggregation_id=tile_info.aggregation_id, tile_id_version=tile_info.tile_id_version
@@ -338,7 +338,7 @@ class TileCache:
 
         Returns
         -------
-        dict[TileInfoRefType, TileGenSql]
+        dict[TileInfoKey, TileGenSql]
         """
         out = {}
         interpreter = GraphInterpreter(graph, source_type=self.source_type)
@@ -420,9 +420,9 @@ class TileCache:
         ----------
         unique_tile_infos : dict[str, TileGenSql]
             Mapping from tile id to TileGenSql
-        keys_with_tracker : list[TileInfoRefType]
+        keys_with_tracker : list[TileInfoKey]
             List of tile ids with existing tracker tables
-        keys_no_tracker : list[TileInfoRefType]
+        keys_no_tracker : list[TileInfoKey]
             List of tile ids without existing tracker table
         request_id : str
             Request ID
@@ -482,9 +482,9 @@ class TileCache:
         ----------
         request_id : str
             Request ID
-        keys : list[TileInfoRefType]
+        keys : list[TileInfoKey]
             List of aggregation ids
-        unique_tile_infos : dict[TileInfoRefType, TileGenSql]
+        unique_tile_infos : dict[TileInfoKey, TileGenSql]
             Mapping from tile id to TileGenSql
 
         Returns

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -1370,18 +1370,13 @@ def test_non_float_tile_value_added_to_tile_table(event_view, source_type):
     """
     Test case to ensure non-float tile value can be added to an existing tile table without issues
     """
-    # Make the aggregation_id unique in this test case. Otherwise, the tile cache would have been
-    # calculated using the tile id version 2, causing a tile table not found error. This is a test
-    # specific issue due to the patch and doesn't happen in actual workflow.
-    filtered_event_view = event_view[event_view["ÀMOUNT"] > 1.234]
-
-    feature_group_1 = filtered_event_view.groupby("ÜSER ID").aggregate_over(
+    feature_group_1 = event_view.groupby("ÜSER ID").aggregate_over(
         method="count",
         windows=["2h"],
         feature_names=["COUNT_2h"],
     )
     feature_list_1 = FeatureList([feature_group_1], name="feature_list_1")
-    feature_group_2 = filtered_event_view.groupby("ÜSER ID").aggregate_over(
+    feature_group_2 = event_view.groupby("ÜSER ID").aggregate_over(
         value_column="ËVENT_TIMESTAMP",
         method="latest",
         windows=["7d"],

--- a/tests/integration/tile/test_tile_cache.py
+++ b/tests/integration/tile/test_tile_cache.py
@@ -81,7 +81,7 @@ async def invoke_tile_manager_and_check_tracker_table(session, tile_cache, reque
     await tile_cache.invoke_tile_manager(requests)
 
     for request in requests:
-        tracker_table_name = f"{request.aggregation_id}_entity_tracker"
+        tracker_table_name = f"{request.aggregation_id}_v2_entity_tracker"
         df_entity_tracker = await session.execute_query(f"SELECT * FROM {tracker_table_name}")
 
         # The üser id column should be the primary key (unique) of the tracker table

--- a/tests/unit/query_graph/interpreter/test_interpreter.py
+++ b/tests/unit/query_graph/interpreter/test_interpreter.py
@@ -215,6 +215,7 @@ def test_graph_interpreter_tile_gen(query_graph_with_groupby, groupby_node_aggre
     info_dict.pop("sql_template")
     assert info_dict == {
         "tile_table_id": "TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725",
+        "tile_id_version": 1,
         "aggregation_id": f"avg_{groupby_node_aggregation_id}",
         "columns": [
             InternalName.TILE_START_DATE.value,
@@ -299,6 +300,7 @@ def test_graph_interpreter_on_demand_tile_gen(
     info_dict.pop("sql_template")
     assert info_dict == {
         "tile_table_id": "TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725",
+        "tile_id_version": 1,
         "aggregation_id": f"avg_{groupby_node_aggregation_id}",
         "columns": [
             InternalName.TILE_START_DATE.value,
@@ -375,6 +377,7 @@ def test_graph_interpreter_tile_gen_with_category(query_graph_with_category_grou
     info_dict.pop("sql_template")
     assert info_dict == {
         "tile_table_id": "TILE_F3600_M1800_B900_FEB86FDFF3B041DC98880F9B22EE9078FBCF5226",
+        "tile_id_version": 1,
         "aggregation_id": f"avg_{aggregation_id}",
         "columns": [
             InternalName.TILE_START_DATE.value,
@@ -415,6 +418,7 @@ def test_graph_interpreter_on_demand_tile_gen_two_groupby(
     info_dict.pop("sql_template")
     assert info_dict == {
         "tile_table_id": "TILE_F3600_M1800_B900_8502F6BC497F17F84385ABE4346FD392F2F56725",
+        "tile_id_version": 1,
         "aggregation_id": f"avg_{groupby_node_aggregation_id}",
         "columns": [
             "__FB_TILE_START_DATE_COLUMN",
@@ -486,6 +490,7 @@ def test_graph_interpreter_on_demand_tile_gen_two_groupby(
     info_dict.pop("sql_template")
     assert info_dict == {
         "tile_table_id": "TILE_F3600_M1800_B900_7BD30FF1B8E84ADD2B289714C473F1A21E9BC624",
+        "tile_id_version": 1,
         "aggregation_id": f"sum_{aggregation_id}",
         "columns": [
             "__FB_TILE_START_DATE_COLUMN",


### PR DESCRIPTION
## Description

Follow up on https://github.com/featurebyte/featurebyte/pull/2151: this updates tile cache logic to be aware of tile id version. This is needed since existing tile cache is invalid for new features using the new tile id version.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
