### PR TITLE
Update comparison in test_feature_table_cache.py to avoid flakiness

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -655,7 +655,6 @@ def dimension_dataframe_fixture(item_ids):
             "item_type": item_types,
         }
     )
-    data = pd.concat([data, data], ignore_index=True)
     yield data
 
 

--- a/tests/integration/service/test_feature_table_cache.py
+++ b/tests/integration/service/test_feature_table_cache.py
@@ -172,7 +172,7 @@ async def test_create_feature_table_cache(
         source_type=source_type,
     )
     df = await session.execute_query(query)
-    assert df.shape[0] == 50
+    assert df.shape[0] == observation_table.num_rows
     observation_table_cols = list({col.name for col in observation_table_model.columns_info})
     assert set(df.columns.tolist()) == set(
         [InternalName.TABLE_ROW_INDEX] + observation_table_cols + cached_column_names
@@ -262,7 +262,7 @@ async def test_update_feature_table_cache(
         source_type=source_type,
     )
     df = await session.execute_query(query)
-    assert df.shape[0] == 50
+    assert df.shape[0] == observation_table.num_rows
     observation_table_cols = list({col.name for col in observation_table_model.columns_info})
     assert set(df.columns.tolist()) == set(
         [InternalName.TABLE_ROW_INDEX] + observation_table_cols + features
@@ -327,7 +327,10 @@ async def test_create_view_from_cache(
             source_type=source_type,
         )
         df = await session.execute_query(query)
-        assert df.shape == (50, len(set(feature_names + observation_table_cols)) + 1)
+        assert df.shape == (
+            observation_table.num_rows,
+            len(set(feature_names + observation_table_cols)) + 1,
+        )
         assert df.columns.tolist() == (
             [InternalName.TABLE_ROW_INDEX] + observation_table_cols + feature_names
         )
@@ -352,7 +355,10 @@ async def test_create_view_from_cache(
         )
         df = await session.execute_query(query)
         assert len(feature_list.feature_names) == 9
-        assert df.shape == (50, len(set(feature_list.feature_names + observation_table_cols)) + 1)
+        assert df.shape == (
+            observation_table.num_rows,
+            len(set(feature_list.feature_names + observation_table_cols)) + 1,
+        )
         assert df.columns.tolist() == (
             [InternalName.TABLE_ROW_INDEX] + observation_table_cols + feature_list.feature_names
         )
@@ -414,5 +420,5 @@ async def test_read_from_cache(
         graph=feature_cluster.graph,
         nodes=feature_cluster.nodes,
     )
-    assert df.shape[0] == 50
+    assert df.shape[0] == observation_table.num_rows
     assert set(df.columns.tolist()) == set([InternalName.TABLE_ROW_INDEX] + features)


### PR DESCRIPTION
## Description

The test can sometimes fail because the number of rows is not exactly 50.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
