### PR TITLE
[chore] Remove `entity_id` & `critical_data_info` from table registration

### DIFF
--- a/featurebyte/query_graph/model/column_info.py
+++ b/featurebyte/query_graph/model/column_info.py
@@ -20,28 +20,7 @@ class ColumnSpecWithDescription(ColumnSpec):
     description: Optional[str] = Field(default=None)
 
 
-class ColumnInfoWithoutSemanticId(ColumnSpecWithDescription):
-    """
-    ColumnInfo for storing column information
-
-    name: str
-        Column name
-    dtype: DBVarType
-        Variable type of the column
-    entity_id: Optional[PydanticObjectId]
-        Entity id associated with the column
-    critical_data_info: Optional[CriticalDataInfo]
-        Critical data info of the column
-    description: Optional[str]
-        Column description
-    """
-
-    entity_id: Optional[PydanticObjectId] = Field(default=None)
-    critical_data_info: Optional[CriticalDataInfo] = Field(default=None)
-    description: Optional[str] = Field(default=None)
-
-
-class ColumnInfo(ColumnInfoWithoutSemanticId):
+class ColumnInfo(ColumnSpecWithDescription):
     """
     ColumnInfo for storing column information
 

--- a/featurebyte/routes/common/base_table.py
+++ b/featurebyte/routes/common/base_table.py
@@ -19,6 +19,7 @@ from featurebyte.query_graph.model.column_info import ColumnInfo
 from featurebyte.query_graph.model.critical_data_info import CriticalDataInfo
 from featurebyte.routes.common.base import BaseDocumentController, PaginatedDocument
 from featurebyte.schema.table import TableServiceUpdate, TableUpdate
+from featurebyte.service.base_table_document import DocumentCreate
 from featurebyte.service.dimension_table import DimensionTableService
 from featurebyte.service.entity import EntityService
 from featurebyte.service.event_table import EventTableService
@@ -167,7 +168,7 @@ class BaseTableDocumentController(  # pylint: disable=too-many-instance-attribut
             )
         return document
 
-    async def create_table(self, data: TableDocumentT) -> TableDocumentT:
+    async def create_table(self, data: DocumentCreate) -> TableDocumentT:
         """
         Create Table record at persistent
 

--- a/featurebyte/routes/dimension_table/api.py
+++ b/featurebyte/routes/dimension_table/api.py
@@ -137,7 +137,7 @@ class DimensionTableRouter(
         self, request: Request, data: DimensionTableCreate
     ) -> DimensionTableModel:
         controller = self.get_controller_for_request(request)
