### PR TITLE
[DEV-3083] Support cancellation for historical features table creation task

### DIFF
--- a/.changelog/DEV-3083.yaml
+++ b/.changelog/DEV-3083.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Support cancellation for historical features table creation task"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/schema/worker/task/historical_feature_table.py
+++ b/featurebyte/schema/worker/task/historical_feature_table.py
@@ -20,3 +20,4 @@ class HistoricalFeatureTableTaskPayload(BaseTaskPayload, HistoricalFeatureTableC
     command = WorkerCommand.HISTORICAL_FEATURE_TABLE_CREATE
     task_type = TaskType.CPU_TASK
     observation_set_storage_path: Optional[str]
+    is_revocable = True

--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -458,7 +458,7 @@ class FeatureTableCacheService:
             )
             _ = await session.execute_query(query)
             return True
-        except session._no_schema_error:
+        except session._no_schema_error:  # pylint: disable=protected-access
             return False
 
     async def create_or_update_feature_table_cache(

--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -445,6 +445,22 @@ class FeatureTableCacheService:
                 if_exists=True,
             )
 
+    @staticmethod
+    async def _feature_table_cache_exists(
+        cache_metadata: FeatureTableCacheMetadataModel, session: BaseSession
+    ) -> bool:
+        try:
+            query = sql_to_string(
+                expressions.select(expressions.Count(this=expressions.Star()))
+                .from_(quoted_identifier(cache_metadata.table_name))
+                .limit(1),
+                source_type=session.source_type,
+            )
+            _ = await session.execute_query(query)
+            return True
+        except session._no_schema_error:
+            return False
+
     async def create_or_update_feature_table_cache(
         self,
         feature_store: FeatureStoreModel,
@@ -498,7 +514,12 @@ class FeatureTableCacheService:
                 observation_table_id=observation_table.id,
             )
         )
-        feature_table_cache_exists = bool(cache_metadata.feature_definitions)
+        db_session = await self.session_manager_service.get_feature_store_session(
+            feature_store=feature_store
+        )
+        feature_table_cache_exists = await self._feature_table_cache_exists(
+            cache_metadata, db_session
+        )
 
         hashes = await self.get_feature_definition_hashes(graph, nodes, feature_list_id)
         non_cached_nodes = await self.get_non_cached_nodes(cache_metadata, nodes, hashes)
@@ -522,10 +543,6 @@ class FeatureTableCacheService:
                     is_feature_list_deployed = feature_list.deployed
                 except DocumentNotFoundError:
                     is_feature_list_deployed = False
-
-            db_session = await self.session_manager_service.get_feature_store_session(
-                feature_store=feature_store
-            )
 
             if feature_table_cache_exists:
                 # if feature table cache exists - update existing table with new features

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -552,10 +552,10 @@ def get_training_events_and_expected_result():
 @pytest.mark.parametrize(
     "in_out_formats",
     [
-        # ("dataframe", "dataframe"),
-        # ("dataframe", "table"),
+        ("dataframe", "dataframe"),
+        ("dataframe", "table"),
         ("table", "table"),  # input is observation table
-        # ("uploaded_table", "table"),  # input is observation table from uploaded parquet file
+        ("uploaded_table", "table"),  # input is observation table from uploaded parquet file
     ],
 )
 @pytest.mark.usefixtures("patched_num_features_per_query")

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -552,10 +552,10 @@ def get_training_events_and_expected_result():
 @pytest.mark.parametrize(
     "in_out_formats",
     [
-        ("dataframe", "dataframe"),
-        ("dataframe", "table"),
+        # ("dataframe", "dataframe"),
+        # ("dataframe", "table"),
         ("table", "table"),  # input is observation table
-        ("uploaded_table", "table"),  # input is observation table from uploaded parquet file
+        # ("uploaded_table", "table"),  # input is observation table from uploaded parquet file
     ],
 )
 @pytest.mark.usefixtures("patched_num_features_per_query")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -20,6 +20,7 @@ import pytest_asyncio
 from bson.objectid import ObjectId
 from cachetools import TTLCache
 from fastapi.testclient import TestClient
