### PR TITLE
[chore] Refactor ParentEntityLookupService to use EntityRelationshipInfo 

### DIFF
--- a/featurebyte/exception.py
+++ b/featurebyte/exception.py
@@ -166,13 +166,6 @@ class UnexpectedServingNamesMappingError(BaseUnprocessableEntityError):
     """
 
 
-class EntityJoinPathNotFoundError(FeatureByteException):
-    """
-    Raised when it is not possible to identify a join path to an entity using the provided entities
-    as children entities
-    """
-
-
 class InvalidSettingsError(FeatureByteException):
     """
     Raised when configuration has invalid settings

--- a/featurebyte/feast/utils/registry_construction.py
+++ b/featurebyte/feast/utils/registry_construction.py
@@ -35,10 +35,7 @@ from featurebyte.feast.model.online_store import get_feast_online_store_details
 from featurebyte.feast.utils.on_demand_view import OnDemandFeatureViewConstructor
 from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
 from featurebyte.models.entity import EntityModel
-from featurebyte.models.entity_lookup_feature_table import (
-    EntityLookupStep,
-    get_entity_lookup_feature_tables,
-)
+from featurebyte.models.entity_lookup_feature_table import get_entity_lookup_feature_tables
 from featurebyte.models.feature import FeatureModel
 from featurebyte.models.feature_list import FeatureListModel
 from featurebyte.models.feature_store import FeatureStoreModel
@@ -48,6 +45,7 @@ from featurebyte.models.offline_store_ingest_query import (
     get_time_aggregate_ttl_in_secs,
 )
 from featurebyte.models.online_store import OnlineStoreModel
+from featurebyte.models.parent_serving import EntityLookupStep
 from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
 from featurebyte.query_graph.sql.entity import get_combined_serving_names
 

--- a/featurebyte/models/entity_lookup_feature_table.py
+++ b/featurebyte/models/entity_lookup_feature_table.py
@@ -10,8 +10,7 @@ from dataclasses import dataclass
 from bson import ObjectId
 
 from featurebyte.enum import DBVarType, TableDataType
