### PR TITLE
[chore] Invalidate session cache when SQL execution fails

### DIFF
--- a/featurebyte/session/databricks_unity.py
+++ b/featurebyte/session/databricks_unity.py
@@ -33,7 +33,9 @@ class DatabricksUnitySchemaInitializer(BaseSparkSchemaInitializer):
         await super().create_schema()
         # grant permissions on schema to the group
         assert isinstance(self.session, DatabricksUnitySession)
-        grant_permissions_query = f"GRANT ALL PRIVILEGES ON SCHEMA `{self.session.schema_name}` TO `{self.session.group_name}`"
+        grant_permissions_query = (
+            f"ALTER SCHEMA `{self.session.schema_name}` OWNER TO `{self.session.group_name}`"
+        )
         await self.session.execute_query(grant_permissions_query)
 
     async def register_missing_objects(self) -> None:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -57,8 +57,8 @@ from featurebyte.routes.registry import app_container_config
 from featurebyte.schema.catalog import CatalogCreate
 from featurebyte.schema.task import TaskStatus
 from featurebyte.schema.worker.task.base import BaseTaskPayload
-from featurebyte.session.base import DEFAULT_EXECUTE_QUERY_TIMEOUT_SECONDS
-from featurebyte.session.manager import SessionManager, session_cache
+from featurebyte.session.base import DEFAULT_EXECUTE_QUERY_TIMEOUT_SECONDS, session_cache
+from featurebyte.session.manager import SessionManager
 from featurebyte.session.snowflake import SnowflakeSession
 from featurebyte.storage.local import LocalStorage
 from featurebyte.worker import get_redis

--- a/tests/unit/session/test_manager.py
+++ b/tests/unit/session/test_manager.py
@@ -4,15 +4,19 @@ Tests for SessionManager class
 
 import logging
 import time
+from unittest import mock
 from unittest.mock import Mock, patch
 
+import pandas as pd
 import pytest
+import pytest_asyncio
 from pytest import LogCaptureFixture
 
 from featurebyte.api.feature_store import FeatureStore
 from featurebyte.exception import SessionInitializationTimeOut
 from featurebyte.query_graph.node.schema import SQLiteDetails
-from featurebyte.session.manager import SessionManager, session_cache
+from featurebyte.session.base import DEFAULT_EXECUTE_QUERY_TIMEOUT_SECONDS, session_cache
+from featurebyte.session.manager import SessionManager
 
 
 @pytest.fixture(autouse=True, name="caplog_handle")
@@ -134,3 +138,76 @@ async def test_session_manager_get_new_session_timeout(
         with pytest.raises(SessionInitializationTimeOut) as exc:
             await session_manager.get_session(snowflake_feature_store, timeout=0.5)
         assert "Session creation timed out after" in str(exc.value)
+
+
+@pytest_asyncio.fixture(name="cached_session_and_cache_key")
+async def cached_session_setup(
+    snowflake_feature_store_params,
+    snowflake_connector,
+    snowflake_query_map,
+    session_manager,
+):
+    """Setup for cached session tests"""
+    _ = snowflake_connector
+
+    def _side_effect(query, timeout=DEFAULT_EXECUTE_QUERY_TIMEOUT_SECONDS):
+        _ = timeout
+        res = snowflake_query_map.get(query)
+        if res is not None:
+            return pd.DataFrame(res)
+        return None
+
+    assert len(session_cache) == 0
+    snowflake_feature_store = FeatureStore(**snowflake_feature_store_params, type="snowflake")
+    with mock.patch(
+        "featurebyte.session.snowflake.SnowflakeSession.execute_query"
+    ) as mock_execute_query:
+        mock_execute_query.side_effect = _side_effect
+        session = await session_manager.get_session(snowflake_feature_store, timeout=0.5)
+
+    # check the session is cached
+    session_cache_key = session._cache_key
+    assert session_cache_key is not None
+    assert session_cache_key in session_cache
+    yield session, session_cache_key
+
+
+@pytest.mark.asyncio
+async def test_session_manager__invalidate_cache_when_execute_query_failed(
+    cached_session_and_cache_key,
+):
+    """Test session cache is invalidated when execute_query fails"""
+    session, session_cache_key = cached_session_and_cache_key
+
+    # simulate exception during query execution
+    assert session_cache_key in session_cache
+    with mock.patch(
+        "featurebyte.session.base.BaseSession.get_async_query_stream"
+    ) as mock_get_async_query_stream:
+        exc_message = "Some error"
+        mock_get_async_query_stream.side_effect = Exception(exc_message)
+        with pytest.raises(Exception, match=exc_message):
+            await session.execute_query("SELECT * FROM some_table")
+
+    # check the session is invalidated
+    assert session_cache_key not in session_cache
+
+
+@pytest.mark.asyncio
+async def test_session_manager__invalidate_cache_when_execute_query_blocking_failed(
+    cached_session_and_cache_key, snowflake_connector_patches
+):
+    """Test session cache is invalidated when execute_query fails"""
+    session, session_cache_key = cached_session_and_cache_key
+
+    # simulate exception during query execution
+    cursor = snowflake_connector_patches["cursor"]
+    exc_message = "Some error"
+    cursor.execute.side_effect = Exception(exc_message)
+
+    assert session_cache_key in session_cache
+    with pytest.raises(Exception, match=exc_message):
+        session.execute_query_blocking("SELECT * FROM some_table")
+
+    # check the session is invalidated
+    assert session_cache_key not in session_cache


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
This PR updates session caching logic to invalidate the session cache when the latest query execution encountered exception. By doing this, bad cached session will be removed immediately once it hits query execution exception.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
