### PR TITLE
[chore] Fix possible cause of flakiness in azure storage tests

### DIFF
--- a/tests/integration/storage/test_azure_storage.py
+++ b/tests/integration/storage/test_azure_storage.py
@@ -39,5 +39,5 @@ class TestAzureBlobStorageSuite(BaseStorageTestSuite):
 
             # cleanup remote folder
             async with get_azure_storage_blob_client() as client:
-                async for blob in client.list_blobs():
+                async for blob in client.list_blobs(name_starts_with=prefix):
                     await client.delete_blob(blob.name, delete_snapshots="include")


### PR DESCRIPTION
## Description

`prefix` is handled on our end and not by Azure client:

https://github.com/featurebyte/featurebyte/blob/aa3cc98212fdeb76075bdd0da311f8697ca321d6/featurebyte/storage/azure.py#L41-L60

so listing blobs probably will list everything under the container regardless of prefix, causing interference between tests: 

https://github.com/featurebyte/featurebyte/blob/e3704e04634867c6134f949f4e2dd804d26d3399/tests/integration/storage/test_azure_storage.py#L40-L43

Clean up should only delete files created within the test session, which can be filtered using the prefix.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
