### PR TITLE
[chore] Surface original error on drop_table failures

### DIFF
--- a/featurebyte/exception.py
+++ b/featurebyte/exception.py
@@ -215,6 +215,12 @@ class DataWarehouseConnectionError(BaseUnprocessableEntityError):
     """
 
 
+class DataWarehouseOperationError(BaseUnprocessableEntityError):
+    """
+    Raise when data warehouse operations failed
+    """
+
+
 class DocumentError(BaseUnprocessableEntityError):
     """
     General exception raised when there are some issue at persistent layer operations

--- a/featurebyte/session/base.py
+++ b/featurebyte/session/base.py
@@ -645,6 +645,11 @@ class BaseSession(BaseModel):
             Database name
         if_exists : bool
             If True, drop the table only if it exists
+
+        Raises
+        ------
+        DataWarehouseOperationError
+            If the operation failed
         """
 
         async def _drop(is_view: bool) -> None:

--- a/featurebyte/session/base.py
+++ b/featurebyte/session/base.py
@@ -29,7 +29,7 @@ from sqlglot.expressions import Expression
 from featurebyte.common.path_util import get_package_root
 from featurebyte.common.utils import create_new_arrow_stream_writer, dataframe_from_arrow_stream
 from featurebyte.enum import InternalName, MaterializedTableNamePrefix, SourceType, StrEnum
-from featurebyte.exception import QueryExecutionTimeOut
+from featurebyte.exception import DataWarehouseOperationError, QueryExecutionTimeOut
 from featurebyte.logging import get_logger
 from featurebyte.models.user_defined_function import UserDefinedFunctionModel
 from featurebyte.query_graph.model.column_info import ColumnSpecWithDescription
@@ -667,8 +667,16 @@ class BaseSession(BaseModel):
 
         try:
             await _drop(is_view=False)
-        except:  # pylint: disable=bare-except
-            await _drop(is_view=True)
+        except Exception as exc:  # pylint: disable=bare-except
+            msg = str(exc)
+            if "VIEW" in msg:
+                try:
+                    await _drop(is_view=True)
+                    return
+                except Exception as exc_view:  # pylint: disable=bare-except
+                    msg = str(exc_view)
+                    raise DataWarehouseOperationError(msg) from exc_view
+            raise DataWarehouseOperationError(msg) from exc
 
     def format_quoted_identifier(self, identifier_name: str) -> str:
         """


### PR DESCRIPTION
## Description

This reworks the logic in session `drop_table` to surface original error message on failures.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
