### PR TITLE
[chore] Fix entity universe for aggregate asat features without entity

### DIFF
--- a/featurebyte/models/entity_universe.py
+++ b/featurebyte/models/entity_universe.py
@@ -175,9 +175,7 @@ class AggregateAsAtNodeEntityUniverseConstructor(BaseEntityUniverseConstructor):
         node = cast(AggregateAsAtNode, self.node)
 
         if not node.parameters.serving_names:
-            return expressions.select(
-                expressions.alias_(make_literal_value(1), "dummy_entity", quoted=True)
-            )
+            return get_dummy_entity_universe()
 
         ts_col = node.parameters.effective_timestamp_column
         filtered_aggregate_input_expr = self.aggregate_input_expr.where(
@@ -266,6 +264,20 @@ class ItemAggregateNodeEntityUniverseConstructor(BaseEntityUniverseConstructor):
             .from_(self.aggregate_input_expr.subquery())
         )
         return universe_expr
+
+
+def get_dummy_entity_universe() -> Select:
+    """
+    Returns a dummy entity universe (actual value not important since it doesn't affect features
+    calculation)
+
+    Returns
+    -------
+    Select
+    """
+    return expressions.select(
+        expressions.alias_(make_literal_value(1), "dummy_entity", quoted=True)
+    )
 
 
 def get_entity_universe_constructor(
@@ -413,9 +425,7 @@ def construct_window_aggregates_universe(
     Expression
     """
     if not serving_names:
-        return expressions.select(
-            expressions.alias_(make_literal_value(1), "dummy_entity", quoted=True)
-        )
+        return get_dummy_entity_universe()
 
     assert len(aggregate_result_table_names) > 0
 

--- a/featurebyte/models/entity_universe.py
+++ b/featurebyte/models/entity_universe.py
@@ -174,6 +174,11 @@ class AggregateAsAtNodeEntityUniverseConstructor(BaseEntityUniverseConstructor):
     def get_entity_universe_template(self) -> Expression:
         node = cast(AggregateAsAtNode, self.node)
 
+        if not node.parameters.serving_names:
+            return expressions.select(
+                expressions.alias_(make_literal_value(1), "dummy_entity", quoted=True)
+            )
+
         ts_col = node.parameters.effective_timestamp_column
         filtered_aggregate_input_expr = self.aggregate_input_expr.where(
             expressions.and_(

--- a/tests/integration/api/test_scd_view_operations.py
+++ b/tests/integration/api/test_scd_view_operations.py
@@ -509,6 +509,9 @@ def test_aggregate_asat__no_entity(scd_table, scd_dataframe, config, source_type
     feature = scd_view.groupby([]).aggregate_asat(
         method="count", feature_name="Current Number of Users"
     )
+    feature_other = scd_view.groupby("User Status").aggregate_asat(
+        method="count", feature_name="Current Number of Users With This Status"
+    )
 
     # check preview
     df = feature.preview(
@@ -544,18 +547,29 @@ def test_aggregate_asat__no_entity(scd_table, scd_dataframe, config, source_type
     pd.testing.assert_frame_equal(df, expected, check_dtype=False)
 
     # check online serving
+    feature_list = FeatureList([feature, feature_other], "feature_list")
     feature_list.save()
     deployment = feature_list.deploy(make_production_ready=True)
     deployment.enable()
 
     try:
-        data = OnlineFeaturesRequestPayload(entity_serving_names=[{"row_number": 1}])
+        data = OnlineFeaturesRequestPayload(
+            entity_serving_names=[{"user_status": "STÀTUS_CODE_47"}]
+        )
         res = config.get_client().post(
             f"/deployment/{deployment.id}/online_features",
             json=data.json_dict(),
         )
         assert res.status_code == 200
-        assert res.json() == {"features": [{"row_number": 1, "Current Number of Users": 9}]}
+        assert res.json() == {
+            "features": [
+                {
+                    "user_status": "STÀTUS_CODE_47",
+                    "Current Number of Users With This Status": 2,
+                    "Current Number of Users": 9,
+                }
+            ]
+        }
     finally:
         deployment.disable()
 

--- a/tests/integration/api/test_scd_view_operations.py
+++ b/tests/integration/api/test_scd_view_operations.py
@@ -510,7 +510,7 @@ def test_aggregate_asat__no_entity(scd_table, scd_dataframe, config, source_type
         method="count", feature_name="Current Number of Users"
     )
     feature_other = scd_view.groupby("User Status").aggregate_asat(
-        method="count", feature_name="Current Number of Users With This Status"
+        method="count", feature_name="Current Number of Users With This Status V2"
     )
 
     # check preview
@@ -565,7 +565,7 @@ def test_aggregate_asat__no_entity(scd_table, scd_dataframe, config, source_type
             "features": [
                 {
                     "user_status": "STÀTUS_CODE_47",
-                    "Current Number of Users With This Status": 2,
+                    "Current Number of Users With This Status V2": 2,
                     "Current Number of Users": 9,
                 }
             ]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1784,7 +1784,7 @@ def aggregate_asat_feature_fixture(snowflake_scd_table_with_entity, gender_entit
 
 
 @pytest.fixture(name="aggregate_asat_no_entity_feature")
-def aggregate_asat_no_entity_feature_fixture(snowflake_scd_table_with_entity, gender_entity):
+def aggregate_asat_no_entity_feature_fixture(snowflake_scd_table_with_entity):
     """
     Fixture to get an aggregate asat feature from SCD table without entity
     """

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1771,7 +1771,7 @@ def scd_lookup_feature_fixture(snowflake_scd_table_with_entity):
 @pytest.fixture(name="aggregate_asat_feature")
 def aggregate_asat_feature_fixture(snowflake_scd_table_with_entity, gender_entity):
     """
-    Fixture to get a lookup feature from SCD table
+    Fixture to get an aggregate asat feature from SCD table
     """
     snowflake_scd_table_with_entity["col_boolean"].as_entity(gender_entity.name)
     scd_view = snowflake_scd_table_with_entity.get_view()
@@ -1779,6 +1779,20 @@ def aggregate_asat_feature_fixture(snowflake_scd_table_with_entity, gender_entit
         value_column=None,
         method="count",
         feature_name="asat_gender_count",
+    )
+    return feature
+
+
+@pytest.fixture(name="aggregate_asat_no_entity_feature")
+def aggregate_asat_no_entity_feature_fixture(snowflake_scd_table_with_entity, gender_entity):
+    """
+    Fixture to get an aggregate asat feature from SCD table without entity
+    """
+    scd_view = snowflake_scd_table_with_entity.get_view()
+    feature = scd_view.groupby([]).aggregate_asat(
+        value_column=None,
+        method="count",
+        feature_name="asat_overall_count",
     )
     return feature
 

--- a/tests/unit/models/test_entity_universe.py
+++ b/tests/unit/models/test_entity_universe.py
@@ -46,6 +46,18 @@ def aggregate_asat_graph_and_node(aggregate_asat_feature):
 
 
 @pytest.fixture
+def aggregate_asat_no_entity_graph_and_node(aggregate_asat_no_entity_feature):
+    """
+    Fixture for an aggregate_asat aggregate node (no entity)
+    """
+    graph = aggregate_asat_no_entity_feature.graph
+    aggregate_asat_node = get_node_from_feature(
+        aggregate_asat_no_entity_feature, NodeType.AGGREGATE_AS_AT
+    )
+    return graph, aggregate_asat_node
+
+
+@pytest.fixture
 def lookup_graph_and_node_same_input(scd_lookup_feature):
     """
     Fixture for a new lookup feature that has the same input as the original lookup feature
@@ -146,6 +158,22 @@ def test_aggregate_asat_universe(catalog, aggregate_asat_graph_and_node):
             "effective_timestamp" >= __fb_last_materialized_timestamp
             AND "effective_timestamp" < __fb_current_feature_timestamp
         )
+        """
+    ).strip()
+    assert constructor.get_entity_universe_template().sql(pretty=True) == expected
+
+
+def test_aggregate_asat_no_entity_universe(catalog, aggregate_asat_no_entity_graph_and_node):
+    """
+    Test aggregate as-at feature's universe (no entity)
+    """
+    _ = catalog
+    graph, node = aggregate_asat_no_entity_graph_and_node
+    constructor = get_entity_universe_constructor(graph, node, SourceType.SNOWFLAKE)
+    expected = textwrap.dedent(
+        """
+        SELECT
+          1 AS "dummy_entity"
         """
     ).strip()
     assert constructor.get_entity_universe_template().sql(pretty=True) == expected


### PR DESCRIPTION
## Description

This fixes incorrect entity universe for aggregated asat features without an entity.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