-        return await controller.create_table(data=data)  # type: ignore
+        return await controller.create_table(data=data)
 
     async def get_dimension_table_info(
         self, request: Request, dimension_table_id: PydanticObjectId, verbose: bool = VerboseQuery

--- a/featurebyte/routes/event_table/api.py
+++ b/featurebyte/routes/event_table/api.py
@@ -137,7 +137,7 @@ class EventTableRouter(
 
     async def create_object(self, request: Request, data: EventTableCreate) -> EventTableModel:
         controller = self.get_controller_for_request(request)
-        return await controller.create_table(data=data)  # type: ignore
+        return await controller.create_table(data=data)
 
     async def get_event_table_info(
         self, request: Request, event_table_id: PydanticObjectId, verbose: bool = VerboseQuery

--- a/featurebyte/routes/item_table/api.py
+++ b/featurebyte/routes/item_table/api.py
@@ -127,7 +127,7 @@ class ItemTableRouter(
 
     async def create_object(self, request: Request, data: ItemTableCreate) -> ItemTableModel:
         controller = self.get_controller_for_request(request)
-        return await controller.create_table(data=data)  # type: ignore
+        return await controller.create_table(data=data)
 
     async def get_item_table_info(
         self, request: Request, item_table_id: PydanticObjectId, verbose: bool = VerboseQuery

--- a/featurebyte/routes/item_table/controller.py
+++ b/featurebyte/routes/item_table/controller.py
@@ -10,7 +10,7 @@ from featurebyte.enum import SemanticType
 from featurebyte.models.item_table import ItemTableModel
 from featurebyte.routes.common.base_table import BaseTableDocumentController
 from featurebyte.schema.info import ItemTableInfo
-from featurebyte.schema.item_table import ItemTableList, ItemTableServiceUpdate
+from featurebyte.schema.item_table import ItemTableCreate, ItemTableList, ItemTableServiceUpdate
 from featurebyte.service.entity import EntityService
 from featurebyte.service.event_table import EventTableService
 from featurebyte.service.feature import FeatureService
@@ -71,7 +71,7 @@ class ItemTableController(
         self.table_info_service = table_info_service
         self.event_table_service = event_table_service
 
-    async def create_table(self, data: ItemTableModel) -> ItemTableModel:
+    async def create_table(self, data: ItemTableCreate) -> ItemTableModel:  # type: ignore[override]
         # check existence of event table first before creating item table
         _ = await self.event_table_service.get_document(document_id=data.event_table_id)
         return await super().create_table(data=data)

--- a/featurebyte/routes/scd_table/api.py
+++ b/featurebyte/routes/scd_table/api.py
@@ -127,7 +127,7 @@ class SCDTableRouter(
 
     async def create_object(self, request: Request, data: SCDTableCreate) -> SCDTableModel:
         controller = self.get_controller_for_request(request)
-        return await controller.create_table(data=data)  # type: ignore
+        return await controller.create_table(data=data)
 
     async def get_scd_table_info(
         self, request: Request, scd_table_id: PydanticObjectId, verbose: bool = VerboseQuery

--- a/featurebyte/schema/table.py
+++ b/featurebyte/schema/table.py
@@ -13,7 +13,7 @@ from featurebyte.common.validator import columns_info_validator
 from featurebyte.models.base import FeatureByteBaseModel, NameStr, PydanticObjectId
 from featurebyte.models.feature_store import TableStatus
 from featurebyte.models.proxy_table import ProxyTableModel
-from featurebyte.query_graph.model.column_info import ColumnInfo, ColumnInfoWithoutSemanticId
+from featurebyte.query_graph.model.column_info import ColumnInfo, ColumnSpecWithDescription
 from featurebyte.query_graph.model.common_table import TabularSource
 from featurebyte.query_graph.model.critical_data_info import CriticalDataInfo
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema, PaginationMixin
@@ -27,7 +27,7 @@ class TableCreate(FeatureByteBaseModel):
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
     name: NameStr
     tabular_source: TabularSource
-    columns_info: List[ColumnInfoWithoutSemanticId]
+    columns_info: List[ColumnSpecWithDescription]
     record_creation_timestamp_column: Optional[StrictStr]
     description: Optional[StrictStr]
 

--- a/tests/unit/routes/test_context.py
+++ b/tests/unit/routes/test_context.py
@@ -87,6 +87,7 @@ class TestContextApi(BaseCatalogApiTestSuite):
         """Setup for post route"""
         api_object_filename_pairs = [
             ("entity", "entity"),
+            ("entity", "entity_transaction"),
             ("event_table", "event_table"),
             ("item_table", "item_table"),
         ]
@@ -94,6 +95,10 @@ class TestContextApi(BaseCatalogApiTestSuite):
             payload = self.load_payload(f"tests/fixtures/request_payloads/{filename}.json")
             response = api_client.post(f"/{api_object}", json=payload)
             assert response.status_code == HTTPStatus.CREATED, response.json()
+
+            if api_object.endswith("_table"):
+                # tag table entity for table objects
+                self.tag_table_entity(api_client, api_object, payload)
 
     def multiple_success_payload_generator(self, api_client):
         """Payload generator to create multiple success response"""

--- a/tests/unit/routes/test_deployment.py
+++ b/tests/unit/routes/test_deployment.py
@@ -50,6 +50,7 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
         catalog_id = api_client.get("/catalog").json()["data"][0]["_id"]
         api_object_filename_pairs = [
             ("entity", "entity"),
+            ("entity", "entity_transaction"),
             ("event_table", "event_table"),
             ("feature", "feature_sum_30m"),
             ("feature_list", "feature_list_single"),
@@ -59,6 +60,11 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
             payload = self.load_payload(f"tests/fixtures/request_payloads/{filename}.json")
             response = api_client.post(f"/{api_object}", json=payload)
             assert response.status_code == HTTPStatus.CREATED, response.json()
+
+            if api_object.endswith("_table"):
+                # tag table entity for table objects
+                self.tag_table_entity(api_client, api_object, payload)
+
             if api_object == "feature":
                 self.make_feature_production_ready(api_client, response.json()["_id"], catalog_id)
 

--- a/tests/unit/routes/test_feature_list.py
+++ b/tests/unit/routes/test_feature_list.py
@@ -114,6 +114,7 @@ class TestFeatureListApi(BaseCatalogApiTestSuite):  # pylint: disable=too-many-p
         """
         api_object_filename_pairs = [
             ("entity", "entity"),
+            ("entity", "entity_transaction"),
             ("context", "context"),
             ("event_table", "event_table"),
             ("feature", "feature_sum_30m"),
@@ -122,6 +123,10 @@ class TestFeatureListApi(BaseCatalogApiTestSuite):  # pylint: disable=too-many-p
             payload = self.load_payload(f"tests/fixtures/request_payloads/{filename}.json")
             response = api_client.post(f"/{api_object}", json=payload)
             assert response.status_code == HTTPStatus.CREATED, response.json()
+
+            if api_object.endswith("_table"):
+                # tag table entity for table objects
+                self.tag_table_entity(api_client, api_object, payload)
 
     @staticmethod
     def _save_a_new_feature_version(api_client, feature_id, time_modulo_frequency=None):

--- a/tests/unit/routes/test_item_table.py
+++ b/tests/unit/routes/test_item_table.py
@@ -162,7 +162,13 @@ class TestItemTableApi(BaseTableApiTestSuite):
                 "table_name": "items_table",
             },
             "status": "PUBLIC_DRAFT",
-            "entities": [],
+            "entities": [
+                {
+                    "name": "transaction",
+                    "serving_names": ["transaction_id"],
+                    "catalog_name": "grocery",
+                },
+            ],
             "semantics": ["event_id", "item_id"],
             "column_count": 6,
             "event_table_name": "sf_event_table",
@@ -185,7 +191,7 @@ class TestItemTableApi(BaseTableApiTestSuite):
             {
                 "name": "event_id_col",
                 "dtype": "INT",
-                "entity": None,
+                "entity": "transaction",
                 "semantic": "event_id",
                 "critical_data_info": None,
                 "description": None,

--- a/tests/unit/routes/test_target.py
+++ b/tests/unit/routes/test_target.py
@@ -68,6 +68,7 @@ class TestTargetApi(BaseCatalogApiTestSuite):
         """
         api_object_filename_pairs = [
             ("entity", "entity"),
+            ("entity", "entity_transaction"),
             ("event_table", "event_table"),
             ("item_table", "item_table"),
         ]
@@ -75,6 +76,10 @@ class TestTargetApi(BaseCatalogApiTestSuite):
             payload = self.load_payload(f"tests/fixtures/request_payloads/{filename}.json")
             response = api_client.post(f"/{api_object}", json=payload)
             assert response.status_code == HTTPStatus.CREATED, response.json()
+
+            if api_object.endswith("_table"):
+                # tag table entity for table objects
+                self.tag_table_entity(api_client, api_object, payload)
 
     def multiple_success_payload_generator(self, api_client):
         """Create multiple payload for setting up create_multiple_success_responses fixture"""

--- a/tests/unit/service/test_context.py
+++ b/tests/unit/service/test_context.py
@@ -3,6 +3,7 @@ Test ContextService
 """
 
 import pytest
+import pytest_asyncio
 
 from featurebyte.exception import DocumentUpdateError
 from featurebyte.query_graph.enum import NodeOutputType, NodeType
@@ -12,9 +13,20 @@ from featurebyte.query_graph.node.input import InputNode
 from featurebyte.schema.context import ContextUpdate
 
 
-@pytest.fixture(name="input_event_table_node")
-def input_event_table_node_fixture(event_table):
+@pytest_asyncio.fixture(name="input_event_table_node")
+async def input_event_table_node_fixture(event_table, app_container, entity, entity_transaction):
     """Input event_table node of a graph"""
+    controller = app_container.event_table_controller
+    await controller.update_column_entity(
+        document_id=event_table.id,
+        column_name="col_int",
+        entity_id=entity_transaction.id,
+    )
+    await controller.update_column_entity(
+        document_id=event_table.id,
+        column_name="cust_id",
+        entity_id=entity.id,
+    )
     return {
         "name": "input_1",
         "type": "input",

--- a/tests/unit/service/test_info.py
+++ b/tests/unit/service/test_info.py
@@ -89,7 +89,7 @@ async def test_get_entity_info(app_container, entity):
 
 
 @pytest.mark.asyncio
-async def test_get_event_table_info(app_container, event_table, entity):
+async def test_get_event_table_info(app_container, event_table):
     """Test get_event_table_info"""
     info = await app_container.event_table_controller.get_info(
         document_id=event_table.id, verbose=False
@@ -109,9 +109,7 @@ async def test_get_event_table_info(app_container, event_table, entity):
         default_feature_job_setting=FeatureJobSetting(
             blind_spot="10m", frequency="30m", time_modulo_frequency="5m"
         ),
-        entities=[
-            EntityBriefInfo(name="customer", serving_names=["cust_id"], catalog_name="grocery")
-        ],
+        entities=[],
         semantics=["event_timestamp"],
         column_count=9,
         columns_info=None,
@@ -141,7 +139,7 @@ async def test_get_event_table_info(app_container, event_table, entity):
                     description="Timestamp column",
                 ),
                 TableColumnInfo(name="created_at", dtype="TIMESTAMP_TZ"),
-                TableColumnInfo(name="cust_id", dtype="INT", entity=entity.name),
+                TableColumnInfo(name="cust_id", dtype="INT"),
             ],
         }
     )

--- a/tests/unit/test_generate_payload_fixtures.py
+++ b/tests/unit/test_generate_payload_fixtures.py
@@ -277,8 +277,16 @@ def test_save_payload_fixtures(  # pylint: disable=too-many-arguments
         (feature_list_multiple, "feature_list_multi"),
         (float_target, "target"),
     ]
+    table_names = {"event_table", "item_table", "dimension_table", "scd_table"}
     for api_object, name in api_object_name_pairs:
         json_payload = api_object._get_create_payload()
+        if name in table_names:
+            # for tables, overwrite the columns_info to include entity related columns
+            columns_info = api_object.cached_model.json_dict()["columns_info"]
+            for col_info in columns_info:
+                col_info.pop("semantic_id")
+            json_payload["columns_info"] = columns_info
+
         json_payload["_COMMENT"] = generated_comment
         update_or_check_payload_fixture(request_payload_dir, name, json_payload, update_fixtures)
 


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR removes `entity_id` and `critical_data_info` from `columns_info` in table registration. By doing those, entity ID & critical data info will not be set during table registration.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
