### PR TITLE
[chore] Refactor and simplify Aggregate sql ast node

### DIFF
--- a/featurebyte/models/entity_universe.py
+++ b/featurebyte/models/entity_universe.py
@@ -22,10 +22,10 @@ from featurebyte.query_graph.node import Node
 from featurebyte.query_graph.node.generic import AggregateAsAtNode, ItemGroupbyNode, LookupNode
 from featurebyte.query_graph.node.input import EventTableInputNodeParameters
 from featurebyte.query_graph.node.nested import ItemViewGraphNodeParameters
-from featurebyte.query_graph.sql.ast.base import EventTableTimestampFilter
 from featurebyte.query_graph.sql.ast.literal import make_literal_value
 from featurebyte.query_graph.sql.builder import SQLOperationGraph
 from featurebyte.query_graph.sql.common import (
+    EventTableTimestampFilter,
     SQLType,
     get_fully_qualified_table_name,
     get_qualified_column_identifier,

--- a/featurebyte/models/user_defined_function.py
+++ b/featurebyte/models/user_defined_function.py
@@ -303,6 +303,7 @@ class UserDefinedFunctionModel(FeatureByteBaseDocumentModel):
                 source_type=source_type,
                 to_filter_scd_by_current_flag=False,
                 event_table_timestamp_filter=None,
+                aggregation_specs=None,
             )
         )
         sql_tree = select(sql_node.sql)

--- a/featurebyte/query_graph/sql/ast/aggregate.py
+++ b/featurebyte/query_graph/sql/ast/aggregate.py
@@ -3,9 +3,8 @@ Module for aggregation related sql generation
 """
 from __future__ import annotations
 
-from typing import Dict, Optional, cast
+from typing import Optional, cast
 
-from abc import abstractmethod
 from dataclasses import dataclass
 
 from sqlglot.expressions import Expression, Select
@@ -13,14 +12,7 @@ from sqlglot.expressions import Expression, Select
 from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.sql.ast.base import SQLNodeContext, TableNode
 from featurebyte.query_graph.sql.common import SQLType, quoted_identifier
-from featurebyte.query_graph.sql.specifications.lookup import LookupSpec
-from featurebyte.query_graph.sql.specifications.lookup_target import LookupTargetSpec
-from featurebyte.query_graph.sql.specs import (
-    AggregateAsAtSpec,
-    AggregationSource,
-    ForwardAggregateSpec,
-    ItemAggregationSpec,
-)
+from featurebyte.query_graph.sql.specs import AggregationSource
 
 
 @dataclass
@@ -70,7 +62,7 @@ class Aggregate(TableNode):
             columns_map = source_node.copy().columns_map
         else:
             assert context.sql_type == SQLType.POST_AGGREGATION
-            columns_map = cls.construct_columns_map(context=context, source_node=source_node)
+            columns_map = cls.construct_columns_map(context=context)
 
         return cls(
             context=context,
@@ -79,9 +71,7 @@ class Aggregate(TableNode):
         )
 
     @staticmethod
-    def construct_columns_map(
-        context: SQLNodeContext, source_node: TableNode
-    ) -> dict[str, Expression]:
+    def construct_columns_map(context: SQLNodeContext) -> dict[str, Expression]:
         """
         Construct columns_map by instantiating the appropriate AggregationSpec
 
@@ -89,8 +79,6 @@ class Aggregate(TableNode):
         ----------
         context: SQLNodeContext
             Context when building SQLNode
-        source_node: TableNode
-            The input TableNode to be aggregated
 
         Returns
         -------
@@ -131,119 +119,3 @@ class Aggregate(TableNode):
             query_node_name=source_node.context.current_query_node.name,
             is_scd_filtered_by_current_flag=source_node.context.to_filter_scd_by_current_flag,
         )
