### PR TITLE
[DEV-3160] Fix spark to dtype conversion for map types

### DIFF
--- a/.changelog/DEV-3160.yaml
+++ b/.changelog/DEV-3160.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: session
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix dtype detected wrongly for MAP type in Spark session"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/tests/unit/session/test_databricks_session.py
+++ b/tests/unit/session/test_databricks_session.py
@@ -169,9 +169,6 @@ async def test_databricks_session(databricks_session_dict):
         "col_date": ColumnSpecWithDescription(
             name="col_date", dtype=DBVarType.DATE, description="Date Column"
         ),
-        "col_decimal": ColumnSpecWithDescription(
-            name="col_decimal", dtype=DBVarType.FLOAT, description="Decimal Column"
-        ),
         "col_double": ColumnSpecWithDescription(
             name="col_double", dtype=DBVarType.FLOAT, description="Double Column"
         ),
@@ -195,6 +192,9 @@ async def test_databricks_session(databricks_session_dict):
         ),
         "col_map": ColumnSpecWithDescription(
             name="col_map", dtype=DBVarType.DICT, description="Map Column"
+        ),
+        "col_decimal": ColumnSpecWithDescription(
+            name="col_decimal", dtype=DBVarType.FLOAT, description="Decimal Column"
         ),
         "col_struct": ColumnSpecWithDescription(
             name="col_struct", dtype=DBVarType.DICT, description="Struct Column"


### PR DESCRIPTION
## Description

Fix spark to dtype conversion for map types.
Before the fix: MAP types are detected as "UNKNOWN"
After the fix: MAP types are detected as "DICT"

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
