### PR TITLE
[chore] Handle view creation error in feature table cache service

### DIFF
--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -658,7 +658,7 @@ class FeatureTableCacheService:
         progress_callback: Optional[
             Callable[[int, Optional[str]], Coroutine[Any, Any, None]]
         ] = None,
-    ) -> None:
+    ) -> bool:
         """
         Create or update cache table and create a new view which refers to the cached table
 
@@ -683,6 +683,11 @@ class FeatureTableCacheService:
             than those defined in Entities
         progress_callback: Optional[Callable[[int, Optional[str]], Coroutine[Any, Any, None]]]
             Optional progress callback function
+
+        Returns
+        -------
+        bool
+            Whether the output is a view
         """
         with timer(
             "Update feature table cache",
@@ -739,6 +744,7 @@ class FeatureTableCacheService:
         sql = sql_to_string(create_expr, source_type=db_session.source_type)
         try:
             await db_session.execute_query_long_running(sql)
+            return True
         except:  # pylint: disable=bare-except
             logger.info(
                 "Failed to create view. Trying to create a table instead",
@@ -755,3 +761,4 @@ class FeatureTableCacheService:
             )
             sql = sql_to_string(create_expr, source_type=db_session.source_type)
             await db_session.execute_query_long_running(sql)
+            return False

--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -324,7 +324,7 @@ class FeatureTableCacheService:
                 ),
                 source_type=db_session.source_type,
             )
-            await db_session.execute_query(query)
+            await db_session.execute_query_long_running(query)
         finally:
             await db_session.drop_table(
                 database_name=db_session.database_name,
@@ -386,7 +386,9 @@ class FeatureTableCacheService:
                 )
                 for node, definition in non_cached_nodes
             ]
-            await db_session.execute_query(adapter.alter_table_add_columns(table_exr, columns_expr))
+            await db_session.execute_query_long_running(
+                adapter.alter_table_add_columns(table_exr, columns_expr)
+            )
 
             # merge temp table into cache table
             merge_conditions = [
@@ -434,7 +436,7 @@ class FeatureTableCacheService:
                     ),
                 ],
             )
-            await db_session.execute_query(
+            await db_session.execute_query_long_running(
                 sql_to_string(merge_expr, source_type=db_session.source_type)
             )
         finally:
@@ -456,7 +458,7 @@ class FeatureTableCacheService:
                 .limit(1),
                 source_type=session.source_type,
             )
-            _ = await session.execute_query(query)
+            _ = await session.execute_query_long_running(query)
             return True
         except session._no_schema_error:  # pylint: disable=protected-access
             return False
@@ -641,7 +643,7 @@ class FeatureTableCacheService:
             )
         )
         sql = sql_to_string(select_expr, source_type=db_session.source_type)
-        return await db_session.execute_query(sql)
+        return await db_session.execute_query_long_running(sql)
 
     async def create_view_or_table_from_cache(
         self,
@@ -736,7 +738,7 @@ class FeatureTableCacheService:
         )
         sql = sql_to_string(create_expr, source_type=db_session.source_type)
         try:
-            await db_session.execute_query(sql)
+            await db_session.execute_query_long_running(sql)
         except:  # pylint: disable=bare-except
             logger.info(
                 "Failed to create view. Trying to create a table instead",
@@ -752,4 +754,4 @@ class FeatureTableCacheService:
                 replace=False,
             )
             sql = sql_to_string(create_expr, source_type=db_session.source_type)
-            await db_session.execute_query(sql)
+            await db_session.execute_query_long_running(sql)

--- a/featurebyte/service/historical_features.py
+++ b/featurebyte/service/historical_features.py
@@ -64,7 +64,7 @@ class HistoricalFeatureExecutor(QueryExecutor[HistoricalFeatureExecutorParams]):
             isinstance(executor_params.observation_set, ObservationTableModel)
             and executor_params.observation_set.has_row_index
         ):