-
-
-# @dataclass
-# class Lookup(Aggregate):
-#     """
-#     Lookup SQLNode
-#     """
-#
-#     query_node_type = NodeType.LOOKUP
-#
-#     @staticmethod
-#     def construct_columns_map(
-#         context: SQLNodeContext, source_node: TableNode
-#     ) -> dict[str, Expression]:
-#         # Create LookupSpec which determines the internal aggregated result names
-#         columns_map = {}
-#         specs = LookupSpec.from_query_graph_node(
-#             context.query_node,
-#             graph=context.graph,
-#             aggregation_source=Aggregate.get_aggregation_source_from_source_node(source_node),
-#         )
-#         for spec in specs:
-#             columns_map[spec.feature_name] = quoted_identifier(spec.agg_result_name)
-#         return columns_map
-#
-#
-# @dataclass
-# class LookupTarget(Aggregate):
-#     """
-#     LookupTarget SQLNode
-#     """
-#
-#     query_node_type = NodeType.LOOKUP_TARGET
-#
-#     @staticmethod
-#     def construct_columns_map(
-#         context: SQLNodeContext, source_node: TableNode
-#     ) -> dict[str, Expression]:
-#         # Create LookupTargetSpec which determines the internal aggregated result names
-#         columns_map = {}
-#         specs = LookupTargetSpec.from_query_graph_node(
-#             context.query_node,
-#             graph=context.graph,
-#             aggregation_source=Aggregate.get_aggregation_source_from_source_node(source_node),
-#         )
-#         for spec in specs:
-#             columns_map[spec.feature_name] = quoted_identifier(spec.agg_result_name)
-#         return columns_map
-#
-#
-# @dataclass
-# class AsAt(Aggregate):
-#     """
-#     AsAt SQLNode
-#     """
-#
-#     query_node_type = NodeType.AGGREGATE_AS_AT
-#
-#     @staticmethod
-#     def construct_columns_map(
-#         context: SQLNodeContext, source_node: TableNode
-#     ) -> dict[str, Expression]:
-#         columns_map = {}
-#         spec = AggregateAsAtSpec.from_query_graph_node(
-#             context.query_node,
-#             graph=context.graph,
-#             aggregation_source=Aggregate.get_aggregation_source_from_source_node(source_node),
-#         )[0]
-#         feature_name = cast(str, spec.parameters.name)
-#         columns_map[feature_name] = quoted_identifier(spec.agg_result_name)
-#         return columns_map
-#
-#
-# @dataclass
-# class Item(Aggregate):
-#     """
-#     Item SQLNode
-#     """
-#
-#     query_node_type = NodeType.ITEM_GROUPBY
-#
-#     @staticmethod
-#     def construct_columns_map(
-#         context: SQLNodeContext, source_node: TableNode
-#     ) -> dict[str, Expression]:
-#         columns_map = {}
-#         spec = ItemAggregationSpec.from_query_graph_node(
-#             context.query_node,
-#             graph=context.graph,
-#             aggregation_source=Aggregate.get_aggregation_source_from_source_node(source_node),
-#         )[0]
-#         feature_name = cast(str, spec.parameters.name)
-#         columns_map[feature_name] = quoted_identifier(spec.agg_result_name)
-#         return columns_map
-#
-#
-# @dataclass
-# class Forward(Aggregate):
-#     """
-#     Forward SQLNode
-#     """
-#
-#     query_node_type = NodeType.FORWARD_AGGREGATE
-#
-#     @staticmethod
-#     def construct_columns_map(
-#         context: SQLNodeContext, source_node: TableNode
-#     ) -> dict[str, Expression]:
-#         columns_map: Dict[str, Expression] = {}
-#         spec = ForwardAggregateSpec.from_query_graph_node(
-#             context.query_node,
-#             graph=context.graph,
-#             aggregation_source=Aggregate.get_aggregation_source_from_source_node(source_node),
-#         )[0]
-#         columns_map[spec.parameters.name] = quoted_identifier(spec.agg_result_name)
-#         return columns_map

--- a/featurebyte/query_graph/sql/ast/base.py
+++ b/featurebyte/query_graph/sql/ast/base.py
@@ -9,7 +9,6 @@ from abc import ABC, abstractmethod
 from copy import copy
 from dataclasses import dataclass, field
 
-from bson import ObjectId
 from sqlglot import expressions
 from sqlglot.expressions import Expression, Select, select
 
@@ -18,28 +17,11 @@ from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.model.graph import QueryGraphModel
 from featurebyte.query_graph.node import Node
 from featurebyte.query_graph.sql.adapter import BaseAdapter, get_sql_adapter
-from featurebyte.query_graph.sql.common import SQLType
+from featurebyte.query_graph.sql.common import EventTableTimestampFilter, SQLType
+from featurebyte.query_graph.sql.specs import AggregationSpec
 
 SQLNodeT = TypeVar("SQLNodeT", bound="SQLNode")
 TableNodeT = TypeVar("TableNodeT", bound="TableNode")
-
-
-@dataclass
-class EventTableTimestampFilter:
-    """
-    Information about the timestamp filter to be applied when selecting from EventTable
-
-    timestamp_column_name: str
-        Name of the timestamp column
-    event_table_id: ObjectId
-        Id of the EventTable. Only EventTable matching this id should be filtered.
-    """
-
-    timestamp_column_name: str
-    event_table_id: ObjectId
-    start_timestamp_placeholder_name: Optional[str] = None
-    end_timestamp_placeholder_name: Optional[str] = None
-    to_cast_placeholders: Optional[bool] = True
 
 
 @dataclass
@@ -68,6 +50,7 @@ class SQLNodeContext:  # pylint: disable=too-many-instance-attributes
     input_sql_nodes: list[SQLNode]
     to_filter_scd_by_current_flag: Optional[bool]
     event_table_timestamp_filter: Optional[EventTableTimestampFilter]
