### PR TITLE
[DEV-3093] Fix databricks integration in SDK

### DIFF
--- a/.changelog/DEV-3093.yaml
+++ b/.changelog/DEV-3093.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Databricks integration is not working as expected."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/__init__.py
+++ b/featurebyte/__init__.py
@@ -133,17 +133,24 @@ def get_active_profile() -> Profile:
     conf = Configurations()
 
     # check if we are in DataBricks environment and valid secrets are present create a profile automatically
-    db_utils = globals().get("dbutils")
-    if db_utils:
+    try:
+        from databricks.sdk.runtime import dbutils  # pylint: disable=import-outside-toplevel
+        from pyspark.errors.exceptions.captured import (  # pylint: disable=import-outside-toplevel
+            IllegalArgumentException,
+        )
+
         if len(conf.profiles) == 1 and conf.profiles[0].name == "local":
             api_url = None
             api_token = None
             try:
-                api_url = db_utils.secrets.get(scope="featurebyte", key="api-url")
-                api_token = db_utils.secrets.get(scope="featurebyte", key="api-token")
-            except Exception:  # pylint: disable=broad-except
+                api_url = dbutils.secrets.get(scope="featurebyte", key="api-url")
+                api_token = dbutils.secrets.get(scope="featurebyte", key="api-token")
+            except IllegalArgumentException:
                 logger.info(
-                    "Add the secrets (featurebyte.api-url, featurebyte.api-token) for auto profile creation."
+                    "Add the secrets (featurebyte.api-url, featurebyte.api-token) for auto profile creation:\n"
+                    "databricks secrets create-scope --scope featurebyte\n"
+                    "databricks secrets put --scope featurebyte --key api-url --string-value <api-url>\n"
+                    "databricks secrets put --scope featurebyte --key api-token --string-value <api-token>"
                 )
             if api_url and api_token:
                 register_profile(
@@ -152,6 +159,8 @@ def get_active_profile() -> Profile:
                     api_token=api_token,
                     make_default=True,
                 )
+    except (ModuleNotFoundError, ImportError, ValueError):
+        pass
 
     if not conf.profile:
         logger.error(

--- a/featurebyte/api/materialized_table.py
+++ b/featurebyte/api/materialized_table.py
@@ -92,21 +92,22 @@ class MaterializedTableMixin(MaterializedTableModel):
             When spark is not available in the current environment.
         """
 
-        spark = globals().get("spark")
-        if spark is None:
-            raise NotImplementedError("Spark is not available in the current environment.")
+        try:
+            from databricks.sdk.runtime import spark  # pylint: disable=import-outside-toplevel
 
-        fully_qualified_table_name = sql_to_string(
-            get_fully_qualified_table_name(
-                {
-                    "table_name": self.location.table_details.table_name,
-                    "schema_name": self.location.table_details.schema_name,
-                    "database_name": self.location.table_details.database_name,
-                }
-            ),
-            source_type=SourceType.SPARK,
-        )
-        return spark.table(fully_qualified_table_name)
+            fully_qualified_table_name = sql_to_string(
+                get_fully_qualified_table_name(
+                    {
+                        "table_name": self.location.table_details.table_name,
+                        "schema_name": self.location.table_details.schema_name,
+                        "database_name": self.location.table_details.database_name,
+                    }
+                ),
+                source_type=SourceType.SPARK,
+            )
+            return spark.table(fully_qualified_table_name)
+        except (ModuleNotFoundError, ImportError, ValueError) as exc:
+            raise NotImplementedError("Spark is not available in the current environment.") from exc
 
     def delete(self) -> None:
         """

--- a/featurebyte/api/materialized_table.py
+++ b/featurebyte/api/materialized_table.py
@@ -93,7 +93,9 @@ class MaterializedTableMixin(MaterializedTableModel):
         """
 
         try:
-            from databricks.sdk.runtime import spark  # pylint: disable=import-outside-toplevel
+            from pyspark.sql import SparkSession  # pylint: disable=import-outside-toplevel
+
+            spark = SparkSession.builder.getOrCreate()
 
             fully_qualified_table_name = sql_to_string(
                 get_fully_qualified_table_name(

--- a/scripts/enforce_import_rules.py
+++ b/scripts/enforce_import_rules.py
@@ -144,6 +144,8 @@ if __name__ == "__main__":
         "typeguard",
         "yaml",
         "IPython",
+        "databricks",
+        "pyspark",
     }
 
     # Common libraries that can be imported from both backend and client


### PR DESCRIPTION
## Description

Using `globals` to get DataBricks runtime variables does not work.
Use the `databricks.sdk.runtime` module to get these variables instead.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