-            await self.feature_table_cache_service.create_view_from_cache(
+            await self.feature_table_cache_service.create_view_or_table_from_cache(
                 feature_store=executor_params.feature_store,
                 observation_table=executor_params.observation_set,
                 graph=executor_params.graph,

--- a/featurebyte/service/historical_features.py
+++ b/featurebyte/service/historical_features.py
@@ -24,6 +24,7 @@ from featurebyte.service.session_manager import SessionManagerService
 from featurebyte.service.target_helper.base_feature_or_target_computer import (
     BasicExecutorParams,
     Computer,
+    ExecutionResult,
     ExecutorParams,
     QueryExecutor,
 )
@@ -59,12 +60,12 @@ class HistoricalFeatureExecutor(QueryExecutor[HistoricalFeatureExecutorParams]):
         self.tile_cache_service = tile_cache_service
         self.feature_table_cache_service = feature_table_cache_service
 
-    async def execute(self, executor_params: HistoricalFeatureExecutorParams) -> None:
+    async def execute(self, executor_params: HistoricalFeatureExecutorParams) -> ExecutionResult:
         if (
             isinstance(executor_params.observation_set, ObservationTableModel)
             and executor_params.observation_set.has_row_index
         ):
-            await self.feature_table_cache_service.create_view_or_table_from_cache(
+            is_output_view = await self.feature_table_cache_service.create_view_or_table_from_cache(
                 feature_store=executor_params.feature_store,
                 observation_table=executor_params.observation_set,
                 graph=executor_params.graph,
@@ -89,6 +90,8 @@ class HistoricalFeatureExecutor(QueryExecutor[HistoricalFeatureExecutorParams]):
                 output_table_details=executor_params.output_table_details,
                 progress_callback=executor_params.progress_callback,
             )
+            is_output_view = False
+        return ExecutionResult(is_output_view=is_output_view)
 
 
 class HistoricalFeaturesValidationParametersService:

--- a/featurebyte/service/target_helper/base_feature_or_target_computer.py
+++ b/featurebyte/service/target_helper/base_feature_or_target_computer.py
@@ -65,13 +65,22 @@ class ExecutorParams(BasicExecutorParams):
 ExecutorParamsT = TypeVar("ExecutorParamsT", bound=ExecutorParams)
 
 
+@dataclass
+class ExecutionResult:
+    """
+    Execution result
+    """
+
+    is_output_view: bool
+
+
 class QueryExecutor(Generic[ExecutorParamsT]):
     """
     Query executor
     """
 
     @abstractmethod
-    async def execute(self, executor_params: ExecutorParamsT) -> None:
+    async def execute(self, executor_params: ExecutorParamsT) -> ExecutionResult:
         """
         Execute queries
 
@@ -79,6 +88,10 @@ class QueryExecutor(Generic[ExecutorParamsT]):
         ----------
         executor_params: ExecutorParamsT
             Executor parameters
+
+        Returns
+        -------
+        ExecutionResult
         """
 
 
@@ -147,7 +160,7 @@ class Computer(Generic[ComputeRequestT, ExecutorParamsT]):
         observation_set: Union[pd.DataFrame, ObservationTableModel],
         compute_request: ComputeRequestT,
         output_table_details: TableDetails,
-    ) -> None:
+    ) -> ExecutionResult:
         """
         Compute targets or features
 
@@ -159,6 +172,10 @@ class Computer(Generic[ComputeRequestT, ExecutorParamsT]):
             Compute request
         output_table_details: TableDetails
             Table details to write the results to
+
+        Returns
+        -------
+        ExecutionResult
         """
         validation_parameters = await self.get_validation_parameters(compute_request)
 
@@ -190,4 +207,4 @@ class Computer(Generic[ComputeRequestT, ExecutorParamsT]):
             ),
             validation_parameters=validation_parameters,
         )
-        await self.query_executor.execute(params)
+        return await self.query_executor.execute(params)