+    aggregation_specs: Optional[dict[str, list[AggregationSpec]]]
 
     def __post_init__(self) -> None:
         self.parameters = self.query_node.parameters.dict()

--- a/featurebyte/query_graph/sql/ast/join_feature.py
+++ b/featurebyte/query_graph/sql/ast/join_feature.py
@@ -152,7 +152,7 @@ class JoinFeature(TableNode):
             current_columns=view_node.columns,
             current_query_index=0,
         )
-        return result.updated_table_expr, dict(agg_specs_mapping)
+        return result.updated_table_expr, dict(agg_specs_mapping)  # type: ignore[arg-type]
 
     @staticmethod
     def _get_feature_expr(

--- a/featurebyte/query_graph/sql/ast/join_feature.py
+++ b/featurebyte/query_graph/sql/ast/join_feature.py
@@ -172,6 +172,8 @@ class JoinFeature(TableNode):
             Query node for the item aggregation feature
         source_type: SourceType
             Source type information
+        aggregation_specs: dict[str, list[AggregationSpec]]
+            Aggregation specs to use when constructing SQLOperationGraph
 
         Returns
         -------

--- a/featurebyte/query_graph/sql/ast/tile.py
+++ b/featurebyte/query_graph/sql/ast/tile.py
@@ -323,32 +323,32 @@ class BuildTileNode(TableNode):  # pylint: disable=too-many-instance-attributes
         return sql_node
 
 
-@dataclass
-class AggregatedTilesNode(TableNode):
-    """Node with tiles already aggregated
-
-    The purpose of this node is to allow feature SQL generation to retrieve the post-aggregation
-    feature transform expression. The columns_map of this node has the mapping from user defined
-    feature names to internal aggregated column names. The feature expression can be obtained by
-    calling get_column_expr().
-    """
-
-    query_node_type = NodeType.GROUPBY
-
-    @property
-    def sql(self) -> Expression:
-        # This will not be called anywhere
-        raise NotImplementedError()
-
-    @classmethod
-    def build(cls, context: SQLNodeContext) -> AggregatedTilesNode | None:
-        sql_node = None
-        if context.sql_type == SQLType.POST_AGGREGATION:
-            agg_specs = TileBasedAggregationSpec.from_groupby_query_node(
-                context.graph, context.query_node, context.adapter
-            )
-            columns_map = {}
-            for agg_spec in agg_specs:
-                columns_map[agg_spec.feature_name] = quoted_identifier(agg_spec.agg_result_name)
-            sql_node = AggregatedTilesNode(context=context, columns_map=columns_map)
-        return sql_node
+# @dataclass
+# class AggregatedTilesNode(TableNode):
+#     """Node with tiles already aggregated
+#
+#     The purpose of this node is to allow feature SQL generation to retrieve the post-aggregation
+#     feature transform expression. The columns_map of this node has the mapping from user defined
+#     feature names to internal aggregated column names. The feature expression can be obtained by
+#     calling get_column_expr().
+#     """
+#
+#     query_node_type = NodeType.GROUPBY
+#
+#     @property
+#     def sql(self) -> Expression:
+#         # This will not be called anywhere
+#         raise NotImplementedError()
+#
+#     @classmethod
+#     def build(cls, context: SQLNodeContext) -> AggregatedTilesNode | None:
+#         sql_node = None
+#         if context.sql_type == SQLType.POST_AGGREGATION:
+#             agg_specs = TileBasedAggregationSpec.from_groupby_query_node(
+#                 context.graph, context.query_node, context.adapter
+#             )
+#             columns_map = {}
+#             for agg_spec in agg_specs:
+#                 columns_map[agg_spec.feature_name] = quoted_identifier(agg_spec.agg_result_name)
+#             sql_node = AggregatedTilesNode(context=context, columns_map=columns_map)
+#         return sql_node

--- a/featurebyte/query_graph/sql/ast/tile.py
+++ b/featurebyte/query_graph/sql/ast/tile.py
@@ -26,7 +26,6 @@ from featurebyte.query_graph.sql.groupby_helper import (
     _split_agg_and_snowflake_vector_aggregation_columns,
 )
 from featurebyte.query_graph.sql.query_graph_util import get_parent_dtype
-from featurebyte.query_graph.sql.specs import TileBasedAggregationSpec
 from featurebyte.query_graph.sql.tiling import InputColumn, TileSpec, get_aggregator
 
 
@@ -321,34 +320,3 @@ class BuildTileNode(TableNode):  # pylint: disable=too-many-instance-attributes
             adapter=context.adapter,
         )
         return sql_node
