### PR TITLE
[DEV-3046] Move Feast registry protobuf from Mongo record to remote storage

### DIFF
--- a/featurebyte/app.py
+++ b/featurebyte/app.py
@@ -51,7 +51,7 @@ from featurebyte.schema import APIServiceStatus
 from featurebyte.schema.task import TaskId
 from featurebyte.utils.messaging import REDIS_URI
 from featurebyte.utils.persistent import MongoDBImpl
-from featurebyte.utils.storage import get_temp_storage
+from featurebyte.utils.storage import get_storage, get_temp_storage
 from featurebyte.worker import get_celery
 
 logger = get_logger(__name__)
@@ -74,6 +74,7 @@ def _dep_injection_func(
     request.state.app_container = LazyAppContainer(
         user=request.state.user,
         persistent=MongoDBImpl(),
+        storage=get_storage(),
         temp_storage=get_temp_storage(),
         celery=get_celery(),
         catalog_id=active_catalog_id,

--- a/featurebyte/feast/model/registry.py
+++ b/featurebyte/feast/model/registry.py
@@ -20,7 +20,7 @@ class FeastRegistryModel(FeatureByteCatalogBaseDocumentModel):
     """Feast registry model"""
 
     offline_table_name_prefix: str
-    registry: bytes = Field(default_factory=bytes)
+    registry: bytes = Field(default_factory=bytes, exclude=True)
     feature_store_id: PydanticObjectId
     registry_path: Optional[str] = Field(default=None)
 

--- a/featurebyte/feast/model/registry.py
+++ b/featurebyte/feast/model/registry.py
@@ -1,10 +1,13 @@
 """
 Feast registry model
 """
+from typing import Optional
+
 import pymongo
 
 # pylint: disable=no-name-in-module
 from feast.protos.feast.core.Registry_pb2 import Registry as RegistryProto
+from pydantic import Field
 
 from featurebyte.models.base import (
     FeatureByteCatalogBaseDocumentModel,
@@ -17,8 +20,9 @@ class FeastRegistryModel(FeatureByteCatalogBaseDocumentModel):
     """Feast registry model"""
 
     offline_table_name_prefix: str
-    registry: bytes
+    registry: bytes = Field(default_factory=bytes)
     feature_store_id: PydanticObjectId
+    registry_path: Optional[str] = Field(default=None)
 
     def registry_proto(self) -> RegistryProto:
         """

--- a/featurebyte/feast/schema/registry.py
+++ b/featurebyte/feast/schema/registry.py
@@ -24,5 +24,5 @@ class FeastRegistryUpdate(BaseDocumentServiceUpdateSchema):
     feature_lists: Optional[List[FeatureListModel]]
 
     # these fields are not expected to be updated directly
-    registry: Optional[bytes]
     feature_store_id: Optional[PydanticObjectId]
+    registry_path: Optional[str]

--- a/featurebyte/feast/service/registry.py
+++ b/featurebyte/feast/service/registry.py
@@ -295,7 +295,7 @@ class FeastRegistryService(
             query_filter=self._construct_get_query_filter(document_id=document.id),
             update={
                 "$set": {"registry_path": document.registry_path},
-                "$unset": {"registry": ""},
+                "$unset": {"registry": ""},  # remove registry field from older document
             },
             user_id=self.user.id,
             disable_audit=self.should_disable_audit,

--- a/featurebyte/feast/service/registry.py
+++ b/featurebyte/feast/service/registry.py
@@ -3,7 +3,7 @@ Feast registry service
 """
 from __future__ import annotations
 
-from typing import Any, List, Optional, cast
+from typing import Any, List, Optional
 
 import random
 from pathlib import Path

--- a/featurebyte/feast/service/registry.py
+++ b/featurebyte/feast/service/registry.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Any, List, Optional, cast
 
 import random
+from pathlib import Path
 
 from bson import ObjectId
 from redis import Redis
@@ -23,6 +24,7 @@ from featurebyte.service.entity_lookup_feature_table import EntityLookupFeatureT
 from featurebyte.service.feature import FeatureService
 from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.service.online_store import OnlineStoreService
+from featurebyte.storage import Storage
 
 
 class FeastRegistryService(
@@ -44,6 +46,7 @@ class FeastRegistryService(
         online_store_service: OnlineStoreService,
         catalog_service: CatalogService,
         entity_lookup_feature_table_service: EntityLookupFeatureTableService,
+        storage: Storage,
         redis: Redis[Any],
     ):
         super().__init__(
@@ -59,6 +62,7 @@ class FeastRegistryService(
         self.online_store_service = online_store_service
         self.catalog_service = catalog_service
         self.entity_lookup_feature_table_service = entity_lookup_feature_table_service
+        self.storage = storage
 
     async def _create_project_name(
         self, catalog_id: ObjectId, hex_digit_num: int = 7, max_try: int = 100
@@ -131,7 +135,8 @@ class FeastRegistryService(
 
         query_result = await self.list_documents_as_dict(query_filter=query_filter, page_size=1)
         if query_result["total"]:
-            return FeastRegistryModel(**query_result["data"][0])
+            registry = await self._populate_registry(FeastRegistryModel(**query_result["data"][0]))
+            return registry
 
         registry = await self.create_document(data=FeastRegistryCreate(feature_lists=[]))
         return registry
@@ -141,6 +146,7 @@ class FeastRegistryService(
         project_name: Optional[str],
         offline_table_name_prefix: Optional[str],
         feature_lists: List[FeatureListModel],
+        document_id: Optional[ObjectId] = None,
     ) -> FeastRegistryModel:
         feature_ids = set()
         for feature_list in feature_lists:
@@ -203,11 +209,24 @@ class FeastRegistryService(
             entity_lookup_steps_mapping=entity_lookup_steps_mapping,
         )
         return FeastRegistryModel(
+            _id=document_id,
             name=project_name,
             offline_table_name_prefix=offline_table_name_prefix,
             registry=feast_registry_proto.SerializeToString(),
             feature_store_id=feature_store_id,
         )
+
+    async def _populate_registry(self, document: FeastRegistryModel) -> FeastRegistryModel:
+        if document.registry_path and not document.registry:
+            document.registry = await self.storage.get_bytes(Path(document.registry_path))
+        return document
+
+    async def _move_registry_to_storage(self, document: FeastRegistryModel) -> FeastRegistryModel:
+        feast_registry_path = Path(f"feast_registry/{document.id}/feast_registry.pb")
+        await self.storage.put_bytes(document.registry, feast_registry_path)
+        document.registry_path = str(feast_registry_path)
+        document.registry = b""
+        return document
 
     async def create_document(self, data: FeastRegistryCreate) -> FeastRegistryModel:
         """
@@ -226,7 +245,23 @@ class FeastRegistryService(
         document = await self._construct_feast_registry_model(
             project_name=None, offline_table_name_prefix=None, feature_lists=data.feature_lists
         )
+        document = await self._move_registry_to_storage(document)
         return await super().create_document(data=document)  # type: ignore
+
+    async def get_document(
+        self,
+        document_id: ObjectId,
+        exception_detail: str | None = None,
+        use_raw_query_filter: bool = False,
+        **kwargs: Any,
+    ) -> FeastRegistryModel:
+        document = await super().get_document(
+            document_id=document_id,
+            exception_detail=exception_detail,
+            use_raw_query_filter=use_raw_query_filter,
+            **kwargs,
+        )
+        return await self._populate_registry(document)
 
     async def update_document(
         self,
@@ -237,7 +272,6 @@ class FeastRegistryService(
         return_document: bool = True,
         skip_block_modification_check: bool = False,
     ) -> Optional[FeastRegistryModel]:
-        assert data.registry is None, "Registry will be generated automatically from feature lists"
         assert data.feature_store_id is None, "Not allowed to update feature store ID directly"
         if data.feature_lists is None:
             return await self.get_document(document_id=document_id)
@@ -247,13 +281,20 @@ class FeastRegistryService(
             project_name=original_doc.name,
             offline_table_name_prefix=original_doc.offline_table_name_prefix,
             feature_lists=data.feature_lists,
+            document_id=document_id,
         )
+        assert recreated_model.id == document_id
+
+        if original_doc.registry_path:
+            await self.storage.delete(Path(original_doc.registry_path))
+        await self._move_registry_to_storage(recreated_model)
+
         updated = await super().update_document(
             document_id=document_id,
             data=FeastRegistryUpdate(
-                registry=recreated_model.registry,
                 feature_store_id=recreated_model.feature_store_id,
                 feature_lists=None,
+                registry_path=recreated_model.registry_path,
             ),
             exclude_none=exclude_none,
             document=document,
@@ -273,5 +314,5 @@ class FeastRegistryService(
         async for feast_registry_model in self.list_documents_iterator(
             query_filter={"catalog_id": self.catalog_id}
         ):
-            return feast_registry_model
+            return await self._populate_registry(feast_registry_model)
         return None

--- a/featurebyte/service/deploy.py
+++ b/featurebyte/service/deploy.py
@@ -720,11 +720,11 @@ class DeployService:
                 features.append(updated_feature)
                 await feature_update_progress(
                     int(len(features) / len(feature_list.feature_ids) * 100),
-                    "Disabling features online...",
+                    f"Disabling features online ({feature.name}) ...",
                 )
 
             # undeploy feature list if not used in other deployment
-            await self._update_progress(71, "Undeploying feature list...")
+            await self._update_progress(71, f"Undeploying feature list ({feature_list.name}) ...")
             await self.feature_list_management_service.undeploy_feature_list(
                 feature_list=feature_list, deployment_id=deployment.id
             )

--- a/featurebyte/storage/base.py
+++ b/featurebyte/storage/base.py
@@ -157,6 +157,42 @@ class Storage(ABC):
                 text = await file_obj.read()
             return text
 
+    async def put_bytes(self, content: bytes, remote_path: Path) -> None:
+        """
+        Upload bytes content to storage as bytes file
+
+        Parameters
+        ----------
+        content: bytes
+            Bytes value to be stored
+        remote_path: Path
+            Path of remote file to upload to
+        """
+        async with aiofiles.tempfile.NamedTemporaryFile(mode="w+b") as file_obj:
+            await file_obj.write(content)
+            await file_obj.flush()
+            await self.put(Path(str(file_obj.name)), remote_path)
+
+    async def get_bytes(self, remote_path: Path) -> bytes:
+        """
+        Download bytes content from storage bytes file
+
+        Parameters
+        ----------
+        remote_path: Path
+            Path of remote file to be downloaded
+
+        Returns
+        -------
+        bytes
+            Bytes data
+        """
+        async with aiofiles.tempfile.NamedTemporaryFile(mode="r+b") as tmp_file:
+            await self.get(remote_path, Path(str(tmp_file.name)))
+            async with aiofiles.open(tmp_file.name, mode="r+b") as file_obj:
+                content = await file_obj.read()
+            return content
+
     async def put_dataframe(self, dataframe: DataFrame, remote_path: Path) -> None:
         """
         Upload dataframe to storage as parquet file

--- a/tests/integration/feature_store_integration/test_update_online_store.py
+++ b/tests/integration/feature_store_integration/test_update_online_store.py
@@ -29,6 +29,15 @@ def always_enable_feast_integration_fixture():
         yield
 
 
+@pytest.fixture(name="always_patch_app_get_storage", scope="module", autouse=True)
+def always_patch_app_get_storage_fixture(storage):
+    """
+    Patch app.get_storage for all tests in this module
+    """
+    with patch("featurebyte.app.get_storage", return_value=storage):
+        yield
+
+
 @pytest_asyncio.fixture(name="catalog_online_store_disabled", scope="module")
 def catalog_online_store_disabled_fixture(catalog):
     """

--- a/tests/unit/feast/model/test_registry.py
+++ b/tests/unit/feast/model/test_registry.py
@@ -9,15 +9,17 @@ from featurebyte.feast.model.registry import FeastRegistryModel
 def test_feast_registry_model(feast_registry_proto):
     """Test feast registry model"""
     feature_store_id = ObjectId()
+    registry_bytes = feast_registry_proto.SerializeToString()
     feast_registry = FeastRegistryModel(
         name="feast_registry",
         offline_table_name_prefix="cat1",
-        registry=feast_registry_proto.SerializeToString(),
+        registry=registry_bytes,
         feature_store_id=feature_store_id,
     )
     feast_registry_dict = feast_registry.dict()
+    assert "registry" not in feast_registry_dict
 
-    deserialize_feast_registry = FeastRegistryModel(**feast_registry_dict)
+    deserialize_feast_registry = FeastRegistryModel(**feast_registry_dict, registry=registry_bytes)
     assert deserialize_feast_registry.name == "feast_registry"
     assert deserialize_feast_registry.registry_proto() == feast_registry_proto
     assert deserialize_feast_registry.feature_store_id == feature_store_id

--- a/tests/unit/service/test_feast_registry.py
+++ b/tests/unit/service/test_feast_registry.py
@@ -60,7 +60,7 @@ async def registry_with_path_fixture(
     mock_offline_store_feature_manager_dependencies,
 ):
     """Fixture for registry without path"""
-    _ = mock_update_data_warehouse
+    _ = mock_update_data_warehouse, mock_offline_store_feature_manager_dependencies
 
     await deploy_service.update_deployment(deployment_id=deployment_id, to_enable_deployment=True)
 

--- a/tests/unit/service/test_feast_registry.py
+++ b/tests/unit/service/test_feast_registry.py
@@ -1,0 +1,164 @@
+"""Test feast registry service"""
+import pytest
+import pytest_asyncio
+from bson import ObjectId
+
+from featurebyte.feast.schema.registry import FeastRegistryUpdate
+
+
+@pytest.fixture(autouse=True)
+def enable_feast_integration(enable_feast_integration):
+    """Enable feast integration"""
+    _ = enable_feast_integration
+    yield
+
+
+@pytest.fixture(name="registry_service")
+def registry_service_fixture(app_container):
+    """Fixture for registry service"""
+    return app_container.feast_registry_service
+
+
+@pytest.fixture(name="deploy_service")
+def deploy_service_fixture(app_container):
+    """Fixture for deploy service"""
+    return app_container.deploy_service
+
+
+@pytest.fixture(name="storage")
+def storage_fixture(app_container):
+    """Fixture for storage"""
+    return app_container.storage
+
+
+@pytest_asyncio.fixture(name="deployment_id")
+async def deployment_id_fixture(app_container, feature_list):
+    """Fixture for test deployment"""
+    feature_readiness_service = app_container.feature_readiness_service
+    for feature_id in feature_list.feature_ids:
+        await feature_readiness_service.update_feature(
+            feature_id=feature_id, readiness="PRODUCTION_READY"
+        )
+
+    deploy_service = app_container.deploy_service
+    deployment_id = ObjectId()
+    await deploy_service.create_deployment(
+        feature_list_id=feature_list.id,
+        deployment_id=deployment_id,
+        deployment_name="test_deployment",
+        to_enable_deployment=False,
+    )
+    return deployment_id
+
+
+@pytest_asyncio.fixture(name="registry_with_path")
+async def registry_with_path_fixture(
+    deploy_service,
+    registry_service,
+    deployment_id,
+    mock_update_data_warehouse,
+    mock_offline_store_feature_manager_dependencies,
+):
+    """Fixture for registry without path"""
+    _ = mock_update_data_warehouse
+
+    await deploy_service.update_deployment(deployment_id=deployment_id, to_enable_deployment=True)
+
+    registry = await registry_service.get_feast_registry_for_catalog()
+    registry_doc = await registry_service.get_document_as_dict(document_id=registry.id)
+    assert registry_doc["registry_path"]
+    assert "registry" not in registry_doc
+    return registry
+
+
+@pytest_asyncio.fixture(name="registry_without_path")
+async def registry_without_path_fixture(
+    registry_with_path,
+    registry_service,
+    persistent,
+    user_id,
+):
+    """Fixture for registry without path"""
+    registry_id = ObjectId()
+    registry_doc = registry_with_path.dict(by_alias=True)
+    registry_doc["_id"] = registry_id
+    registry_doc["registry_path"] = None
+    registry_doc["registry"] = registry_with_path.registry
+    await persistent.insert_one(
+        collection_name="feast_registry", document=registry_doc, user_id=user_id
+    )
+
+    registry = await registry_service.get_document(document_id=registry_id)
+    assert registry.registry_path is None
+    return registry
+
+
+@pytest.mark.asyncio
+async def test_get_document__registry_without_path(registry_without_path, registry_service):
+    """Test get document"""
+    registry = await registry_service.get_document(document_id=registry_without_path.id)
+    assert registry == registry_without_path
+    assert registry.registry_path is None
+    assert registry.registry
+
+
+@pytest.mark.asyncio
+async def test_get_document__registry_with_path(registry_with_path, registry_service, storage):
+    """Test get document"""
+    registry = await registry_service.get_document(document_id=registry_with_path.id)
+    assert registry == registry_with_path
+    assert registry.registry_path
+    assert registry.registry
+
+    # check that registry is stored in storage
+    registry_bytes = await storage.get_bytes(registry.registry_path)
+    assert registry.registry == registry_bytes
+
+
+@pytest.mark.asyncio
+async def test_update_document__registry_without_path(
+    registry_without_path, registry_service, storage, feature_list
+):
+    """Test update document on older record (registry without path)"""
+    registry = await registry_service.update_document(
+        document_id=registry_without_path.id,
+        data=FeastRegistryUpdate(feature_lists=[feature_list]),
+    )
+    assert registry.registry_path
+    assert registry.registry
+
+    # get original registry document & check that it has been updated
+    registry_doc = await registry_service.get_document_as_dict(document_id=registry.id)
+    assert "registry" not in registry_doc
+    assert registry_doc["registry_path"]
+
+    # check the registry is stored in storage
+    registry_bytes = await storage.get_bytes(registry_doc["registry_path"])
+    assert registry.registry == registry_bytes
+
+
+@pytest.mark.asyncio
+async def test_update_document__registry_with_path(
+    registry_with_path, registry_service, storage, feature_list
+):
+    """Test update document on older record (registry with path)"""
+    registry = await registry_service.update_document(
+        document_id=registry_with_path.id,
+        data=FeastRegistryUpdate(feature_lists=[feature_list]),
+    )
+    assert registry.registry
+    assert registry.name == registry_with_path.name
+    assert registry.registry_path == registry_with_path.registry_path
+    assert registry.offline_table_name_prefix == registry_with_path.offline_table_name_prefix
+
+    # check get_feast_registry_for_catalog returns the updated registry
+    retrieved_registry = await registry_service.get_feast_registry_for_catalog()
+    assert retrieved_registry == registry
+
+    # get original registry document
+    registry_doc = await registry_service.get_document_as_dict(document_id=registry.id)
+    assert "registry" not in registry_doc
+
+    # check underlying storage
+    registry_bytes = await storage.get_bytes(registry.registry_path)
+    assert registry.registry == registry_bytes

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -24,6 +24,7 @@ from tests.util.helper import (
     deploy_feature_list,
     get_relationship_info,
     undeploy_feature,
+    undeploy_feature_async,
 )
 
 
@@ -471,7 +472,7 @@ async def test_feature_table_undeploy(
     Test feature table creation and update when two features are deployed
     """
     # Simulate online enabling two features then online disable one
-    undeploy_feature(deployed_float_feature)
+    await undeploy_feature_async(deployed_float_feature, app_container)
 
     feature_tables = await get_all_feature_tables(document_service)
     assert set(feature_tables.keys()) == {
@@ -529,7 +530,7 @@ async def test_feature_table_undeploy(
     assert args[1] == ["sum_1d_V231227"]
 
     # Check online disabling the last feature deletes the feature table
-    undeploy_feature(deployed_float_feature_post_processed)
+    await undeploy_feature_async(deployed_float_feature_post_processed, app_container)
     feature_tables = await get_all_feature_tables(document_service)
     assert len(feature_tables) == 0
     assert not await has_scheduled_task(periodic_task_service, feature_table)

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -23,7 +23,6 @@ from tests.util.helper import (
     deploy_feature,
     deploy_feature_list,
     get_relationship_info,
-    undeploy_feature,
     undeploy_feature_async,
 )
 

--- a/tests/util/helper.py
+++ b/tests/util/helper.py
@@ -844,11 +844,22 @@ async def deploy_feature(
 
 
 def undeploy_feature(feature):
-    """
-    Helper function to undeploy a single feature
-    """
+    """Helper function to undeploy a single feature"""
     deployment: Deployment = Deployment.get(f"{feature.name}_list")
     deployment.disable()  # pylint: disable=no-member
+
+
+async def undeploy_feature_async(feature, app_container):
+    """
+    Helper function to undeploy a feature. This version can control storage used through the
+    app_container parameter.
+    """
+    async for deployment in app_container.deployment_service.list_documents_iterator(
+        query_filter={"name": f"{feature.name}_list"}
+    ):
+        await app_container.deploy_service.update_deployment(
+            deployment_id=deployment.id, to_enable_deployment=False
+        )
 
 
 def tz_localize_if_needed(df, source_type):


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
Due to the 16MB Mongo record limitation, this PR move Feast registry protobuf from Mongo record to remote storage.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
