### PR TITLE
[DEV-3136] Improve efficiency of construct_tile_gen_sql in TileCache

### DIFF
--- a/.changelog/DEV-3136.yaml
+++ b/.changelog/DEV-3136.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Avoid repeated graph flattening in GraphInterpreter and improve tile sql generation efficiency"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/query_graph/sql/adapter/base.py
+++ b/featurebyte/query_graph/sql/adapter/base.py
@@ -679,7 +679,7 @@ class BaseAdapter(ABC):  # pylint: disable=too-many-public-methods
         Select
         """
         _ = vector_aggregate_columns, quote_vector_agg_aliases
-        return input_expr.select(*select_keys, *agg_exprs).group_by(*keys)
+        return input_expr.select(*select_keys, *agg_exprs, copy=False).group_by(*keys, copy=False)
 
     @classmethod
     @abstractmethod

--- a/featurebyte/query_graph/sql/ast/tile.py
+++ b/featurebyte/query_graph/sql/ast/tile.py
@@ -167,6 +167,7 @@ class BuildTileNode(TableNode):  # pylint: disable=too-many-instance-attributes
                 join_alias="R",
                 join_type="inner",
                 on=join_conditions_expr,
+                copy=False,
             )
         )
         return cast(Select, select_expr)
@@ -243,7 +244,7 @@ class BuildTileNode(TableNode):  # pylint: disable=too-many-instance-attributes
             "index",
             *keys,
             *window_exprs,
-        ).from_(input_tiled.subquery(copy=False))
+        ).from_(input_tiled.subquery(copy=False), copy=False)
 
         outer_condition = expressions.EQ(
             this=quoted_identifier(self.ROW_NUMBER),
@@ -256,7 +257,7 @@ class BuildTileNode(TableNode):  # pylint: disable=too-many-instance-attributes
                 *[spec.tile_column_name for spec in self.tile_specs],
             )
             .from_(inner_expr.subquery(copy=False))
-            .where(outer_condition)
+            .where(outer_condition, copy=False)
         )
 
         return tile_expr

--- a/featurebyte/query_graph/sql/ast/tile.py
+++ b/featurebyte/query_graph/sql/ast/tile.py
@@ -71,7 +71,7 @@ class BuildTileNode(TableNode):  # pylint: disable=too-many-instance-attributes
             ),
             alias="index",
         )
-        input_tiled = select("*", tile_index_expr).from_(input_filtered.subquery())
+        input_tiled = select("*", tile_index_expr).from_(input_filtered.subquery(copy=False))
         keys = [quoted_identifier(k) for k in self.keys]
         if self.value_by is not None:
             keys.append(quoted_identifier(self.value_by))
@@ -183,7 +183,7 @@ class BuildTileNode(TableNode):  # pylint: disable=too-many-instance-attributes
     ) -> Expression:
         inner_groupby_keys = [expressions.Identifier(this="index"), *keys]
         groupby_keys = [GroupbyKey(expr=key, name=key.name) for key in inner_groupby_keys]
-        original_query = select().from_(input_tiled.subquery())
+        original_query = select().from_(input_tiled.subquery(copy=False))
 
         groupby_columns = []
         for spec in self.tile_specs:
@@ -243,7 +243,7 @@ class BuildTileNode(TableNode):  # pylint: disable=too-many-instance-attributes
             "index",
             *keys,
             *window_exprs,
-        ).from_(input_tiled.subquery())
+        ).from_(input_tiled.subquery(copy=False))
 
         outer_condition = expressions.EQ(
             this=quoted_identifier(self.ROW_NUMBER),
@@ -255,7 +255,7 @@ class BuildTileNode(TableNode):  # pylint: disable=too-many-instance-attributes
                 *keys,
                 *[spec.tile_column_name for spec in self.tile_specs],
             )
-            .from_(inner_expr.subquery())
+            .from_(inner_expr.subquery(copy=False))
             .where(outer_condition)
         )
 

--- a/featurebyte/query_graph/sql/interpreter/base.py
+++ b/featurebyte/query_graph/sql/interpreter/base.py
@@ -9,7 +9,7 @@ from sqlglot import expressions
 
 from featurebyte.enum import SourceType
 from featurebyte.query_graph.graph import QueryGraph
-from featurebyte.query_graph.model.graph import GraphNodeNameMap, QueryGraphModel
+from featurebyte.query_graph.model.graph import QueryGraphModel
 from featurebyte.query_graph.node import Node
 from featurebyte.query_graph.sql.adapter import get_sql_adapter
 from featurebyte.query_graph.sql.ast.base import ExpressionNode, TableNode

--- a/featurebyte/query_graph/sql/interpreter/preview.py
+++ b/featurebyte/query_graph/sql/interpreter/preview.py
@@ -864,8 +864,9 @@ class PreviewMixin(BaseGraphInterpreter):
         DescribeQueries
             SQL code, type conversions to apply on result, row indices, columns
         """