-
-
-# @dataclass
-# class AggregatedTilesNode(TableNode):
-#     """Node with tiles already aggregated
-#
-#     The purpose of this node is to allow feature SQL generation to retrieve the post-aggregation
-#     feature transform expression. The columns_map of this node has the mapping from user defined
-#     feature names to internal aggregated column names. The feature expression can be obtained by
-#     calling get_column_expr().
-#     """
-#
-#     query_node_type = NodeType.GROUPBY
-#
-#     @property
-#     def sql(self) -> Expression:
-#         # This will not be called anywhere
-#         raise NotImplementedError()
-#
-#     @classmethod
-#     def build(cls, context: SQLNodeContext) -> AggregatedTilesNode | None:
-#         sql_node = None
-#         if context.sql_type == SQLType.POST_AGGREGATION:
-#             agg_specs = TileBasedAggregationSpec.from_groupby_query_node(
-#                 context.graph, context.query_node, context.adapter
-#             )
-#             columns_map = {}
-#             for agg_spec in agg_specs:
-#                 columns_map[agg_spec.feature_name] = quoted_identifier(agg_spec.agg_result_name)
-#             sql_node = AggregatedTilesNode(context=context, columns_map=columns_map)
-#         return sql_node

--- a/featurebyte/query_graph/sql/builder.py
+++ b/featurebyte/query_graph/sql/builder.py
@@ -12,18 +12,14 @@ from featurebyte.enum import SourceType
 from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.model.graph import QueryGraphModel
 from featurebyte.query_graph.node import Node
-from featurebyte.query_graph.sql.ast.base import (
-    EventTableTimestampFilter,
-    SQLNode,
-    SQLNodeContext,
-    TableNode,
-)
+from featurebyte.query_graph.sql.ast.base import SQLNode, SQLNodeContext, TableNode
 from featurebyte.query_graph.sql.ast.generic import (
     handle_filter_node,
     make_assign_node,
     make_project_node,
 )
-from featurebyte.query_graph.sql.common import SQLType
+from featurebyte.query_graph.sql.common import EventTableTimestampFilter, SQLType
+from featurebyte.query_graph.sql.specs import AggregationSpec
 
 
 class NodeRegistry:
@@ -117,6 +113,7 @@ class SQLOperationGraph:
         source_type: SourceType,
         to_filter_scd_by_current_flag: bool = False,
         event_table_timestamp_filter: Optional[EventTableTimestampFilter] = None,
+        aggregation_specs: dict[str, list[AggregationSpec]] = None,
     ) -> None:
         self.sql_nodes: dict[str, SQLNode | TableNode] = {}
         self.query_graph = query_graph
@@ -124,6 +121,7 @@ class SQLOperationGraph:
         self.source_type = source_type
         self.to_filter_scd_by_current_flag = to_filter_scd_by_current_flag
         self.event_table_timestamp_filter = event_table_timestamp_filter
