### PR TITLE
[chore] Move volume creation from `create_schema` to `register_missing_objects`

### DIFF
--- a/featurebyte/session/databricks_unity.py
+++ b/featurebyte/session/databricks_unity.py
@@ -38,6 +38,7 @@ class DatabricksUnitySchemaInitializer(BaseSparkSchemaInitializer):
 
     async def register_missing_objects(self) -> None:
         # create staging volume if not exists
+        assert isinstance(self.session, DatabricksUnitySession)
         await self.session.execute_query(f"CREATE VOLUME IF NOT EXISTS {self.session.volume_name}")
 
         # register missing other common objects by calling the super method

--- a/featurebyte/session/databricks_unity.py
+++ b/featurebyte/session/databricks_unity.py
@@ -35,8 +35,13 @@ class DatabricksUnitySchemaInitializer(BaseSparkSchemaInitializer):
         assert isinstance(self.session, DatabricksUnitySession)
         grant_permissions_query = f"GRANT ALL PRIVILEGES ON SCHEMA `{self.session.schema_name}` TO `{self.session.group_name}`"
         await self.session.execute_query(grant_permissions_query)
+
+    async def register_missing_objects(self) -> None:
         # create staging volume if not exists
         await self.session.execute_query(f"CREATE VOLUME IF NOT EXISTS {self.session.volume_name}")
+
+        # register missing other common objects by calling the super method
+        await super().register_missing_objects()
 
     @property
     def sql_directory_name(self) -> str:


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
If the DataBricks schema has been created, the volume creation will be skipped. This PR removes this assumption by moving volume creation logic into `register_missing_objects`.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
