### PR TITLE
[chore] Limit number of features for feature list preview

### DIFF
--- a/featurebyte/service/feature_preview.py
+++ b/featurebyte/service/feature_preview.py
@@ -289,6 +289,11 @@ class FeaturePreviewService(PreviewService):
         -------
         dict[str, Any]
             Dataframe converted to json string
+
+        Raises
+        ------
+        LimitExceededError
+            raised if the feature list preview has more than 30 features
         """
         if featurelist_preview.feature_list_id is not None:
             feature_list_model = await self.feature_list_service.get_document(


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
This PR prevents previewing feature list with more than 30 number of features. This is to prevent API server becomes unresponsive when previewing large feature list.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