+        self.aggregation_specs = aggregation_specs
 
     def build(self, target_node: Node) -> Any:
         """Build the graph from a given query Node, working backwards
@@ -187,6 +185,7 @@ class SQLOperationGraph:
             input_sql_nodes=input_sql_nodes,
             to_filter_scd_by_current_flag=self.to_filter_scd_by_current_flag,
             event_table_timestamp_filter=self.event_table_timestamp_filter,
+            aggregation_specs=self.aggregation_specs,
         )
 
         # Construct an appropriate SQLNode based on the candidates defined in NodeRegistry

--- a/featurebyte/query_graph/sql/builder.py
+++ b/featurebyte/query_graph/sql/builder.py
@@ -113,7 +113,7 @@ class SQLOperationGraph:
         source_type: SourceType,
         to_filter_scd_by_current_flag: bool = False,
         event_table_timestamp_filter: Optional[EventTableTimestampFilter] = None,
-        aggregation_specs: dict[str, list[AggregationSpec]] = None,
+        aggregation_specs: Optional[dict[str, list[AggregationSpec]]] = None,
     ) -> None:
         self.sql_nodes: dict[str, SQLNode | TableNode] = {}
         self.query_graph = query_graph

--- a/featurebyte/query_graph/sql/common.py
+++ b/featurebyte/query_graph/sql/common.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 from typing import Dict, Optional, Sequence, Tuple, Union
 
+from dataclasses import dataclass
 from enum import Enum
 
+from bson import ObjectId
 from sqlglot import expressions
 from sqlglot.expressions import Expression, select
 
@@ -189,3 +191,21 @@ class SQLType(Enum):
     MATERIALIZE = "materialize"
     AGGREGATION = "aggregation"
     POST_AGGREGATION = "post_aggregation"
+
+
+@dataclass
+class EventTableTimestampFilter:
+    """
+    Information about the timestamp filter to be applied when selecting from EventTable
+
+    timestamp_column_name: str
+        Name of the timestamp column
+    event_table_id: ObjectId
+        Id of the EventTable. Only EventTable matching this id should be filtered.
+    """
+
+    timestamp_column_name: str
+    event_table_id: ObjectId
+    start_timestamp_placeholder_name: Optional[str] = None
+    end_timestamp_placeholder_name: Optional[str] = None
+    to_cast_placeholders: Optional[bool] = True

--- a/featurebyte/query_graph/sql/feature_compute.py
+++ b/featurebyte/query_graph/sql/feature_compute.py
@@ -717,6 +717,8 @@ class FeatureExecutionPlanner:
         ----------
         node : Node
             Query graph node
+        aggregation_specs: dict[str, list[AggregationSpec]]
+            Aggregation specs to use when constructing SQLOperationGraph
         """
         sql_graph = SQLOperationGraph(
             self.graph,

--- a/featurebyte/query_graph/sql/feature_compute.py
+++ b/featurebyte/query_graph/sql/feature_compute.py
@@ -605,7 +605,7 @@ class FeatureExecutionPlanner:
         for agg_spec in self.get_aggregation_specs(node):
             self.plan.add_aggregation_spec(agg_spec, original_node_name)
             aggregation_specs[agg_spec.node_name].append(agg_spec)
-        self.update_feature_specs(node, dict(aggregation_specs))
+        self.update_feature_specs(node, dict(aggregation_specs))  # type: ignore[arg-type]
 
     def get_aggregation_specs(  # pylint: disable=too-many-branches
         self, node: Node

--- a/featurebyte/query_graph/sql/interpreter/tile.py
+++ b/featurebyte/query_graph/sql/interpreter/tile.py
@@ -14,9 +14,8 @@ from featurebyte.query_graph.model.graph import QueryGraphModel
 from featurebyte.query_graph.node import Node
 from featurebyte.query_graph.node.generic import GroupByNode
 from featurebyte.query_graph.node.metadata.operation import SourceDataColumn
-from featurebyte.query_graph.sql.ast.base import EventTableTimestampFilter
 from featurebyte.query_graph.sql.builder import SQLOperationGraph
-from featurebyte.query_graph.sql.common import SQLType
+from featurebyte.query_graph.sql.common import EventTableTimestampFilter, SQLType
 from featurebyte.query_graph.sql.interpreter.base import BaseGraphInterpreter
 from featurebyte.query_graph.sql.template import SqlExpressionTemplate
 from featurebyte.query_graph.transform.operation_structure import OperationStructureExtractor

--- a/featurebyte/query_graph/sql/parent_serving.py
+++ b/featurebyte/query_graph/sql/parent_serving.py
@@ -152,6 +152,7 @@ def _get_lookup_spec_from_join_step(
     )
 
     return LookupSpec(
+        node_name="dummy",
         input_column_name=join_step.parent.key,
         feature_name=join_step.parent.serving_name,
         entity_column=join_step.child.key,

--- a/featurebyte/query_graph/sql/specifications/base_lookup.py
+++ b/featurebyte/query_graph/sql/specifications/base_lookup.py
@@ -26,7 +26,6 @@ class BaseLookupSpec(NonTileBasedAggregationSpec, ABC):
     """
 
     input_column_name: str
-    feature_name: str
     entity_column: str
     serving_names: list[str]
     scd_parameters: Optional[SCDLookupParameters]

--- a/featurebyte/query_graph/sql/specifications/lookup.py
+++ b/featurebyte/query_graph/sql/specifications/lookup.py
@@ -37,6 +37,7 @@ class LookupSpec(BaseLookupSpec):
         specs = []
         for input_column_name, feature_name in zip(params.input_column_names, params.feature_names):
             spec = LookupSpec(
+                node_name=node.name,
                 input_column_name=input_column_name,
                 feature_name=feature_name,
                 entity_column=params.entity_column,

--- a/featurebyte/query_graph/sql/specifications/lookup_target.py
+++ b/featurebyte/query_graph/sql/specifications/lookup_target.py
@@ -39,6 +39,7 @@ class LookupTargetSpec(BaseLookupSpec):
         specs = []
         for input_column_name, feature_name in zip(params.input_column_names, params.feature_names):
             spec = LookupTargetSpec(
+                node_name=node.name,
                 input_column_name=input_column_name,
                 feature_name=feature_name,
                 entity_column=params.entity_column,

--- a/tests/unit/query_graph/sql/aggregator/test_forward.py
+++ b/tests/unit/query_graph/sql/aggregator/test_forward.py
@@ -38,6 +38,8 @@ def forward_spec_fixture(forward_node_parameters, entity_id):
     forward spec fixture
     """
     return ForwardAggregateSpec(
+        node_name="forward_aggregate_1",
+        feature_name=forward_node_parameters.name,
         serving_names=["serving_cust_id", "other_serving_key"],
         serving_names_mapping=None,
         parameters=forward_node_parameters,

--- a/tests/unit/query_graph/test_asat_aggregator.py
+++ b/tests/unit/query_graph/test_asat_aggregator.py
@@ -48,6 +48,8 @@ def aggregation_spec_without_end_timestamp(
     aggregate_as_at_node_parameters, scd_aggregation_source, entity_id
 ):
     return AggregateAsAtSpec(
+        node_name="aggregate_as_at_1",
+        feature_name=aggregate_as_at_node_parameters.name,
         serving_names=["serving_cust_id"],
         serving_names_mapping=None,
         parameters=aggregate_as_at_node_parameters,
@@ -62,6 +64,8 @@ def aggregation_spec_with_end_timestamp(
     aggregate_as_at_node_parameters_with_end_timestamp, scd_aggregation_source, entity_id
 ):
     return AggregateAsAtSpec(
+        node_name="aggregate_as_at_2",
+        feature_name=aggregate_as_at_node_parameters_with_end_timestamp.name,
         serving_names=["serving_cust_id"],
         serving_names_mapping=None,
         parameters=aggregate_as_at_node_parameters_with_end_timestamp,
@@ -76,6 +80,8 @@ def aggregation_spec_with_serving_names_mapping(
     aggregate_as_at_node_parameters_with_end_timestamp, scd_aggregation_source, entity_id
 ):
     return AggregateAsAtSpec(
+        node_name="aggregate_as_at_3",
+        feature_name=aggregate_as_at_node_parameters_with_end_timestamp.name,
         serving_names=["serving_cust_id"],
         serving_names_mapping={"serving_cust_id": "new_serving_cust_id"},
         parameters=aggregate_as_at_node_parameters_with_end_timestamp,
@@ -100,9 +106,11 @@ def aggregation_specs_same_source_different_agg_funcs(
     params_2.agg_func = "max"
 
     specs = []
-    for params in [params_1, params_2]:
+    for i, params in enumerate([params_1, params_2]):
         specs.append(
             AggregateAsAtSpec(
+                node_name=f"aggregate_as_at_{i}",
+                feature_name=params.name,
                 serving_names=["serving_cust_id"],
                 serving_names_mapping=None,
                 parameters=params,
@@ -130,9 +138,11 @@ def aggregation_specs_same_source_different_keys(
     params_2.__dict__.update({"keys": ["key_2"], "serving_names": ["serving_key_2"]})
 
     specs = []
-    for params in [params_1, params_2]:
+    for i, params in enumerate([params_1, params_2]):
         specs.append(
             AggregateAsAtSpec(
+                node_name=f"aggregate_as_at_{i}",
+                feature_name=params.name,
                 serving_names=params.serving_names,
                 serving_names_mapping=None,
                 parameters=params,
@@ -152,6 +162,8 @@ def aggregation_spec_with_category(
     parameters = aggregate_as_at_node_parameters_with_end_timestamp.copy()
     parameters.value_by = "category_col"
     return AggregateAsAtSpec(
+        node_name="aggregate_as_at_1",
+        feature_name=parameters.name,
         serving_names=["serving_cust_id"],
         serving_names_mapping=None,
         parameters=parameters,

--- a/tests/unit/query_graph/test_feature_common.py
+++ b/tests/unit/query_graph/test_feature_common.py
@@ -24,6 +24,7 @@ def test_aggregation_spec__from_groupby_query_node(
     )
     expected_agg_specs = [
         TileBasedAggregationSpec(
+            node_name=groupby_node.name,
             window=7200,
             frequency=3600,
             blind_spot=900,
@@ -50,6 +51,7 @@ def test_aggregation_spec__from_groupby_query_node(
             **expected_pruned_graph_and_node_1,
         ),
         TileBasedAggregationSpec(
+            node_name=groupby_node.name,
             window=172800,
             frequency=3600,
             blind_spot=900,
@@ -100,6 +102,7 @@ def test_aggregation_spec__override_serving_names(
     )
     expected_agg_specs = [
         TileBasedAggregationSpec(
+            node_name=groupby_node.name,
             window=7200,
             frequency=3600,
             blind_spot=900,
@@ -126,6 +129,7 @@ def test_aggregation_spec__override_serving_names(
             **expected_pruned_graph_and_node_1,
         ),
         TileBasedAggregationSpec(
+            node_name=groupby_node.name,
             window=172800,
             frequency=3600,
             blind_spot=900,

--- a/tests/unit/query_graph/test_feature_compute.py
+++ b/tests/unit/query_graph/test_feature_compute.py
@@ -34,6 +34,7 @@ from tests.util.helper import assert_equal_with_expected_fixture
 def agg_spec_template_fixture(expected_pruned_graph_and_node_1):
     """Fixture for an AggregationSpec"""
     agg_spec = TileBasedAggregationSpec(
+        node_name=expected_pruned_graph_and_node_1["pruned_node"].name,
         window=86400,
         frequency=3600,
         blind_spot=120,
@@ -92,6 +93,8 @@ def item_agg_spec_fixture():
         agg_func="count",
     )
     agg_spec = ItemAggregationSpec(
+        node_name="item_groupby_1",
+        feature_name=parameters.name,
         parameters=parameters,
         serving_names=["OID"],
         serving_names_mapping=None,
@@ -244,11 +247,13 @@ def test_feature_execution_planner(
         query_graph_with_groupby, source_type=SourceType.SNOWFLAKE, is_online_serving=False
     )
     plan = planner.generate_plan([groupby_node])
-    assert list(
+    actual = list(
         plan.aggregators["window"].window_aggregation_spec_set.get_grouped_aggregation_specs()
-    ) == [
+    )
+    expected = [
         [
             TileBasedAggregationSpec(
+                node_name=groupby_node.name,
                 window=7200,
                 frequency=3600,
                 blind_spot=900,
@@ -277,6 +282,7 @@ def test_feature_execution_planner(
         ],
         [
             TileBasedAggregationSpec(
+                node_name=groupby_node.name,
                 window=172800,
                 frequency=3600,
                 blind_spot=900,
@@ -304,6 +310,7 @@ def test_feature_execution_planner(
             )
         ],
     ]
+    assert actual == expected
     assert plan.feature_specs == {
         "a_2h_average": FeatureSpec(
             feature_name="a_2h_average",
@@ -342,6 +349,7 @@ def test_feature_execution_planner__serving_names_mapping(
     ) == [
         [
             TileBasedAggregationSpec(
+                node_name=groupby_node.name,
                 window=7200,
                 frequency=3600,
                 blind_spot=900,
@@ -370,6 +378,7 @@ def test_feature_execution_planner__serving_names_mapping(
         ],
         [
             TileBasedAggregationSpec(
+                node_name=groupby_node.name,
                 window=172800,
                 frequency=3600,
                 blind_spot=900,

--- a/tests/unit/query_graph/test_item_aggregator.py
+++ b/tests/unit/query_graph/test_item_aggregator.py
@@ -30,6 +30,8 @@ def aggregation_spec_order_size(item_aggregation_source):
         name="order_size",
     )
     return ItemAggregationSpec(
+        node_name="item_groupby_1",
+        feature_name=params.name,
         serving_names=["serving_order_id"],
         serving_names_mapping={"serving_order_id": "new_serving_order_id"},
         parameters=params,
@@ -49,6 +51,8 @@ def aggregation_spec_max_item_price(item_aggregation_source):
         name="max_item_price",
     )
     return ItemAggregationSpec(
+        node_name="item_groupby_2",
+        feature_name=params.name,
         serving_names=["serving_order_id"],
         serving_names_mapping={"serving_order_id": "new_serving_order_id"},
         parameters=params,
@@ -69,6 +73,8 @@ def aggregation_spec_with_category(item_aggregation_source):
         name="max_item_price_by_type",
     )
     return ItemAggregationSpec(
+        node_name="item_groupby_3",
+        feature_name=params.name,
         serving_names=["serving_order_id"],
         serving_names_mapping={"serving_order_id": "new_serving_order_id"},
         parameters=params,

--- a/tests/unit/query_graph/test_lookup.py
+++ b/tests/unit/query_graph/test_lookup.py
@@ -6,6 +6,7 @@ import textwrap
 from featurebyte.enum import SourceType
 from featurebyte.query_graph.sql.builder import SQLOperationGraph
 from featurebyte.query_graph.sql.common import SQLType
+from featurebyte.query_graph.sql.specifications.lookup import LookupSpec
 
 
 def test_lookup_node_aggregation(global_graph, lookup_node):
@@ -30,12 +31,22 @@ def test_lookup_node_aggregation(global_graph, lookup_node):
     )
 
 
-def test_lookup_node_post_aggregation(global_graph, lookup_feature_node):
+def test_lookup_node_post_aggregation(global_graph, lookup_feature_node, lookup_node):
     """
     Test post aggregation expressions for Lookup node is correct
     """
+    aggregation_specs = {
+        lookup_node.name: LookupSpec.from_query_graph_node(
+            node=lookup_node,
+            graph=global_graph,
+            source_type=SourceType.SNOWFLAKE,
+        )
+    }
     sql_graph = SQLOperationGraph(
-        global_graph, sql_type=SQLType.POST_AGGREGATION, source_type=SourceType.SNOWFLAKE
+        global_graph,
+        sql_type=SQLType.POST_AGGREGATION,
+        source_type=SourceType.SNOWFLAKE,
+        aggregation_specs=aggregation_specs,
     )
     expr = sql_graph.build(lookup_feature_node).sql
     assert (

--- a/tests/unit/query_graph/test_lookup_aggregator.py
+++ b/tests/unit/query_graph/test_lookup_aggregator.py
@@ -104,7 +104,7 @@ def update_aggregator(aggregator, specs):
 
 
 def test_lookup_aggregator__offline_dimension_only(
-    offline_lookup_aggregator, dimension_lookup_specs, entity_id
+    offline_lookup_aggregator, dimension_lookup_specs, lookup_node, entity_id
 ):
     """
     Test lookup aggregator with only dimension lookup
@@ -119,6 +119,7 @@ def test_lookup_aggregator__offline_dimension_only(
         spec.pop("aggregation_source")
     assert specs == [
         {
+            "node_name": lookup_node.name,
             "serving_names": ["CUSTOMER_ID"],
             "serving_names_mapping": None,
             "input_column_name": "cust_value_1",
@@ -130,6 +131,7 @@ def test_lookup_aggregator__offline_dimension_only(
             "is_parent_lookup": False,
         },
         {
+            "node_name": lookup_node.name,
             "serving_names": ["CUSTOMER_ID"],
             "serving_names_mapping": None,
             "input_column_name": "cust_value_2",
@@ -148,7 +150,7 @@ def test_lookup_aggregator__offline_dimension_only(
 
 @pytest.mark.parametrize("is_online_serving", [False])
 def test_lookup_aggregator__offline_scd_only(
-    offline_lookup_aggregator, scd_lookup_specs_with_current_flag, entity_id
+    offline_lookup_aggregator, scd_lookup_specs_with_current_flag, entity_id, scd_lookup_node
 ):
     """
     Test lookup aggregator with only scd lookups
@@ -166,6 +168,7 @@ def test_lookup_aggregator__offline_scd_only(
         spec.pop("aggregation_source")
     assert specs == [
         {
+            "node_name": scd_lookup_node.name,
             "serving_names": ["CUSTOMER_ID"],
             "entity_ids": [entity_id],
             "serving_names_mapping": None,
@@ -190,6 +193,7 @@ def test_lookup_aggregator__online_with_current_flag(
     online_lookup_aggregator,
     scd_lookup_specs_with_current_flag,
     entity_id,
+    scd_lookup_node,
 ):
     """
     Test lookup aggregator with only scd lookups
@@ -205,6 +209,7 @@ def test_lookup_aggregator__online_with_current_flag(
         spec.pop("aggregation_source")
     assert specs == [
         {
+            "node_name": scd_lookup_node.name,
             "serving_names": ["CUSTOMER_ID"],
             "entity_ids": [entity_id],
             "serving_names_mapping": None,
@@ -254,6 +259,7 @@ def test_lookup_aggregator__online_without_current_flag(
     online_lookup_aggregator,
     scd_lookup_specs_without_current_flag,
     entity_id,
+    scd_lookup_without_current_flag_node,
 ):
     """
     Test lookup aggregator with only scd lookups without a current flag column
@@ -272,6 +278,7 @@ def test_lookup_aggregator__online_without_current_flag(
         spec.pop("aggregation_source")
     assert specs == [
         {
+            "node_name": scd_lookup_without_current_flag_node.name,
             "serving_names": ["CUSTOMER_ID"],
             "entity_ids": [entity_id],
             "serving_names_mapping": None,
@@ -296,6 +303,7 @@ def test_lookup_aggregator__online_with_offset(
     online_lookup_aggregator,
     scd_lookup_specs_with_offset,
     entity_id,
+    scd_offset_lookup_node,
 ):
     """
     Test lookup aggregator with only scd lookups with offset
@@ -314,6 +322,7 @@ def test_lookup_aggregator__online_with_offset(
         spec.pop("aggregation_source")
     assert specs == [
         {
+            "node_name": scd_offset_lookup_node.name,
             "serving_names": ["CUSTOMER_ID"],
             "entity_ids": [entity_id],
             "serving_names_mapping": None,
@@ -333,7 +342,9 @@ def test_lookup_aggregator__online_with_offset(
     ]
 
 
-def test_lookup_aggregator__event_table(offline_lookup_aggregator, event_lookup_specs, entity_id):
+def test_lookup_aggregator__event_table(
+    offline_lookup_aggregator, event_lookup_specs, entity_id, event_lookup_node
+):
     """
     Test lookup features from EventTable
     """
@@ -347,6 +358,7 @@ def test_lookup_aggregator__event_table(offline_lookup_aggregator, event_lookup_
         spec.pop("aggregation_source")
     assert specs == [
         {
+            "node_name": event_lookup_node.name,
             "entity_ids": [entity_id],
             "serving_names": ["ORDER_ID"],
             "serving_names_mapping": None,

--- a/tests/unit/query_graph/test_sql.py
+++ b/tests/unit/query_graph/test_sql.py
@@ -59,6 +59,7 @@ def make_context(node_type=None, parameters=None, input_sql_nodes=None, sql_type
         source_type=SourceType.SNOWFLAKE,
         to_filter_scd_by_current_flag=False,
         event_table_timestamp_filter=None,
+        aggregation_specs=None,
     )
     return context
 


### PR DESCRIPTION
## Description

This refactors and simplifies the Aggregate sql ast node to reduce code duplication. The handling of all aggregation node types is now consolidated into a single class. The refactored logic should also be more efficient since `update_feature_specs` doesn't have to re-extract aggregation specifications from graph again.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
