### PR TITLE
[chore] Use frozen relationships for offline store feature tables

### DIFF
--- a/featurebyte/models/offline_store_feature_table.py
+++ b/featurebyte/models/offline_store_feature_table.py
@@ -26,6 +26,7 @@ from featurebyte.models.entity_universe import EntityUniverseModel
 from featurebyte.models.feature import FeatureModel
 from featurebyte.models.feature_list import FeatureCluster
 from featurebyte.models.offline_store_ingest_query import OfflineStoreIngestQueryGraph
+from featurebyte.models.parent_serving import FeatureNodeRelationshipsInfo
 from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.query_graph.model.entity_relationship_info import EntityRelationshipInfo
 from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
@@ -318,6 +319,7 @@ def get_combined_ingest_graph(
     all_offline_ingest_graphs = []
 
     primary_entity_ids = sorted([entity.id for entity in primary_entities])
+    feature_node_relationships_info = []
     for feature in features:
         offline_ingest_graphs = (
             feature.offline_store_info.extract_offline_store_ingest_query_graphs()
@@ -335,7 +337,15 @@ def get_combined_ingest_graph(
 
             graph, node = offline_ingest_graph.ingest_graph_and_node()
             local_query_graph, local_name_map = local_query_graph.load(graph)
-            output_nodes.append(local_query_graph.get_node_by_name(local_name_map[node.name]))
+            mapped_node = local_query_graph.get_node_by_name(local_name_map[node.name])
+            output_nodes.append(mapped_node)
+            feature_node_relationships_info.append(
+                FeatureNodeRelationshipsInfo(
+                    node_name=mapped_node.name,
+                    relationships_info=feature.relationships_info or [],
+                    primary_entity_ids=offline_ingest_graph.primary_entity_ids,
+                )
+            )
             output_column_names.append(offline_ingest_graph.output_column_name)
             output_dtypes.append(offline_ingest_graph.output_dtype)
             all_offline_ingest_graphs.append(offline_ingest_graph)
@@ -344,6 +354,7 @@ def get_combined_ingest_graph(
         feature_store_id=features[0].tabular_source.feature_store_id,
         graph=local_query_graph,
         node_names=[node.name for node in output_nodes],
+        feature_node_relationships_infos=feature_node_relationships_info,
     )
 
     return OfflineIngestGraphMetadata(

--- a/featurebyte/service/entity_validation.py
+++ b/featurebyte/service/entity_validation.py
@@ -3,19 +3,117 @@ Module to support serving using parent-child relationship
 """
 from __future__ import annotations
 
-from typing import Optional, Tuple
+from typing import List, Optional, Sequence, Tuple
+
+from dataclasses import dataclass
+
+from bson import ObjectId
 
 from featurebyte.exception import RequiredEntityNotProvidedError, UnexpectedServingNamesMappingError
 from featurebyte.models.entity_validation import EntityInfo
-from featurebyte.models.feature_list import FeatureListModel
+from featurebyte.models.feature_list import FeatureCluster, FeatureListModel
 from featurebyte.models.feature_store import FeatureStoreModel
+from featurebyte.models.offline_store_feature_table import OfflineStoreFeatureTableModel
 from featurebyte.models.parent_serving import EntityRelationshipsContext, ParentServingPreparation
+from featurebyte.query_graph.model.entity_relationship_info import EntityRelationshipInfo
 from featurebyte.query_graph.model.graph import QueryGraphModel
 from featurebyte.query_graph.node import Node
 from featurebyte.query_graph.node.schema import FeatureStoreDetails
 from featurebyte.query_graph.sql.feature_compute import FeatureExecutionPlanner
 from featurebyte.service.entity import EntityService
 from featurebyte.service.parent_serving import ParentEntityLookupService
+
+
+def to_use_frozen_relationships(
+    feature_cluster_like: Optional[List[FeatureCluster]] | Optional[FeatureCluster],
+) -> bool:
+    """
+    Whether the feature cluster has the field feature_node_relationships_infos populated. If so, sql
+    generation should use it to compute features based on frozen relationships.
+
+    Parameters
+    ----------
+    feature_cluster_like: Optional[List[FeatureCluster]] | Optional[FeatureCluster]
+        The feature cluster like object from FeatureListModel or OfflineStoreFeatureTableModel
+
+    Returns
+    -------
+    bool
+    """
+    if feature_cluster_like is None:
+        return False
+    if isinstance(feature_cluster_like, list):
+        feature_cluster = feature_cluster_like[0]
+    else:
+        feature_cluster = feature_cluster_like
+    return feature_cluster.feature_node_relationships_infos is not None
+
+
+@dataclass
+class EntityRelationshipsContextParameters:
+    """
+    Parameters required to construct a EntityRelationshipsContext object
+
+    Can be created from FeatureListModel or OfflineFeatureStoreTableModel objects.
+    """
+
+    feature_cluster: FeatureCluster
+    primary_entity_ids: Sequence[ObjectId]
+    relationships_info: Optional[List[EntityRelationshipInfo]]
+
+    @classmethod
+    def from_feature_list(
+        cls, feature_list_model: FeatureListModel
+    ) -> Optional[EntityRelationshipsContextParameters]:
+        """
+        Create EntityRelationshipsContextParameters from a FeatureListModel
+
+        Parameters
+        ----------
+        feature_list_model: FeatureListModel
+            Feature list model
+
+        Returns
+        -------
+        Optional[EntityRelationshipsContextParameters]
+            None for legacy documents without the required information
+        """
+        if feature_list_model.feature_clusters is not None:
+            feature_cluster = feature_list_model.feature_clusters[0]
+            if feature_cluster.feature_node_relationships_infos is not None:
+                return EntityRelationshipsContextParameters(
+                    feature_cluster=feature_cluster,
+                    primary_entity_ids=feature_list_model.primary_entity_ids,
+                    relationships_info=feature_list_model.relationships_info,
+                )
+        return None
+
+    @classmethod
+    def from_offline_store_feature_table(
+        cls, offline_store_feature_table_model: OfflineStoreFeatureTableModel
+    ) -> Optional[EntityRelationshipsContextParameters]:
+        """
+        Create EntityRelationshipsContextParameters from a OfflineStoreFeatureTableModel
+
+        Parameters
+        ----------
+        offline_store_feature_table_model: OfflineStoreFeatureTableModel
+            Offline store feature table model
+
+        Returns
+        -------
+        Optional[EntityRelationshipsContextParameters]
+            None for legacy documents without the required information
+        """
+        if offline_store_feature_table_model.feature_cluster is not None:
+            feature_cluster = offline_store_feature_table_model.feature_cluster
+            if feature_cluster.feature_node_relationships_infos is not None:
+                return EntityRelationshipsContextParameters(
+                    feature_cluster=feature_cluster,
+                    primary_entity_ids=offline_store_feature_table_model.primary_entity_ids,
+                    relationships_info=None,
+                )
+        return None
 
 
 class EntityValidationService:
@@ -38,6 +136,7 @@ class EntityValidationService:
         feature_list_model: Optional[FeatureListModel],
         request_column_names: set[str],
         serving_names_mapping: dict[str, str] | None = None,
+        offline_store_feature_table_model: Optional[OfflineStoreFeatureTableModel] = None,
     ) -> EntityInfo:
         """
         Create an EntityInfo instance given graph and request
@@ -53,6 +152,9 @@ class EntityValidationService:
         serving_names_mapping : dict[str, str] | None
             Optional serving names mapping if the entities are provided under different serving
             names in the request
+        offline_store_feature_table_model: Optional[OfflineStoreFeatureTableModel]
+            Offline store feature table model when the request is initiated by feature materialize
+            service
 
         Returns
         -------
@@ -77,14 +179,18 @@ class EntityValidationService:
             candidate_serving_names
         )
 
-        # Extract required entities from feature list (faster) or graph
+        # Extract required entities from feature cluster (faster) or graph
+        required_entity_ids: Optional[Sequence[ObjectId]] = None
         if feature_list_model is not None:
-            if self._to_use_frozen_relationships(feature_list_model):
+            if to_use_frozen_relationships(feature_list_model.feature_clusters):
                 required_entity_ids = feature_list_model.primary_entity_ids
             else:
                 required_entity_ids = feature_list_model.entity_ids
-            required_entities = await self.entity_service.get_entities(set(required_entity_ids))
-        else:
+        elif offline_store_feature_table_model is not None:
+            if to_use_frozen_relationships(offline_store_feature_table_model.feature_cluster):
+                required_entity_ids = offline_store_feature_table_model.primary_entity_ids
+
+        if required_entity_ids is None:
             assert graph_nodes is not None
             graph, nodes = graph_nodes
             planner = FeatureExecutionPlanner(
@@ -92,8 +198,9 @@ class EntityValidationService:
                 is_online_serving=False,
                 serving_names_mapping=serving_names_mapping,
             )
-            plan = planner.generate_plan(nodes)
-            required_entities = await self.entity_service.get_entities(plan.required_entity_ids)
+            required_entity_ids = list(planner.generate_plan(nodes).required_entity_ids)
+
+        required_entities = await self.entity_service.get_entities(set(required_entity_ids))
 
         return EntityInfo(
             provided_entities=provided_entities,
@@ -108,6 +215,7 @@ class EntityValidationService:
         graph_nodes: Optional[Tuple[QueryGraphModel, list[Node]]] = None,
         feature_list_model: Optional[FeatureListModel] = None,
         serving_names_mapping: dict[str, str] | None = None,
+        offline_store_feature_table_model: Optional[OfflineStoreFeatureTableModel] = None,
     ) -> ParentServingPreparation:
         """
         Validate that entities are provided correctly in feature requests
@@ -125,6 +233,9 @@ class EntityValidationService:
         serving_names_mapping : dict[str, str] | None
             Optional serving names mapping if the entities are provided under different serving
             names in the request
+        offline_store_feature_table_model: Optional[OfflineStoreFeatureTableModel]
+            Offline store feature table model when the request is initiated by feature materialize
+            service
 
         Returns
         -------
@@ -145,6 +256,7 @@ class EntityValidationService:
             feature_list_model=feature_list_model,
             request_column_names=request_column_names,
             serving_names_mapping=serving_names_mapping,
+            offline_store_feature_table_model=offline_store_feature_table_model,
         )
 
         if serving_names_mapping is not None:
@@ -179,6 +291,7 @@ class EntityValidationService:
         entity_relationships_context = await self._get_entity_relationships_context(
             entity_info,
             feature_list_model,
+            offline_store_feature_table_model=offline_store_feature_table_model,
         )
         return ParentServingPreparation(
             join_steps=join_steps,
@@ -186,39 +299,46 @@ class EntityValidationService:
             entity_relationships_context=entity_relationships_context,
         )
 
-    @staticmethod
-    def _to_use_frozen_relationships(feature_list_model: FeatureListModel) -> bool:
-        return (
-            feature_list_model.feature_clusters is not None
-            and feature_list_model.feature_clusters[0].feature_node_relationships_infos is not None
-        )
-
     async def _get_entity_relationships_context(
         self,
         entity_info: EntityInfo,
         feature_list_model: Optional[FeatureListModel],
+        offline_store_feature_table_model: Optional[OfflineStoreFeatureTableModel],
     ) -> Optional[EntityRelationshipsContext]:
-        if feature_list_model is None or feature_list_model.feature_clusters is None:
+        if feature_list_model is not None:
+            parameters = EntityRelationshipsContextParameters.from_feature_list(feature_list_model)
+        elif offline_store_feature_table_model is not None:
+            parameters = EntityRelationshipsContextParameters.from_offline_store_feature_table(
+                offline_store_feature_table_model
+            )
+        else:
+            parameters = None
+        if parameters is None:
             return None
+        return await self._get_entity_relationships_context_from_parameters(
+            entity_info=entity_info,
+            parameters=parameters,
+        )
 
-        feature_cluster = feature_list_model.feature_clusters[0]
-        if feature_cluster.feature_node_relationships_infos is None:
-            return None
-
-        all_relationships = set(feature_list_model.relationships_info or [])
-        all_relationships.update(feature_list_model.feature_clusters[0].combined_relationships_info)
+    async def _get_entity_relationships_context_from_parameters(
+        self,
+        entity_info: EntityInfo,
+        parameters: EntityRelationshipsContextParameters,
+    ) -> EntityRelationshipsContext:
+        all_relationships = set(parameters.relationships_info or [])
+        all_relationships.update(parameters.feature_cluster.combined_relationships_info)
         entity_lookup_step_creator = (
             await self.parent_entity_lookup_service.get_entity_lookup_step_creator(
                 list(all_relationships)
             )
         )
         return EntityRelationshipsContext(
-            feature_list_primary_entity_ids=feature_list_model.primary_entity_ids,
+            feature_list_primary_entity_ids=parameters.primary_entity_ids,
             feature_list_serving_names=[
                 entity_info.get_effective_serving_name(entity_info.get_entity(entity_id))
-                for entity_id in feature_list_model.primary_entity_ids
+                for entity_id in parameters.primary_entity_ids
             ],
-            feature_list_relationships_info=feature_list_model.relationships_info,
-            feature_node_relationships_infos=feature_cluster.feature_node_relationships_infos,
+            feature_list_relationships_info=parameters.relationships_info or [],
+            feature_node_relationships_infos=parameters.feature_cluster.feature_node_relationships_infos,
             entity_lookup_step_creator=entity_lookup_step_creator,
         )

--- a/featurebyte/service/entity_validation.py
+++ b/featurebyte/service/entity_validation.py
@@ -57,8 +57,13 @@ class EntityRelationshipsContextParameters:
     Can be created from FeatureListModel or OfflineFeatureStoreTableModel objects.
     """
 
+    # Graph and nodes representing a list of features
     feature_cluster: FeatureCluster
+
+    # Primary entity ids of the features represented by the feature cluster
     primary_entity_ids: Sequence[ObjectId]
+
+    # Relationships available to lookup primary entity from serving entity
     relationships_info: Optional[List[EntityRelationshipInfo]]
 
     @classmethod
@@ -108,6 +113,9 @@ class EntityRelationshipsContextParameters:
         if offline_store_feature_table_model.feature_cluster is not None:
             feature_cluster = offline_store_feature_table_model.feature_cluster
             if feature_cluster.feature_node_relationships_infos is not None:
+                # Set relationships_info to None because when computing features for offline store
+                # feature tables, the serving entity is always the primary entity of the feature
+                # table, so no lookup is required there.
                 return EntityRelationshipsContextParameters(
                     feature_cluster=feature_cluster,
                     primary_entity_ids=offline_store_feature_table_model.primary_entity_ids,

--- a/featurebyte/service/feature_materialize.py
+++ b/featurebyte/service/feature_materialize.py
@@ -191,6 +191,7 @@ class FeatureMaterializeService:  # pylint: disable=too-many-instance-attributes
             parent_serving_preparation = await self.entity_validation_service.validate_entities_or_prepare_for_parent_serving(
                 graph_nodes=(feature_table_model.feature_cluster.graph, nodes),
                 feature_list_model=None,
+                offline_store_feature_table_model=feature_table_model,
                 request_column_names=set(feature_table_model.serving_names),
                 feature_store=feature_store,
             )

--- a/tests/fixtures/feature_materialize/materialize_features_queries_internal_relationships.sql
+++ b/tests/fixtures/feature_materialize/materialize_features_queries_internal_relationships.sql
@@ -1,0 +1,221 @@
+CREATE TABLE "sf_db"."sf_schema"."TEMP_REQUEST_TABLE_000000000000000000000000" AS
+SELECT DISTINCT
+  CHILD."col_text" AS "cust_id"
+FROM (
+  SELECT DISTINCT
+    "col_boolean" AS "gender"
+  FROM (
+    SELECT
+      "col_int" AS "col_int",
+      "col_float" AS "col_float",
+      "col_text" AS "col_text",
+      "col_binary" AS "col_binary",
+      "col_boolean" AS "col_boolean",
+      "effective_timestamp" AS "effective_timestamp",
+      "end_timestamp" AS "end_timestamp",
+      "date_of_birth" AS "date_of_birth",
+      "created_at" AS "created_at",
+      "cust_id" AS "cust_id"
+    FROM "sf_database"."sf_schema"."scd_table"
+    WHERE
+      "effective_timestamp" >= CAST('1970-01-01 00:00:00' AS TIMESTAMPNTZ)
+      AND "effective_timestamp" < CAST('2022-01-01 00:00:00' AS TIMESTAMPNTZ)
+  )
+) AS PARENT
+LEFT JOIN "sf_database"."sf_schema"."scd_table" AS CHILD
+  ON PARENT."gender" = CHILD."col_boolean"
+UNION
+SELECT DISTINCT
+  "col_text" AS "cust_id"
+FROM (
+  SELECT
+    "col_int" AS "col_int",
+    "col_float" AS "col_float",
+    "col_text" AS "col_text",
+    "col_binary" AS "col_binary",
+    "col_boolean" AS "col_boolean",
+    "effective_timestamp" AS "effective_timestamp",
+    "end_timestamp" AS "end_timestamp",
+    "date_of_birth" AS "date_of_birth",
+    "created_at" AS "created_at",
+    "cust_id" AS "cust_id"
+  FROM "sf_database"."sf_schema"."scd_table"
+  WHERE
+    "effective_timestamp" >= CAST('1970-01-01 00:00:00' AS TIMESTAMPNTZ)
+    AND "effective_timestamp" < CAST('2022-01-01 00:00:00' AS TIMESTAMPNTZ)
+);
+
+CREATE TABLE "sf_db"."sf_schema"."TEMP_FEATURE_TABLE_000000000000000000000000" AS
+WITH ONLINE_REQUEST_TABLE AS (
+  SELECT
+    REQ."cust_id",
+    CAST('2022-01-01 00:00:00' AS TIMESTAMPNTZ) AS POINT_IN_TIME
+  FROM "sf_db"."sf_schema"."TEMP_REQUEST_TABLE_000000000000000000000000" AS REQ
+), JOINED_PARENTS_ONLINE_REQUEST_TABLE AS (
+  SELECT
+    REQ."cust_id" AS "cust_id",
+    REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
+    REQ."cust_id_61cf998018e860c9dca7f15a" AS "cust_id_61cf998018e860c9dca7f15a"
+  FROM (
+    SELECT
+      L."cust_id" AS "cust_id",
+      L."POINT_IN_TIME" AS "POINT_IN_TIME",
+      R."col_boolean" AS "cust_id_61cf998018e860c9dca7f15a"
+    FROM (
+      SELECT
+        "__FB_KEY_COL_0",
+        "__FB_LAST_TS",
+        "cust_id",
+        "POINT_IN_TIME"
+      FROM (
+        SELECT
+          "__FB_KEY_COL_0",
+          LAG("__FB_EFFECTIVE_TS_COL") IGNORE NULLS OVER (PARTITION BY "__FB_KEY_COL_0" ORDER BY "__FB_TS_COL", "__FB_TS_TIE_BREAKER_COL") AS "__FB_LAST_TS",
+          "cust_id",
+          "POINT_IN_TIME",
+          "__FB_EFFECTIVE_TS_COL"
+        FROM (
+          SELECT
+            CAST(CONVERT_TIMEZONE('UTC', "POINT_IN_TIME") AS TIMESTAMP) AS "__FB_TS_COL",
+            "cust_id" AS "__FB_KEY_COL_0",
+            NULL AS "__FB_EFFECTIVE_TS_COL",
+            2 AS "__FB_TS_TIE_BREAKER_COL",
+            "cust_id" AS "cust_id",
+            "POINT_IN_TIME" AS "POINT_IN_TIME"
+          FROM (
+            SELECT
+              REQ."cust_id",
+              REQ."POINT_IN_TIME"
+            FROM ONLINE_REQUEST_TABLE AS REQ
+          )
+          UNION ALL
+          SELECT
+            CAST(CONVERT_TIMEZONE('UTC', "effective_timestamp") AS TIMESTAMP) AS "__FB_TS_COL",
+            "col_text" AS "__FB_KEY_COL_0",
+            "effective_timestamp" AS "__FB_EFFECTIVE_TS_COL",
+            1 AS "__FB_TS_TIE_BREAKER_COL",
+            NULL AS "cust_id",
+            NULL AS "POINT_IN_TIME"
+          FROM (
+            SELECT
+              "col_int" AS "col_int",
+              "col_float" AS "col_float",
+              "is_active" AS "is_active",
+              "col_text" AS "col_text",
+              "col_binary" AS "col_binary",
+              "col_boolean" AS "col_boolean",
+              "effective_timestamp" AS "effective_timestamp",
+              "end_timestamp" AS "end_timestamp",
+              "date_of_birth" AS "date_of_birth",
+              "created_at" AS "created_at",
+              "cust_id" AS "cust_id"
+            FROM "sf_database"."sf_schema"."scd_table"
+          )
+        )
+      )
+      WHERE
+        "__FB_EFFECTIVE_TS_COL" IS NULL
+    ) AS L
+    LEFT JOIN (
+      SELECT
+        "col_int" AS "col_int",
+        "col_float" AS "col_float",
+        "is_active" AS "is_active",
+        "col_text" AS "col_text",
+        "col_binary" AS "col_binary",
+        "col_boolean" AS "col_boolean",
+        "effective_timestamp" AS "effective_timestamp",
+        "end_timestamp" AS "end_timestamp",
+        "date_of_birth" AS "date_of_birth",
+        "created_at" AS "created_at",
+        "cust_id" AS "cust_id"
+      FROM "sf_database"."sf_schema"."scd_table"
+    ) AS R
+      ON L."__FB_LAST_TS" = R."effective_timestamp" AND L."__FB_KEY_COL_0" = R."col_text"
+  ) AS REQ
+), "REQUEST_TABLE_POINT_IN_TIME_cust_id_61cf998018e860c9dca7f15a" AS (
+  SELECT DISTINCT
+    "POINT_IN_TIME",
+    "cust_id_61cf998018e860c9dca7f15a"
+  FROM JOINED_PARENTS_ONLINE_REQUEST_TABLE
+), _FB_AGGREGATED AS (
+  SELECT
+    REQ."cust_id",
+    REQ."POINT_IN_TIME",
+    REQ."cust_id_61cf998018e860c9dca7f15a",
+    "T0"."_fb_internal_cust_id_lookup_col_boolean_project_1" AS "_fb_internal_cust_id_lookup_col_boolean_project_1",
+    "T1"."_fb_internal_cust_id_61cf998018e860c9dca7f15a_as_at_count_None_col_boolean_None_project_1" AS "_fb_internal_cust_id_61cf998018e860c9dca7f15a_as_at_count_None_col_boolean_None_project_1"
+  FROM JOINED_PARENTS_ONLINE_REQUEST_TABLE AS REQ
+  LEFT JOIN (
+    SELECT
+      "col_text" AS "cust_id",
+      "col_boolean" AS "_fb_internal_cust_id_lookup_col_boolean_project_1"
+    FROM (
+      SELECT
+        "col_int" AS "col_int",
+        "col_float" AS "col_float",
+        "col_text" AS "col_text",
+        "col_binary" AS "col_binary",
+        "col_boolean" AS "col_boolean",
+        "effective_timestamp" AS "effective_timestamp",
+        "end_timestamp" AS "end_timestamp",
+        "date_of_birth" AS "date_of_birth",
+        "created_at" AS "created_at",
+        "cust_id" AS "cust_id"
+      FROM "sf_database"."sf_schema"."scd_table"
+      WHERE
+        "is_active" = TRUE
+    )
+  ) AS T0
+    ON REQ."cust_id" = T0."cust_id"
+  LEFT JOIN (
+    SELECT
+      REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
+      REQ."cust_id_61cf998018e860c9dca7f15a" AS "cust_id_61cf998018e860c9dca7f15a",
+      COUNT(*) AS "_fb_internal_cust_id_61cf998018e860c9dca7f15a_as_at_count_None_col_boolean_None_project_1"
+    FROM "REQUEST_TABLE_POINT_IN_TIME_cust_id_61cf998018e860c9dca7f15a" AS REQ
+    INNER JOIN (
+      SELECT
+        "col_int" AS "col_int",
+        "col_float" AS "col_float",
+        "col_text" AS "col_text",
+        "col_binary" AS "col_binary",
+        "col_boolean" AS "col_boolean",
+        "effective_timestamp" AS "effective_timestamp",
+        "end_timestamp" AS "end_timestamp",
+        "date_of_birth" AS "date_of_birth",
+        "created_at" AS "created_at",
+        "cust_id" AS "cust_id"
+      FROM "sf_database"."sf_schema"."scd_table"
+    ) AS SCD
+      ON REQ."cust_id_61cf998018e860c9dca7f15a" = SCD."col_boolean"
+      AND (
+        SCD."effective_timestamp" <= REQ."POINT_IN_TIME"
+        AND (
+          SCD."end_timestamp" > REQ."POINT_IN_TIME" OR SCD."end_timestamp" IS NULL
+        )
+      )
+    GROUP BY
+      REQ."POINT_IN_TIME",
+      REQ."cust_id_61cf998018e860c9dca7f15a"
+  ) AS T1
+    ON REQ."POINT_IN_TIME" = T1."POINT_IN_TIME"
+    AND REQ."cust_id_61cf998018e860c9dca7f15a" = T1."cust_id_61cf998018e860c9dca7f15a"
+)
+SELECT
+  AGG."cust_id",
+  (
+    CONCAT(
+      (
+        CONCAT(CAST("_fb_internal_cust_id_lookup_col_boolean_project_1" AS VARCHAR), '_')
+      ),
+      CAST(CASE
+        WHEN (
+          "_fb_internal_cust_id_61cf998018e860c9dca7f15a_as_at_count_None_col_boolean_None_project_1" IS NULL
+        )
+        THEN 0
+        ELSE "_fb_internal_cust_id_61cf998018e860c9dca7f15a_as_at_count_None_col_boolean_None_project_1"
+      END AS VARCHAR)
+    )
+  ) AS "complex_parent_child_feature_V220101"
+FROM _FB_AGGREGATED AS AGG;

--- a/tests/fixtures/feature_materialize/materialize_features_queries_internal_relationships.sql
+++ b/tests/fixtures/feature_materialize/materialize_features_queries_internal_relationships.sql
@@ -55,12 +55,12 @@ WITH ONLINE_REQUEST_TABLE AS (
   SELECT
     REQ."cust_id" AS "cust_id",
     REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
-    REQ."cust_id_61cf998018e860c9dca7f15a" AS "cust_id_61cf998018e860c9dca7f15a"
+    REQ."cust_id_000000000000000000000000" AS "cust_id_000000000000000000000000"
   FROM (
     SELECT
       L."cust_id" AS "cust_id",
       L."POINT_IN_TIME" AS "POINT_IN_TIME",
-      R."col_boolean" AS "cust_id_61cf998018e860c9dca7f15a"
+      R."col_boolean" AS "cust_id_000000000000000000000000"
     FROM (
       SELECT
         "__FB_KEY_COL_0",
@@ -133,18 +133,18 @@ WITH ONLINE_REQUEST_TABLE AS (
     ) AS R
       ON L."__FB_LAST_TS" = R."effective_timestamp" AND L."__FB_KEY_COL_0" = R."col_text"
   ) AS REQ
-), "REQUEST_TABLE_POINT_IN_TIME_cust_id_61cf998018e860c9dca7f15a" AS (
+), "REQUEST_TABLE_POINT_IN_TIME_cust_id_000000000000000000000000" AS (
   SELECT DISTINCT
     "POINT_IN_TIME",
-    "cust_id_61cf998018e860c9dca7f15a"
+    "cust_id_000000000000000000000000"
   FROM JOINED_PARENTS_ONLINE_REQUEST_TABLE
 ), _FB_AGGREGATED AS (
   SELECT
     REQ."cust_id",
     REQ."POINT_IN_TIME",
-    REQ."cust_id_61cf998018e860c9dca7f15a",
+    REQ."cust_id_000000000000000000000000",
     "T0"."_fb_internal_cust_id_lookup_col_boolean_project_1" AS "_fb_internal_cust_id_lookup_col_boolean_project_1",
-    "T1"."_fb_internal_cust_id_61cf998018e860c9dca7f15a_as_at_count_None_col_boolean_None_project_1" AS "_fb_internal_cust_id_61cf998018e860c9dca7f15a_as_at_count_None_col_boolean_None_project_1"
+    "T1"."_fb_internal_cust_id_000000000000000000000000_as_at_count_None_col_boolean_None_project_1" AS "_fb_internal_cust_id_000000000000000000000000_as_at_count_None_col_boolean_None_project_1"
   FROM JOINED_PARENTS_ONLINE_REQUEST_TABLE AS REQ
   LEFT JOIN (
     SELECT
@@ -171,9 +171,9 @@ WITH ONLINE_REQUEST_TABLE AS (
   LEFT JOIN (
     SELECT
       REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
-      REQ."cust_id_61cf998018e860c9dca7f15a" AS "cust_id_61cf998018e860c9dca7f15a",
-      COUNT(*) AS "_fb_internal_cust_id_61cf998018e860c9dca7f15a_as_at_count_None_col_boolean_None_project_1"
-    FROM "REQUEST_TABLE_POINT_IN_TIME_cust_id_61cf998018e860c9dca7f15a" AS REQ
+      REQ."cust_id_000000000000000000000000" AS "cust_id_000000000000000000000000",
+      COUNT(*) AS "_fb_internal_cust_id_000000000000000000000000_as_at_count_None_col_boolean_None_project_1"
+    FROM "REQUEST_TABLE_POINT_IN_TIME_cust_id_000000000000000000000000" AS REQ
     INNER JOIN (
       SELECT
         "col_int" AS "col_int",
@@ -188,7 +188,7 @@ WITH ONLINE_REQUEST_TABLE AS (
         "cust_id" AS "cust_id"
       FROM "sf_database"."sf_schema"."scd_table"
     ) AS SCD
-      ON REQ."cust_id_61cf998018e860c9dca7f15a" = SCD."col_boolean"
+      ON REQ."cust_id_000000000000000000000000" = SCD."col_boolean"
       AND (
         SCD."effective_timestamp" <= REQ."POINT_IN_TIME"
         AND (
@@ -197,10 +197,10 @@ WITH ONLINE_REQUEST_TABLE AS (
       )
     GROUP BY
       REQ."POINT_IN_TIME",
-      REQ."cust_id_61cf998018e860c9dca7f15a"
+      REQ."cust_id_000000000000000000000000"
   ) AS T1
     ON REQ."POINT_IN_TIME" = T1."POINT_IN_TIME"
-    AND REQ."cust_id_61cf998018e860c9dca7f15a" = T1."cust_id_61cf998018e860c9dca7f15a"
+    AND REQ."cust_id_000000000000000000000000" = T1."cust_id_000000000000000000000000"
 )
 SELECT
   AGG."cust_id",
@@ -211,10 +211,10 @@ SELECT
       ),
       CAST(CASE
         WHEN (
-          "_fb_internal_cust_id_61cf998018e860c9dca7f15a_as_at_count_None_col_boolean_None_project_1" IS NULL
+          "_fb_internal_cust_id_000000000000000000000000_as_at_count_None_col_boolean_None_project_1" IS NULL
         )
         THEN 0
-        ELSE "_fb_internal_cust_id_61cf998018e860c9dca7f15a_as_at_count_None_col_boolean_None_project_1"
+        ELSE "_fb_internal_cust_id_000000000000000000000000_as_at_count_None_col_boolean_None_project_1"
       END AS VARCHAR)
     )
   ) AS "complex_parent_child_feature_V220101"

--- a/tests/fixtures/offline_store_feature_table/feature_cluster_disabled_one_feature.json
+++ b/tests/fixtures/offline_store_feature_table/feature_cluster_disabled_one_feature.json
@@ -1,7 +1,17 @@
 {
     "combined_relationships_info": [],
     "feature_node_definition_hashes": null,
-    "feature_node_relationships_infos": null,
+    "feature_node_relationships_infos": [
+        {
+            "node_name": "alias_1",
+            "primary_entity_ids": [
+                {
+                    "$oid": "63f94ed6ea1f050131379214"
+                }
+            ],
+            "relationships_info": []
+        }
+    ],
     "feature_store_id": {
         "$oid": "646f6c190ed28a5271fb02a1"
     },

--- a/tests/fixtures/offline_store_feature_table/feature_cluster_one_feature.json
+++ b/tests/fixtures/offline_store_feature_table/feature_cluster_one_feature.json
@@ -1,7 +1,17 @@
 {
     "combined_relationships_info": [],
     "feature_node_definition_hashes": null,
-    "feature_node_relationships_infos": null,
+    "feature_node_relationships_infos": [
+        {
+            "node_name": "alias_1",
+            "primary_entity_ids": [
+                {
+                    "$oid": "63f94ed6ea1f050131379214"
+                }
+            ],
+            "relationships_info": []
+        }
+    ],
     "feature_store_id": {
         "$oid": "646f6c190ed28a5271fb02a1"
     },

--- a/tests/fixtures/offline_store_feature_table/feature_cluster_two_features.json
+++ b/tests/fixtures/offline_store_feature_table/feature_cluster_two_features.json
@@ -1,7 +1,26 @@
 {
     "combined_relationships_info": [],
     "feature_node_definition_hashes": null,
-    "feature_node_relationships_infos": null,
+    "feature_node_relationships_infos": [
+        {
+            "node_name": "alias_1",
+            "primary_entity_ids": [
+                {
+                    "$oid": "63f94ed6ea1f050131379214"
+                }
+            ],
+            "relationships_info": []
+        },
+        {
+            "node_name": "alias_2",
+            "primary_entity_ids": [
+                {
+                    "$oid": "63f94ed6ea1f050131379214"
+                }
+            ],
+            "relationships_info": []
+        }
+    ],
     "feature_store_id": {
         "$oid": "646f6c190ed28a5271fb02a1"
     },

--- a/tests/fixtures/offline_store_feature_table/feature_cluster_with_internal_relationships.json
+++ b/tests/fixtures/offline_store_feature_table/feature_cluster_with_internal_relationships.json
@@ -1,0 +1,384 @@
+{
+    "combined_relationships_info": [
+        {
+            "entity_column_name": "col_text",
+            "entity_id": {
+                "$oid": "63f94ed6ea1f050131379214"
+            },
+            "related_entity_column_name": "col_boolean",
+            "related_entity_id": {
+                "$oid": "65f11f1d8a03610e41399306"
+            },
+            "relation_table_id": {
+                "$oid": "6337f9651050ee7d123466cd"
+            },
+            "relationship_type": "child_parent"
+        }
+    ],
+    "feature_node_definition_hashes": null,
+    "feature_node_relationships_infos": [
+        {
+            "node_name": "alias_2",
+            "primary_entity_ids": [
+                {
+                    "$oid": "63f94ed6ea1f050131379214"
+                }
+            ],
+            "relationships_info": [
+                {
+                    "entity_column_name": "col_text",
+                    "entity_id": {
+                        "$oid": "63f94ed6ea1f050131379214"
+                    },
+                    "related_entity_column_name": "col_boolean",
+                    "related_entity_id": {
+                        "$oid": "65f11f1d8a03610e41399306"
+                    },
+                    "relation_table_id": {
+                        "$oid": "6337f9651050ee7d123466cd"
+                    },
+                    "relationship_type": "child_parent"
+                }
+            ]
+        }
+    ],
+    "feature_store_id": {
+        "$oid": "646f6c190ed28a5271fb02a1"
+    },
+    "graph": {
+        "edges": [
+            {
+                "source": "input_1",
+                "target": "graph_1"
+            },
+            {
+                "source": "graph_1",
+                "target": "lookup_1"
+            },
+            {
+                "source": "graph_1",
+                "target": "aggregate_as_at_1"
+            },
+            {
+                "source": "aggregate_as_at_1",
+                "target": "project_1"
+            },
+            {
+                "source": "project_1",
+                "target": "is_null_1"
+            },
+            {
+                "source": "project_1",
+                "target": "conditional_1"
+            },
+            {
+                "source": "is_null_1",
+                "target": "conditional_1"
+            },
+            {
+                "source": "conditional_1",
+                "target": "alias_1"
+            },
+            {
+                "source": "alias_1",
+                "target": "cast_1"
+            },
+            {
+                "source": "lookup_1",
+                "target": "project_2"
+            },
+            {
+                "source": "project_2",
+                "target": "cast_2"
+            },
+            {
+                "source": "cast_2",
+                "target": "concat_1"
+            },
+            {
+                "source": "concat_1",
+                "target": "concat_2"
+            },
+            {
+                "source": "cast_1",
+                "target": "concat_2"
+            },
+            {
+                "source": "concat_2",
+                "target": "alias_2"
+            }
+        ],
+        "nodes": [
+            {
+                "name": "input_1",
+                "output_type": "frame",
+                "parameters": {
+                    "columns": [
+                        {
+                            "dtype": "INT",
+                            "name": "col_int"
+                        },
+                        {
+                            "dtype": "FLOAT",
+                            "name": "col_float"
+                        },
+                        {
+                            "dtype": "BOOL",
+                            "name": "is_active"
+                        },
+                        {
+                            "dtype": "VARCHAR",
+                            "name": "col_text"
+                        },
+                        {
+                            "dtype": "BINARY",
+                            "name": "col_binary"
+                        },
+                        {
+                            "dtype": "BOOL",
+                            "name": "col_boolean"
+                        },
+                        {
+                            "dtype": "TIMESTAMP_TZ",
+                            "name": "effective_timestamp"
+                        },
+                        {
+                            "dtype": "TIMESTAMP_TZ",
+                            "name": "end_timestamp"
+                        },
+                        {
+                            "dtype": "TIMESTAMP",
+                            "name": "date_of_birth"
+                        },
+                        {
+                            "dtype": "TIMESTAMP_TZ",
+                            "name": "created_at"
+                        },
+                        {
+                            "dtype": "INT",
+                            "name": "cust_id"
+                        }
+                    ],
+                    "current_flag_column": "is_active",
+                    "effective_timestamp_column": "effective_timestamp",
+                    "end_timestamp_column": "end_timestamp",
+                    "feature_store_details": {
+                        "details": null,
+                        "type": "snowflake"
+                    },
+                    "id": {
+                        "$oid": "6337f9651050ee7d123466cd"
+                    },
+                    "natural_key_column": "col_text",
+                    "surrogate_key_column": "col_int",
+                    "table_details": {
+                        "database_name": "sf_database",
+                        "schema_name": "sf_schema",
+                        "table_name": "scd_table"
+                    },
+                    "type": "scd_table"
+                },
+                "type": "input"
+            },
+            {
+                "name": "graph_1",
+                "output_type": "frame",
+                "parameters": {
+                    "graph": {
+                        "edges": [
+                            {
+                                "source": "proxy_input_1",
+                                "target": "project_1"
+                            }
+                        ],
+                        "nodes": [
+                            {
+                                "name": "proxy_input_1",
+                                "output_type": "frame",
+                                "parameters": {
+                                    "input_order": 0
+                                },
+                                "type": "proxy_input"
+                            },
+                            {
+                                "name": "project_1",
+                                "output_type": "frame",
+                                "parameters": {
+                                    "columns": [
+                                        "col_int",
+                                        "col_float",
+                                        "col_text",
+                                        "col_binary",
+                                        "col_boolean",
+                                        "effective_timestamp",
+                                        "end_timestamp",
+                                        "date_of_birth",
+                                        "created_at",
+                                        "cust_id"
+                                    ]
+                                },
+                                "type": "project"
+                            }
+                        ]
+                    },
+                    "metadata": {
+                        "column_cleaning_operations": [],
+                        "drop_column_names": [
+                            "is_active"
+                        ],
+                        "table_id": {
+                            "$oid": "6337f9651050ee7d123466cd"
+                        },
+                        "view_mode": "auto"
+                    },
+                    "output_node_name": "project_1",
+                    "type": "scd_view"
+                },
+                "type": "graph"
+            },
+            {
+                "name": "lookup_1",
+                "output_type": "frame",
+                "parameters": {
+                    "entity_column": "col_text",
+                    "entity_id": {
+                        "$oid": "63f94ed6ea1f050131379214"
+                    },
+                    "event_parameters": null,
+                    "feature_names": [
+                        "some_lookup_feature"
+                    ],
+                    "input_column_names": [
+                        "col_boolean"
+                    ],
+                    "scd_parameters": {
+                        "current_flag_column": "is_active",
+                        "effective_timestamp_column": "effective_timestamp",
+                        "end_timestamp_column": "end_timestamp",
+                        "natural_key_column": "col_text",
+                        "offset": null
+                    },
+                    "serving_name": "cust_id"
+                },
+                "type": "lookup"
+            },
+            {
+                "name": "aggregate_as_at_1",
+                "output_type": "frame",
+                "parameters": {
+                    "agg_func": "count",
+                    "backward": true,
+                    "current_flag_column": "is_active",
+                    "effective_timestamp_column": "effective_timestamp",
+                    "end_timestamp_column": "end_timestamp",
+                    "entity_ids": [
+                        {
+                            "$oid": "65f11f1d8a03610e41399306"
+                        }
+                    ],
+                    "keys": [
+                        "col_boolean"
+                    ],
+                    "name": "asat_gender_count",
+                    "natural_key_column": "col_text",
+                    "offset": null,
+                    "parent": null,
+                    "serving_names": [
+                        "gender"
+                    ],
+                    "value_by": null
+                },
+                "type": "aggregate_as_at"
+            },
+            {
+                "name": "project_1",
+                "output_type": "series",
+                "parameters": {
+                    "columns": [
+                        "asat_gender_count"
+                    ]
+                },
+                "type": "project"
+            },
+            {
+                "name": "is_null_1",
+                "output_type": "series",
+                "parameters": {},
+                "type": "is_null"
+            },
+            {
+                "name": "conditional_1",
+                "output_type": "series",
+                "parameters": {
+                    "value": 0
+                },
+                "type": "conditional"
+            },
+            {
+                "name": "alias_1",
+                "output_type": "series",
+                "parameters": {
+                    "name": "asat_gender_count"
+                },
+                "type": "alias"
+            },
+            {
+                "name": "cast_1",
+                "output_type": "series",
+                "parameters": {
+                    "from_dtype": "INT",
+                    "type": "str"
+                },
+                "type": "cast"
+            },
+            {
+                "name": "project_2",
+                "output_type": "series",
+                "parameters": {
+                    "columns": [
+                        "some_lookup_feature"
+                    ]
+                },
+                "type": "project"
+            },
+            {
+                "name": "cast_2",
+                "output_type": "series",
+                "parameters": {
+                    "from_dtype": "BOOL",
+                    "type": "str"
+                },
+                "type": "cast"
+            },
+            {
+                "name": "concat_1",
+                "output_type": "series",
+                "parameters": {
+                    "right_op": false,
+                    "value": "_"
+                },
+                "type": "concat"
+            },
+            {
+                "name": "concat_2",
+                "output_type": "series",
+                "parameters": {
+                    "right_op": false,
+                    "value": null
+                },
+                "type": "concat"
+            },
+            {
+                "name": "alias_2",
+                "output_type": "series",
+                "parameters": {
+                    "name": "complex_parent_child_feature_V231227"
+                },
+                "type": "alias"
+            }
+        ]
+    },
+    "node_names": [
+        "alias_2"
+    ]
+}

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -401,6 +401,28 @@ def test_feature_tables_expected(
     assert set(offline_store_feature_tables.keys()) == expected_feature_table_names
 
 
+@pytest.mark.order(1)
+@pytest.mark.parametrize("source_type", SNOWFLAKE_SPARK_DATABRICKS_UNITY, indirect=True)
+def test_feature_cluster_with_expected_internal_relationships(offline_store_feature_tables):
+    """
+    Check that feature level relationship information are included in feature cluster correctly
+
+    Table cat1_userid_1d is one such table. It should include non-empty relationships info because
+    the complex feature "Complex Feature by User" requires parent-child relationship within the
+    feature table.
+    """
+    feature_tables_with_internal_relationships = {}
+    for name, feature_table_model in offline_store_feature_tables.items():
+        if feature_table_model.feature_cluster.feature_node_relationships_infos is None:
+            continue
+        for info in feature_table_model.feature_cluster.feature_node_relationships_infos:
+            if info.relationships_info:
+                feature_tables_with_internal_relationships[name] = feature_table_model
+                break
+    feature_table_names = list(feature_tables_with_internal_relationships.keys())
+    assert feature_table_names == ["cat1_userid_1d"]
+
+
 @pytest.mark.order(2)
 @pytest.mark.parametrize("source_type", SNOWFLAKE_SPARK_DATABRICKS_UNITY, indirect=True)
 @pytest.mark.asyncio

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -850,6 +850,12 @@ def transaction_entity_id_fixture():
     return ObjectId("63f94ed6ea1f050131379204")
 
 
+@pytest.fixture(name="gender_entity_id")
+def gender_entity_id_fixture():
+    """Gender entity ID"""
+    return ObjectId("65f11f1d8a03610e41399306")
+
+
 @pytest.fixture(name="snowflake_event_table")
 def snowflake_event_table_fixture(
     snowflake_database_table,
@@ -1076,12 +1082,12 @@ def transaction_entity_fixture(transaction_entity_id, catalog):
 
 
 @pytest.fixture(name="gender_entity")
-def gender_entity_fixture(catalog):
+def gender_entity_fixture(gender_entity_id, catalog):
     """
     Gender entity fixture
     """
     _ = catalog
-    entity = Entity(name="gender", serving_names=["gender"])
+    entity = Entity(name="gender", serving_names=["gender"], _id=gender_entity_id)
     entity.save()
     yield entity
 
@@ -1824,6 +1830,22 @@ def aggregate_asat_no_entity_feature_fixture(snowflake_scd_table_with_entity):
         method="count",
         feature_name="asat_overall_count",
     )
+    return feature
+
+
+@pytest.fixture(name="feature_with_internal_parent_child_relationships")
+def feature_with_internal_parent_child_relationships_fixture(
+    scd_lookup_feature, aggregate_asat_feature
+):
+    """
+    Feature with internal parent child relationships, for example:
+
+    C = A + B
+
+    where B is a parent of A
+    """
+    feature = scd_lookup_feature.astype(str) + "_" + aggregate_asat_feature.astype(str)
+    feature.name = "complex_parent_child_feature"
     return feature
 
 

--- a/tests/unit/service/test_feature_materialize.py
+++ b/tests/unit/service/test_feature_materialize.py
@@ -189,7 +189,7 @@ async def offline_store_feature_table_no_entity_fixture(
 
 
 @pytest_asyncio.fixture(name="offline_store_feature_table_internal_relationships")
-async def offline_store_feature_table_no_entity_fixture(
+async def offline_store_feature_table_internal_relationships_fixture(
     app_container, deployed_feature_list_internal_relationships
 ):
     """

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -1,6 +1,7 @@
 """
 Tests for OfflineStoreFeatureTableManagerService
 """
+# pylint: disable=too-many-lines
 from typing import Dict
 
 import os
@@ -1003,7 +1004,6 @@ async def test_feature_with_internal_parent_child_relationships(
     app_container,
     document_service,
     deployed_feature_with_internal_parent_child_relationships,
-    storage,
     update_fixtures,
 ):
     """

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -202,6 +202,21 @@ async def deployed_complex_feature(
 
 
 @pytest_asyncio.fixture
+async def deployed_feature_with_internal_parent_child_relationships(
+    app_container,
+    feature_with_internal_parent_child_relationships,
+    mock_update_data_warehouse,
+    mock_offline_store_feature_manager_dependencies,
+):
+    """
+    Fixture for a complex feature with internal parent child relationships
+    """
+    _ = mock_update_data_warehouse
+    _ = mock_offline_store_feature_manager_dependencies
+    return await deploy_feature(app_container, feature_with_internal_parent_child_relationships)
+
+
+@pytest_asyncio.fixture
 async def deployed_feature_list_when_all_features_already_deployed(
     app_container,
     float_feature,
@@ -981,3 +996,67 @@ async def test_enabled_serving_entity_ids_updated_no_op_deploy(
         f"fb_entity_lookup_{transaction_to_customer_relationship_info_id}",
         "cat1_cust_id_30m",
     }
+
+
+@pytest.mark.asyncio
+async def test_feature_with_internal_parent_child_relationships(
+    app_container,
+    document_service,
+    deployed_feature_with_internal_parent_child_relationships,
+    storage,
+    update_fixtures,
+):
+    """
+    Test feature with internal parent child relationships. That information should be reflected in
+    the feature cluster of the offline store feature table.
+    """
+    catalog_id = app_container.catalog_id
+    feature_tables = await get_all_feature_tables(document_service)
+    assert set(feature_tables.keys()) == {
+        "cat1_cust_id_1d",
+    }
+    feature_table = feature_tables["cat1_cust_id_1d"]
+
+    feature_table_dict = feature_table.dict(
+        by_alias=True, exclude={"created_at", "updated_at", "id"}
+    )
+    feature_cluster = feature_table_dict.pop("feature_cluster")
+
+    # Remove dynamic fields before comparison
+    for node_info in feature_cluster["feature_node_relationships_infos"]:
+        for info in node_info["relationships_info"]:
+            info.pop("_id")
+    for info in feature_cluster["combined_relationships_info"]:
+        info.pop("_id")
+
+    _ = feature_table_dict.pop("entity_universe")  # covered in service/test_feature_materialize.py
+    assert feature_table_dict == {
+        "block_modification_by": [],
+        "catalog_id": catalog_id,
+        "description": None,
+        "entity_lookup_info": None,
+        "feature_cluster_path": feature_table_dict["feature_cluster_path"],
+        "feature_ids": [deployed_feature_with_internal_parent_child_relationships.id],
+        "feature_job_setting": {
+            "blind_spot": "0s",
+            "frequency": "86400s",
+            "time_modulo_frequency": "0s",
+        },
+        "feature_store_id": ObjectId("646f6c190ed28a5271fb02a1"),
+        "has_ttl": False,
+        "last_materialized_at": None,
+        "name": "cat1_cust_id_1d",
+        "name_prefix": "cat1",
+        "name_suffix": None,
+        "online_stores_last_materialized_at": [],
+        "output_column_names": ["complex_parent_child_feature_V231227"],
+        "output_dtypes": ["VARCHAR"],
+        "primary_entity_ids": [ObjectId("63f94ed6ea1f050131379214")],
+        "serving_names": ["cust_id"],
+        "user_id": ObjectId("63f9506dd478b94127123456"),
+    }
+    assert_equal_json_fixture(
+        feature_cluster,
+        "tests/fixtures/offline_store_feature_table/feature_cluster_with_internal_relationships.json",
+        update_fixtures,
+    )


### PR DESCRIPTION
## Description

This updates feature computation for offline store feature tables to use frozen relationships. Main changes:

1. Populate `feature_node_relationships_info` in the feature cluster for offline feature table models
2. Update `EntityValidationService` to be aware of offline store feature table models when constructing the ParentServingPreparation object

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