-from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
-from featurebyte.models.entity import EntityModel
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.entity_universe import (
     EntityUniverseModel,
     EntityUniverseParams,
@@ -21,7 +20,7 @@ from featurebyte.models.event_table import EventTableModel
 from featurebyte.models.feature_list import FeatureCluster, FeatureListModel
 from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.models.offline_store_feature_table import OfflineStoreFeatureTableModel
-from featurebyte.models.proxy_table import ProxyTableModel
+from featurebyte.models.parent_serving import EntityLookupStep
 from featurebyte.models.scd_table import SCDTableModel
 from featurebyte.models.sqlglot_expression import SqlglotExpressionModel
 from featurebyte.query_graph.enum import NodeOutputType, NodeType
@@ -32,17 +31,6 @@ from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
 from featurebyte.query_graph.node import Node
 from featurebyte.query_graph.node.generic import SCDBaseParameters
 from featurebyte.query_graph.transform.decompose_point import FeatureJobSettingExtractor
-
-
-class EntityLookupStep(FeatureByteBaseModel):
-    """
-    EntityLookupStep class
-    """
-
-    id: PydanticObjectId
-    child_entity: EntityModel
-    parent_entity: EntityModel
-    relation_table: ProxyTableModel
 
 
 @dataclass

--- a/featurebyte/models/entity_lookup_feature_table.py
+++ b/featurebyte/models/entity_lookup_feature_table.py
@@ -155,17 +155,10 @@ def _get_entity_lookup_graph(
         input_nodes=[],
     )
 
-    child_column_name = None
-    parent_column_name = None
     feature_dtype = None
     for column_info in relation_table.columns_info:
-        if column_info.entity_id == lookup_step.child.entity_id:
-            child_column_name = column_info.name
-        elif column_info.entity_id == lookup_step.parent.entity_id:
-            parent_column_name = column_info.name
+        if column_info.entity_id == lookup_step.parent.entity_id:
             feature_dtype = column_info.dtype
-    assert child_column_name is not None
-    assert parent_column_name is not None
     assert feature_dtype is not None
 
     additional_params: Dict[str, Any]
@@ -192,9 +185,9 @@ def _get_entity_lookup_graph(
     lookup_node = graph.add_operation(
         node_type=NodeType.LOOKUP,
         node_params={
-            "input_column_names": [parent_column_name],
+            "input_column_names": [lookup_step.parent.key],
             "feature_names": [lookup_step.parent.serving_name],
-            "entity_column": child_column_name,
+            "entity_column": lookup_step.child.key,
             "serving_name": lookup_step.child.serving_name,
             "entity_id": lookup_step.child.entity_id,
             **additional_params,

--- a/featurebyte/models/parent_serving.py
+++ b/featurebyte/models/parent_serving.py
@@ -6,26 +6,25 @@ from __future__ import annotations
 from typing import List
 
 from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
-from featurebyte.models.entity import EntityModel
 from featurebyte.models.proxy_table import ProxyTableModel
 from featurebyte.query_graph.node.schema import FeatureStoreDetails
 
 
+class EntityLookupInfo(FeatureByteBaseModel):
+    """
+    Information about an entity such as keys, serving names, that are relevant in the context of an
+    EntityLookupStep
+    """
+
+    entity_id: PydanticObjectId
+    key: str
+    serving_name: str
+
+
 class EntityLookupStep(FeatureByteBaseModel):
     """
-    EntityLookupStep class
-    """
-
-    id: PydanticObjectId
-    child_entity: EntityModel
-    parent_entity: EntityModel
-    relation_table: ProxyTableModel
-
-
-class JoinStep(FeatureByteBaseModel):
-    """
-    JoinStep contains all information required to perform a join between two related entities for
-    the purpose of serving parent features
+    EntityLookupStep contains all information required to perform a join between two related
+    entities for the purpose of serving parent features
 
     table: ProxyTableModel
         The table encoding the relationship between the two entities
@@ -39,11 +38,10 @@ class JoinStep(FeatureByteBaseModel):
         Serving name of the child entity
     """
 
+    id: PydanticObjectId
     table: ProxyTableModel
-    parent_key: str
-    parent_serving_name: str
-    child_key: str
-    child_serving_name: str
+    parent: EntityLookupInfo
+    child: EntityLookupInfo
 
 
 class ParentServingPreparation(FeatureByteBaseModel):
@@ -56,5 +54,5 @@ class ParentServingPreparation(FeatureByteBaseModel):
         Feature store information
     """
 
-    join_steps: List[JoinStep]
+    join_steps: List[EntityLookupStep]
     feature_store_details: FeatureStoreDetails

--- a/featurebyte/models/parent_serving.py
+++ b/featurebyte/models/parent_serving.py
@@ -5,9 +5,21 @@ from __future__ import annotations
 
 from typing import List
 
-from featurebyte.models.base import FeatureByteBaseModel
+from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
+from featurebyte.models.entity import EntityModel
 from featurebyte.models.proxy_table import ProxyTableModel
 from featurebyte.query_graph.node.schema import FeatureStoreDetails
+
+
+class EntityLookupStep(FeatureByteBaseModel):
+    """
+    EntityLookupStep class
+    """
+
+    id: PydanticObjectId
+    child_entity: EntityModel
+    parent_entity: EntityModel
+    relation_table: ProxyTableModel
 
 
 class JoinStep(FeatureByteBaseModel):

--- a/featurebyte/models/parent_serving.py
+++ b/featurebyte/models/parent_serving.py
@@ -14,6 +14,14 @@ class EntityLookupInfo(FeatureByteBaseModel):
     """
     Information about an entity such as keys, serving names, that are relevant in the context of an
     EntityLookupStep
+
+    entity_id: PydanticObjectId
+        Entity id
+    key: str
+        Column name in the table that is tagged as the entity
+    serving_name: str
+        Serving name of the entity. Alternatively, this can be thought of as the input or output
+        column name of the parent entity lookup operation.
     """
 
     entity_id: PydanticObjectId
@@ -26,16 +34,14 @@ class EntityLookupStep(FeatureByteBaseModel):
     EntityLookupStep contains all information required to perform a join between two related
     entities for the purpose of serving parent features
 
+    id: PydanticObjectId
+        Identifier of the EntityRelationshipInfo corresponding to this lookup step
     table: ProxyTableModel
         The table encoding the relationship between the two entities
-    parent_key: str
-        Column name in the table that is tagged as the parent entity
-    parent_serving_name: str
-        Serving name of the parent entity
-    child_key: str
-        Column name in the table that is tagged as the child entity
-    child_serving_name: str
-        Serving name of the child entity
+    parent: EntityLookupInfo
+        Information about the parent entity
+    child: EntityLookupInfo
+        Information about the child entity
     """
 
     id: PydanticObjectId

--- a/featurebyte/query_graph/sql/parent_serving.py
+++ b/featurebyte/query_graph/sql/parent_serving.py
@@ -11,7 +11,7 @@ from sqlglot import expressions
 from sqlglot.expressions import Select, select
 
 from featurebyte.enum import SpecialColumnName, TableDataType
-from featurebyte.models.parent_serving import JoinStep
+from featurebyte.models.parent_serving import EntityLookupStep
 from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.query_graph.node.generic import EventLookupParameters, SCDLookupParameters
 from featurebyte.query_graph.node.schema import FeatureStoreDetails
@@ -46,7 +46,7 @@ class ParentEntityLookupResult:
 def construct_request_table_with_parent_entities(
     request_table_name: str,
     request_table_columns: list[str],
-    join_steps: list[JoinStep],
+    join_steps: list[EntityLookupStep],
     feature_store_details: FeatureStoreDetails,
 ) -> ParentEntityLookupResult:
     """
@@ -58,7 +58,7 @@ def construct_request_table_with_parent_entities(
         Request table name
     request_table_columns: list[str]
         Column names in the request table
-    join_steps: list[JoinStep]
+    join_steps: list[EntityLookupStep]
         The list of join steps to be applied. Each step joins a parent entity into the request
         table. Subsequent joins can use the newly joined columns as the join key.
     feature_store_details: FeatureStoreDetails
@@ -81,8 +81,8 @@ def construct_request_table_with_parent_entities(
             feature_store_details=feature_store_details,
             current_columns=current_columns,
         )
-        current_columns.append(join_step.parent_serving_name)
-        new_columns.append(join_step.parent_serving_name)
+        current_columns.append(join_step.parent.serving_name)
+        new_columns.append(join_step.parent.serving_name)
 
     return ParentEntityLookupResult(
         table_expr=table_expr,
@@ -94,7 +94,7 @@ def construct_request_table_with_parent_entities(
 
 def _apply_join_step(
     table_expr: Select,
-    join_step: JoinStep,
+    join_step: EntityLookupStep,
     feature_store_details: FeatureStoreDetails,
     current_columns: list[str],
 ) -> Select:
@@ -118,7 +118,7 @@ def _apply_join_step(
 
 
 def _get_lookup_spec_from_join_step(
-    join_step: JoinStep,
+    join_step: EntityLookupStep,
     feature_store_details: FeatureStoreDetails,
 ) -> LookupSpec:
     # Set up data specific parameters
@@ -152,10 +152,10 @@ def _get_lookup_spec_from_join_step(
     )
 
     return LookupSpec(
-        input_column_name=join_step.parent_key,
-        feature_name=join_step.parent_serving_name,
-        entity_column=join_step.child_key,
-        serving_names=[join_step.child_serving_name],
+        input_column_name=join_step.parent.key,
+        feature_name=join_step.parent.serving_name,
+        entity_column=join_step.child.key,
+        serving_names=[join_step.child.serving_name],
         aggregation_source=aggregation_source,
         scd_parameters=scd_parameters,
         event_parameters=event_parameters,

--- a/featurebyte/service/entity.py
+++ b/featurebyte/service/entity.py
@@ -69,23 +69,6 @@ class EntityService(BaseDocumentService[EntityModel, EntityCreate, EntityService
         )
         return [doc async for doc in docs]
 
-    async def get_children_entities(self, entity_id: ObjectId) -> list[EntityModel]:
-        """
-        Retrieve the children of an entity
-
-        Parameters
-        ----------
-        entity_id: ObjectId
-            Entity identifier
-
-        Returns
-        -------
-        list[EntityModel]
-        """
-        query_filter = {"parents": {"$elemMatch": {"id": ObjectId(entity_id)}}}
-        docs = self.list_documents_iterator(query_filter=query_filter)
-        return [doc async for doc in docs]
-
     async def get_entities(self, entity_ids: set[ObjectId]) -> list[EntityModel]:
         """
         Retrieve entities given a list of entity ids

--- a/featurebyte/service/entity_lookup_feature_table.py
+++ b/featurebyte/service/entity_lookup_feature_table.py
@@ -6,13 +6,11 @@ from __future__ import annotations
 from typing import Dict, List, Optional
 
 from featurebyte.models.base import PydanticObjectId
-from featurebyte.models.entity_lookup_feature_table import (
-    EntityLookupStep,
-    get_entity_lookup_feature_tables,
-)
+from featurebyte.models.entity_lookup_feature_table import get_entity_lookup_feature_tables
 from featurebyte.models.feature_list import FeatureListModel
 from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.models.offline_store_feature_table import OfflineStoreFeatureTableModel
+from featurebyte.models.parent_serving import EntityLookupStep
 from featurebyte.query_graph.model.entity_relationship_info import EntityRelationshipInfo
 from featurebyte.service.entity import EntityService
 from featurebyte.service.feature import FeatureService

--- a/featurebyte/service/entity_validation.py
+++ b/featurebyte/service/entity_validation.py
@@ -5,11 +5,7 @@ from __future__ import annotations
 
 from typing import Optional, Tuple
 
-from featurebyte.exception import (
-    EntityJoinPathNotFoundError,
-    RequiredEntityNotProvidedError,
-    UnexpectedServingNamesMappingError,
-)
+from featurebyte.exception import RequiredEntityNotProvidedError, UnexpectedServingNamesMappingError
 from featurebyte.models.entity_validation import EntityInfo
 from featurebyte.models.feature_list import FeatureListModel
 from featurebyte.models.feature_store import FeatureStoreModel
@@ -170,7 +166,7 @@ class EntityValidationService:
             join_steps = await self.parent_entity_lookup_service.get_required_join_steps(
                 entity_info
             )
-        except EntityJoinPathNotFoundError:
+        except RequiredEntityNotProvidedError:
             raise RequiredEntityNotProvidedError(  # pylint: disable=raise-missing-from
                 entity_info.format_missing_entities_error(
                     [entity.id for entity in entity_info.missing_entities]

--- a/featurebyte/service/parent_serving.py
+++ b/featurebyte/service/parent_serving.py
@@ -49,6 +49,8 @@ class ParentEntityLookupService:
         if entity_info.are_all_required_entities_provided():
             return []
 
+        # Use currently available relationships. Later to be updated to use frozen relationships
+        # stored in the feature list.
         relationships_info = []
         async for info in self.relationship_info_service.list_documents_iterator(
             query_filter={},

--- a/featurebyte/service/parent_serving.py
+++ b/featurebyte/service/parent_serving.py
@@ -3,17 +3,16 @@ Module to support serving parent features using child entities
 """
 from __future__ import annotations
 
-from typing import List, Tuple
+from typing import List
 
 from collections import OrderedDict
 
-from bson import ObjectId
-
-from featurebyte.exception import EntityJoinPathNotFoundError
-from featurebyte.models.entity import EntityModel
 from featurebyte.models.entity_validation import EntityInfo
 from featurebyte.models.parent_serving import JoinStep
+from featurebyte.query_graph.model.entity_lookup_plan import EntityLookupPlanner
+from featurebyte.query_graph.model.entity_relationship_info import EntityRelationshipInfo
 from featurebyte.service.entity import EntityService
+from featurebyte.service.relationship_info import RelationshipInfoService
 from featurebyte.service.table import TableService
 
 
@@ -27,9 +26,11 @@ class ParentEntityLookupService:
         self,
         entity_service: EntityService,
         table_service: TableService,
+        relationship_info_service: RelationshipInfoService,
     ):
         self.entity_service = entity_service
         self.table_service = table_service
+        self.relationship_info_service = relationship_info_service
 
     async def get_required_join_steps(self, entity_info: EntityInfo) -> list[JoinStep]:
         """
@@ -48,126 +49,88 @@ class ParentEntityLookupService:
         if entity_info.are_all_required_entities_provided():
             return []
 
+        relationships_info = []
+        async for info in self.relationship_info_service.list_documents_iterator(
+            query_filter={},
+        ):
+            relationships_info.append(EntityRelationshipInfo(**info.dict(by_alias=True)))
+
+        lookup_steps = EntityLookupPlanner.generate_lookup_steps(
+            available_entity_ids=list(entity_info.provided_entity_ids),
+            required_entity_ids=list(entity_info.required_entity_ids),
+            relationships_info=relationships_info,
+        )
+
         # all_join_steps is a mapping from parent serving name to JoinStep. Each parent serving name
         # should be looked up exactly once and then reused.
         all_join_steps: dict[str, JoinStep] = OrderedDict()
-        current_available_entities = entity_info.provided_entity_ids
 
-        for entity in entity_info.missing_entities:
-            join_path = await self._get_entity_join_path(entity, current_available_entities)
-
-            # Extract list of JoinStep
-            join_steps = await self._get_join_steps_from_join_path(entity_info, join_path)
-            for join_step in join_steps:
-                if join_step.parent_serving_name not in all_join_steps:
-                    all_join_steps[join_step.parent_serving_name] = join_step
-
-            # All the entities in the path are now available
-            current_available_entities.update([entity.id for entity in join_path])
+        for join_step in await self._get_join_steps(entity_info, lookup_steps):
+            if join_step.parent_serving_name not in all_join_steps:
+                all_join_steps[join_step.parent_serving_name] = join_step
 
         return list(all_join_steps.values())
 
-    async def _get_join_steps_from_join_path(
-        self, entity_info: EntityInfo, join_path: list[EntityModel]
+    async def _get_join_steps(
+        self,
+        entity_info: EntityInfo,
+        entity_relationships_info: List[EntityRelationshipInfo],
     ) -> list[JoinStep]:
         """
-        Convert a list of join path (list of EntityModel) into a list of JoinStep
+        Convert a list of join path (list of EntityRelationshipInfo) into a list of JoinStep
 
         Parameters
-        ----------
-        entity_info: EntityInfo
-            Entity information
-        join_path: list[EntityModel]
-            A list of related entities from a given entity to a target entity
+        ---------
+        entity_relationships_info: List[EntityRelationshipInfo]
+            List of EntityRelationshipInfo objects
 
         Returns
         -------
-        list[JoinStep]
+        Dict[PydanticObjectId, EntityLookupStep]
         """
+        # Retrieve all required models in batch
+        all_entity_ids = set()
+        all_table_ids = set()
+        for info in entity_relationships_info:
+            all_entity_ids.update([info.entity_id, info.related_entity_id])
+            all_table_ids.add(info.relation_table_id)
+
+        entities_by_id = {
+            entity.id: entity
+            async for entity in self.entity_service.list_documents_iterator(
+                query_filter={"_id": {"$in": list(all_entity_ids)}}
+            )
+        }
+        tables_by_id = {
+            table.id: table
+            async for table in self.table_service.list_documents_iterator(
+                query_filter={"_id": {"$in": list(all_table_ids)}}
+            )
+        }
 
         join_steps = []
+        for info in entity_relationships_info:
+            relation_table = tables_by_id[info.relation_table_id]
+            parent_entity = entities_by_id[info.related_entity_id]
+            child_entity = entities_by_id[info.entity_id]
 
-        # Retrieve all entities in batch
-        all_entities = await self.entity_service.get_entities({entity.id for entity in join_path})
-        entities_by_id = {entity.id: entity for entity in all_entities}
+            child_column_name = None
+            parent_column_name = None
+            for column_info in relation_table.columns_info:
+                if column_info.entity_id == child_entity.id:
+                    child_column_name = column_info.name
+                elif column_info.entity_id == parent_entity.id:
+                    parent_column_name = column_info.name
+            assert child_column_name is not None
+            assert parent_column_name is not None
 
-        for child_entity, parent_entity in zip(join_path, join_path[1:]):
-            child_entity_id = child_entity.id
-            parent_entity_id = parent_entity.id
-
-            # Retrieve the relationship for the table id defined in the relationship
-            parents = entities_by_id[child_entity_id].parents
-            relationship = next(parent for parent in parents if parent.id == parent_entity_id)
-
-            # Retrieve the join keys from the table
-            data = await self.table_service.get_document(relationship.table_id)
-            child_key, parent_key = None, None
-            for column_info in data.columns_info:
-                name = column_info.name
-                if column_info.entity_id == child_entity_id:
-                    child_key = name
-                if column_info.entity_id == parent_entity_id:
-                    parent_key = name
-
-            assert child_key is not None
-            assert parent_key is not None
-
-            # Converting table to dict by_alias to preserve the correct id when constructing JoinStep
             join_step = JoinStep(
-                table=data.dict(by_alias=True),
-                parent_key=parent_key,
+                table=relation_table.dict(by_alias=True),
+                parent_key=parent_column_name,
                 parent_serving_name=entity_info.get_effective_serving_name(parent_entity),
-                child_key=child_key,
+                child_key=child_column_name,
                 child_serving_name=entity_info.get_effective_serving_name(child_entity),
             )
             join_steps.append(join_step)
 
         return join_steps
-
-    async def _get_entity_join_path(
-        self,
-        required_entity: EntityModel,
-        available_entity_ids: set[ObjectId],
-    ) -> list[EntityModel]:
-        """
-        Get a join path given a required entity (missing but required for feature generation) and
-        a list of provided entities.
-
-        The result is a list of entities where each pair of adjacent entities are related to each
-        other. A child appears before its parent in this list.
-
-        Parameters
-        ----------
-        required_entity: EntityModel
-            Required entity
-        available_entity_ids: set[ObjectId]
-            List of currently available entities
-
-        Returns
-        -------
-        list[EntityModel]
-
-        Raises
-        ------
-        EntityJoinPathNotFoundError
-            If a join path cannot be identified
-        """
-        pending: List[Tuple[EntityModel, List[EntityModel]]] = [(required_entity, [])]
-        queued = set()
-
-        while pending:
-            (current_entity, current_path), pending = pending[0], pending[1:]
-            updated_path = [current_entity] + current_path
-
-            if current_entity.id in available_entity_ids:
-                return updated_path
-
-            children_entities = await self.entity_service.get_children_entities(current_entity.id)
-            for child_entity in children_entities:
-                if child_entity.name not in queued:
-                    queued.add(child_entity.name)
-                    pending.append((child_entity, updated_path))
-
-        raise EntityJoinPathNotFoundError(
-            f"Cannot find a join path for entity {required_entity.name}"
-        )

--- a/tests/unit/models/test_entity_universe.py
+++ b/tests/unit/models/test_entity_universe.py
@@ -5,6 +5,7 @@ import textwrap
 from datetime import datetime
 
 import pytest
+from bson import ObjectId
 
 from featurebyte import SourceType
 from featurebyte.models.entity_universe import (
@@ -13,7 +14,7 @@ from featurebyte.models.entity_universe import (
     get_combined_universe,
     get_entity_universe_constructor,
 )
-from featurebyte.models.parent_serving import JoinStep
+from featurebyte.models.parent_serving import EntityLookupInfo, EntityLookupStep
 from featurebyte.models.sqlglot_expression import SqlglotExpressionModel
 from featurebyte.query_graph.enum import NodeType
 
@@ -75,12 +76,19 @@ def join_steps(snowflake_scd_table_with_entity):
     Fixture for a join steps to be applied when constructing entity universe
     """
     return [
-        JoinStep(
+        EntityLookupStep(
+            id=ObjectId(),
             table=snowflake_scd_table_with_entity.cached_model,
-            parent_key="col_text",
-            parent_serving_name="cust_id",
-            child_key="cust_id_child",
-            child_serving_name="cust_id_child_serving_name",
+            parent=EntityLookupInfo(
+                key="col_text",
+                serving_name="cust_id",
+                entity_id=ObjectId(),
+            ),
+            child=EntityLookupInfo(
+                key="cust_id_child",
+                serving_name="cust_id_child_serving_name",
+                entity_id=ObjectId(),
+            ),
         )
     ]
 

--- a/tests/unit/query_graph/conftest.py
+++ b/tests/unit/query_graph/conftest.py
@@ -1452,11 +1452,18 @@ def parent_serving_preparation_fixture():
     parent_serving_preparation = ParentServingPreparation(
         join_steps=[
             {
+                "id": ObjectId(),
                 "table": data_model,
-                "parent_key": "col_int",
-                "parent_serving_name": "COL_INT",
-                "child_key": "col_text",
-                "child_serving_name": "COL_TEXT",
+                "parent": {
+                    "key": "col_int",
+                    "serving_name": "COL_INT",
+                    "entity_id": ObjectId(),
+                },
+                "child": {
+                    "key": "col_text",
+                    "serving_name": "COL_TEXT",
+                    "entity_id": ObjectId(),
+                },
             }
         ],
         feature_store_details=feature_store_details,

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -862,7 +862,7 @@ async def create_table_and_add_parent(
         event_table_service,
         [(child_column, child_entity.id), (parent_column, parent_entity.id)],
     )
-    await relationship_info_service.create_document(
+    relationship_info = await relationship_info_service.create_document(
         data=RelationshipInfoCreate(
             name=f"{child_entity.id}_{parent_entity.id}",
             relationship_type=RelationshipType.CHILD_PARENT,
@@ -872,7 +872,7 @@ async def create_table_and_add_parent(
             enabled=True,
         )
     )
-    return table
+    return table, relationship_info
 
 
 @pytest_asyncio.fixture(name="b_is_parent_of_a")

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -18,7 +18,6 @@ from bson.objectid import ObjectId
 from featurebyte import Catalog
 from featurebyte.enum import SemanticType, SourceType
 from featurebyte.models.base import DEFAULT_CATALOG_ID
-from featurebyte.models.entity import ParentEntity
 from featurebyte.models.online_store import OnlineStoreModel, RedisOnlineStoreDetails
 from featurebyte.models.relationship import RelationshipType
 from featurebyte.routes.block_modification_handler import BlockModificationHandler
@@ -27,7 +26,7 @@ from featurebyte.routes.registry import app_container_config
 from featurebyte.schema.catalog import CatalogCreate, CatalogOnlineStoreUpdate
 from featurebyte.schema.context import ContextCreate
 from featurebyte.schema.dimension_table import DimensionTableCreate
-from featurebyte.schema.entity import EntityCreate, EntityServiceUpdate
+from featurebyte.schema.entity import EntityCreate
 from featurebyte.schema.event_table import EventTableCreate, EventTableServiceUpdate
 from featurebyte.schema.feature import FeatureServiceCreate
 from featurebyte.schema.feature_list import FeatureListServiceCreate

--- a/tests/unit/service/test_entity.py
+++ b/tests/unit/service/test_entity.py
@@ -35,19 +35,3 @@ async def test_entity_service__get_entities(entity_a, entity_b, entity_service):
 
     entities = await entity_service.get_entities({ObjectId()})
     assert entities == []
-
-
-@pytest.mark.asyncio
-async def test_entity_service__get_children(
-    entity_a, entity_b, entity_c, entity_service, relationships
-):
-    """
-    Test get_children (should get immediate children only)
-    """
-    _ = relationships
-
-    children = await entity_service.get_children_entities(entity_b.id)
-    assert [child.id for child in children] == [entity_a.id]
-
-    children = await entity_service.get_children_entities(entity_c.id)
-    assert [child.id for child in children] == [entity_b.id]

--- a/tests/unit/service/test_parent_serving.py
+++ b/tests/unit/service/test_parent_serving.py
@@ -5,7 +5,7 @@ import pytest
 
 from featurebyte.exception import RequiredEntityNotProvidedError
 from featurebyte.models.entity_validation import EntityInfo
-from featurebyte.models.parent_serving import JoinStep
+from featurebyte.models.parent_serving import EntityLookupInfo, EntityLookupStep
 
 
 @pytest.mark.asyncio
@@ -29,16 +29,23 @@ async def test_get_join_steps__one_step(
 
     a (provided) --> b (required)
     """
-    data = b_is_parent_of_a
+    data, relationship_info = b_is_parent_of_a
     entity_info = EntityInfo(required_entities=[entity_a, entity_b], provided_entities=[entity_a])
     join_steps = await parent_entity_lookup_service.get_required_join_steps(entity_info)
     assert join_steps == [
-        JoinStep(
+        EntityLookupStep(
+            id=relationship_info.id,
             table=data.dict(by_alias=True),
-            parent_key="b",
-            parent_serving_name="B",
-            child_key="a",
-            child_serving_name="A",
+            parent=EntityLookupInfo(
+                key="b",
+                serving_name="B",
+                entity_id=entity_b.id,
+            ),
+            child=EntityLookupInfo(
+                key="a",
+                serving_name="A",
+                entity_id=entity_a.id,
+            ),
         )
     ]
 
@@ -46,6 +53,7 @@ async def test_get_join_steps__one_step(
 @pytest.mark.asyncio
 async def test_get_join_steps__two_steps(
     entity_a,
+    entity_b,
     entity_c,
     b_is_parent_of_a,
     c_is_parent_of_b,
@@ -56,24 +64,38 @@ async def test_get_join_steps__two_steps(
 
     a (provided) --> b --> c (required)
     """
-    data_a_to_b = b_is_parent_of_a
-    data_b_to_c = c_is_parent_of_b
+    data_a_to_b, rel_a_to_b = b_is_parent_of_a
+    data_b_to_c, rel_b_to_c = c_is_parent_of_b
     entity_info = EntityInfo(required_entities=[entity_a, entity_c], provided_entities=[entity_a])
     join_steps = await parent_entity_lookup_service.get_required_join_steps(entity_info)
     assert join_steps == [
-        JoinStep(
+        EntityLookupStep(
+            id=rel_a_to_b.id,
             table=data_a_to_b.dict(by_alias=True),
-            parent_key="b",
-            parent_serving_name="B",
-            child_key="a",
-            child_serving_name="A",
+            parent=EntityLookupInfo(
+                entity_id=entity_b.id,
+                key="b",
+                serving_name="B",
+            ),
+            child=EntityLookupInfo(
+                entity_id=entity_a.id,
+                key="a",
+                serving_name="A",
+            ),
         ),
-        JoinStep(
+        EntityLookupStep(
+            id=rel_b_to_c.id,
             table=data_b_to_c.dict(by_alias=True),
-            parent_key="c",
-            parent_serving_name="C",
-            child_key="b",
-            child_serving_name="B",
+            parent=EntityLookupInfo(
+                entity_id=entity_c.id,
+                key="c",
+                serving_name="C",
+            ),
+            child=EntityLookupInfo(
+                entity_id=entity_b.id,
+                key="b",
+                serving_name="B",
+            ),
         ),
     ]
 
@@ -81,6 +103,7 @@ async def test_get_join_steps__two_steps(
 @pytest.mark.asyncio
 async def test_get_join_steps__two_branches(
     entity_a,
+    entity_b,
     entity_c,
     entity_d,
     b_is_parent_of_a,
@@ -94,34 +117,55 @@ async def test_get_join_steps__two_branches(
     a (provided) --> b --> c (required)
                       `--> d (required)
     """
-    data_a_to_b = b_is_parent_of_a
-    data_b_to_c = c_is_parent_of_b
-    data_b_to_d = d_is_parent_of_b
+    data_a_to_b, rel_a_to_b = b_is_parent_of_a
+    data_b_to_c, rel_b_to_c = c_is_parent_of_b
+    data_b_to_d, rel_b_to_d = d_is_parent_of_b
     entity_info = EntityInfo(
         required_entities=[entity_a, entity_c, entity_d], provided_entities=[entity_a]
     )
     join_steps = await parent_entity_lookup_service.get_required_join_steps(entity_info)
     assert join_steps == [
-        JoinStep(
+        EntityLookupStep(
+            id=rel_a_to_b.id,
             table=data_a_to_b.dict(by_alias=True),
-            parent_key="b",
-            parent_serving_name="B",
-            child_key="a",
-            child_serving_name="A",
+            parent=EntityLookupInfo(
+                key="b",
+                serving_name="B",
+                entity_id=entity_b.id,
+            ),
+            child=EntityLookupInfo(
+                key="a",
+                serving_name="A",
+                entity_id=entity_a.id,
+            ),
         ),
-        JoinStep(
+        EntityLookupStep(
+            id=rel_b_to_d.id,
             table=data_b_to_d.dict(by_alias=True),
-            parent_key="d",
-            parent_serving_name="D",
-            child_key="b",
-            child_serving_name="B",
+            parent=EntityLookupInfo(
+                key="d",
+                serving_name="D",
+                entity_id=entity_d.id,
+            ),
+            child=EntityLookupInfo(
+                key="b",
+                serving_name="B",
+                entity_id=entity_b.id,
+            ),
         ),
-        JoinStep(
+        EntityLookupStep(
+            id=rel_b_to_c.id,
             table=data_b_to_c.dict(by_alias=True),
-            parent_key="c",
-            parent_serving_name="C",
-            child_key="b",
-            child_serving_name="B",
+            parent=EntityLookupInfo(
+                key="c",
+                serving_name="C",
+                entity_id=entity_c.id,
+            ),
+            child=EntityLookupInfo(
+                key="b",
+                serving_name="B",
+                entity_id=entity_b.id,
+            ),
         ),
     ]
 
@@ -129,6 +173,7 @@ async def test_get_join_steps__two_branches(
 @pytest.mark.asyncio
 async def test_get_join_steps__serving_names_mapping(
     entity_a,
+    entity_b,
     entity_c,
     entity_d,
     b_is_parent_of_a,
@@ -142,9 +187,9 @@ async def test_get_join_steps__serving_names_mapping(
     a (provided) --> b --> c (required)
                       `--> d (required)
     """
-    data_a_to_b = b_is_parent_of_a
-    data_b_to_c = c_is_parent_of_b
-    data_b_to_d = d_is_parent_of_b
+    data_a_to_b, rel_a_to_b = b_is_parent_of_a
+    data_b_to_c, rel_b_to_c = c_is_parent_of_b
+    data_b_to_d, rel_b_to_d = d_is_parent_of_b
     entity_info = EntityInfo(
         required_entities=[entity_a, entity_c, entity_d],
         provided_entities=[entity_a],
@@ -152,26 +197,47 @@ async def test_get_join_steps__serving_names_mapping(
     )
     join_steps = await parent_entity_lookup_service.get_required_join_steps(entity_info)
     assert join_steps == [
-        JoinStep(
+        EntityLookupStep(
+            id=rel_a_to_b.id,
             table=data_a_to_b.dict(by_alias=True),
-            parent_key="b",
-            parent_serving_name="B",
-            child_key="a",
-            child_serving_name="new_A",
+            parent=EntityLookupInfo(
+                key="b",
+                serving_name="B",
+                entity_id=entity_b.id,
+            ),
+            child=EntityLookupInfo(
+                key="a",
+                serving_name="new_A",
+                entity_id=entity_a.id,
+            ),
         ),
-        JoinStep(
+        EntityLookupStep(
+            id=rel_b_to_d.id,
             table=data_b_to_d.dict(by_alias=True),
-            parent_key="d",
-            parent_serving_name="D",
-            child_key="b",
-            child_serving_name="B",
+            parent=EntityLookupInfo(
+                key="d",
+                serving_name="D",
+                entity_id=entity_d.id,
+            ),
+            child=EntityLookupInfo(
+                key="b",
+                serving_name="B",
+                entity_id=entity_b.id,
+            ),
         ),
-        JoinStep(
+        EntityLookupStep(
+            id=rel_b_to_c.id,
             table=data_b_to_c.dict(by_alias=True),
-            parent_key="c",
-            parent_serving_name="C",
-            child_key="b",
-            child_serving_name="B",
+            parent=EntityLookupInfo(
+                key="c",
+                serving_name="C",
+                entity_id=entity_c.id,
+            ),
+            child=EntityLookupInfo(
+                key="b",
+                serving_name="B",
+                entity_id=entity_b.id,
+            ),
         ),
     ]
 
@@ -206,6 +272,7 @@ async def test_get_join_steps__not_found_with_relationships(
 async def test_get_join_steps__multiple_provided(
     entity_a,
     entity_b,
+    entity_c,
     entity_d,
     b_is_parent_of_a,
     c_is_parent_of_b,
@@ -220,24 +287,38 @@ async def test_get_join_steps__multiple_provided(
     a (provided) --> b (provided) --> c --> d (required)
     """
     _ = b_is_parent_of_a
-    data_b_to_c = c_is_parent_of_b
-    data_c_to_d = d_is_parent_of_c
+    data_b_to_c, rel_b_to_c = c_is_parent_of_b
+    data_c_to_d, rel_c_to_d = d_is_parent_of_c
     entity_info = EntityInfo(required_entities=[entity_d], provided_entities=[entity_a, entity_b])
     join_steps = await parent_entity_lookup_service.get_required_join_steps(entity_info)
     assert join_steps == [
-        JoinStep(
+        EntityLookupStep(
+            id=rel_b_to_c.id,
             table=data_b_to_c.dict(by_alias=True),
-            parent_key="c",
-            parent_serving_name="C",
-            child_key="b",
-            child_serving_name="B",
+            parent=EntityLookupInfo(
+                key="c",
+                serving_name="C",
+                entity_id=entity_c.id,
+            ),
+            child=EntityLookupInfo(
+                key="b",
+                serving_name="B",
+                entity_id=entity_b.id,
+            ),
         ),
-        JoinStep(
+        EntityLookupStep(
+            id=rel_c_to_d.id,
             table=data_c_to_d.dict(by_alias=True),
-            parent_key="d",
-            parent_serving_name="D",
-            child_key="c",
-            child_serving_name="C",
+            parent=EntityLookupInfo(
+                key="d",
+                serving_name="D",
+                entity_id=entity_d.id,
+            ),
+            child=EntityLookupInfo(
+                key="c",
+                serving_name="C",
+                entity_id=entity_c.id,
+            ),
         ),
     ]
 
@@ -257,17 +338,20 @@ async def test_required_entity__complex_and_should_not_error(
     c --> d --> a (provided) --> b (required)
      `------>´
     """
-    data_a_to_b = b_is_parent_of_a
+    data_a_to_b, rel_a_to_b = b_is_parent_of_a
     _ = d_is_parent_of_c
     _ = a_is_parent_of_c_and_d
     entity_info = EntityInfo(required_entities=[entity_b], provided_entities=[entity_a])
     join_steps = await parent_entity_lookup_service.get_required_join_steps(entity_info)
     assert join_steps == [
-        JoinStep(
+        EntityLookupStep(
+            id=rel_a_to_b.id,
             table=data_a_to_b.dict(by_alias=True),
-            parent_key="b",
-            parent_serving_name="B",
-            child_key="a",
-            child_serving_name="A",
+            parent=EntityLookupInfo(
+                key="b",
+                serving_name="B",
+                entity_id=entity_b.id,
+            ),
+            child=EntityLookupInfo(key="a", serving_name="A", entity_id=entity_a.id),
         ),
     ]

--- a/tests/unit/service/test_parent_serving.py
+++ b/tests/unit/service/test_parent_serving.py
@@ -3,7 +3,7 @@ Unit tests for ParentEntityLookupService
 """
 import pytest
 
-from featurebyte.exception import EntityJoinPathNotFoundError
+from featurebyte.exception import RequiredEntityNotProvidedError
 from featurebyte.models.entity_validation import EntityInfo
 from featurebyte.models.parent_serving import JoinStep
 
@@ -110,16 +110,16 @@ async def test_get_join_steps__two_branches(
             child_serving_name="A",
         ),
         JoinStep(
-            table=data_b_to_c.dict(by_alias=True),
-            parent_key="c",
-            parent_serving_name="C",
+            table=data_b_to_d.dict(by_alias=True),
+            parent_key="d",
+            parent_serving_name="D",
             child_key="b",
             child_serving_name="B",
         ),
         JoinStep(
-            table=data_b_to_d.dict(by_alias=True),
-            parent_key="d",
-            parent_serving_name="D",
+            table=data_b_to_c.dict(by_alias=True),
+            parent_key="c",
+            parent_serving_name="C",
             child_key="b",
             child_serving_name="B",
         ),
@@ -160,16 +160,16 @@ async def test_get_join_steps__serving_names_mapping(
             child_serving_name="new_A",
         ),
         JoinStep(
-            table=data_b_to_c.dict(by_alias=True),
-            parent_key="c",
-            parent_serving_name="C",
+            table=data_b_to_d.dict(by_alias=True),
+            parent_key="d",
+            parent_serving_name="D",
             child_key="b",
             child_serving_name="B",
         ),
         JoinStep(
-            table=data_b_to_d.dict(by_alias=True),
-            parent_key="d",
-            parent_serving_name="D",
+            table=data_b_to_c.dict(by_alias=True),
+            parent_key="c",
+            parent_serving_name="C",
             child_key="b",
             child_serving_name="B",
         ),
@@ -182,7 +182,7 @@ async def test_get_join_steps__not_found(entity_a, entity_b, parent_entity_looku
     Test no path can be found because no valid relationships are registered
     """
     entity_info = EntityInfo(required_entities=[entity_a, entity_b], provided_entities=[entity_a])
-    with pytest.raises(EntityJoinPathNotFoundError):
+    with pytest.raises(RequiredEntityNotProvidedError):
         _ = await parent_entity_lookup_service.get_required_join_steps(entity_info)
 
 
@@ -198,7 +198,7 @@ async def test_get_join_steps__not_found_with_relationships(
     """
     _ = c_is_parent_of_b
     entity_info = EntityInfo(required_entities=[entity_c], provided_entities=[entity_a])
-    with pytest.raises(EntityJoinPathNotFoundError):
+    with pytest.raises(RequiredEntityNotProvidedError):
         _ = await parent_entity_lookup_service.get_required_join_steps(entity_info)
 
 


### PR DESCRIPTION
## Description

This is a refactoring to parent entity lookup related logic. Main changes:

1. Refactor and simplify ParentEntityLookupService to use EntityRelationshipInfo and EntityLookupPlanner 
3. Consolidate JoinStep and EntityLookupStep classes which contain similar information

This will prepare us to transition to using frozen relationships for parent entity lookup.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