+from snowflake.connector import ProgrammingError
 from snowflake.connector.constants import QueryStatus
 
 from featurebyte import (
@@ -1848,6 +1849,7 @@ def mock_snowflake_session_fixture():
         source_type=SourceType.SNOWFLAKE,
         database_name="sf_db",
         schema_name="sf_schema",
+        _no_schema_error=ProgrammingError,
     )
 
 

--- a/tests/unit/service/test_feature_table_cache.py
+++ b/tests/unit/service/test_feature_table_cache.py
@@ -3,7 +3,6 @@ Test FeatureTableCacheService
 """
 import json
 import os
-import textwrap
 from unittest.mock import patch
 
 import pytest
@@ -18,6 +17,7 @@ from featurebyte.query_graph.model.common_table import TabularSource
 from featurebyte.query_graph.node.schema import TableDetails
 from featurebyte.schema.feature import FeatureServiceCreate
 from featurebyte.schema.feature_list import FeatureListServiceCreate
+from tests.util.helper import assert_sql_equal
 
 
 @pytest.fixture(name="auto_mocks", autouse=True)
@@ -360,16 +360,14 @@ async def test_update_feature_table_cache(
     call_args = mock_snowflake_session.execute_query.await_args_list
     sqls = [arg[0][0] for arg in call_args]
 
-    assert (
-        sqls[0]
-        == textwrap.dedent(
-            f"""
+    assert_sql_equal(
+        sqls[0],
+        f"""
         SELECT
           COUNT(*)
         FROM "{feature_table_cache.table_name}"
         LIMIT 1
-        """
-        ).strip()
+        """,
     )
     assert sqls[1] == (
         "ALTER TABLE "
@@ -449,16 +447,14 @@ async def test_update_feature_table_cache__mix_cached_and_non_cached_features(
     call_args = mock_snowflake_session.execute_query.await_args_list
     sqls = [arg[0][0] for arg in call_args]
 
-    assert (
-        sqls[0]
-        == textwrap.dedent(
-            f"""
+    assert_sql_equal(
+        sqls[0],
+        f"""
         SELECT
           COUNT(*)
         FROM "{feature_table_cache.table_name}"
         LIMIT 1
-        """
-        ).strip()
+        """,
     )
     assert sqls[1] == (
         "ALTER TABLE "
@@ -515,16 +511,14 @@ async def test_create_view_from_cache__create_cache(
     call_args = mock_snowflake_session.execute_query.await_args_list
     sqls = [arg[0][0] for arg in call_args]
 
-    assert (
-        sqls[0]
-        == textwrap.dedent(
-            f"""
+    assert_sql_equal(
+        sqls[0],
+        f"""
         SELECT
           COUNT(*)
         FROM "{feature_table_cache.table_name}"
         LIMIT 1
-        """
-        ).strip()
+        """,
     )
     assert sqls[1] == (
         "CREATE TABLE "
@@ -604,16 +598,14 @@ async def test_create_view_from_cache__update_cache(
     sqls = [arg[0][0] for arg in call_args]
     assert len(sqls) == 4
 
-    assert (
-        sqls[0]
-        == textwrap.dedent(
-            f"""
+    assert_sql_equal(
+        sqls[0],
+        f"""
         SELECT
           COUNT(*)
         FROM "{feature_table_cache.table_name}"
         LIMIT 1
-        """
-        ).strip()
+        """,
     )
     assert sqls[1] == (
         "ALTER TABLE "

--- a/tests/unit/service/test_feature_table_cache.py
+++ b/tests/unit/service/test_feature_table_cache.py
@@ -3,11 +3,14 @@ Test FeatureTableCacheService
 """
 import json
 import os
+import textwrap
 from unittest.mock import patch
 
 import pytest
 import pytest_asyncio
 from bson import ObjectId
