### PR TITLE
[chore] Improve entity validation and feature clusters handling

### DIFF
--- a/featurebyte/api/feature_list.py
+++ b/featurebyte/api/feature_list.py
@@ -1229,7 +1229,7 @@ class FeatureList(BaseFeatureGroup, DeletableApiObject, SavableApiObject, Featur
         ...   serving_names_mapping={"GROCERYCUSTOMERGUID": "CUSTOMERGUID"}
         ... )
         """
-        kwargs = {}
+        kwargs: dict[str, Any] = {}
         if self.saved:
             kwargs["feature_list_id"] = self.id
         else:

--- a/featurebyte/api/feature_list.py
+++ b/featurebyte/api/feature_list.py
@@ -1229,12 +1229,16 @@ class FeatureList(BaseFeatureGroup, DeletableApiObject, SavableApiObject, Featur
         ...   serving_names_mapping={"GROCERYCUSTOMERGUID": "CUSTOMERGUID"}
         ... )
         """
+        kwargs = {}
+        if self.saved:
+            kwargs["feature_list_id"] = self.id
+        else:
+            kwargs["feature_clusters"] = self._get_feature_clusters()
         featurelist_get_historical_features = FeatureListGetHistoricalFeatures(
-            feature_list_id=self.id,
-            feature_clusters=self._get_feature_clusters(),
             serving_names_mapping=serving_names_mapping,
+            **kwargs,
         )