+        flat_node = self.get_flattened_node(node_name)
         operation_structure = QueryGraph(**self.query_graph.dict()).extract_operation_structure(
-            self.query_graph.get_node_by_name(node_name), keep_all_source_columns=True
+            self.query_graph.get_node_by_name(flat_node.name), keep_all_source_columns=True
         )
 
         sample_sql_tree, type_conversions = self._construct_sample_sql(

--- a/featurebyte/query_graph/sql/interpreter/preview.py
+++ b/featurebyte/query_graph/sql/interpreter/preview.py
@@ -140,9 +140,9 @@ class PreviewMixin(BaseGraphInterpreter):
         Tuple[expressions.Select, dict[Optional[str], DBVarType]]
             SQL expression for data sample, column to apply conversion on resulting dataframe
         """
-        flat_graph, flat_node = self.flatten_graph(node_name=node_name)
+        flat_node = self.get_flattened_node(node_name)
         sql_graph = SQLOperationGraph(
-            flat_graph, sql_type=SQLType.MATERIALIZE, source_type=self.source_type
+            self.query_graph, sql_type=SQLType.MATERIALIZE, source_type=self.source_type
         )
         sql_node = sql_graph.build(flat_node)
 

--- a/featurebyte/query_graph/sql/interpreter/preview.py
+++ b/featurebyte/query_graph/sql/interpreter/preview.py
@@ -156,7 +156,7 @@ class PreviewMixin(BaseGraphInterpreter):
 
         # apply type conversions
         operation_structure = QueryGraph(**self.query_graph.dict()).extract_operation_structure(
-            self.query_graph.get_node_by_name(node_name), keep_all_source_columns=True
+            self.query_graph.get_node_by_name(flat_node.name), keep_all_source_columns=True
         )
         if skip_conversion:
             type_conversions: dict[Optional[str], DBVarType] = {}

--- a/featurebyte/query_graph/sql/interpreter/tile.py
+++ b/featurebyte/query_graph/sql/interpreter/tile.py
@@ -239,8 +239,8 @@ class TileGenMixin(BaseGraphInterpreter):
         -------
         List[TileGenSql]
         """
-        flat_graph, flat_starting_node = self.flatten_graph(node_name=starting_node.name)
+        flat_starting_node = self.get_flattened_node(starting_node.name)
         generator = TileSQLGenerator(
-            flat_graph, is_on_demand=is_on_demand, source_type=self.source_type
+            self.query_graph, is_on_demand=is_on_demand, source_type=self.source_type
         )
         return generator.construct_tile_gen_sql(flat_starting_node)

--- a/tests/unit/query_graph/sql/ast/test_special_operations.py
+++ b/tests/unit/query_graph/sql/ast/test_special_operations.py
@@ -13,11 +13,12 @@ def test_handle_filter_node(snowflake_event_view_with_entity):
     """
     view = snowflake_event_view_with_entity
     filtered_view = view[view["col_float"] > 1.5]
-    graph, node = BaseGraphInterpreter(view.graph, SourceType.SNOWFLAKE).flatten_graph(
-        filtered_view.node.name
-    )
+    interpreter = BaseGraphInterpreter(view.graph, SourceType.SNOWFLAKE)
+    node = interpreter.get_flattened_node(filtered_view.node.name)
     sql_node = SQLOperationGraph(
-        query_graph=graph, sql_type=SQLType.AGGREGATION, source_type=SourceType.SNOWFLAKE
+        query_graph=interpreter.query_graph,
+        sql_type=SQLType.AGGREGATION,
+        source_type=SourceType.SNOWFLAKE,
     ).build(node)
     assert sql_node.context.query_node.name.startswith("input")
     assert sql_node.context.current_query_node.name == node.name
@@ -29,11 +30,12 @@ def test_handle_assign_node(snowflake_event_view_with_entity):
     """
     view = snowflake_event_view_with_entity
     view["col_float"] = view["col_float"] + 1.5
-    graph, node = BaseGraphInterpreter(view.graph, SourceType.SNOWFLAKE).flatten_graph(
-        view.node.name
-    )
+    interpreter = BaseGraphInterpreter(view.graph, SourceType.SNOWFLAKE)
+    node = interpreter.get_flattened_node(view.node.name)
     sql_node = SQLOperationGraph(
-        query_graph=graph, sql_type=SQLType.AGGREGATION, source_type=SourceType.SNOWFLAKE
+        query_graph=interpreter.query_graph,
+        sql_type=SQLType.AGGREGATION,
+        source_type=SourceType.SNOWFLAKE,
     ).build(node)
     assert sql_node.context.query_node.name.startswith("input")
     assert sql_node.context.current_query_node.name == node.name
@@ -45,11 +47,12 @@ def test_handle_project_node(snowflake_event_view_with_entity):
     """
     view = snowflake_event_view_with_entity
     view = view[["col_int", "col_float"]]
-    graph, node = BaseGraphInterpreter(view.graph, SourceType.SNOWFLAKE).flatten_graph(
-        view.node.name
-    )
+    interpreter = BaseGraphInterpreter(view.graph, SourceType.SNOWFLAKE)
+    node = interpreter.get_flattened_node(view.node.name)
     sql_node = SQLOperationGraph(
-        query_graph=graph, sql_type=SQLType.AGGREGATION, source_type=SourceType.SNOWFLAKE
+        query_graph=interpreter.query_graph,
+        sql_type=SQLType.AGGREGATION,
+        source_type=SourceType.SNOWFLAKE,
     ).build(node)
     assert sql_node.context.query_node.name.startswith("input")
     assert sql_node.context.current_query_node.name == node.name


### PR DESCRIPTION
## Description

This improves the efficiency of `construct_tile_gen_sql` when used by `TileCache`, specifically in the `_get_unique_tile_infos` method.

The problem is that `GraphInterpreter` repeatedly flattens the same query graph when processing each node, but graph flattening is expensive and we should avoid doing that. Profiling shows the issue:

<img width="1864" alt="image" src="https://github.com/featurebyte/featurebyte/assets/2175543/0fc3645d-2741-4a45-be51-d6cfca92ad4e">

To fix the issue, this refactors `GraphInterpreter` to flatten the graph once and reuse the result when processing different nodes. It also removes some of the deep copies made by sqlglot when constructing the sql which are not necessary and affect runtime.

Timing comparison using a large graph with about 5000 nodes and calling `TileCache::_get_unique_tile_infos` on 100 nodes: 60.5s (before) vs 1.3s (after).

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
