### PR TITLE
[DEV-3255] Set default schema for snowflake session

### DIFF
--- a/.changelog/DEV-3255.yaml
+++ b/.changelog/DEV-3255.yaml
@@ -1,0 +1,31 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: session
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+note: "Set active schema for the snowflake explicitly. The connector does not set the active schema specified."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/session/snowflake.py
+++ b/featurebyte/session/snowflake.py
@@ -96,6 +96,11 @@ class SnowflakeSession(BaseSession):
 
         cursor = self._connection.cursor()
         cursor.execute(f'USE ROLE "{self.role_name}"')
+        try:
+            cursor.execute(f'USE SCHEMA "{self.database_name}"."{self.schema_name}"')
+        except self._no_schema_error:
+            # the schema may not exist yet if the feature store is being created
+            pass
         # set timezone to UTC
         cursor.execute(
             "ALTER SESSION SET TIMEZONE='UTC', TIMESTAMP_OUTPUT_FORMAT='YYYY-MM-DD HH24:MI:SS.FF9 TZHTZM'"

--- a/tests/unit/session/test_snowflake_session.py
+++ b/tests/unit/session/test_snowflake_session.py
@@ -66,6 +66,7 @@ async def test_snowflake_session__credential_from_config(
     # check session initialization includes timezone and role specification
     cursor_execute_args_list = snowflake_connector_cursor.execute.call_args_list
     assert cursor_execute_args_list[0][0] == ('USE ROLE "TESTING"',)
+    assert cursor_execute_args_list[1][0] == ('USE SCHEMA "sf_database"."FEATUREBYTE"',)
     assert cursor_execute_args_list[-1][0] == (
         "ALTER SESSION SET TIMEZONE='UTC', TIMESTAMP_OUTPUT_FORMAT='YYYY-MM-DD HH24:MI:SS.FF9 TZHTZM'",
     )


### PR DESCRIPTION
## Description

Set default schema for snowflake session.

The following error can appear when initializing a session without the fix
```
090106 (22000): Cannot perform CREATE TABLE. This session does not have a current schema. Call 'USE SCHEMA', or use a qualified name."
```


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
