### PR TITLE
[DEV-3230] Add initialization for new precomputed lookup feature tables

### DIFF
--- a/featurebyte/service/feature_materialize.py
+++ b/featurebyte/service/feature_materialize.py
@@ -746,17 +746,17 @@ class FeatureMaterializeService:  # pylint: disable=too-many-instance-attributes
                 feature_table_serving_names=current_feature_table.serving_names,
                 materialized_features=materialized_features,
             )
-            if offline_info is not None:
-                column_names, materialize_end_date, is_new_table = offline_info
-                if is_new_table:
-                    await self._update_offline_last_materialized_at(
-                        current_feature_table, materialized_features.feature_timestamp
-                    )
-                await self._initialize_new_columns_online(
-                    feature_table=current_feature_table,
-                    column_names=column_names,
-                    end_date=materialize_end_date,
+        if offline_info is not None:
+            column_names, materialize_end_date, is_new_table = offline_info
+            if is_new_table:
+                await self._update_offline_last_materialized_at(
+                    current_feature_table, materialized_features.feature_timestamp
                 )
+            await self._initialize_new_columns_online(
+                feature_table=current_feature_table,
+                column_names=column_names,
+                end_date=materialize_end_date,
+            )
 
     async def _initialize_new_columns_offline(
         self,

--- a/featurebyte/service/feature_materialize.py
+++ b/featurebyte/service/feature_materialize.py
@@ -366,89 +366,113 @@ class FeatureMaterializeService:  # pylint: disable=too-many-instance-attributes
         )
         result = []
         for lookup_feature_table in precomputed_lookup_feature_tables:
-            unique_id = ObjectId()
-            lookup_universe_table_details = TableDetails(
-                database_name=session.database_name,
-                schema_name=session.schema_name,
-                table_name=f"TEMP_LOOKUP_UNIVERSE_TABLE_{unique_id}".upper(),
-            )
-            create_entity_universe_table_query = sql_to_string(
-                adapter.create_table_as(
-                    table_details=lookup_universe_table_details,
-                    select_expr=lookup_feature_table.entity_universe.get_entity_universe_expr(
-                        current_feature_timestamp=feature_timestamp,
-                        last_materialized_timestamp=(
-                            lookup_feature_table.last_materialized_at
-                            if use_last_materialized_timestamp
-                            else None
-                        ),
-                    ),
-                ),
-                source_type=session.source_type,
-            )
-            await session.execute_query_long_running(create_entity_universe_table_query)
-            lookup_feature_table_details = TableDetails(
-                database_name=session.database_name,
-                schema_name=session.schema_name,
-                table_name=f"TEMP_LOOKUP_FEATURE_TABLE_{unique_id}".upper(),
-            )
-            create_lookup_feature_table_query = sql_to_string(
-                adapter.create_table_as(
-                    table_details=lookup_feature_table_details,
-                    select_expr=expressions.select(
-                        *(
-                            [
-                                get_qualified_column_identifier(column_name, "L")
-                                for column_name in lookup_feature_table.serving_names
-                            ]
-                            + [
-                                get_qualified_column_identifier(column_name, "R")
-                                for column_name in column_names
-                            ]
-                        )
-                    )
-                    .from_(
-                        expressions.Table(
-                            this=quoted_identifier(lookup_universe_table_details.table_name),
-                            alias=expressions.TableAlias(this="L"),
-                        ),
-                    )
-                    .join(
-                        expressions.Table(
-                            this=quoted_identifier(materialized_feature_table_name),
-                            alias=expressions.TableAlias(this="R"),
-                        ),
-                        join_type="left",
-                        on=expressions.and_(
-                            *[
-                                expressions.EQ(
-                                    this=get_qualified_column_identifier(serving_name, "L"),
-                                    expression=get_qualified_column_identifier(serving_name, "R"),
-                                )
-                                for serving_name in feature_table_model.serving_names
-                            ]
-                        ),
-                    ),
-                ),
-                source_type=session.source_type,
-            )
-            await session.execute_query_long_running(create_lookup_feature_table_query)
-            await session.drop_table(
-                table_name=lookup_universe_table_details.table_name,
-                schema_name=lookup_universe_table_details.schema_name,  # type: ignore
-                database_name=lookup_universe_table_details.database_name,  # type: ignore
-                if_exists=True,
-            )
-            lookup_materialized_features = MaterializedFeatures(
-                materialized_table_name=lookup_feature_table_details.table_name,
-                column_names=column_names,
-                data_types=[adapter.get_physical_type_from_dtype(dtype) for dtype in column_dtypes],
-                serving_names=lookup_feature_table.serving_names,
+            lookup_materialized_features = await self._materialize_precomputed_lookup_feature_table(
+                session=session,
+                adapter=adapter,
                 feature_timestamp=feature_timestamp,
-                source_type=session.source_type,
+                materialized_feature_table_name=materialized_feature_table_name,
+                column_names=column_names,
+                column_dtypes=column_dtypes,
+                source_feature_table_serving_names=feature_table_model.serving_names,
+                use_last_materialized_timestamp=use_last_materialized_timestamp,
+                lookup_feature_table=lookup_feature_table,
             )
             result.append((lookup_feature_table, lookup_materialized_features))
         return result
+
+    @staticmethod
+    async def _materialize_precomputed_lookup_feature_table(
+        session: BaseSession,
+        adapter: BaseAdapter,
+        feature_timestamp: datetime,
+        materialized_feature_table_name: str,
+        column_names: List[str],
+        column_dtypes: List[DBVarType],
+        use_last_materialized_timestamp: bool,
+        source_feature_table_serving_names: List[str],
+        lookup_feature_table: OfflineStoreFeatureTableModel,
+    ) -> MaterializedFeatures:
+        unique_id = ObjectId()
+        lookup_universe_table_details = TableDetails(
+            database_name=session.database_name,
+            schema_name=session.schema_name,
+            table_name=f"TEMP_LOOKUP_UNIVERSE_TABLE_{unique_id}".upper(),
+        )
+        create_entity_universe_table_query = sql_to_string(
+            adapter.create_table_as(
+                table_details=lookup_universe_table_details,
+                select_expr=lookup_feature_table.entity_universe.get_entity_universe_expr(
+                    current_feature_timestamp=feature_timestamp,
+                    last_materialized_timestamp=(
+                        lookup_feature_table.last_materialized_at
+                        if use_last_materialized_timestamp
+                        else None
+                    ),
+                ),
+            ),
+            source_type=session.source_type,
+        )
+        await session.execute_query_long_running(create_entity_universe_table_query)
+        lookup_feature_table_details = TableDetails(
+            database_name=session.database_name,
+            schema_name=session.schema_name,
+            table_name=f"TEMP_LOOKUP_FEATURE_TABLE_{unique_id}".upper(),
+        )
+        create_lookup_feature_table_query = sql_to_string(
+            adapter.create_table_as(
+                table_details=lookup_feature_table_details,
+                select_expr=expressions.select(
+                    *(
+                        [
+                            get_qualified_column_identifier(column_name, "L")
+                            for column_name in lookup_feature_table.serving_names
+                        ]
+                        + [
+                            get_qualified_column_identifier(column_name, "R")
+                            for column_name in column_names
+                        ]
+                    )
+                )
+                .from_(
+                    expressions.Table(
+                        this=quoted_identifier(lookup_universe_table_details.table_name),
+                        alias=expressions.TableAlias(this="L"),
+                    ),
+                )
+                .join(
+                    expressions.Table(
+                        this=quoted_identifier(materialized_feature_table_name),
+                        alias=expressions.TableAlias(this="R"),
+                    ),
+                    join_type="left",
+                    on=expressions.and_(
+                        *[
+                            expressions.EQ(
+                                this=get_qualified_column_identifier(serving_name, "L"),
+                                expression=get_qualified_column_identifier(serving_name, "R"),
+                            )
+                            for serving_name in source_feature_table_serving_names
+                        ]
+                    ),
+                ),
+            ),
+            source_type=session.source_type,
+        )
+        await session.execute_query_long_running(create_lookup_feature_table_query)
+        await session.drop_table(
+            table_name=lookup_universe_table_details.table_name,
+            schema_name=lookup_universe_table_details.schema_name,  # type: ignore
+            database_name=lookup_universe_table_details.database_name,  # type: ignore
+            if_exists=True,
+        )
+        return MaterializedFeatures(
+            materialized_table_name=lookup_feature_table_details.table_name,
+            column_names=column_names,
+            data_types=[adapter.get_physical_type_from_dtype(dtype) for dtype in column_dtypes],
+            serving_names=lookup_feature_table.serving_names,
+            feature_timestamp=feature_timestamp,
+            source_type=session.source_type,
+        )
 
     def get_table_update_lock(self, offline_store_table_name: str) -> Lock:
         """
@@ -567,26 +591,172 @@ class FeatureMaterializeService:  # pylint: disable=too-many-instance-attributes
                 current_feature_table,
                 materialized_features,
             ) in materialized_features_set.iterate_materialized_features():
-                with self.get_table_update_lock(current_feature_table.name):
-                    offline_info = await self._initialize_new_columns_offline(
+                await self._initialize_new_columns_offline_and_online(
+                    session=session,
+                    current_feature_table=current_feature_table,
+                    source_feature_table=feature_table_model,
+                    materialized_features=materialized_features,
+                )
+
+    async def initialize_precomputed_lookup_feature_table(
+        self,
+        source_feature_table_id: PydanticObjectId,
+        lookup_feature_tables: List[OfflineStoreFeatureTableModel],
+    ) -> None:
+        """
+        Initialize a precomputed lookup feature table by creating it and backfill using the source
+        feature table
+
+        Parameters
+        ----------
+        source_feature_table_id: PydanticObjectId
+            Id of the source feature table
+        lookup_feature_tables: List[OfflineStoreFeatureTableModel]
+            Precomputed lookup feature tables to be initialized
+        """
+        source_feature_table = await self.offline_store_feature_table_service.get_document(
+            source_feature_table_id
+        )
+        session = await self._get_session(source_feature_table)
+        num_rows_in_feature_table = await self._num_rows_in_feature_table(
+            session, source_feature_table.name
+        )
+        if num_rows_in_feature_table is None or num_rows_in_feature_table == 0:
+            # The source feature table is empty as well, so all the tables can be initialized
+            # together by initialize_new_columns() later.
+            return
+
+        # The source feature table already exists, but precomputed lookup tables don't. In this
+        # case, need to initialize lookup feature tables to have the same columns as the source
+        # feature table.
+        async with self._get_latest_from_feature_table(
+            session, source_feature_table
+        ) as source_features:
+            for lookup_feature_table in lookup_feature_tables:
+                materialized_lookup_features = (
+                    await self._materialize_precomputed_lookup_feature_table(
                         session=session,
-                        feature_table_name=current_feature_table.name,
-                        feature_table_column_names=feature_table_model.output_column_names,
-                        feature_table_column_dtypes=feature_table_model.output_dtypes,
-                        feature_table_serving_names=current_feature_table.serving_names,
-                        materialized_features=materialized_features,
+                        adapter=get_sql_adapter(session.source_type),
+                        feature_timestamp=source_features.feature_timestamp,
+                        materialized_feature_table_name=source_feature_table.name,
+                        column_names=source_feature_table.output_column_names,
+                        column_dtypes=source_feature_table.output_dtypes,
+                        use_last_materialized_timestamp=False,
+                        source_feature_table_serving_names=source_feature_table.serving_names,
+                        lookup_feature_table=lookup_feature_table,
                     )
-                    if offline_info is not None:
-                        column_names, materialize_end_date, is_new_table = offline_info
-                        if is_new_table:
-                            await self._update_offline_last_materialized_at(
-                                current_feature_table, materialized_features.feature_timestamp
-                            )
-                        await self._initialize_new_columns_online(
-                            feature_table=current_feature_table,
-                            column_names=column_names,
-                            end_date=materialize_end_date,
-                        )
+                )
+                try:
+                    await self._initialize_new_columns_offline_and_online(
+                        session=session,
+                        current_feature_table=lookup_feature_table,
+                        source_feature_table=source_feature_table,
+                        materialized_features=materialized_lookup_features,
+                    )
+                finally:
+                    await session.drop_table(
+                        table_name=materialized_lookup_features.materialized_table_name,
+                        schema_name=session.schema_name,
+                        database_name=session.database_name,
+                        if_exists=True,
+                    )
+
+    @asynccontextmanager
+    async def _get_latest_from_feature_table(  # pylint: disable=too-many-locals
+        self,
+        session: BaseSession,
+        feature_table_model: OfflineStoreFeatureTableModel,
+    ) -> AsyncIterator[MaterializedFeatures]:
+
+        timestamp_cols = [quoted_identifier(InternalName.FEATURE_TIMESTAMP_COLUMN.value)]
+        join_key_cols = [quoted_identifier(col) for col in feature_table_model.serving_names]
+        feature_name_cols = [
+            quoted_identifier(col) for col in feature_table_model.output_column_names
+        ]
+        row_number_expr = expressions.Window(
+            this=expressions.RowNumber(),
+            partition_by=join_key_cols,
+            order=expressions.Order(
+                expressions=[
+                    expressions.Ordered(this=timestamp_col, desc=True)
+                    for timestamp_col in timestamp_cols
+                ]
+            ),
+            over=expressions.WindowSpec(),
+        )
+        select_fields = timestamp_cols + join_key_cols + feature_name_cols
+
+        inner_expr = expressions.Select(
+            expressions=select_fields
+            + [expressions.alias_(row_number_expr, "_row_number", quoted=True)],
+        ).from_(expressions.Table(this=quoted_identifier(feature_table_model.name)))
+        expr = (
+            expressions.Select(expressions=select_fields)
+            .from_(inner_expr.subquery())
+            .where(
+                expressions.EQ(
+                    this=quoted_identifier("_row_number"),
+                    expression=expressions.Literal(this=1, is_string=False),
+                )
+            )
+        )
+        unique_id = str(ObjectId())
+        output_table_details = TableDetails(
+            database_name=session.database_name,
+            schema_name=session.schema_name,
+            table_name=f"TEMP_FEATURE_TABLE_{unique_id}".upper(),
+        )
+        feature_timestamp = pd.Timestamp(
+            await self._get_last_feature_timestamp(session, feature_table_model.name)
+        ).to_pydatetime()
+        try:
+            await session.create_table_as(table_details=output_table_details, select_expr=expr)
+            yield MaterializedFeatures(
+                materialized_table_name=output_table_details.table_name,
+                column_names=feature_table_model.output_column_names,
+                data_types=[
+                    get_sql_adapter(session.source_type).get_physical_type_from_dtype(dtype)
+                    for dtype in feature_table_model.output_dtypes
+                ],
+                serving_names=feature_table_model.serving_names,
+                feature_timestamp=feature_timestamp,
+                source_type=session.source_type,
+            )
+        finally:
+            await session.drop_table(
+                table_name=output_table_details.table_name,
+                schema_name=session.schema_name,
+                database_name=session.database_name,
+                if_exists=True,
+            )
+
+    async def _initialize_new_columns_offline_and_online(
+        self,
+        session: BaseSession,
+        current_feature_table: OfflineStoreFeatureTableModel,
+        source_feature_table: OfflineStoreFeatureTableModel,
+        materialized_features: MaterializedFeatures,
+    ) -> None:
+        with self.get_table_update_lock(current_feature_table.name):
+            offline_info = await self._initialize_new_columns_offline(
+                session=session,
+                feature_table_name=current_feature_table.name,
+                feature_table_column_names=source_feature_table.output_column_names,
+                feature_table_column_dtypes=source_feature_table.output_dtypes,
+                feature_table_serving_names=current_feature_table.serving_names,
+                materialized_features=materialized_features,
+            )
+            if offline_info is not None:
+                column_names, materialize_end_date, is_new_table = offline_info
+                if is_new_table:
+                    await self._update_offline_last_materialized_at(
+                        current_feature_table, materialized_features.feature_timestamp
+                    )
+                await self._initialize_new_columns_online(
+                    feature_table=current_feature_table,
+                    column_names=column_names,
+                    end_date=materialize_end_date,
+                )
 
     async def _initialize_new_columns_offline(
         self,

--- a/featurebyte/service/offline_store_feature_table_manager.py
+++ b/featurebyte/service/offline_store_feature_table_manager.py
@@ -605,6 +605,10 @@ class OfflineStoreFeatureTableManagerService:  # pylint: disable=too-many-instan
         for table in new_tables:
             await self.offline_store_feature_table_service.create_document(table)
 
+        await self.feature_materialize_service.initialize_precomputed_lookup_feature_table(
+            feature_table_id, new_tables
+        )
+
         for table in removed_tables:
             await self._delete_offline_store_feature_table(table.id)
 

--- a/tests/fixtures/feature_materialize/initialize_precomputed_lookup_feature_table.sql
+++ b/tests/fixtures/feature_materialize/initialize_precomputed_lookup_feature_table.sql
@@ -1,0 +1,179 @@
+SELECT
+  COUNT(*)
+FROM "cat1_gender_1d";
+
+SELECT
+  MAX("__feature_timestamp") AS RESULT
+FROM "cat1_gender_1d";
+
+CREATE TABLE "sf_db"."sf_schema"."TEMP_FEATURE_TABLE_000000000000000000000000" AS
+SELECT
+  "__feature_timestamp",
+  "gender",
+  "__feature_requiring_parent_serving_V220101__part1"
+FROM (
+  SELECT
+    "__feature_timestamp",
+    "gender",
+    "__feature_requiring_parent_serving_V220101__part1",
+    ROW_NUMBER() OVER (PARTITION BY "gender" ORDER BY "__feature_timestamp" DESC NULLS LAST) AS "_row_number"
+  FROM "cat1_gender_1d"
+)
+WHERE
+  "_row_number" = 1;
+
+CREATE TABLE "sf_db"."sf_schema"."TEMP_LOOKUP_UNIVERSE_TABLE_000000000000000000000000" AS
+WITH ENTITY_UNIVERSE AS (
+  SELECT
+    CAST('2022-01-05 00:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
+    "cust_id"
+  FROM (
+    SELECT DISTINCT
+      "col_text" AS "cust_id"
+    FROM (
+      SELECT
+        "col_int" AS "col_int",
+        "col_float" AS "col_float",
+        "is_active" AS "is_active",
+        "col_text" AS "col_text",
+        "col_binary" AS "col_binary",
+        "col_boolean" AS "col_boolean",
+        "effective_timestamp" AS "effective_timestamp",
+        "end_timestamp" AS "end_timestamp",
+        "date_of_birth" AS "date_of_birth",
+        "created_at" AS "created_at",
+        "cust_id" AS "cust_id"
+      FROM "sf_database"."sf_schema"."scd_table"
+      WHERE
+        "effective_timestamp" >= CAST('1970-01-01 00:00:00' AS TIMESTAMPNTZ)
+        AND "effective_timestamp" < CAST('2022-01-05 00:00:00' AS TIMESTAMPNTZ)
+    )
+  )
+), JOINED_PARENTS_ENTITY_UNIVERSE AS (
+  SELECT
+    REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
+    REQ."cust_id" AS "cust_id",
+    REQ."gender" AS "gender"
+  FROM (
+    SELECT
+      L."POINT_IN_TIME" AS "POINT_IN_TIME",
+      L."cust_id" AS "cust_id",
+      R."col_boolean" AS "gender"
+    FROM (
+      SELECT
+        "__FB_KEY_COL_0",
+        "__FB_LAST_TS",
+        "POINT_IN_TIME",
+        "cust_id"
+      FROM (
+        SELECT
+          "__FB_KEY_COL_0",
+          LAG("__FB_EFFECTIVE_TS_COL") IGNORE NULLS OVER (PARTITION BY "__FB_KEY_COL_0" ORDER BY "__FB_TS_COL" NULLS FIRST, "__FB_TS_TIE_BREAKER_COL") AS "__FB_LAST_TS",
+          "POINT_IN_TIME",
+          "cust_id",
+          "__FB_EFFECTIVE_TS_COL"
+        FROM (
+          SELECT
+            CAST(CONVERT_TIMEZONE('UTC', "POINT_IN_TIME") AS TIMESTAMPNTZ) AS "__FB_TS_COL",
+            "cust_id" AS "__FB_KEY_COL_0",
+            NULL AS "__FB_EFFECTIVE_TS_COL",
+            2 AS "__FB_TS_TIE_BREAKER_COL",
+            "POINT_IN_TIME" AS "POINT_IN_TIME",
+            "cust_id" AS "cust_id"
+          FROM (
+            SELECT
+              REQ."POINT_IN_TIME",
+              REQ."cust_id"
+            FROM ENTITY_UNIVERSE AS REQ
+          )
+          UNION ALL
+          SELECT
+            CAST(CONVERT_TIMEZONE('UTC', "effective_timestamp") AS TIMESTAMPNTZ) AS "__FB_TS_COL",
+            "col_text" AS "__FB_KEY_COL_0",
+            "effective_timestamp" AS "__FB_EFFECTIVE_TS_COL",
+            1 AS "__FB_TS_TIE_BREAKER_COL",
+            NULL AS "POINT_IN_TIME",
+            NULL AS "cust_id"
+          FROM (
+            SELECT
+              "col_int" AS "col_int",
+              "col_float" AS "col_float",
+              "is_active" AS "is_active",
+              "col_text" AS "col_text",
+              "col_binary" AS "col_binary",
+              "col_boolean" AS "col_boolean",
+              "effective_timestamp" AS "effective_timestamp",
+              "end_timestamp" AS "end_timestamp",
+              "date_of_birth" AS "date_of_birth",
+              "created_at" AS "created_at",
+              "cust_id" AS "cust_id"
+            FROM "sf_database"."sf_schema"."scd_table"
+            WHERE
+              NOT "effective_timestamp" IS NULL
+          )
+        )
+      )
+      WHERE
+        "__FB_EFFECTIVE_TS_COL" IS NULL
+    ) AS L
+    LEFT JOIN (
+      SELECT
+        ANY_VALUE("col_int") AS "col_int",
+        ANY_VALUE("col_float") AS "col_float",
+        ANY_VALUE("is_active") AS "is_active",
+        "col_text",
+        ANY_VALUE("col_binary") AS "col_binary",
+        ANY_VALUE("col_boolean") AS "col_boolean",
+        "effective_timestamp",
+        ANY_VALUE("end_timestamp") AS "end_timestamp",
+        ANY_VALUE("date_of_birth") AS "date_of_birth",
+        ANY_VALUE("created_at") AS "created_at",
+        ANY_VALUE("cust_id") AS "cust_id"
+      FROM (
+        SELECT
+          "col_int" AS "col_int",
+          "col_float" AS "col_float",
+          "is_active" AS "is_active",
+          "col_text" AS "col_text",
+          "col_binary" AS "col_binary",
+          "col_boolean" AS "col_boolean",
+          "effective_timestamp" AS "effective_timestamp",
+          "end_timestamp" AS "end_timestamp",
+          "date_of_birth" AS "date_of_birth",
+          "created_at" AS "created_at",
+          "cust_id" AS "cust_id"
+        FROM "sf_database"."sf_schema"."scd_table"
+        WHERE
+          NOT "effective_timestamp" IS NULL
+      )
+      GROUP BY
+        "effective_timestamp",
+        "col_text"
+    ) AS R
+      ON L."__FB_LAST_TS" = R."effective_timestamp" AND L."__FB_KEY_COL_0" = R."col_text"
+  ) AS REQ
+)
+SELECT
+  "POINT_IN_TIME",
+  "cust_id",
+  "gender"
+FROM JOINED_PARENTS_ENTITY_UNIVERSE;
+
+CREATE TABLE "sf_db"."sf_schema"."TEMP_LOOKUP_FEATURE_TABLE_000000000000000000000000" AS
+SELECT
+  L."cust_id",
+  R."__feature_requiring_parent_serving_V220101__part1"
+FROM "TEMP_LOOKUP_UNIVERSE_TABLE_000000000000000000000000" AS L
+LEFT JOIN "cat1_gender_1d" AS R
+  ON L."gender" = R."gender";
+
+SELECT
+  COUNT(*)
+FROM "cat1_gender_1d_via_cust_id_000000";
+
+CREATE TABLE "sf_db"."sf_schema"."cat1_gender_1d_via_cust_id_000000" AS
+SELECT
+  CAST('2022-01-05T00:00:00' AS TIMESTAMPNTZ) AS "__feature_timestamp",
+  "cust_id",
+  "__feature_requiring_parent_serving_V220101__part1"
+FROM "TEMP_LOOKUP_FEATURE_TABLE_000000000000000000000000";

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2350,6 +2350,7 @@ def mock_offline_store_feature_manager_dependencies_fixture():
     patch_targets = {
         "featurebyte.service.offline_store_feature_table_manager.FeatureMaterializeService": [
             "initialize_new_columns",
+            "initialize_precomputed_lookup_feature_table",
             "drop_columns",
             "drop_table",
         ],


### PR DESCRIPTION
## Description

Follow up to #2295.

When a feature list is deployed for a different use case, there can be a scenario where a source feature table already exists when its precomputed lookup feature tables are being created. Such precomputed lookup feature tables need to be initialized differently. This PR adds handling for that.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