-        feature_store_id = featurelist_get_historical_features.feature_clusters[0].feature_store_id  # type: ignore[index]
+        feature_store_id = self._features[0].tabular_source.feature_store_id
         feature_table_create_params = HistoricalFeatureTableCreate(
             name=historical_feature_table_name,
             observation_table_id=(

--- a/featurebyte/models/historical_feature_table.py
+++ b/featurebyte/models/historical_feature_table.py
@@ -3,6 +3,8 @@ HistoricalFeatureTableModel
 """
 from __future__ import annotations
 
+from typing import Optional
+
 import pymongo
 
 from featurebyte.models.base import PydanticObjectId
@@ -15,7 +17,9 @@ class HistoricalFeatureTableModel(BaseFeatureOrTargetTableModel):
     HistoricalFeatureTable is the result of asynchronous historical features requests
     """
 
-    feature_list_id: PydanticObjectId
+    # Id of the feature list used to compute the historical feature table. None if the feature list
+    # was not saved.
+    feature_list_id: Optional[PydanticObjectId]
 
     class Settings(MaterializedTableModel.Settings):
         """

--- a/featurebyte/routes/batch_feature_table/controller.py
+++ b/featurebyte/routes/batch_feature_table/controller.py
@@ -74,16 +74,11 @@ class BatchFeatureTableController(
         feature_list = await self.feature_list_service.get_document(
             document_id=deployment.feature_list_id
         )
-
-        # feature cluster group feature graph by feature store ID, only single feature store is supported
-        assert feature_list.feature_clusters is not None
-        feature_cluster = feature_list.feature_clusters[0]
         feature_store = await self.feature_store_service.get_document(
-            document_id=feature_cluster.feature_store_id
+            document_id=data.feature_store_id
         )
         await self.entity_validation_service.validate_entities_or_prepare_for_parent_serving(
-            graph=feature_cluster.graph,
-            nodes=feature_cluster.nodes,
+            feature_list_model=feature_list,
             request_column_names={col.name for col in batch_request_table.columns_info},
             feature_store=feature_store,
         )

--- a/featurebyte/routes/common/feature_or_target_table.py
+++ b/featurebyte/routes/common/feature_or_target_table.py
@@ -15,6 +15,7 @@ from fastapi import HTTPException, UploadFile
 
 from featurebyte.common.utils import dataframe_from_arrow_stream
 from featurebyte.models.base_feature_or_target_table import BaseFeatureOrTargetTableModel
+from featurebyte.models.feature_list import FeatureListModel
 from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.models.historical_feature_table import HistoricalFeatureTableModel
 from featurebyte.models.observation_table import ObservationTableModel
@@ -73,6 +74,7 @@ class ValidationParameters:
     graph: QueryGraph
     nodes: List[Node]
     feature_store: FeatureStoreModel
+    feature_list_model: Optional[FeatureListModel] = None
     serving_names_mapping: Optional[dict[str, str]] = None
 
 
@@ -203,8 +205,8 @@ class FeatureOrTargetTableController(
 
         validation_parameters = await self.get_validation_parameters(data)
         await self.entity_validation_service.validate_entities_or_prepare_for_parent_serving(
-            graph=validation_parameters.graph,
-            nodes=validation_parameters.nodes,
+            graph_nodes=(validation_parameters.graph, validation_parameters.nodes),
+            feature_list_model=validation_parameters.feature_list_model,
             request_column_names=request_column_names,
             feature_store=validation_parameters.feature_store,
             serving_names_mapping=validation_parameters.serving_names_mapping,

--- a/featurebyte/routes/historical_feature_table/controller.py
+++ b/featurebyte/routes/historical_feature_table/controller.py
@@ -27,6 +27,7 @@ from featurebyte.service.entity_validation import EntityValidationService
 from featurebyte.service.feature_list import FeatureListService
 from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.service.historical_feature_table import HistoricalFeatureTableService
+from featurebyte.service.historical_features import HistoricalFeaturesValidationParametersService
 from featurebyte.service.observation_table import ObservationTableService
 from featurebyte.service.preview import PreviewService
 
@@ -57,6 +58,7 @@ class HistoricalFeatureTableController(
         entity_validation_service: EntityValidationService,
         task_controller: TaskController,
         feature_list_service: FeatureListService,
+        historical_features_validation_parameters_service: HistoricalFeaturesValidationParametersService,
     ):
         super().__init__(
             service=historical_feature_table_service,
@@ -67,6 +69,9 @@ class HistoricalFeatureTableController(
         )
         self.feature_store_service = feature_store_service
         self.feature_list_service = feature_list_service
+        self.historical_features_validation_parameters_service = (
+            historical_features_validation_parameters_service
+        )
 
     async def get_payload(
         self,
@@ -80,26 +85,10 @@ class HistoricalFeatureTableController(
     async def get_validation_parameters(
         self, table_create: HistoricalFeatureTableCreate
     ) -> ValidationParameters:
-        # feature cluster group feature graph by feature store ID, only single feature store is supported
-
-        feature_clusters = table_create.featurelist_get_historical_features.feature_clusters
-        if not feature_clusters:
-            # feature_clusters has become optional, need to derive it from feature_list_id when it is not set
-            feature_clusters = await self.feature_list_service.get_feature_clusters(
-                table_create.featurelist_get_historical_features.feature_list_id  # type: ignore[arg-type]
+        return (
+            await self.historical_features_validation_parameters_service.get_validation_parameters(
+                table_create.featurelist_get_historical_features
             )
-
-        # length of feature_clusters will always be more than 0
-        assert len(feature_clusters) > 0
-        feature_cluster = feature_clusters[0]
-        feature_store = await self.feature_store_service.get_document(
-            document_id=feature_cluster.feature_store_id
-        )
-        return ValidationParameters(
-            graph=feature_cluster.graph,
-            nodes=feature_cluster.nodes,
-            feature_store=feature_store,
-            serving_names_mapping=table_create.featurelist_get_historical_features.serving_names_mapping,
         )
 
     async def get_additional_info_params(

--- a/featurebyte/routes/historical_feature_table/controller.py
+++ b/featurebyte/routes/historical_feature_table/controller.py
@@ -94,6 +94,8 @@ class HistoricalFeatureTableController(
     async def get_additional_info_params(
         self, document: HistoricalFeatureTableModel
     ) -> dict[str, Any]:
+        if document.feature_list_id is None:
+            return {}
         feature_list = await self.feature_list_service.get_document(
             document_id=document.feature_list_id
         )

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -104,6 +104,7 @@ from featurebyte.service.historical_feature_table import HistoricalFeatureTableS
 from featurebyte.service.historical_features import (
     HistoricalFeatureExecutor,
     HistoricalFeaturesService,
+    HistoricalFeaturesValidationParametersService,
 )
 from featurebyte.service.item_table import ItemTableService
 from featurebyte.service.namespace_handler import NamespaceHandler
@@ -273,6 +274,7 @@ app_container_config.register_class(HistoricalFeatureTableService)
 app_container_config.register_class(
     HistoricalFeaturesService, dependency_override={"query_executor": "historical_feature_executor"}
 )
+app_container_config.register_class(HistoricalFeaturesValidationParametersService)
 app_container_config.register_class(ItemTableController)
 app_container_config.register_class(ItemTableService)
 app_container_config.register_class(MongoBackedCredentialProvider)

--- a/featurebyte/schema/info.py
+++ b/featurebyte/schema/info.py
@@ -417,8 +417,8 @@ class HistoricalFeatureTableInfo(BaseFeatureOrTargetTableInfo):
     Schema for historical feature table info
     """
 
-    feature_list_name: str
-    feature_list_version: str
+    feature_list_name: Optional[str]
+    feature_list_version: Optional[str]
 
 
 class TargetTableInfo(BaseFeatureOrTargetTableInfo):

--- a/featurebyte/service/feature_list.py
+++ b/featurebyte/service/feature_list.py
@@ -18,7 +18,11 @@ from featurebyte.common.model_util import get_version
 from featurebyte.exception import DocumentError, DocumentInconsistencyError, DocumentNotFoundError
 from featurebyte.models.base import VersionIdentifier
 from featurebyte.models.feature import FeatureModel
-from featurebyte.models.feature_list import FeatureListModel, FeatureReadinessDistribution
+from featurebyte.models.feature_list import (
+    FeatureCluster,
+    FeatureListModel,
+    FeatureReadinessDistribution,
+)
 from featurebyte.models.feature_list_namespace import FeatureListNamespaceModel
 from featurebyte.models.persistent import QueryFilter
 from featurebyte.persistent import Persistent

--- a/featurebyte/service/feature_list.py
+++ b/featurebyte/service/feature_list.py
@@ -18,11 +18,7 @@ from featurebyte.common.model_util import get_version
 from featurebyte.exception import DocumentError, DocumentInconsistencyError, DocumentNotFoundError
 from featurebyte.models.base import VersionIdentifier
 from featurebyte.models.feature import FeatureModel
-from featurebyte.models.feature_list import (
-    FeatureCluster,
-    FeatureListModel,
-    FeatureReadinessDistribution,
-)
+from featurebyte.models.feature_list import FeatureListModel, FeatureReadinessDistribution
 from featurebyte.models.feature_list_namespace import FeatureListNamespaceModel
 from featurebyte.models.persistent import QueryFilter
 from featurebyte.persistent import Persistent
@@ -526,29 +522,6 @@ class FeatureListService(  # pylint: disable=too-many-instance-attributes
                 )
 
         return deleted_count
-
-    async def get_feature_clusters(self, feature_list_id: ObjectId) -> List[FeatureCluster]:
-        """
-        Get list of FeatureCluster from feature_list_id
-
-        Parameters
-        ----------
-        feature_list_id: ObjectId
-            input feature_list_id
-
-        Returns
-        -------
-        List[FeatureCluster]
-        """
-        feature_list = await self.get_document(document_id=feature_list_id)
-
-        features = []
-        async for feature in self.feature_service.list_documents_iterator(
-            query_filter={"_id": {"$in": feature_list.feature_ids}}
-        ):
-            features.append(feature)
-
-        return FeatureListModel.derive_feature_clusters(features)
 
     async def get_sample_entity_serving_names(  # pylint: disable=too-many-locals
         self, feature_list_id: ObjectId, count: int

--- a/featurebyte/service/feature_materialize.py
+++ b/featurebyte/service/feature_materialize.py
@@ -187,8 +187,8 @@ class FeatureMaterializeService:  # pylint: disable=too-many-instance-attributes
                 document_id=feature_table_model.feature_cluster.feature_store_id
             )
             parent_serving_preparation = await self.entity_validation_service.validate_entities_or_prepare_for_parent_serving(
-                graph=feature_table_model.feature_cluster.graph,
-                nodes=nodes,
+                graph_nodes=(feature_table_model.feature_cluster.graph, nodes),
+                feature_list_model=None,
                 request_column_names=set(feature_table_model.serving_names),
                 feature_store=feature_store,
             )

--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -180,8 +180,7 @@ class FeatureTableCacheService:
         nodes_only = [node for node, _ in nodes]
         parent_serving_preparation = (
             await self.entity_validation_service.validate_entities_or_prepare_for_parent_serving(
-                graph=graph,
-                nodes=nodes_only,
+                graph_nodes=(graph, nodes_only),
                 request_column_names=request_column_names,
                 feature_store=feature_store,
                 serving_names_mapping=serving_names_mapping,

--- a/featurebyte/service/online_serving.py
+++ b/featurebyte/service/online_serving.py
@@ -147,8 +147,7 @@ class OnlineServingService:  # pylint: disable=too-many-instance-attributes
 
         parent_serving_preparation = (
             await self.entity_validation_service.validate_entities_or_prepare_for_parent_serving(
-                graph=feature_cluster.graph,
-                nodes=feature_cluster.nodes,
+                feature_list_model=feature_list,
                 request_column_names=request_column_names,
                 feature_store=feature_store,
             )

--- a/featurebyte/service/target_helper/base_feature_or_target_computer.py
+++ b/featurebyte/service/target_helper/base_feature_or_target_computer.py
@@ -3,7 +3,7 @@ Base class for feature or target computer
 """
 from __future__ import annotations
 
-from typing import Any, Callable, Coroutine, Generic, List, Optional, TypeVar, Union
+from typing import Any, Callable, Coroutine, Generic, List, Optional, Tuple, TypeVar, Union
 
 from abc import abstractmethod
 from dataclasses import dataclass
@@ -169,8 +169,8 @@ class Computer(Generic[ComputeRequestT, ExecutorParamsT]):
 
         parent_serving_preparation = (
             await self.entity_validation_service.validate_entities_or_prepare_for_parent_serving(
-                graph=validation_parameters.graph,
-                nodes=validation_parameters.nodes,
+                graph_nodes=(validation_parameters.graph, validation_parameters.nodes),
+                feature_list_model=validation_parameters.feature_list_model,
                 request_column_names=request_column_names,
                 feature_store=validation_parameters.feature_store,
                 serving_names_mapping=validation_parameters.serving_names_mapping,

--- a/tests/unit/service/test_entity_validation.py
+++ b/tests/unit/service/test_entity_validation.py
@@ -6,18 +6,41 @@ import pytest
 from featurebyte.exception import RequiredEntityNotProvidedError, UnexpectedServingNamesMappingError
 
 
+@pytest.fixture(name="graph_nodes")
+def graph_nodes_fixture(production_ready_feature):
+    """
+    Fixture for a feature's graph and nodes
+    """
+    return {"graph_nodes": (production_ready_feature.graph, [production_ready_feature.node])}
+
+
+@pytest.fixture(name="feature_list_model")
+def feature_list_model_fixture(feature_list):
+    """
+    Fixture for a feature list model
+    """
+    return {"feature_list_model": feature_list}
+
+
+@pytest.fixture(name="graph_nodes_or_feature_list", params=["graph_nodes", "feature_list_model"])
+def graph_nodes_or_feature_list_fixture(request):
+    """
+    Fixture for graph_nodes or feature_list_model as input for
+    validate_entities_or_prepare_for_parent_serving
+    """
+    return request.getfixturevalue(request.param)
+
+
 @pytest.mark.asyncio
 async def test_required_entity__missing(
-    entity_validation_service, production_ready_feature, feature_store
+    entity_validation_service, graph_nodes_or_feature_list, feature_store
 ):
     """
     Test a required entity is missing
     """
     with pytest.raises(RequiredEntityNotProvidedError) as exc:
         await entity_validation_service.validate_entities_or_prepare_for_parent_serving(
-            graph_nodes=(production_ready_feature.graph, [production_ready_feature.node]),
-            request_column_names=["a"],
-            feature_store=feature_store,
+            request_column_names=["a"], feature_store=feature_store, **graph_nodes_or_feature_list
         )
     expected = (
         'Required entities are not provided in the request: customer (serving name: "cust_id")'
@@ -27,46 +50,44 @@ async def test_required_entity__missing(
 
 @pytest.mark.asyncio
 async def test_required_entity__no_error(
-    entity_validation_service, production_ready_feature, feature_store
+    entity_validation_service, graph_nodes_or_feature_list, feature_store
 ):
     """
     Test required entity is provided
     """
     await entity_validation_service.validate_entities_or_prepare_for_parent_serving(
-        graph_nodes=(production_ready_feature.graph, [production_ready_feature.node]),
-        request_column_names=["cust_id"],
-        feature_store=feature_store,
+        request_column_names=["cust_id"], feature_store=feature_store, **graph_nodes_or_feature_list
     )
 
 
 @pytest.mark.asyncio
 async def test_required_entity__serving_names_mapping(
-    entity_validation_service, production_ready_feature, feature_store
+    entity_validation_service, graph_nodes_or_feature_list, feature_store
 ):
     """
     Test validating with serving names mapping
     """
     # ok if the provided name matches the overrides in serving_names_mapping
     await entity_validation_service.validate_entities_or_prepare_for_parent_serving(
-        graph_nodes=(production_ready_feature.graph, [production_ready_feature.node]),
         request_column_names=["new_cust_id"],
         serving_names_mapping={"cust_id": "new_cust_id"},
         feature_store=feature_store,
+        **graph_nodes_or_feature_list,
     )
 
 
 @pytest.mark.asyncio
 async def test_required_entity__serving_names_mapping_invalid(
-    entity_validation_service, production_ready_feature, feature_store
+    entity_validation_service, graph_nodes_or_feature_list, feature_store
 ):
     """
     Test validating with serving names mapping that is invalid
     """
     with pytest.raises(UnexpectedServingNamesMappingError) as exc:
         await entity_validation_service.validate_entities_or_prepare_for_parent_serving(
-            graph_nodes=(production_ready_feature.graph, [production_ready_feature.node]),
             request_column_names=["new_cust_id"],
             serving_names_mapping={"cust_idz": "new_cust_id"},
             feature_store=feature_store,
+            **graph_nodes_or_feature_list,
         )
     assert str(exc.value) == "Unexpected serving names provided in serving_names_mapping: cust_idz"

--- a/tests/unit/service/test_entity_validation.py
+++ b/tests/unit/service/test_entity_validation.py
@@ -15,8 +15,7 @@ async def test_required_entity__missing(
     """
     with pytest.raises(RequiredEntityNotProvidedError) as exc:
         await entity_validation_service.validate_entities_or_prepare_for_parent_serving(
-            graph=production_ready_feature.graph,
-            nodes=[production_ready_feature.node],
+            graph_nodes=(production_ready_feature.graph, [production_ready_feature.node]),
             request_column_names=["a"],
             feature_store=feature_store,
         )
@@ -34,8 +33,7 @@ async def test_required_entity__no_error(
     Test required entity is provided
     """
     await entity_validation_service.validate_entities_or_prepare_for_parent_serving(
-        graph=production_ready_feature.graph,
-        nodes=[production_ready_feature.node],
+        graph_nodes=(production_ready_feature.graph, [production_ready_feature.node]),
         request_column_names=["cust_id"],
         feature_store=feature_store,
     )
@@ -50,8 +48,7 @@ async def test_required_entity__serving_names_mapping(
     """
     # ok if the provided name matches the overrides in serving_names_mapping
     await entity_validation_service.validate_entities_or_prepare_for_parent_serving(
-        graph=production_ready_feature.graph,
-        nodes=[production_ready_feature.node],
+        graph_nodes=(production_ready_feature.graph, [production_ready_feature.node]),
         request_column_names=["new_cust_id"],
         serving_names_mapping={"cust_id": "new_cust_id"},
         feature_store=feature_store,
@@ -67,8 +64,7 @@ async def test_required_entity__serving_names_mapping_invalid(
     """
     with pytest.raises(UnexpectedServingNamesMappingError) as exc:
         await entity_validation_service.validate_entities_or_prepare_for_parent_serving(
-            graph=production_ready_feature.graph,
-            nodes=[production_ready_feature.node],
+            graph_nodes=(production_ready_feature.graph, [production_ready_feature.node]),
             request_column_names=["new_cust_id"],
             serving_names_mapping={"cust_idz": "new_cust_id"},
             feature_store=feature_store,


### PR DESCRIPTION
## Description

This attempts to improve the efficiency of entity validation and feature clusters handling:

1. In entity validation, provide a fast path to retrieve required entities through a FeatureListModel rather than always from the graph which is more CPU expensive (graph processing).
2. For saved feature lists, avoid calling `derive_feature_clusters()` to re-generate feature clusters since it is already available. Deriving feature clusters from scratch is expensive.

Testing using feature list with about 300 features, timing of `POST /historical_feature_table` before: 14s, after: 0.3s.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
