### PR TITLE
[DEV-3071] Fix incorrect parent entity serving validation error

### DIFF
--- a/featurebyte/exception.py
+++ b/featurebyte/exception.py
@@ -173,13 +173,6 @@ class EntityJoinPathNotFoundError(FeatureByteException):
     """
 
 
-class AmbiguousEntityRelationshipError(FeatureByteException):
-    """
-    Raised when the relationship between entities is ambiguous and automatic serving of parent
-    features is not possible
-    """
-
-
 class InvalidSettingsError(FeatureByteException):
     """
     Raised when configuration has invalid settings

--- a/featurebyte/service/entity_validation.py
+++ b/featurebyte/service/entity_validation.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from typing import Optional
 
 from featurebyte.exception import (
-    AmbiguousEntityRelationshipError,
     EntityJoinPathNotFoundError,
     RequiredEntityNotProvidedError,
     UnexpectedServingNamesMappingError,
@@ -159,7 +158,7 @@ class EntityValidationService:
             join_steps = await self.parent_entity_lookup_service.get_required_join_steps(
                 entity_info
             )
-        except (EntityJoinPathNotFoundError, AmbiguousEntityRelationshipError):
+        except EntityJoinPathNotFoundError:
             raise RequiredEntityNotProvidedError(  # pylint: disable=raise-missing-from
                 entity_info.format_missing_entities_error(
                     [entity.id for entity in entity_info.missing_entities]

--- a/featurebyte/service/parent_serving.py
+++ b/featurebyte/service/parent_serving.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 
 from bson import ObjectId
 
-from featurebyte.exception import AmbiguousEntityRelationshipError, EntityJoinPathNotFoundError
+from featurebyte.exception import EntityJoinPathNotFoundError
 from featurebyte.models.entity import EntityModel
 from featurebyte.models.entity_validation import EntityInfo
 from featurebyte.models.parent_serving import JoinStep
@@ -151,36 +151,22 @@ class ParentEntityLookupService:
         ------
         EntityJoinPathNotFoundError
             If a join path cannot be identified
-        AmbiguousEntityRelationshipError
-            If no unique join path can be identified due to ambiguous relationships
         """
         pending: List[Tuple[EntityModel, List[EntityModel]]] = [(required_entity, [])]
         queued = set()
-        result = None
 
         while pending:
             (current_entity, current_path), pending = pending[0], pending[1:]
             updated_path = [current_entity] + current_path
 
-            if current_entity.id in available_entity_ids and result is None:
-                # Do not exit early, continue to see if there are multiple join paths (can be
-                # detected when an entity is queued more than once)
-                result = updated_path
+            if current_entity.id in available_entity_ids:
+                return updated_path
 
             children_entities = await self.entity_service.get_children_entities(current_entity.id)
             for child_entity in children_entities:
                 if child_entity.name not in queued:
                     queued.add(child_entity.name)
                     pending.append((child_entity, updated_path))
-                else:
-                    # There should be only one way to obtain the parent entity. Raise an error
-                    # otherwise.
-                    raise AmbiguousEntityRelationshipError(
-                        f"Cannot find an unambiguous join path for entity {required_entity.name}"
-                    )
-
-        if result is not None:
-            return result
 
         raise EntityJoinPathNotFoundError(
             f"Cannot find a join path for entity {required_entity.name}"

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -19,7 +19,6 @@ from featurebyte import Catalog
 from featurebyte.enum import SemanticType, SourceType
 from featurebyte.models.base import DEFAULT_CATALOG_ID
 from featurebyte.models.entity import ParentEntity
-from featurebyte.models.entity_validation import EntityInfo
 from featurebyte.models.online_store import OnlineStoreModel, RedisOnlineStoreDetails
 from featurebyte.routes.block_modification_handler import BlockModificationHandler
 from featurebyte.routes.lazy_app_container import LazyAppContainer
@@ -959,40 +958,6 @@ async def d_is_parent_of_c_fixture(
     )
 
 
-@pytest_asyncio.fixture(name="e_is_parent_of_c_and_d")
-async def e_is_parent_of_c_and_d_fixture(
-    entity_c,
-    entity_d,
-    entity_e,
-    entity_service,
-    event_table_service,
-    test_dir,
-    feature_store,
-):
-    """
-    Fixture to make E a parent of C and D
-    """
-    _ = feature_store
-    await create_table_and_add_parent(
-        test_dir,
-        event_table_service,
-        entity_service,
-        child_entity=entity_c,
-        parent_entity=entity_e,
-        child_column="c",
-        parent_column="e",
-    )
-    await create_table_and_add_parent(
-        test_dir,
-        event_table_service,
-        entity_service,
-        child_entity=entity_d,
-        parent_entity=entity_e,
-        child_column="d",
-        parent_column="e",
-    )
-
-
 @pytest_asyncio.fixture(name="a_is_parent_of_c_and_d")
 async def a_is_parent_of_c_and_d_fixture(
     entity_a,
@@ -1025,33 +990,6 @@ async def a_is_parent_of_c_and_d_fixture(
         child_column="d",
         parent_column="a",
     )
-
-
-@pytest.fixture
-def entity_info_with_ambiguous_relationships(
-    entity_a,
-    entity_e,
-    b_is_parent_of_a,
-    c_is_parent_of_b,
-    d_is_parent_of_b,
-    e_is_parent_of_c_and_d,
-) -> EntityInfo:
-    """
-    EntityInfo the arises from ambiguous relationships
-
-    a (provided) --> b --> c ---> e (required)
-                      `--> d --´
-    """
-    _ = b_is_parent_of_a
-    _ = c_is_parent_of_b
-    _ = d_is_parent_of_b
-    _ = e_is_parent_of_c_and_d
-    entity_info = EntityInfo(
-        required_entities=[entity_e],
-        provided_entities=[entity_a],
-        serving_names_mapping={"A": "new_A"},
-    )
-    return entity_info
 
 
 @pytest.fixture

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -993,6 +993,40 @@ async def e_is_parent_of_c_and_d_fixture(
     )
 
 
+@pytest_asyncio.fixture(name="a_is_parent_of_c_and_d")
+async def a_is_parent_of_c_and_d_fixture(
+    entity_a,
+    entity_c,
+    entity_d,
+    entity_service,
+    event_table_service,
+    test_dir,
+    feature_store,
+):
+    """
+    Fixture to make A a parent of C and D
+    """
+    _ = feature_store
+    await create_table_and_add_parent(
+        test_dir,
+        event_table_service,
+        entity_service,
+        child_entity=entity_c,
+        parent_entity=entity_a,
+        child_column="c",
+        parent_column="a",
+    )
+    await create_table_and_add_parent(
+        test_dir,
+        event_table_service,
+        entity_service,
+        child_entity=entity_d,
+        parent_entity=entity_a,
+        child_column="d",
+        parent_column="a",
+    )
+
+
 @pytest.fixture
 def entity_info_with_ambiguous_relationships(
     entity_a,

--- a/tests/unit/service/test_entity_validation.py
+++ b/tests/unit/service/test_entity_validation.py
@@ -1,8 +1,6 @@
 """
 Unit tests for EntityValidationService
 """
-from unittest.mock import Mock, patch
-
 import pytest
 
 from featurebyte.exception import RequiredEntityNotProvidedError, UnexpectedServingNamesMappingError
@@ -76,30 +74,3 @@ async def test_required_entity__serving_names_mapping_invalid(
             feature_store=feature_store,
         )
     assert str(exc.value) == "Unexpected serving names provided in serving_names_mapping: cust_idz"
-
-
-@pytest.mark.asyncio
-async def test_required_entity__ambiguous_relationships(
-    entity_info_with_ambiguous_relationships,
-    entity_validation_service,
-):
-    """
-    Test looking up parent entity when there are ambiguous relationships
-
-    a (provided) --> b --> c ---> e (required)
-                      `--> d --´
-    """
-    with patch(
-        "featurebyte.service.entity_validation.EntityValidationService.get_entity_info_from_request"
-    ) as p:
-        p.return_value = entity_info_with_ambiguous_relationships
-        with pytest.raises(RequiredEntityNotProvidedError) as exc_info:
-            await entity_validation_service.validate_entities_or_prepare_for_parent_serving(
-                Mock(name="graph"),
-                Mock(name="nodes"),
-                Mock(name="request_column_names"),
-                Mock(name="feature_store"),
-            )
-        assert str(exc_info.value) == (
-            'Required entities are not provided in the request: entity_e (serving name: "E")'
-        )

--- a/tests/unit/service/test_parent_serving.py
+++ b/tests/unit/service/test_parent_serving.py
@@ -3,7 +3,7 @@ Unit tests for ParentEntityLookupService
 """
 import pytest
 
-from featurebyte.exception import AmbiguousEntityRelationshipError, EntityJoinPathNotFoundError
+from featurebyte.exception import EntityJoinPathNotFoundError
 from featurebyte.models.entity_validation import EntityInfo
 from featurebyte.models.parent_serving import JoinStep
 
@@ -203,24 +203,6 @@ async def test_get_join_steps__not_found_with_relationships(
 
 
 @pytest.mark.asyncio
-async def test_get_join_steps__ambiguous_relationships(
-    entity_info_with_ambiguous_relationships,
-    parent_entity_lookup_service,
-):
-    """
-    Test looking up parent entity when there are ambiguous relationships
-
-    a (provided) --> b --> c ---> e (required)
-                      `--> d --´
-    """
-    with pytest.raises(AmbiguousEntityRelationshipError) as exc_info:
-        await parent_entity_lookup_service.get_required_join_steps(
-            entity_info_with_ambiguous_relationships
-        )
-    assert str(exc_info.value) == "Cannot find an unambiguous join path for entity entity_e"
-
-
-@pytest.mark.asyncio
 async def test_get_join_steps__multiple_provided(
     entity_a,
     entity_b,
@@ -264,8 +246,6 @@ async def test_get_join_steps__multiple_provided(
 async def test_required_entity__complex_and_should_not_error(
     entity_a,
     entity_b,
-    entity_c,
-    entity_d,
     b_is_parent_of_a,
     d_is_parent_of_c,
     a_is_parent_of_c_and_d,

--- a/tests/unit/service/test_parent_serving.py
+++ b/tests/unit/service/test_parent_serving.py
@@ -258,3 +258,36 @@ async def test_get_join_steps__multiple_provided(
             child_serving_name="C",
         ),
     ]
+
+
+@pytest.mark.asyncio
+async def test_required_entity__complex_and_should_not_error(
+    entity_a,
+    entity_b,
+    entity_c,
+    entity_d,
+    b_is_parent_of_a,
+    d_is_parent_of_c,
+    a_is_parent_of_c_and_d,
+    parent_entity_lookup_service,
+):
+    """
+    Test a case where lookup parent entity should pass without error
+
+    c --> d --> a (provided) --> b (required)
+     `------>´
+    """
+    data_a_to_b = b_is_parent_of_a
+    _ = d_is_parent_of_c
+    _ = a_is_parent_of_c_and_d
+    entity_info = EntityInfo(required_entities=[entity_b], provided_entities=[entity_a])
+    join_steps = await parent_entity_lookup_service.get_required_join_steps(entity_info)
+    assert join_steps == [
+        JoinStep(
+            table=data_a_to_b.dict(by_alias=True),
+            parent_key="b",
+            parent_serving_name="B",
+            child_key="a",
+            child_serving_name="A",
+        ),
+    ]


### PR DESCRIPTION
## Description

Currently the validation logic for parent entity lookup can raise false alarms in some cases. To prevent that, simplifies the validation logic by removing the `AmbiguousEntityRelationshipError`. There isn't a situation where we want to rely on this behaviour, and we should aim to guard against such invalid relationships on entity tagging time rather than when serving features.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
