### PR TITLE
[chore] Specify longer timeout when calling list_tables from tile_cache

### DIFF
--- a/featurebyte/session/base.py
+++ b/featurebyte/session/base.py
@@ -216,7 +216,10 @@ class BaseSession(BaseModel):
 
     @abstractmethod
     async def list_tables(
-        self, database_name: str | None = None, schema_name: str | None = None
+        self,
+        database_name: str | None = None,
+        schema_name: str | None = None,
+        timeout: float = INTERACTIVE_SESSION_TIMEOUT_SECONDS,
     ) -> list[TableSpec]:
         """
         Execute SQL query to retrieve table names
@@ -227,6 +230,8 @@ class BaseSession(BaseModel):
             Database name
         schema_name: str | None
             Schema name
+        timeout: float
+            Timeout in seconds
 
         Returns
         -------

--- a/featurebyte/session/base_spark.py
+++ b/featurebyte/session/base_spark.py
@@ -20,7 +20,12 @@ from featurebyte.query_graph.model.column_info import ColumnSpecWithDescription
 from featurebyte.query_graph.model.table import TableDetails, TableSpec
 from featurebyte.query_graph.sql.ast.literal import make_literal_value
 from featurebyte.query_graph.sql.common import get_fully_qualified_table_name, sql_to_string
-from featurebyte.session.base import BaseSchemaInitializer, BaseSession, MetadataSchemaInitializer
+from featurebyte.session.base import (
+    INTERACTIVE_SESSION_TIMEOUT_SECONDS,
+    BaseSchemaInitializer,
+    BaseSession,
+    MetadataSchemaInitializer,
+)
 
 logger = get_logger(__name__)
 
@@ -223,10 +228,13 @@ class BaseSparkSession(BaseSession, ABC):
         return output
 
     async def list_tables(
-        self, database_name: str | None = None, schema_name: str | None = None
+        self,
+        database_name: str | None = None,
+        schema_name: str | None = None,
+        timeout: float = INTERACTIVE_SESSION_TIMEOUT_SECONDS,
     ) -> list[TableSpec]:
         tables = await self.execute_query_interactive(
-            f"SHOW TABLES IN `{database_name}`.`{schema_name}`"
+            f"SHOW TABLES IN `{database_name}`.`{schema_name}`", timeout=timeout
         )
         output = []
         if tables is not None:

--- a/featurebyte/session/databricks_unity.py
+++ b/featurebyte/session/databricks_unity.py
@@ -9,7 +9,7 @@ from pydantic import Field, PrivateAttr
 
 from featurebyte import SourceType
 from featurebyte.query_graph.model.table import TableSpec
-from featurebyte.session.base import BaseSchemaInitializer
+from featurebyte.session.base import INTERACTIVE_SESSION_TIMEOUT_SECONDS, BaseSchemaInitializer
 from featurebyte.session.base_spark import BaseSparkSchemaInitializer
 from featurebyte.session.databricks import DatabricksSession
 
@@ -105,11 +105,15 @@ class DatabricksUnitySession(DatabricksSession):
         return output
 
     async def list_tables(
-        self, database_name: str | None = None, schema_name: str | None = None
+        self,
+        database_name: str | None = None,
+        schema_name: str | None = None,
+        timeout: float = INTERACTIVE_SESSION_TIMEOUT_SECONDS,
     ) -> list[TableSpec]:
         tables = await self.execute_query_interactive(
             f"SELECT TABLE_NAME FROM `{database_name}`.INFORMATION_SCHEMA.TABLES "
-            f"WHERE TABLE_SCHEMA = '{schema_name}'"
+            f"WHERE TABLE_SCHEMA = '{schema_name}'",
+            timeout=timeout,
         )
         output = []
         if tables is not None:

--- a/featurebyte/session/snowflake.py
+++ b/featurebyte/session/snowflake.py
@@ -36,7 +36,12 @@ from featurebyte.query_graph.sql.common import (
     quoted_identifier,
     sql_to_string,
 )
-from featurebyte.session.base import APPLICATION_NAME, BaseSchemaInitializer, BaseSession
+from featurebyte.session.base import (
+    APPLICATION_NAME,
+    INTERACTIVE_SESSION_TIMEOUT_SECONDS,
+    BaseSchemaInitializer,
+    BaseSession,
+)
 from featurebyte.session.enum import SnowflakeDataType
 
 logger = get_logger(__name__)
@@ -140,10 +145,12 @@ class SnowflakeSession(BaseSession):
         self,
         database_name: str | None = None,
         schema_name: str | None = None,
+        timeout: float = INTERACTIVE_SESSION_TIMEOUT_SECONDS,
     ) -> list[TableSpec]:
         tables = await self.execute_query_interactive(
             f'SELECT TABLE_NAME, COMMENT FROM "{database_name}".INFORMATION_SCHEMA.TABLES '
-            f"WHERE TABLE_SCHEMA = '{schema_name}'"
+            f"WHERE TABLE_SCHEMA = '{schema_name}'",
+            timeout=timeout,
         )
         output = []
         if tables is not None:

--- a/featurebyte/session/sqlite.py
+++ b/featurebyte/session/sqlite.py
@@ -15,7 +15,11 @@ from pydantic import Field
 from featurebyte.enum import DBVarType, SourceType
 from featurebyte.query_graph.model.column_info import ColumnSpecWithDescription
 from featurebyte.query_graph.model.table import TableSpec
-from featurebyte.session.base import BaseSchemaInitializer, BaseSession
+from featurebyte.session.base import (
+    INTERACTIVE_SESSION_TIMEOUT_SECONDS,
+    BaseSchemaInitializer,
+    BaseSession,
+)
 
 
 class SQLiteSession(BaseSession):
@@ -47,9 +51,14 @@ class SQLiteSession(BaseSession):
         return []
 
     async def list_tables(
-        self, database_name: str | None = None, schema_name: str | None = None
+        self,
+        database_name: str | None = None,
+        schema_name: str | None = None,
+        timeout: float = INTERACTIVE_SESSION_TIMEOUT_SECONDS,
     ) -> list[TableSpec]:
-        tables = await self.execute_query("SELECT name FROM sqlite_master WHERE type = 'table'")
+        tables = await self.execute_query(
+            "SELECT name FROM sqlite_master WHERE type = 'table'", timeout=timeout
+        )
         output = []
         if tables is not None:
             for _, (name,) in tables[["name"]].iterrows():

--- a/featurebyte/tile/tile_cache.py
+++ b/featurebyte/tile/tile_cache.py
@@ -36,6 +36,8 @@ from featurebyte.session.base import BaseSession
 
 logger = get_logger(__name__)
 
+TILE_CACHE_LIST_TABLES_TIMEOUT_SECONDS = 60 * 10
+
 
 @dataclass(frozen=True)
 class TileInfoKey:
@@ -383,7 +385,9 @@ class TileCache:
         """
         all_trackers = set()
         for table in await self.session.list_tables(
-            database_name=self.session.database_name, schema_name=self.session.schema_name
+            database_name=self.session.database_name,
+            schema_name=self.session.schema_name,
+            timeout=TILE_CACHE_LIST_TABLES_TIMEOUT_SECONDS,
         ):
             # always convert to upper case in case some backends change the casing
             table_name = table.name.upper()


### PR DESCRIPTION
## Description

This sets a longer timeout for `list_tables()` where it is expected to take longer in the get historical features task.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