+from snowflake.connector import ProgrammingError
+from sqlglot import parse_one
 
 from featurebyte.models.observation_table import ObservationTableModel
 from featurebyte.models.request_input import SourceTableRequestInput
@@ -173,6 +176,27 @@ def intercepted_definition_hashes_for_nodes_fixture(feature_table_cache_service)
         yield mocked_method
 
 
+@pytest.fixture(name="mock_snowflake_session")
+def mock_snowflake_session_fixture(mock_snowflake_session, feature_table_cache_metadata_service):
+    """
+    Patch session query results
+    """
+
+    async def mock_execute_query(query):
+        if "LIMIT 1" in query:
+            table_name = parse_one(query).args["from"].expressions[0].name
+            async for doc in feature_table_cache_metadata_service.list_documents_iterator(
+                query_filter={"table_name": table_name}
+            ):
+                if len(doc.feature_definitions) > 0:
+                    return
+            raise ProgrammingError("table not found")
+
+    mock_snowflake_session.execute_query.side_effect = mock_execute_query
+
+    yield mock_snowflake_session
+
+
 @pytest.mark.parametrize("feature_list_id_provided", [True, False])
 @pytest.mark.asyncio
 async def test_get_feature_definition_hashes(
@@ -228,7 +252,7 @@ async def test_create_feature_table_cache(
     assert params["output_table_details"].table_name == "__TEMP__FEATURE_TABLE_CACHE_ObjectId"
     assert params["is_feature_list_deployed"] == feature_list.deployed
 
-    assert mock_snowflake_session.execute_query.await_count == 1
+    assert mock_snowflake_session.execute_query.await_count == 2
 
     feature_table_cache = (
         await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
@@ -237,7 +261,10 @@ async def test_create_feature_table_cache(
     )
     assert len(feature_table_cache.feature_definitions) == 2
 
-    sql = mock_snowflake_session.execute_query.await_args.args[0]
+    sql = mock_snowflake_session.execute_query.await_args_list[0].args[0]
+    assert "COUNT(*)" in sql
+
+    sql = mock_snowflake_session.execute_query.await_args_list[1].args[0]
     assert sql == (
         "CREATE TABLE "
         f'"sf_db"."sf_schema"."{feature_table_cache.table_name}" AS\n'
@@ -275,7 +302,7 @@ async def test_update_feature_table_cache(
     params = mock_get_historical_features.await_args.kwargs
     assert params["graph"] == feature_list.feature_clusters[0].graph
     assert params["nodes"] == feature_list.feature_clusters[0].nodes[:1]
-    assert mock_snowflake_session.execute_query.await_count == 1
+    assert mock_snowflake_session.execute_query.await_count == 2
 
     feature_table_cache = (
         await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
@@ -283,6 +310,9 @@ async def test_update_feature_table_cache(
         )
     )
     assert len(feature_table_cache.feature_definitions) == 1
+
+    sql = mock_snowflake_session.execute_query.await_args_list[0].args[0]
+    assert "COUNT(*)" in sql
 
     # check first create sql
     sql = mock_snowflake_session.execute_query.await_args.args[0]
@@ -318,7 +348,7 @@ async def test_update_feature_table_cache(
     assert params["output_table_details"].table_name == "__TEMP__FEATURE_TABLE_CACHE_ObjectId"
     assert params["is_feature_list_deployed"] == feature_list.deployed
 
-    assert mock_snowflake_session.execute_query.await_count == 2
+    assert mock_snowflake_session.execute_query.await_count == 3
 
     feature_table_cache = (
         await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
@@ -330,12 +360,23 @@ async def test_update_feature_table_cache(
     call_args = mock_snowflake_session.execute_query.await_args_list
     sqls = [arg[0][0] for arg in call_args]
 
-    assert sqls[0] == (
+    assert (
+        sqls[0]
+        == textwrap.dedent(
+            f"""
+        SELECT
+          COUNT(*)
+        FROM "{feature_table_cache.table_name}"
+        LIMIT 1
+        """
+        ).strip()
+    )
+    assert sqls[1] == (
         "ALTER TABLE "
         f'"sf_db"."sf_schema"."{feature_table_cache.table_name}" ADD '
         'COLUMN "FEATURE_ada88371db4be31a4e9c0538fb675d8e573aed24" FLOAT'
     )
-    assert sqls[1] == (
+    assert sqls[2] == (
         "MERGE INTO "
         f'"sf_db"."sf_schema"."{feature_table_cache.table_name}" AS '
         "feature_table_cache USING "
@@ -396,7 +437,7 @@ async def test_update_feature_table_cache__mix_cached_and_non_cached_features(
     assert params["output_table_details"].table_name == "__TEMP__FEATURE_TABLE_CACHE_ObjectId"
     assert params["is_feature_list_deployed"] == feature_list.deployed
 
-    assert mock_snowflake_session.execute_query.await_count == 2
+    assert mock_snowflake_session.execute_query.await_count == 3
 
     feature_table_cache = (
         await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
@@ -408,12 +449,23 @@ async def test_update_feature_table_cache__mix_cached_and_non_cached_features(
     call_args = mock_snowflake_session.execute_query.await_args_list
     sqls = [arg[0][0] for arg in call_args]
 
-    assert sqls[0] == (
+    assert (
+        sqls[0]
+        == textwrap.dedent(
+            f"""
+        SELECT
+          COUNT(*)
+        FROM "{feature_table_cache.table_name}"
+        LIMIT 1
+        """
+        ).strip()
+    )
+    assert sqls[1] == (
         "ALTER TABLE "
         f'"sf_db"."sf_schema"."{feature_table_cache.table_name}" ADD '
         'COLUMN "FEATURE_ada88371db4be31a4e9c0538fb675d8e573aed24" FLOAT'
     )
-    assert sqls[1] == (
+    assert sqls[2] == (
         "MERGE INTO "
         f'"sf_db"."sf_schema"."{feature_table_cache.table_name}" AS '
         "feature_table_cache USING "
@@ -452,7 +504,7 @@ async def test_create_view_from_cache__create_cache(
     )
 
     assert mock_get_historical_features.await_count == 1
-    assert mock_snowflake_session.execute_query.await_count == 2
+    assert mock_snowflake_session.execute_query.await_count == 3
 
     feature_table_cache = (
         await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
@@ -463,7 +515,18 @@ async def test_create_view_from_cache__create_cache(
     call_args = mock_snowflake_session.execute_query.await_args_list
     sqls = [arg[0][0] for arg in call_args]
 
-    assert sqls[0] == (
+    assert (
+        sqls[0]
+        == textwrap.dedent(
+            f"""
+        SELECT
+          COUNT(*)
+        FROM "{feature_table_cache.table_name}"
+        LIMIT 1
+        """
+        ).strip()
+    )
+    assert sqls[1] == (
         "CREATE TABLE "
         f'"sf_db"."sf_schema"."{feature_table_cache.table_name}" AS\n'
         "SELECT\n"
@@ -474,7 +537,7 @@ async def test_create_view_from_cache__create_cache(
         '  "sum_2h" AS "FEATURE_ada88371db4be31a4e9c0538fb675d8e573aed24"\n'
         'FROM "__TEMP__FEATURE_TABLE_CACHE_ObjectId"'
     )
-    assert sqls[1] == (
+    assert sqls[2] == (
         'CREATE VIEW "sf_db"."sf_schema"."result_view" AS\n'
         "SELECT\n"
         '  "__FB_TABLE_ROW_INDEX",\n'
@@ -513,7 +576,7 @@ async def test_create_view_from_cache__update_cache(
         feature_list_id=feature_list.id,
     )
     assert mock_get_historical_features.await_count == 1
-    assert mock_snowflake_session.execute_query.await_count == 2
+    assert mock_snowflake_session.execute_query.await_count == 3
 
     mock_get_historical_features.reset_mock()
     mock_snowflake_session.reset_mock()
@@ -529,7 +592,7 @@ async def test_create_view_from_cache__update_cache(
         feature_list_id=feature_list.id,
     )
     assert mock_get_historical_features.await_count == 1
-    assert mock_snowflake_session.execute_query.await_count == 3
+    assert mock_snowflake_session.execute_query.await_count == 4
 
     feature_table_cache = (
         await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
@@ -539,14 +602,25 @@ async def test_create_view_from_cache__update_cache(
 
     call_args = mock_snowflake_session.execute_query.await_args_list
     sqls = [arg[0][0] for arg in call_args]
-    assert len(sqls) == 3
+    assert len(sqls) == 4
 
-    assert sqls[0] == (
+    assert (
+        sqls[0]
+        == textwrap.dedent(
+            f"""
+        SELECT
+          COUNT(*)
+        FROM "{feature_table_cache.table_name}"
+        LIMIT 1
+        """
+        ).strip()
+    )
+    assert sqls[1] == (
         "ALTER TABLE "
         f'"sf_db"."sf_schema"."{feature_table_cache.table_name}" ADD '
         'COLUMN "FEATURE_ada88371db4be31a4e9c0538fb675d8e573aed24" FLOAT'
     )
-    assert sqls[1] == (
+    assert sqls[2] == (
         "MERGE INTO "
         f'"sf_db"."sf_schema"."{feature_table_cache.table_name}" AS '
         "feature_table_cache USING "
@@ -556,7 +630,7 @@ async def test_create_view_from_cache__update_cache(
         'feature_table_cache."FEATURE_ada88371db4be31a4e9c0538fb675d8e573aed24" = '
         'partial_features."sum_2h"'
     )
-    assert sqls[2] == (
+    assert sqls[3] == (
         'CREATE VIEW "sf_db"."sf_schema"."result_view" AS\n'
         "SELECT\n"
         '  "__FB_TABLE_ROW_INDEX",\n'
@@ -595,7 +669,7 @@ async def test_create_feature_table_cache__with_target(
     assert params["output_table_details"].schema_name == "sf_schema"
     assert params["output_table_details"].table_name == "__TEMP__FEATURE_TABLE_CACHE_ObjectId"
 
-    assert mock_snowflake_session.execute_query.await_count == 1
+    assert mock_snowflake_session.execute_query.await_count == 2
 
     feature_table_cache = (
         await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
@@ -636,7 +710,7 @@ async def test_read_from_cache(
         feature_list_id=feature_list.id,
     )
     assert mock_get_historical_features.await_count == 1
-    assert mock_snowflake_session.execute_query.await_count == 1
+    assert mock_snowflake_session.execute_query.await_count == 2
 
     mock_snowflake_session.reset_mock()
 

--- a/tests/util/helper.py
+++ b/tests/util/helper.py
@@ -359,6 +359,16 @@ def assert_preview_result_equal(df_preview, expected_dict, dict_like_columns=Non
     fb_assert_frame_equal(df_preview, df_expected, dict_like_columns=dict_like_columns)
 
 
+def assert_sql_equal(actual, expected):
+    """
+    Compare sql potentially with multiple lines. Leading and trailing spaces and newlines are
+    stripped before comparison.
+    """
+    actual = textwrap.dedent(actual).strip()
+    expected = textwrap.dedent(expected).strip()
+    assert actual == expected
+
+
 def iet_entropy(view, group_by_col, window, name, feature_job_setting=None):
     """
     Create feature to capture the entropy of inter-event interval time,


### PR DESCRIPTION
## Description

This updates the historical features table creation task to be revokable. The task itself already handles deletion of temporary tables on exception, except a potential discrepancy when checking the existence of feature cache table which is fixed in this PR. 

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
