### PR TITLE
[DEV-3225] Limit asset names to 255 characters

### DIFF
--- a/.changelog/DEV-3225.yaml
+++ b/.changelog/DEV-3225.yaml
@@ -1,0 +1,36 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: models
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Limit asset names to 255 characters in length to ensure they can be referenced as identifiers in SQL queries
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+    + This change ensures that asset names are compatible with the maximum length of identifiers in SQL queries
+    + This change will prevent errors when querying assets with long names
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/models/base.py
+++ b/featurebyte/models/base.py
@@ -4,7 +4,7 @@ FeatureByte specific BaseModel
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 import json
 import re
@@ -25,6 +25,19 @@ Model = TypeVar("Model", bound="FeatureByteBaseModel")
 DEFAULT_CATALOG_ID = ObjectId("23eda344d0313fb925f7883a")
 ACTIVE_CATALOG_ID: Optional[ObjectId] = None
 CAMEL_CASE_TO_SNAKE_CASE_PATTERN = re.compile("((?!^)(?<!_)[A-Z][a-z]+|(?<=[a-z0-9])[A-Z])")
+
+
+if TYPE_CHECKING:
+    NameStr = str
+else:
+
+    class NameStr(StrictStr):
+        """
+        Name string type
+        """
+
+        min_length = 0
+        max_length = 255
 
 
 def get_active_catalog_id() -> Optional[ObjectId]:
@@ -268,7 +281,7 @@ class FeatureByteBaseDocumentModel(FeatureByteBaseModel):
     user_id: Optional[PydanticObjectId] = Field(
         default=None, allow_mutation=False, description="User identifier"
     )
-    name: Optional[StrictStr] = Field(description="Record name")
+    name: Optional[NameStr] = Field(description="Record name")
     created_at: Optional[datetime] = Field(
         default=None, allow_mutation=False, description="Record creation time"
     )