--- a/featurebyte/service/target_helper/compute_target.py
+++ b/featurebyte/service/target_helper/compute_target.py
@@ -46,7 +46,7 @@ class TargetExecutor(QueryExecutor[ExecutorParams]):
             isinstance(executor_params.observation_set, ObservationTableModel)
             and executor_params.observation_set.has_row_index
         ):
-            await self.feature_table_cache_service.create_view_from_cache(
+            await self.feature_table_cache_service.create_view_or_table_from_cache(
                 feature_store=executor_params.feature_store,
                 observation_table=executor_params.observation_set,
                 graph=executor_params.graph,

--- a/featurebyte/service/target_helper/compute_target.py
+++ b/featurebyte/service/target_helper/compute_target.py
@@ -15,6 +15,7 @@ from featurebyte.service.session_manager import SessionManagerService
 from featurebyte.service.target_helper.base_feature_or_target_computer import (
     BasicExecutorParams,
     Computer,
+    ExecutionResult,
     ExecutorParams,
     QueryExecutor,
 )
@@ -33,7 +34,7 @@ class TargetExecutor(QueryExecutor[ExecutorParams]):
 
     async def execute(  # pylint: disable=too-many-locals
         self, executor_params: ExecutorParams
-    ) -> None:
+    ) -> ExecutionResult:
         """
         Get targets.
 
@@ -41,12 +42,16 @@ class TargetExecutor(QueryExecutor[ExecutorParams]):
         ----------
         executor_params: ExecutorParams
             Executor parameters
+
+        Returns
+        -------
+        ExecutionResult
         """
         if (
             isinstance(executor_params.observation_set, ObservationTableModel)
             and executor_params.observation_set.has_row_index
         ):
-            await self.feature_table_cache_service.create_view_or_table_from_cache(
+            is_output_view = await self.feature_table_cache_service.create_view_or_table_from_cache(
                 feature_store=executor_params.feature_store,
                 observation_table=executor_params.observation_set,
                 graph=executor_params.graph,
@@ -67,6 +72,8 @@ class TargetExecutor(QueryExecutor[ExecutorParams]):
                 parent_serving_preparation=executor_params.parent_serving_preparation,
                 progress_callback=executor_params.progress_callback,
             )
+            is_output_view = False
+        return ExecutionResult(is_output_view=is_output_view)
 
 
 class TargetComputer(Computer[ComputeTargetRequest, ExecutorParams]):

--- a/featurebyte/worker/task/historical_feature_table.py
+++ b/featurebyte/worker/task/historical_feature_table.py
@@ -7,7 +7,6 @@ from typing import Any
 
 from featurebyte.logging import get_logger
 from featurebyte.models.historical_feature_table import HistoricalFeatureTableModel
-from featurebyte.models.observation_table import ObservationTableModel
 from featurebyte.schema.worker.task.historical_feature_table import (
     HistoricalFeatureTableTaskPayload,
 )
@@ -59,17 +58,12 @@ class HistoricalFeatureTableTask(DataWarehouseMixin, BaseTask[HistoricalFeatureT
         location = await self.historical_feature_table_service.generate_materialized_table_location(
             payload.feature_store_id
         )
-        is_view = (
-            isinstance(observation_set, ObservationTableModel)
-            and observation_set.has_row_index is True
-        )
         async with self.drop_table_on_error(
             db_session=db_session,
             table_details=location.table_details,
             payload=payload,
-            is_view=is_view,
         ):
-            await self.historical_features_service.compute(
+            result = await self.historical_features_service.compute(
                 observation_set=observation_set,
                 compute_request=payload.featurelist_get_historical_features,
                 output_table_details=location.table_details,
@@ -92,6 +86,6 @@ class HistoricalFeatureTableTask(DataWarehouseMixin, BaseTask[HistoricalFeatureT
                 feature_list_id=payload.featurelist_get_historical_features.feature_list_id,
                 columns_info=columns_info,
                 num_rows=num_rows,
-                is_view=is_view,
+                is_view=result.is_output_view,
             )
             await self.historical_feature_table_service.create_document(historical_feature_table)

--- a/featurebyte/worker/task/materialized_table_delete.py
+++ b/featurebyte/worker/task/materialized_table_delete.py
@@ -151,7 +151,6 @@ class MaterializedTableDeleteTask(DataWarehouseMixin, BaseTask[MaterializedTable
             table_name=document.location.table_details.table_name,
             schema_name=document.location.table_details.schema_name,  # type: ignore
             database_name=document.location.table_details.database_name,  # type: ignore
-            is_view=document.is_view,
         )
 
     async def execute(self, payload: MaterializedTableDeleteTaskPayload) -> Any:

--- a/featurebyte/worker/task/mixin.py
+++ b/featurebyte/worker/task/mixin.py
@@ -26,7 +26,6 @@ class DataWarehouseMixin:
         db_session: BaseSession,
         table_details: TableDetails,
         payload: BaseTaskPayload,
-        is_view: bool = False,
     ) -> AsyncIterator[None]:
         """
         Drop the table on error
@@ -39,8 +38,6 @@ class DataWarehouseMixin:
             The table details
         payload: BaseTaskPayload
             The task payload
-        is_view: bool
-            Whether it is view, not table
 
         Yields
         ------
@@ -66,6 +63,5 @@ class DataWarehouseMixin:
                 schema_name=table_details.schema_name,
                 database_name=table_details.database_name,
                 if_exists=True,
-                is_view=is_view,
             )
             raise exc

--- a/featurebyte/worker/task/target_table.py
+++ b/featurebyte/worker/task/target_table.py
@@ -67,14 +67,13 @@ class TargetTableTask(DataWarehouseMixin, BaseTask[TargetTableTaskPayload]):
             db_session=db_session,
             table_details=location.table_details,
             payload=payload,
-            is_view=has_row_index,
         ):
             # Graphs and nodes being processed in this task should not be None anymore.
             graph = payload.graph
             node_names = payload.node_names
             assert graph is not None
             assert node_names is not None
-            await self.target_computer.compute(
+            result = await self.target_computer.compute(
                 observation_set=observation_set,
                 compute_request=ComputeTargetRequest(
                     feature_store_id=payload.feature_store_id,
@@ -125,7 +124,7 @@ class TargetTableTask(DataWarehouseMixin, BaseTask[TargetTableTaskPayload]):
                 primary_entity_ids=primary_entity_ids,
                 purpose=purpose,
                 has_row_index=True,
-                is_view=has_row_index,
+                is_view=result.is_output_view,
                 **additional_metadata,
             )
             await self.observation_table_service.create_document(observation_table)

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -572,11 +572,6 @@ async def test_get_historical_features(
     """
     Test getting historical features from FeatureList
     """
-    print("hi")
-    with open(f"/Users/yungsiang/workspace/temp/view-definition-too-large/query_x2.sql") as f:
-        content = f.read()
-        await session.execute_query_long_running(content)
-
     _ = user_entity, new_user_id_entity
     input_format, output_format = in_out_formats
     assert input_format in {"dataframe", "table", "uploaded_table"}

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -572,6 +572,11 @@ async def test_get_historical_features(
     """
     Test getting historical features from FeatureList
     """
+    print("hi")
+    with open(f"/Users/yungsiang/workspace/temp/view-definition-too-large/query_x2.sql") as f:
+        content = f.read()
+        await session.execute_query_long_running(content)
+
     _ = user_entity, new_user_id_entity
     input_format, output_format = in_out_formats
     assert input_format in {"dataframe", "table", "uploaded_table"}

--- a/tests/integration/service/test_feature_table_cache.py
+++ b/tests/integration/service/test_feature_table_cache.py
@@ -308,7 +308,7 @@ async def test_create_view_from_cache(
         feature_names = [
             feature_cluster.graph.get_node_output_column_name(node.name) for node in nodes
         ]
-        await feature_table_cache_service.create_view_from_cache(
+        await feature_table_cache_service.create_view_or_table_from_cache(
             feature_store=feature_store_model,
             observation_table=observation_table_model,
             graph=feature_cluster.graph,
@@ -336,7 +336,7 @@ async def test_create_view_from_cache(
         )
 
         # update cache table with second feature list
-        await feature_table_cache_service.create_view_from_cache(
+        await feature_table_cache_service.create_view_or_table_from_cache(
             feature_store=feature_store_model,
             observation_table=observation_table_model,
             graph=feature_cluster.graph,

--- a/tests/integration/service/test_feature_table_cache.py
+++ b/tests/integration/service/test_feature_table_cache.py
@@ -368,14 +368,12 @@ async def test_create_view_from_cache(
             schema_name=view_1.schema_name,
             database_name=view_1.database_name,
             if_exists=True,
-            is_view=True,
         )
         await session.drop_table(
             table_name=view_2.table_name,
             schema_name=view_2.schema_name,
             database_name=view_2.database_name,
             if_exists=True,
-            is_view=True,
         )
 
 

--- a/tests/unit/service/test_feature_table_cache.py
+++ b/tests/unit/service/test_feature_table_cache.py
@@ -508,7 +508,7 @@ async def test_create_view_from_cache__create_cache(
         schema_name=mock_snowflake_session.schema_name,
         table_name="result_view",
     )
-    await feature_table_cache_service.create_view_or_table_from_cache(
+    is_output_view = await feature_table_cache_service.create_view_or_table_from_cache(
         feature_store=feature_store,
         observation_table=observation_table,
         graph=feature_list.feature_clusters[0].graph,
@@ -520,6 +520,7 @@ async def test_create_view_from_cache__create_cache(
 
     assert mock_get_historical_features.await_count == 1
     assert mock_snowflake_session.execute_query_long_running.await_count == 3
+    assert is_output_view is True
 
     feature_table_cache = (
         await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
@@ -579,7 +580,7 @@ async def test_create_view_from_cache__update_cache(
         schema_name=mock_snowflake_session.schema_name,
         table_name="result_view",
     )
-    await feature_table_cache_service.create_view_or_table_from_cache(
+    is_output_view = await feature_table_cache_service.create_view_or_table_from_cache(
         feature_store=feature_store,
         observation_table=observation_table,
         graph=feature_list.feature_clusters[0].graph,
@@ -590,6 +591,7 @@ async def test_create_view_from_cache__update_cache(
     )
     assert mock_get_historical_features.await_count == 1
     assert mock_snowflake_session.execute_query_long_running.await_count == 3
+    assert is_output_view is True
 
     mock_get_historical_features.reset_mock()
     mock_snowflake_session.reset_mock()
@@ -670,7 +672,7 @@ async def test_create_view_from_cache__create_view_failed(
         schema_name=mock_snowflake_session.schema_name,
         table_name="result_view",
     )
-    await feature_table_cache_service.create_view_or_table_from_cache(
+    is_output_view = await feature_table_cache_service.create_view_or_table_from_cache(
         feature_store=feature_store,
         observation_table=observation_table,
         graph=feature_list.feature_clusters[0].graph,
@@ -682,6 +684,7 @@ async def test_create_view_from_cache__create_view_failed(
 
     assert mock_get_historical_features.await_count == 1
     assert mock_snowflake_session.execute_query_long_running.await_count == 4
+    assert is_output_view is False
 
     feature_table_cache = (
         await feature_table_cache_metadata_service.get_or_create_feature_table_cache(


### PR DESCRIPTION
## Description

This updates feature table cache service to fallback to creating a table instead when creating a view failed. This can happen due to limitations such as the maximum view definition size in Snowflake.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
