### PR TITLE
[chore] Fix columns ordering in historical feature tables

### DIFF
--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -566,7 +566,7 @@ class FeatureTableCacheService:
         ] = None,
     ) -> None:
         """
-        Create create or update cache table and create a new view which refers to the cached table
+        Create or update cache table and create a new view which refers to the cached table
 
         Parameters
         ----------

--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -3,8 +3,6 @@ Module for managing physical feature table cache as well as metadata storage.
 """
 from typing import Any, Callable, Coroutine, Dict, List, Optional, Tuple, cast
 
-from collections import defaultdict
-
 import pandas as pd
 from bson import ObjectId
 from sqlglot import expressions

--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -246,12 +246,12 @@ class FeatureTableCacheService:
                 progress_callback=progress_callback,
             )
 
-            request_column_names = sorted({col.name for col in observation_table.columns_info})
+            request_column_names = [col.name for col in observation_table.columns_info]
             request_columns = [quoted_identifier(col) for col in request_column_names]
             feature_names = [
                 expressions.alias_(
                     quoted_identifier(cast(str, graph.get_node_output_column_name(node.name))),
-                    alias=quoted_identifier(cast(str, feature_definition.feature_name)),
+                    alias=feature_definition.feature_name,
                     quoted=True,
                 )
                 for node, feature_definition in nodes
@@ -615,7 +615,7 @@ class FeatureTableCacheService:
             feature_store=feature_store
         )
 
-        request_column_names = sorted({col.name for col in observation_table.columns_info})
+        request_column_names = [col.name for col in observation_table.columns_info]
         request_columns = [quoted_identifier(col) for col in request_column_names]
         columns_expr = self._get_column_expr(graph, hashes, cast(Dict[str, str], cached_features))
         select_expr = (

--- a/tests/integration/service/test_feature_table_cache.py
+++ b/tests/integration/service/test_feature_table_cache.py
@@ -14,9 +14,14 @@ from featurebyte.query_graph.sql.common import sql_to_string
 
 
 @pytest.fixture(name="feature_list")
-def feature_list_fixture(feature_group, feature_group_per_category):
+def feature_list_fixture(event_view, feature_group, feature_group_per_category):
     """Feature List fixture"""
     feature_group["COUNT_2h / COUNT_24h"] = feature_group["COUNT_2h"] / feature_group["COUNT_24h"]
+    count_2h_duplicate = event_view.groupby("ÜSER ID").aggregate_over(
+        method="count",
+        windows=["2h"],
+        feature_names=["COUNT_2h_DUPLICATE"],
+    )["COUNT_2h_DUPLICATE"]
     feature_list = FeatureList(
         [
             feature_group["COUNT_2h"],
@@ -27,6 +32,7 @@ def feature_list_fixture(feature_group, feature_group_per_category):
             feature_group_per_category["MOST_FREQUENT_ACTION_24h"],
             feature_group_per_category["NUM_UNIQUE_ACTION_24h"],
             feature_group_per_category["ACTION_SIMILARITY_2h_to_24h"],
+            count_2h_duplicate,
         ],
         name="My Feature List for Materialization",
     )
@@ -117,9 +123,12 @@ async def test_create_feature_table_cache(
             observation_table_id=observation_table.id,
         )
     )
-    features = [definition.feature_name for definition in feature_table_cache.feature_definitions]
+    cached_column_names = [
+        definition.feature_name for definition in feature_table_cache.feature_definitions
+    ]
     hashes = [definition.definition_hash for definition in feature_table_cache.feature_definitions]