--- a/featurebyte/models/feature_store.py
+++ b/featurebyte/models/feature_store.py
@@ -16,6 +16,7 @@ from featurebyte.enum import OrderedStrEnum
 from featurebyte.models.base import (
     FeatureByteBaseDocumentModel,
     FeatureByteCatalogBaseDocumentModel,
+    NameStr,
     PydanticObjectId,
     UniqueConstraintResolutionSignature,
     UniqueValuesConstraint,
@@ -32,7 +33,7 @@ from featurebyte.query_graph.node.schema import FeatureStoreDetails
 class FeatureStoreModel(FeatureByteBaseDocumentModel, FeatureStoreDetails):
     """Model for a feature store"""
 
-    name: StrictStr
+    name: NameStr
 
     def get_feature_store_details(self) -> FeatureStoreDetails:
         """

--- a/featurebyte/models/user_defined_function.py
+++ b/featurebyte/models/user_defined_function.py
@@ -18,6 +18,7 @@ from featurebyte.enum import DBVarType, SourceType
 from featurebyte.models.base import (
     FeatureByteBaseDocumentModel,
     FeatureByteBaseModel,
+    NameStr,
     PydanticObjectId,
     UniqueValuesConstraint,
 )
@@ -213,7 +214,7 @@ class UserDefinedFunctionModel(FeatureByteBaseDocumentModel):
         Catalog id of the function (if any), if not provided, it can be used across all catalogs
     """
 
-    name: str
+    name: NameStr
     sql_function_name: str
     function_parameters: List[FunctionParameter]
     output_dtype: DBVarType

--- a/featurebyte/query_graph/node/schema.py
+++ b/featurebyte/query_graph/node/schema.py
@@ -10,7 +10,7 @@ from pydantic import Field, StrictStr, root_validator
 
 from featurebyte.common.doc_util import FBAutoDoc
 from featurebyte.enum import DBVarType, SourceType, StorageType
-from featurebyte.models.base import FeatureByteBaseModel
+from featurebyte.models.base import FeatureByteBaseModel, NameStr
 
 
 class BaseDatabaseDetails(FeatureByteBaseModel):
@@ -273,9 +273,9 @@ class InputNodeFeatureStoreDetails(FeatureByteBaseModel):
 class TableDetails(FeatureByteBaseModel):
     """Table details"""
 
-    database_name: Optional[StrictStr]
-    schema_name: Optional[StrictStr]
-    table_name: StrictStr
+    database_name: Optional[NameStr]
+    schema_name: Optional[NameStr]
+    table_name: NameStr
 
 
 class ColumnSpec(FeatureByteBaseModel):
@@ -283,5 +283,5 @@ class ColumnSpec(FeatureByteBaseModel):
     Schema for columns retrieval
     """
 
-    name: StrictStr
+    name: NameStr
     dtype: DBVarType

--- a/featurebyte/routes/common/base_table.py
+++ b/featurebyte/routes/common/base_table.py
@@ -97,7 +97,9 @@ class BaseTableDocumentController(  # pylint: disable=too-many-instance-attribut
         """
         column_semantic_map = {}
         for field, semantic_type in self.semantic_tag_rules.items():
-            semantic_id = await self.semantic_service.get_or_create_document(name=semantic_type)
+            semantic_id = await self.semantic_service.get_or_create_document(
+                name=semantic_type.value
+            )
             special_column_name = getattr(document, field)
             if special_column_name:
                 column_semantic_map[special_column_name] = semantic_id

--- a/featurebyte/schema/batch_feature_table.py
+++ b/featurebyte/schema/batch_feature_table.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional
 
 from bson import ObjectId
-from pydantic import Field, StrictStr, root_validator
+from pydantic import Field, root_validator
 
-from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
+from featurebyte.models.base import FeatureByteBaseModel, NameStr, PydanticObjectId
 from featurebyte.models.batch_feature_table import BatchFeatureTableModel
 from featurebyte.schema.common.base import PaginationMixin
 from featurebyte.schema.materialized_table import BaseMaterializedTableListRecord
@@ -21,7 +21,7 @@ class BatchFeatureTableCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: StrictStr
+    name: NameStr
     feature_store_id: PydanticObjectId
     batch_request_table_id: PydanticObjectId
     deployment_id: PydanticObjectId

--- a/featurebyte/schema/catalog.py
+++ b/featurebyte/schema/catalog.py
@@ -7,10 +7,11 @@ from __future__ import annotations
 from typing import List, Optional
 
 from bson.objectid import ObjectId
-from pydantic import Field, StrictStr
+from pydantic import Field
 
 from featurebyte.models.base import (
     FeatureByteBaseModel,
+    NameStr,
     PydanticObjectId,
     UniqueConstraintResolutionSignature,
     UniqueValuesConstraint,
@@ -25,7 +26,7 @@ class CatalogCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: StrictStr
+    name: NameStr
     default_feature_store_ids: List[PydanticObjectId]
     online_store_id: Optional[PydanticObjectId] = Field(default=None)
 
@@ -43,7 +44,7 @@ class CatalogUpdate(FeatureByteBaseModel):
     Catalog update schema
     """
 
-    name: Optional[StrictStr]
+    name: Optional[NameStr]
 
 
 class CatalogOnlineStoreUpdate(BaseDocumentServiceUpdateSchema):
@@ -59,7 +60,7 @@ class CatalogServiceUpdate(BaseDocumentServiceUpdateSchema):
     Catalog service update schema
     """
 
-    name: Optional[StrictStr]
+    name: Optional[NameStr]
     is_deleted: Optional[bool]
 
     class Settings(BaseDocumentServiceUpdateSchema.Settings):

--- a/featurebyte/schema/common/feature_or_target.py
+++ b/featurebyte/schema/common/feature_or_target.py
@@ -5,9 +5,9 @@ Feature or target schema
 from typing import Dict, Optional
 
 from bson import ObjectId
-from pydantic import Field, StrictStr
+from pydantic import Field
 
-from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
+from featurebyte.models.base import FeatureByteBaseModel, NameStr, PydanticObjectId
 
 
 class FeatureOrTargetTableCreate(FeatureByteBaseModel):
@@ -16,7 +16,7 @@ class FeatureOrTargetTableCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: StrictStr
+    name: NameStr
     feature_store_id: PydanticObjectId
     observation_table_id: Optional[PydanticObjectId]
 

--- a/featurebyte/schema/context.py
+++ b/featurebyte/schema/context.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 from bson import ObjectId
 from pydantic import Field, StrictStr, root_validator, validator
 
-from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
+from featurebyte.models.base import FeatureByteBaseModel, NameStr, PydanticObjectId
 from featurebyte.models.context import ContextModel
 from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema, PaginationMixin
@@ -19,7 +19,7 @@ class ContextCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: StrictStr
+    name: NameStr
     primary_entity_ids: List[PydanticObjectId]
     description: Optional[StrictStr]
 
@@ -64,7 +64,7 @@ class ContextUpdate(BaseDocumentServiceUpdateSchema):
     remove_default_eda_table: Optional[bool]
     remove_default_preview_table: Optional[bool]
 
-    name: Optional[StrictStr]
+    name: Optional[NameStr]
 
     @root_validator(pre=True)
     @classmethod

--- a/featurebyte/schema/credential.py
+++ b/featurebyte/schema/credential.py
@@ -5,11 +5,12 @@ Pydantic schemas for handling API payloads for credential routes
 from typing import List, Optional
 
 from bson import ObjectId
-from pydantic import Field, StrictStr, validator
+from pydantic import Field, validator
 
 from featurebyte.models.base import (
     FeatureByteBaseDocumentModel,
     FeatureByteBaseModel,
+    NameStr,
     PydanticObjectId,
     UniqueConstraintResolutionSignature,
     UniqueValuesConstraint,
@@ -31,7 +32,7 @@ class CredentialCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: Optional[StrictStr]
+    name: Optional[NameStr]
     feature_store_id: PydanticObjectId
     database_credential: Optional[DatabaseCredential]
     storage_credential: Optional[StorageCredential]

--- a/featurebyte/schema/deployment.py
+++ b/featurebyte/schema/deployment.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional
 
 from bson import ObjectId
-from pydantic import Field, StrictStr
+from pydantic import Field
 
-from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
+from featurebyte.models.base import FeatureByteBaseModel, NameStr, PydanticObjectId
 from featurebyte.models.deployment import DeploymentModel
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema, PaginationMixin
 
@@ -20,7 +20,7 @@ class DeploymentCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: Optional[StrictStr]
+    name: Optional[NameStr]
     feature_list_id: PydanticObjectId
     use_case_id: Optional[PydanticObjectId]
 

--- a/featurebyte/schema/entity.py
+++ b/featurebyte/schema/entity.py
@@ -7,10 +7,11 @@ from __future__ import annotations
 from typing import List, Optional
 
 from bson.objectid import ObjectId
-from pydantic import Field, StrictStr
+from pydantic import Field
 
 from featurebyte.models.base import (
     FeatureByteBaseModel,
+    NameStr,
     PydanticObjectId,
     UniqueConstraintResolutionSignature,
     UniqueValuesConstraint,
@@ -25,8 +26,8 @@ class EntityCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: StrictStr
-    serving_name: StrictStr
+    name: NameStr
+    serving_name: NameStr
 
 
 class EntityList(PaginationMixin):
@@ -42,7 +43,7 @@ class EntityUpdate(FeatureByteBaseModel):
     Entity update schema
     """
 
-    name: StrictStr
+    name: NameStr
 
 
 class EntityServiceUpdate(BaseDocumentServiceUpdateSchema):
@@ -50,7 +51,7 @@ class EntityServiceUpdate(BaseDocumentServiceUpdateSchema):
     Entity service update schema
     """
 
-    name: Optional[str]
+    name: Optional[NameStr]
     ancestor_ids: Optional[List[PydanticObjectId]]
     parents: Optional[List[ParentEntity]]
     table_ids: Optional[List[PydanticObjectId]]

--- a/featurebyte/schema/feature.py
+++ b/featurebyte/schema/feature.py
@@ -9,10 +9,15 @@ from typing import Any, List, Optional
 from datetime import datetime
 
 from bson.objectid import ObjectId
-from pydantic import Field, StrictStr, validator
+from pydantic import Field, validator
 
 from featurebyte.enum import ConflictResolution
-from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId, VersionIdentifier
+from featurebyte.models.base import (
+    FeatureByteBaseModel,
+    NameStr,
+    PydanticObjectId,
+    VersionIdentifier,
+)
 from featurebyte.models.feature import FeatureModel
 from featurebyte.models.feature_namespace import FeatureReadiness
 from featurebyte.query_graph.graph import QueryGraph
@@ -33,7 +38,7 @@ class FeatureCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: StrictStr
+    name: NameStr
     graph: QueryGraph
     node_name: str
     tabular_source: TabularSource
@@ -53,7 +58,7 @@ class BatchFeatureItem(FeatureByteBaseModel):
     """
 
     id: PydanticObjectId
-    name: StrictStr
+    name: NameStr
     node_name: str
     tabular_source: TabularSource
 

--- a/featurebyte/schema/feature_job_setting_analysis.py
+++ b/featurebyte/schema/feature_job_setting_analysis.py
@@ -13,6 +13,7 @@ from pydantic import Field, StrictStr, root_validator
 from featurebyte.models.base import (
     FeatureByteBaseDocumentModel,
     FeatureByteBaseModel,
+    NameStr,
     PydanticObjectId,
 )
 from featurebyte.query_graph.model.common_table import TabularSource
@@ -24,7 +25,7 @@ class EventTableCandidate(FeatureByteBaseModel):
     Event Table Candidate Schema
     """
 
-    name: StrictStr
+    name: NameStr
     tabular_source: TabularSource
     event_timestamp_column: StrictStr
     record_creation_timestamp_column: StrictStr
@@ -36,7 +37,7 @@ class FeatureJobSettingAnalysisCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: Optional[StrictStr]
+    name: Optional[NameStr]
     event_table_id: Optional[PydanticObjectId] = Field(default=None)
     event_table_candidate: Optional[EventTableCandidate] = Field(default=None)
     analysis_date: Optional[datetime] = Field(default=None)

--- a/featurebyte/schema/feature_list.py
+++ b/featurebyte/schema/feature_list.py
@@ -7,13 +7,18 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional, Union
 
 from bson.objectid import ObjectId
-from pydantic import Field, StrictStr, root_validator, validator
+from pydantic import Field, root_validator, validator
 
 from featurebyte.common.doc_util import FBAutoDoc
 from featurebyte.common.validator import version_validator
 from featurebyte.config import FEATURE_PREVIEW_ROW_LIMIT, ONLINE_FEATURE_REQUEST_ROW_LIMIT
 from featurebyte.enum import ConflictResolution
-from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId, VersionIdentifier
+from featurebyte.models.base import (
+    FeatureByteBaseModel,
+    NameStr,
+    PydanticObjectId,
+    VersionIdentifier,
+)
 from featurebyte.models.feature_list import (
     FeatureCluster,
     FeatureListModel,
@@ -38,7 +43,7 @@ class FeatureListCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: StrictStr
+    name: NameStr
     feature_ids: List[PydanticObjectId] = Field(min_items=1)
 
 
@@ -48,7 +53,7 @@ class FeatureListCreateJob(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: StrictStr
+    name: NameStr
     features: Union[List[FeatureParameters], List[PydanticObjectId]] = Field(min_items=1)
     features_conflict_resolution: ConflictResolution
 
@@ -65,7 +70,7 @@ class FeatureListCreateWithBatchFeatureCreationMixin(FeatureByteBaseModel):
     """Feature List Creation with Batch Feature Creation mixin"""
 
     id: PydanticObjectId = Field(default_factory=ObjectId, alias="_id")
-    name: StrictStr
+    name: NameStr
     conflict_resolution: ConflictResolution
     features: List[BatchFeatureItem]
     skip_batch_feature_creation: bool = Field(default=False)

--- a/featurebyte/schema/feature_namespace.py
+++ b/featurebyte/schema/feature_namespace.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 from typing import List, Optional
 
 from bson.objectid import ObjectId
-from pydantic import Field, StrictStr
+from pydantic import Field
 
 from featurebyte.enum import DBVarType
-from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
+from featurebyte.models.base import FeatureByteBaseModel, NameStr, PydanticObjectId
 from featurebyte.models.feature_namespace import (
     DefaultVersionMode,
     FeatureNamespaceModel,
@@ -25,7 +25,7 @@ class FeatureNamespaceCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: StrictStr
+    name: NameStr
     dtype: DBVarType
     feature_ids: List[PydanticObjectId] = Field(default_factory=list)
     readiness: FeatureReadiness

--- a/featurebyte/schema/feature_store.py
+++ b/featurebyte/schema/feature_store.py
@@ -7,10 +7,10 @@ from typing import Any, Dict, List, Optional
 from datetime import datetime
 
 from bson.objectid import ObjectId
-from pydantic import Field, StrictStr, root_validator
+from pydantic import Field, root_validator
 
 from featurebyte.enum import SourceType
-from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
+from featurebyte.models.base import FeatureByteBaseModel, NameStr, PydanticObjectId
 from featurebyte.models.credential import DatabaseCredential, StorageCredential
 from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.query_graph.enum import NodeType
@@ -25,7 +25,7 @@ class FeatureStoreCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: StrictStr
+    name: NameStr
     type: SourceType
     details: DatabaseDetails
     database_credential: Optional[DatabaseCredential]

--- a/featurebyte/schema/historical_feature_table.py
+++ b/featurebyte/schema/historical_feature_table.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import StrictStr, root_validator
+from pydantic import root_validator
 
-from featurebyte.models.base import PydanticObjectId
+from featurebyte.models.base import NameStr, PydanticObjectId
 from featurebyte.models.historical_feature_table import HistoricalFeatureTableModel
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema, PaginationMixin
 from featurebyte.schema.common.feature_or_target import FeatureOrTargetTableCreate
@@ -52,4 +52,4 @@ class HistoricalFeatureTableUpdate(BaseDocumentServiceUpdateSchema):
     HistoricalFeatureTable update payload
     """
 
-    name: Optional[StrictStr]
+    name: Optional[NameStr]

--- a/featurebyte/schema/info.py
+++ b/featurebyte/schema/info.py
@@ -8,10 +8,15 @@ from typing import Any, List, Optional
 
 from datetime import datetime
 
-from pydantic import Field, StrictStr, root_validator, validator
+from pydantic import Field, root_validator, validator
 
 from featurebyte.enum import DBVarType, SourceType
-from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId, VersionIdentifier
+from featurebyte.models.base import (
+    FeatureByteBaseModel,
+    NameStr,
+    PydanticObjectId,
+    VersionIdentifier,
+)
 from featurebyte.models.credential import DatabaseCredentialType, StorageCredentialType
 from featurebyte.models.feature_list import FeatureReadinessDistribution, FeatureTypeFeatureCount
 from featurebyte.models.feature_list_namespace import FeatureListStatus
@@ -148,7 +153,7 @@ class TableColumnInfo(FeatureByteBaseModel):
     """
     TableColumnInfo for storing column information
 
-    name: str
+    name: NameStr
         Column name
     dtype: DBVarType
         Variable type of the column
@@ -162,7 +167,7 @@ class TableColumnInfo(FeatureByteBaseModel):
         Description of the column
     """
 
-    name: StrictStr
+    name: NameStr
     dtype: DBVarType
     entity: Optional[str] = Field(default=None)
     semantic: Optional[str] = Field(default=None)

--- a/featurebyte/schema/observation_table.py
+++ b/featurebyte/schema/observation_table.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 from bson import ObjectId
 from pydantic import Field, StrictStr
 
-from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
+from featurebyte.models.base import FeatureByteBaseModel, NameStr, PydanticObjectId
 from featurebyte.models.observation_table import ObservationInput, ObservationTableModel, Purpose
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema, PaginationMixin
 from featurebyte.schema.request_table import BaseRequestTableCreate, BaseRequestTableListRecord
@@ -34,7 +34,7 @@ class ObservationTableUpload(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: StrictStr
+    name: NameStr
     purpose: Optional[Purpose] = Field(default=None)
     primary_entity_ids: List[PydanticObjectId]
     target_column: Optional[StrictStr] = Field(default=None)
@@ -64,7 +64,7 @@ class ObservationTableUpdate(FeatureByteBaseModel):
     use_case_id_to_add: Optional[PydanticObjectId]
     use_case_id_to_remove: Optional[PydanticObjectId]
     purpose: Optional[Purpose]
-    name: Optional[StrictStr]
+    name: Optional[NameStr]
 
 
 class ObservationTableServiceUpdate(BaseDocumentServiceUpdateSchema, ObservationTableUpdate):

--- a/featurebyte/schema/online_store.py
+++ b/featurebyte/schema/online_store.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from bson.objectid import ObjectId
 from pydantic import Field, StrictStr, validator
 
-from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
+from featurebyte.models.base import FeatureByteBaseModel, NameStr, PydanticObjectId
 from featurebyte.models.online_store import OnlineStoreDetails
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema, PaginationMixin
 
@@ -20,7 +20,7 @@ class OnlineStoreCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: StrictStr
+    name: NameStr
     details: OnlineStoreDetails
 
 

--- a/featurebyte/schema/relationship_info.py
+++ b/featurebyte/schema/relationship_info.py
@@ -7,9 +7,9 @@ from typing import List, Optional
 from datetime import datetime
 
 from bson import ObjectId
-from pydantic import Field, StrictStr
+from pydantic import Field
 
-from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
+from featurebyte.models.base import FeatureByteBaseModel, NameStr, PydanticObjectId
 from featurebyte.models.relationship import RelationshipInfoModel, RelationshipType
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema, PaginationMixin
 
@@ -20,7 +20,7 @@ class RelationshipInfoCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: StrictStr
+    name: NameStr
     relationship_type: RelationshipType
     entity_id: PydanticObjectId
     related_entity_id: PydanticObjectId

--- a/featurebyte/schema/request_table.py
+++ b/featurebyte/schema/request_table.py
@@ -5,9 +5,9 @@ Base class for all request tables.
 from typing import Any, Dict, Optional
 
 from bson import ObjectId
-from pydantic import Field, StrictStr, root_validator
+from pydantic import Field, root_validator
 
-from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
+from featurebyte.models.base import FeatureByteBaseModel, NameStr, PydanticObjectId
 from featurebyte.models.request_input import RequestInputType
 from featurebyte.schema.materialized_table import BaseMaterializedTableListRecord
 
@@ -18,7 +18,7 @@ class BaseRequestTableCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: StrictStr
+    name: NameStr
     feature_store_id: PydanticObjectId
     context_id: Optional[PydanticObjectId]
 

--- a/featurebyte/schema/semantic.py
+++ b/featurebyte/schema/semantic.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from bson.objectid import ObjectId
 from pydantic import Field
 
-from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
+from featurebyte.models.base import FeatureByteBaseModel, NameStr, PydanticObjectId
 from featurebyte.models.relationship import Parent
 from featurebyte.models.semantic import SemanticModel
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema, PaginationMixin
@@ -19,7 +19,7 @@ class SemanticCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: str
+    name: NameStr
 
 
 class SemanticList(PaginationMixin):

--- a/featurebyte/schema/static_source_table.py
+++ b/featurebyte/schema/static_source_table.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 from typing import List, Optional
 
 from bson import ObjectId
-from pydantic import Field, StrictStr
+from pydantic import Field
 
-from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
+from featurebyte.models.base import FeatureByteBaseModel, NameStr, PydanticObjectId
 from featurebyte.models.static_source_table import StaticSourceInput, StaticSourceTableModel
 from featurebyte.schema.common.base import PaginationMixin
 from featurebyte.schema.request_table import BaseRequestTableListRecord
@@ -21,7 +21,7 @@ class StaticSourceTableCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: StrictStr
+    name: NameStr
     feature_store_id: PydanticObjectId
     sample_rows: Optional[int] = Field(ge=0)
     request_input: StaticSourceInput

--- a/featurebyte/schema/table.py
+++ b/featurebyte/schema/table.py
@@ -10,7 +10,7 @@ from bson.objectid import ObjectId
 from pydantic import Field, StrictStr, validator
 
 from featurebyte.common.validator import columns_info_validator
-from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
+from featurebyte.models.base import FeatureByteBaseModel, NameStr, PydanticObjectId
 from featurebyte.models.feature_store import TableStatus
 from featurebyte.models.proxy_table import ProxyTableModel
 from featurebyte.query_graph.model.column_info import ColumnInfo, ColumnInfoWithoutSemanticId
@@ -25,7 +25,7 @@ class TableCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: StrictStr
+    name: NameStr
     tabular_source: TabularSource
     columns_info: List[ColumnInfoWithoutSemanticId]
     record_creation_timestamp_column: Optional[StrictStr]
@@ -129,7 +129,7 @@ class ColumnCriticalDataInfoUpdate(FeatureByteBaseModel):
     Column critical data info update payload schema
     """
 
-    column_name: StrictStr
+    column_name: NameStr
     critical_data_info: Optional[CriticalDataInfo]
 
 
@@ -138,7 +138,7 @@ class ColumnEntityUpdate(FeatureByteBaseModel):
     Column entity update payload schema
     """
 
-    column_name: StrictStr
+    column_name: NameStr
     entity_id: Optional[PydanticObjectId]
 
 
@@ -147,7 +147,7 @@ class ColumnDescriptionUpdate(FeatureByteBaseModel):
     Column description update payload schema
     """
 
-    column_name: StrictStr
+    column_name: NameStr
     description: Optional[StrictStr]
 
 
@@ -156,5 +156,5 @@ class ColumnSemanticUpdate(FeatureByteBaseModel):
     Column semantic update payload schema
     """
 
-    column_name: StrictStr
+    column_name: NameStr
     semantic_id: Optional[PydanticObjectId]

--- a/featurebyte/schema/target.py
+++ b/featurebyte/schema/target.py
@@ -13,6 +13,7 @@ from pydantic import Field, StrictStr
 
 from featurebyte.models.base import (
     FeatureByteBaseModel,
+    NameStr,
     PydanticObjectId,
     UniqueConstraintResolutionSignature,
     UniqueValuesConstraint,
@@ -32,7 +33,7 @@ class TargetCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: StrictStr
+    name: NameStr
     graph: QueryGraph
     node_name: str
     tabular_source: TabularSource
@@ -91,7 +92,7 @@ class TargetServiceUpdate(BaseDocumentServiceUpdateSchema):
     Target service update schema
     """
 
-    name: Optional[str]
+    name: Optional[NameStr]
 
     class Settings(BaseDocumentServiceUpdateSchema.Settings):
         """

--- a/featurebyte/schema/target_namespace.py
+++ b/featurebyte/schema/target_namespace.py
@@ -5,10 +5,10 @@ Target namespace schema
 from typing import List, Optional
 
 from bson import ObjectId
-from pydantic import Field, StrictStr
+from pydantic import Field
 
 from featurebyte.enum import DBVarType
-from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
+from featurebyte.models.base import FeatureByteBaseModel, NameStr, PydanticObjectId
 from featurebyte.models.feature_namespace import DefaultVersionMode
 from featurebyte.models.target_namespace import TargetNamespaceModel
 from featurebyte.schema.common.base import (
@@ -24,7 +24,7 @@ class TargetNamespaceCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: StrictStr
+    name: NameStr
     dtype: Optional[DBVarType]
     target_ids: List[PydanticObjectId] = Field(default_factory=list)
     default_target_id: Optional[PydanticObjectId]

--- a/featurebyte/schema/use_case.py
+++ b/featurebyte/schema/use_case.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import Field, StrictStr, root_validator
 
-from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
+from featurebyte.models.base import FeatureByteBaseModel, NameStr, PydanticObjectId
 from featurebyte.models.use_case import UseCaseModel
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema, PaginationMixin
 
@@ -17,7 +17,7 @@ class UseCaseCreate(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=PydanticObjectId, alias="_id")
-    name: StrictStr
+    name: NameStr
     target_id: Optional[PydanticObjectId]
     target_namespace_id: Optional[PydanticObjectId]
     context_id: PydanticObjectId
@@ -45,7 +45,7 @@ class UseCaseUpdate(BaseDocumentServiceUpdateSchema):
     remove_default_eda_table: Optional[bool]
     remove_default_preview_table: Optional[bool]
 
-    name: Optional[StrictStr]
+    name: Optional[NameStr]
 
     @root_validator(pre=True)
     @classmethod

--- a/featurebyte/schema/user_defined_function.py
+++ b/featurebyte/schema/user_defined_function.py
@@ -8,7 +8,7 @@ from bson import ObjectId
 from pydantic import Field, StrictStr, root_validator, validator
 
 from featurebyte.enum import DBVarType
-from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
+from featurebyte.models.base import FeatureByteBaseModel, NameStr, PydanticObjectId
 from featurebyte.models.user_defined_function import FunctionParameter, UserDefinedFunctionModel
 from featurebyte.query_graph.node.validator import construct_unique_name_validator
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema, PaginationMixin
@@ -20,9 +20,9 @@ class UserDefinedFunctionCreateBase(FeatureByteBaseModel):
     """
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
-    name: StrictStr
+    name: NameStr
     description: Optional[StrictStr] = Field(default=None)
-    sql_function_name: StrictStr
+    sql_function_name: NameStr
     function_parameters: List[FunctionParameter]
     output_dtype: DBVarType
 
@@ -54,7 +54,7 @@ class UserDefinedFunctionUpdate(FeatureByteBaseModel):
     UserDefinedFunction update schema
     """
 
-    sql_function_name: Optional[StrictStr]
+    sql_function_name: Optional[NameStr]
     function_parameters: Optional[List[FunctionParameter]]
     output_dtype: Optional[DBVarType]
 

--- a/featurebyte/schema/worker/task/deployment_create_update.py
+++ b/featurebyte/schema/worker/task/deployment_create_update.py
@@ -8,7 +8,7 @@ from typing_extensions import Annotated, Literal
 from pydantic import BaseModel, Field
 
 from featurebyte.enum import StrEnum, WorkerCommand
-from featurebyte.models.base import PydanticObjectId
+from featurebyte.models.base import NameStr, PydanticObjectId
 from featurebyte.models.deployment import DeploymentModel
 from featurebyte.schema.worker.task.base import BaseTaskPayload, TaskType
 
@@ -24,7 +24,7 @@ class CreateDeploymentPayload(BaseModel):
     """Create deployment"""
 
     type: Literal[DeploymentPayloadType.CREATE] = Field(DeploymentPayloadType.CREATE, const=True)
-    name: Optional[str] = Field(default=None)
+    name: Optional[NameStr] = Field(default=None)
     feature_list_id: PydanticObjectId
     enabled: bool
     use_case_id: Optional[PydanticObjectId] = Field(default=None)

--- a/featurebyte/schema/worker/task/feature_list_create.py
+++ b/featurebyte/schema/worker/task/feature_list_create.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 
 from typing import List, Union
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic import BaseModel, Field
 
 from featurebyte.enum import ConflictResolution, WorkerCommand
-from featurebyte.models.base import PydanticObjectId
+from featurebyte.models.base import NameStr, PydanticObjectId
 from featurebyte.models.feature_list import FeatureListModel
 from featurebyte.schema.worker.task.base import BaseTaskPayload, TaskType
 
@@ -18,7 +18,7 @@ class FeatureParameters(BaseModel):
     """Feature parameters"""
 
     id: PydanticObjectId
-    name: StrictStr
+    name: NameStr
 
 
 class FeaturesParameters(BaseModel):
@@ -36,6 +36,6 @@ class FeatureListCreateTaskPayload(BaseTaskPayload):
     task_type: TaskType = Field(default=TaskType.CPU_TASK)
     output_collection_name = FeatureListModel.collection_name()
     feature_list_id: PydanticObjectId
-    feature_list_name: str
+    feature_list_name: NameStr
     features_parameters_path: str
     features_conflict_resolution: ConflictResolution

--- a/tests/unit/models/test_base.py
+++ b/tests/unit/models/test_base.py
@@ -95,3 +95,14 @@ def test_reference_info(asset_name, expected_collection_name):
     """Test reference info collection name property"""
     ref_info = ReferenceInfo(asset_name=asset_name, document_id=ObjectId())
     assert ref_info.collection_name == expected_collection_name
+
+
+def test_base_model__name_validation():
+    """Test base model id field validation logic"""
+    model = FeatureByteBaseDocumentModel()
+    assert model.id is not None
+    model = FeatureByteBaseDocumentModel(name="test")
+    assert model.id is not None
+    with pytest.raises(ValidationError) as exc:
+        FeatureByteBaseDocumentModel(name="t" * 256)
+    assert "ensure this value has at most 255 characters" in str(exc.value)

--- a/tests/unit/routes/test_item_table.py
+++ b/tests/unit/routes/test_item_table.py
@@ -131,7 +131,7 @@ class TestItemTableApi(BaseTableApiTestSuite):
     async def test_item_id_semantic(self, data_response, app_container):
         """Test item id semantic is set correctly"""
         item_id_semantic = await app_container.semantic_service.get_or_create_document(
-            name=SemanticType.ITEM_ID
+            name=SemanticType.ITEM_ID.value
         )
 
         # check the that semantic ID is set correctly

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -468,7 +468,7 @@ def event_table_factory_fixture(test_dir, feature_store, event_table_service, se
                 data=EventTableCreate(**payload)
             )
             event_timestamp = await semantic_service.get_or_create_document(
-                name=SemanticType.EVENT_TIMESTAMP
+                name=SemanticType.EVENT_TIMESTAMP.value
             )
             columns_info = []
             for col in event_table.columns_info:


### PR DESCRIPTION
## Description

This PR updates the base document model to limit names to 255 characters.
This will prevent unexpected SQL errors due to table / column identifiers exceeding SQL limits for generated database assets.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
