### PR TITLE
[chore] Improve efficiency of feature table cache checks for saved feature lists

### DIFF
--- a/.changelog/DEV-3081.yaml
+++ b/.changelog/DEV-3081.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Improve efficiency of feature table cache checks for saved feature lists"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/models/feature_list.py
+++ b/featurebyte/models/feature_list.py
@@ -218,7 +218,7 @@ class FeatureReadinessDistribution(FeatureByteBaseModel):
         )
 
 
-class FeatureNodeAttributes(FeatureByteBaseModel):
+class FeatureNodeDefinitionHashes(FeatureByteBaseModel):
     """
     Additional information about each node in the FeatureCluster
     """
@@ -236,12 +236,12 @@ class FeatureCluster(FeatureByteBaseModel):
     graph: QueryGraph
     node_names: List[StrictStr]
     feature_node_relationships_infos: Optional[List[FeatureNodeRelationshipsInfo]]
-    feature_node_attributes: Optional[List[FeatureNodeAttributes]]
+    feature_node_definition_hashes: Optional[List[FeatureNodeDefinitionHashes]]
     combined_relationships_info: List[EntityRelationshipInfo] = Field(allow_mutation=False)
 
     @root_validator(pre=True)
     @classmethod
-    def _derive_attributes(cls, values: dict[str, Any]) -> dict[str, Any]:
+    def _derive_combined_relationships_info(cls, values: dict[str, Any]) -> dict[str, Any]:
         if "combined_relationships_info" in values:
             return values
         combined_relationships_info: Set[EntityRelationshipInfo] = set()
@@ -498,7 +498,7 @@ class FeatureListModel(FeatureByteCatalogBaseDocumentModel):
                 feature_objects=group_features
             )
             feature_node_relationships_info = []
-            feature_node_attributes = []
+            feature_node_definition_hashes = []
             for feature, mapped_node in zip(group_features, mapped_nodes):
                 feature_node_relationships_info.append(
                     FeatureNodeRelationshipsInfo(
@@ -507,8 +507,8 @@ class FeatureListModel(FeatureByteCatalogBaseDocumentModel):
                         primary_entity_ids=feature.primary_entity_ids,
                     )
                 )
-                feature_node_attributes.append(
-                    FeatureNodeAttributes(
+                feature_node_definition_hashes.append(
+                    FeatureNodeDefinitionHashes(
                         node_name=mapped_node.name,
                         definition_hash=feature.definition_hash,
                     )
@@ -519,7 +519,7 @@ class FeatureListModel(FeatureByteCatalogBaseDocumentModel):
                     graph=pruned_graph,
                     node_names=[node.name for node in mapped_nodes],
                     feature_node_relationships_infos=feature_node_relationships_info,
-                    feature_node_attributes=feature_node_attributes,
+                    feature_node_definition_hashes=feature_node_definition_hashes,
                 )
             )
         return feature_clusters

--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -133,9 +133,9 @@ class FeatureTableCacheService:
         if feature_list_id is not None:
             feature_list = await self.feature_list_service.get_document(feature_list_id)
             if feature_list.feature_clusters is not None:
-                feature_node_attributes = feature_list.feature_clusters[0].feature_node_attributes
-                if feature_node_attributes is not None:
-                    for info in feature_node_attributes:
+                stored_hashes = feature_list.feature_clusters[0].feature_node_definition_hashes
+                if stored_hashes is not None:
+                    for info in stored_hashes:
                         if info.definition_hash is not None:
                             definition_hashes_mapping[info.node_name] = info.definition_hash
 

--- a/tests/fixtures/request_payloads/historical_feature_table.json
+++ b/tests/fixtures/request_payloads/historical_feature_table.json
@@ -10,6 +10,12 @@
         "feature_clusters": [
             {
                 "combined_relationships_info": [],
+                "feature_node_attributes": [
+                    {
+                        "definition_hash": null,
+                        "node_name": "project_1"
+                    }
+                ],
                 "feature_node_relationships_infos": [
                     {
                         "node_name": "project_1",

--- a/tests/fixtures/request_payloads/historical_feature_table.json
+++ b/tests/fixtures/request_payloads/historical_feature_table.json
@@ -10,7 +10,7 @@
         "feature_clusters": [
             {
                 "combined_relationships_info": [],
-                "feature_node_attributes": [
+                "feature_node_definition_hashes": [
                     {
                         "definition_hash": null,
                         "node_name": "project_1"

--- a/tests/integration/service/test_feature_table_cache.py
+++ b/tests/integration/service/test_feature_table_cache.py
@@ -88,6 +88,31 @@ def observation_table_fixture(event_view):
 
 
 @pytest.mark.asyncio
+async def test_definition_hashes_for_nodes_consistent(
+    feature_table_cache_service,
+    feature_service,
+    feature_list,
+):
+    """
+    Test definition_hashes_for_nodes computes definition hashes that match with saved features
+    """
+    # Compute definition hashes from scratch in feature table cache service
+    computed_hashes = await feature_table_cache_service.definition_hashes_for_nodes(
+        feature_list.cached_model.feature_clusters[0].graph,
+        feature_list.cached_model.feature_clusters[0].nodes,
+    )
+
+    # Compare with saved features
+    saved_hashes = {
+        doc.definition_hash
+        async for doc in feature_service.list_documents_iterator(
+            query_filter={"_id": {"$in": list(feature_list.feature_ids)}}
+        )
+    }
+    assert set(computed_hashes) == saved_hashes
+
+
+@pytest.mark.asyncio
 async def test_create_feature_table_cache(
     feature_store,
     session,


### PR DESCRIPTION
## Description

Currently, `FeatureTableCacheService` always computes the definition hashes for the provided nodes which can be expensive for a large number of features. We can avoid this by storing this information in the feature cluster when saving feature lists.

Timing comparison: using about 300 features when all features are already cached, time taken by `create_or_update_feature_table_cache` - 43s (before) vs 0.2s (after).

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
