### PR TITLE
[DEV-3137] Set a longer timeout for list_table_schema in tile registry

### DIFF
--- a/featurebyte/session/base.py
+++ b/featurebyte/session/base.py
@@ -253,6 +253,7 @@ class BaseSession(BaseModel):
         table_name: str | None,
         database_name: str | None = None,
         schema_name: str | None = None,
+        timeout: float = INTERACTIVE_SESSION_TIMEOUT_SECONDS,
     ) -> OrderedDict[str, ColumnSpecWithDescription]:
         """
         Execute SQL query to retrieve table schema of a given table name and convert the
@@ -266,6 +267,8 @@ class BaseSession(BaseModel):
             Schema name
         table_name: str
             Table name
+        timeout: float
+            Timeout in seconds
 
         Returns
         -------

--- a/featurebyte/session/base_spark.py
+++ b/featurebyte/session/base_spark.py
@@ -309,9 +309,11 @@ class BaseSparkSession(BaseSession, ABC):
         table_name: str | None,
         database_name: str | None = None,
         schema_name: str | None = None,
+        timeout: float = INTERACTIVE_SESSION_TIMEOUT_SECONDS,
     ) -> OrderedDict[str, ColumnSpecWithDescription]:
         schema = await self.execute_query_interactive(
             f"DESCRIBE `{database_name}`.`{schema_name}`.`{table_name}`",
+            timeout=timeout,
         )
         column_name_type_map = collections.OrderedDict()
         if schema is not None:

--- a/featurebyte/session/snowflake.py
+++ b/featurebyte/session/snowflake.py
@@ -293,9 +293,11 @@ class SnowflakeSession(BaseSession):
         table_name: str | None,
         database_name: str | None = None,
         schema_name: str | None = None,
+        timeout: float = INTERACTIVE_SESSION_TIMEOUT_SECONDS,
     ) -> OrderedDict[str, ColumnSpecWithDescription]:
         schema = await self.execute_query_interactive(
             f'SHOW COLUMNS IN "{database_name}"."{schema_name}"."{table_name}"',
+            timeout=timeout,
         )
         column_name_type_map = collections.OrderedDict()
         if schema is not None:

--- a/featurebyte/session/sqlite.py
+++ b/featurebyte/session/sqlite.py
@@ -91,8 +91,9 @@ class SQLiteSession(BaseSession):
         table_name: str | None,
         database_name: str | None = None,
         schema_name: str | None = None,
+        timeout: float = INTERACTIVE_SESSION_TIMEOUT_SECONDS,
     ) -> OrderedDict[str, ColumnSpecWithDescription]:
-        schema = await self.execute_query(f'PRAGMA table_info("{table_name}")')
+        schema = await self.execute_query(f'PRAGMA table_info("{table_name}")', timeout=timeout)
         column_name_type_map = collections.OrderedDict()
         if schema is not None:
             for _, (column_name, data_type) in schema[["name", "type"]].iterrows():

--- a/featurebyte/sql/tile_registry.py
+++ b/featurebyte/sql/tile_registry.py
@@ -9,6 +9,8 @@ from featurebyte.sql.tile_common import TileCommon
 
 logger = get_logger(__name__)
 
+LIST_TABLE_SCHEMA_TIMEOUT_SECONDS = 10 * 60
+
 
 class TileRegistry(TileCommon):
     """
@@ -55,7 +57,10 @@ class TileRegistry(TileCommon):
                 c.upper()
                 for c in (
                     await self._session.list_table_schema(
-                        self.table_name, self._session.database_name, self._session.schema_name
+                        self.table_name,
+                        self._session.database_name,
+                        self._session.schema_name,
+                        timeout=LIST_TABLE_SCHEMA_TIMEOUT_SECONDS,
                     )
                 ).keys()
             ]

--- a/tests/unit/session/test_base.py
+++ b/tests/unit/session/test_base.py
@@ -19,6 +19,7 @@ from featurebyte.enum import SourceType
 from featurebyte.query_graph.model.column_info import ColumnSpecWithDescription
 from featurebyte.query_graph.model.table import TableSpec
 from featurebyte.session.base import (
+    INTERACTIVE_SESSION_TIMEOUT_SECONDS,
     BaseSchemaInitializer,
     BaseSession,
     MetadataSchemaInitializer,
@@ -70,7 +71,9 @@ def base_session_test_fixture():
             table_name: str | None,
             database_name: str | None = None,
             schema_name: str | None = None,
+            timeout: float = INTERACTIVE_SESSION_TIMEOUT_SECONDS,
         ) -> OrderedDict[str, ColumnSpecWithDescription]:
+            _ = timeout
             return collections.OrderedDict()
 
         async def register_table(


### PR DESCRIPTION
## Description

Allow overriding the default timeout for session list_table_schema method and set a higher value when called from TileRegistry.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