-    assert len(features) == len(feature_list_model.feature_ids)
+    # Subtract 1 because one of the features is a duplicate and has the same hash
+    assert len(cached_column_names) == len(feature_list_model.feature_ids) - 1
 
     feature_hashes = []
     async for document in feature_service.list_documents_iterator(
@@ -141,7 +150,7 @@ async def test_create_feature_table_cache(
     assert df.shape[0] == 50
     observation_table_cols = list({col.name for col in observation_table_model.columns_info})
     assert set(df.columns.tolist()) == set(
-        [InternalName.TABLE_ROW_INDEX] + observation_table_cols + features
+        [InternalName.TABLE_ROW_INDEX] + observation_table_cols + cached_column_names
     )
 
 
@@ -317,7 +326,7 @@ async def test_create_view_from_cache(
             source_type=source_type,
         )
         df = await session.execute_query(query)
-        assert len(feature_list.feature_names) == 8
+        assert len(feature_list.feature_names) == 9
         assert df.shape == (50, len(set(feature_list.feature_names + observation_table_cols)) + 1)
         assert df.columns.tolist() == (
             [InternalName.TABLE_ROW_INDEX] + observation_table_cols + feature_list.feature_names

--- a/tests/integration/service/test_feature_table_cache.py
+++ b/tests/integration/service/test_feature_table_cache.py
@@ -3,7 +3,6 @@ Integration test for feature table cache
 """
 import time
 
-import pandas as pd
 import pytest
 from bson import ObjectId
 from sqlglot import parse_one
@@ -12,7 +11,6 @@ from featurebyte import FeatureList
 from featurebyte.enum import InternalName
 from featurebyte.query_graph.node.schema import TableDetails
 from featurebyte.query_graph.sql.common import sql_to_string
-from tests.util.helper import create_observation_table_from_dataframe
 
 
 @pytest.fixture(name="feature_list")

--- a/tests/integration/service/test_feature_table_cache.py
+++ b/tests/integration/service/test_feature_table_cache.py
@@ -270,7 +270,7 @@ async def test_create_view_from_cache(
     try:
         feature_cluster = feature_list_model.feature_clusters[0]
         nodes = feature_cluster.nodes[:5]
-        observation_table_cols = list({col.name for col in observation_table_model.columns_info})
+        observation_table_cols = [col.name for col in observation_table_model.columns_info]
         feature_names = [
             feature_cluster.graph.get_node_output_column_name(node.name) for node in nodes
         ]
@@ -294,8 +294,8 @@ async def test_create_view_from_cache(
         )
         df = await session.execute_query(query)
         assert df.shape == (50, len(set(feature_names + observation_table_cols)) + 1)
-        assert set(df.columns.tolist()) == set(
-            [InternalName.TABLE_ROW_INDEX] + feature_names + observation_table_cols
+        assert df.columns.tolist() == (
+            [InternalName.TABLE_ROW_INDEX] + observation_table_cols + feature_names
         )
 
         # update cache table with second feature list
@@ -319,8 +319,8 @@ async def test_create_view_from_cache(
         df = await session.execute_query(query)
         assert len(feature_list.feature_names) == 8
         assert df.shape == (50, len(set(feature_list.feature_names + observation_table_cols)) + 1)
-        assert set(df.columns.tolist()) == set(
-            [InternalName.TABLE_ROW_INDEX] + feature_list.feature_names + observation_table_cols
+        assert df.columns.tolist() == (
+            [InternalName.TABLE_ROW_INDEX] + observation_table_cols + feature_list.feature_names
         )
     finally:
         await session.drop_table(

--- a/tests/unit/service/test_feature_table_cache.py
+++ b/tests/unit/service/test_feature_table_cache.py
@@ -148,6 +148,11 @@ def feature_list_fixture(request):
     return request.getfixturevalue(request.param)
 
 
+@pytest.fixture(name="feature_list_with_duplicates")
+def feature_list_with_duplicates_fixture():
+    """Feature list with duplicate definition hashes"""
+
+
 @pytest.mark.asyncio
 async def test_create_feature_table_cache(
     feature_store,

--- a/tests/unit/service/test_feature_table_cache.py
+++ b/tests/unit/service/test_feature_table_cache.py
@@ -191,8 +191,8 @@ async def test_create_feature_table_cache(
         f'"sf_db"."sf_schema"."{feature_table_cache.table_name}" AS\n'
         "SELECT\n"
         '  "__FB_TABLE_ROW_INDEX",\n'
-        '  "POINT_IN_TIME",\n'
         '  "cust_id",\n'
+        '  "POINT_IN_TIME",\n'
         '  "sum_30m" AS "FEATURE_1032f6901100176e575f87c44398a81f0d5db5c5",\n'
         '  "sum_2h" AS "FEATURE_ada88371db4be31a4e9c0538fb675d8e573aed24"\n'
         'FROM "__TEMP__FEATURE_TABLE_CACHE_ObjectId"'
@@ -239,8 +239,8 @@ async def test_update_feature_table_cache(
         f'"sf_db"."sf_schema"."{feature_table_cache.table_name}" AS\n'
         "SELECT\n"
         '  "__FB_TABLE_ROW_INDEX",\n'
-        '  "POINT_IN_TIME",\n'
         '  "cust_id",\n'
+        '  "POINT_IN_TIME",\n'
         '  "sum_30m" AS "FEATURE_1032f6901100176e575f87c44398a81f0d5db5c5"\n'
         'FROM "__TEMP__FEATURE_TABLE_CACHE_ObjectId"'
     )
@@ -416,8 +416,8 @@ async def test_create_view_from_cache__create_cache(
         f'"sf_db"."sf_schema"."{feature_table_cache.table_name}" AS\n'
         "SELECT\n"
         '  "__FB_TABLE_ROW_INDEX",\n'
-        '  "POINT_IN_TIME",\n'
         '  "cust_id",\n'
+        '  "POINT_IN_TIME",\n'
         '  "sum_30m" AS "FEATURE_1032f6901100176e575f87c44398a81f0d5db5c5",\n'
         '  "sum_2h" AS "FEATURE_ada88371db4be31a4e9c0538fb675d8e573aed24"\n'
         'FROM "__TEMP__FEATURE_TABLE_CACHE_ObjectId"'
@@ -426,8 +426,8 @@ async def test_create_view_from_cache__create_cache(
         'CREATE VIEW "sf_db"."sf_schema"."result_view" AS\n'
         "SELECT\n"
         '  "__FB_TABLE_ROW_INDEX",\n'
-        '  "POINT_IN_TIME",\n'
         '  "cust_id",\n'
+        '  "POINT_IN_TIME",\n'
         '  "FEATURE_1032f6901100176e575f87c44398a81f0d5db5c5" AS "sum_30m",\n'
         '  "FEATURE_ada88371db4be31a4e9c0538fb675d8e573aed24" AS "sum_2h"\n'
         f'FROM "sf_db"."sf_schema"."{feature_table_cache.table_name}"'
@@ -508,8 +508,8 @@ async def test_create_view_from_cache__update_cache(
         'CREATE VIEW "sf_db"."sf_schema"."result_view" AS\n'
         "SELECT\n"
         '  "__FB_TABLE_ROW_INDEX",\n'
-        '  "POINT_IN_TIME",\n'
         '  "cust_id",\n'
+        '  "POINT_IN_TIME",\n'
         '  "FEATURE_1032f6901100176e575f87c44398a81f0d5db5c5" AS "sum_30m",\n'
         '  "FEATURE_ada88371db4be31a4e9c0538fb675d8e573aed24" AS "sum_2h"\n'
         f'FROM "sf_db"."sf_schema"."{feature_table_cache.table_name}"'
@@ -558,8 +558,8 @@ async def test_create_feature_table_cache__with_target(
         f'"sf_db"."sf_schema"."{feature_table_cache.table_name}" AS\n'
         "SELECT\n"
         '  "__FB_TABLE_ROW_INDEX",\n'
-        '  "POINT_IN_TIME",\n'
         '  "cust_id",\n'
+        '  "POINT_IN_TIME",\n'
         '  "float_target" AS "FEATURE_dfbe0388b776a0bd4e78b6e538889b9b9eea7bb1"\n'
         'FROM "__TEMP__FEATURE_TABLE_CACHE_ObjectId"'
     )


### PR DESCRIPTION
## Description

This fixes the following issues when creating historical feature tables from cache:

1. Columns ordering in historical feature tables to follow original columns ordering of the observation table
2. Incorrect output when there are duplicated definition hashes

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
