### PR TITLE
[DEV-3070] Support auto generated featurebyte profile from databricks secrets

### DIFF
--- a/.changelog/DEV-3070.yaml
+++ b/.changelog/DEV-3070.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: profile
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Create a profile from databricks secrets to simplify access from a Databricks workspace."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/__init__.py
+++ b/featurebyte/__init__.py
@@ -130,20 +130,22 @@ def get_active_profile() -> Profile:
     # check if we are in DataBricks environment and valid secrets are present create a profile automatically
     db_utils = globals().get("dbutils")
     if db_utils:
-        databricks_auto_profile_name = "databricks-auto-profile"
-        if conf.default_profile_name != databricks_auto_profile_name:
+        if len(conf.profiles) == 1 and conf.profiles[0].name == "local":
+            api_url = None
+            api_token = None
             try:
                 api_url = db_utils.secrets.get(scope="featurebyte", key="api-url")
                 api_token = db_utils.secrets.get(scope="featurebyte", key="api-token")
-                register_profile(
-                    profile_name=databricks_auto_profile_name,
-                    api_url=api_url,
-                    api_token=api_token,
-                    make_default=True,
-                )
             except Exception:  # pylint: disable=broad-except
                 logger.info(
                     "Add the secrets (featurebyte.api-url, featurebyte.api-token) for auto profile creation."
+                )
+            if api_url and api_token:
+                register_profile(
+                    profile_name="databricks-auto-profile",
+                    api_url=api_url,
+                    api_token=api_token,
+                    make_default=True,
                 )
 
     if not conf.profile:

--- a/featurebyte/__init__.py
+++ b/featurebyte/__init__.py
@@ -145,7 +145,6 @@ def get_active_profile() -> Profile:
                 logger.info(
                     "Add the secrets (featurebyte.api-url, featurebyte.api-token) for auto profile creation."
                 )
-                pass
 
     if not conf.profile:
         logger.error(

--- a/featurebyte/config.py
+++ b/featurebyte/config.py
@@ -351,6 +351,7 @@ class Configurations:
                 else get_home_path().joinpath("config.yaml")
             )
             self.storage: LocalStorageSettings = LocalStorageSettings()
+            self.default_profile_name: Optional[str] = None
             self._profile: Optional[Profile] = None
             self.profiles: List[Profile] = []
             self.logging: LoggingSettings = LoggingSettings()
@@ -435,8 +436,9 @@ class Configurations:
 
             # Set default _profile if specified
             profile_map = {profile.name: profile for profile in self.profiles}
-            default_profile = settings.pop("default_profile", None)
-            self._profile = profile_map.get(default_profile)
+            self.default_profile_name = settings.pop("default_profile", None)
+            if self.default_profile_name:
+                self._profile = profile_map.get(self.default_profile_name)
 
     @classmethod
     def check_sdk_versions(cls) -> Dict[str, str]:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -119,6 +119,7 @@ def test_register_profile(noop_check_sdk_versions, noop_log_env_summary, config)
             api_url="https://tutorials.featurebyte.com/api/v1",
             api_token="test",
         )
+        assert config.default_profile_name == "local"
 
         # Re-register with different details
         fb.register_profile(
@@ -129,16 +130,19 @@ def test_register_profile(noop_check_sdk_versions, noop_log_env_summary, config)
             profile_name="test2",
             api_url="https://test.featurebyte.com/api/v1",
         )
+        assert config.default_profile_name == "local"
 
         # Update existing profile with different details
         fb.register_profile(
             profile_name="test2",
             api_url="https://test2.featurebyte.com/api/v1",
+            make_default=True,
         )
         _assert_profile_with_details(
             profile_name="test2",
             api_url="https://test2.featurebyte.com/api/v1",
         )
+        assert config.default_profile_name == "test2"
 
     finally:
         # Reset back to original profile


### PR DESCRIPTION
## Description

Automatically generate a profile from registered secrets in DataBricks workspaces to simplify access.

Registering the following secrets in DataBricks to use the featurebyte library without creating a profile
```
databricks secrets put-secret featurebyte api-url --string-value [api-url]
databricks secrets put-secret featurebyte api-token --string-value  [api-token]
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
