### PR TITLE
[chore] Refactor delete_document to not load document as model

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -181,6 +181,7 @@ jobs:
       group: Public Runners
     timeout-minutes: 60
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - 3.10.14
@@ -275,6 +276,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 135
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - 3.10.14

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -314,7 +314,7 @@ tasks:
         sh: printenv PYTEST_SPLITS || echo "1"
     cmds:
       - task: test-setup
-      - poetry run pytest --timeout=900 --junitxml=pytest.xml.4 --cov=featurebyte tests/integration --source-types databricks_unity --splits={{.PYTEST_SPLITS}} --group={{.PYTEST_GROUP}}
+      - poetry run pytest --timeout=1350 --junitxml=pytest.xml.4 --cov=featurebyte tests/integration --source-types databricks_unity --splits={{.PYTEST_SPLITS}} --group={{.PYTEST_GROUP}}
       - task: test-teardown
 
   test-docs:

--- a/featurebyte/feast/model/registry.py
+++ b/featurebyte/feast/model/registry.py
@@ -2,7 +2,7 @@
 Feast registry model
 """
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from pathlib import Path
 
@@ -27,11 +27,12 @@ class FeastRegistryModel(FeatureByteCatalogBaseDocumentModel):
     feature_store_id: PydanticObjectId
     registry_path: Optional[str] = Field(default=None)
 
-    @property
-    def remote_attribute_paths(self) -> List[Path]:
+    @classmethod
+    def _get_remote_attribute_paths(cls, document_dict: Dict[str, Any]) -> List[Path]:
         paths = []
-        if self.registry_path:
-            paths.append(Path(self.registry_path))
+        registry_path = document_dict.get("registry_path")
+        if registry_path:
+            paths.append(Path(registry_path))
         return paths
 
     def registry_proto(self) -> RegistryProto:

--- a/featurebyte/models/base.py
+++ b/featurebyte/models/base.py
@@ -338,15 +338,21 @@ class FeatureByteBaseDocumentModel(FeatureByteBaseModel):
         """
         return cls.Settings.unique_constraints
 
-    @property
-    def remote_attribute_paths(self) -> List[Path]:
+    @classmethod
+    def _get_remote_attribute_paths(cls, document_dict: Dict[str, Any]) -> List[Path]:
         """
-        Remote attribute paths
+        Get remote attribute paths for a document
+
+        Parameters
+        ----------
+        document_dict: Dict[str, Any]
+            Dict representation of the document
 
         Returns
         -------
         List[Path]
         """
+        _ = document_dict
         return []
 
     class Settings:

--- a/featurebyte/models/feature_list.py
+++ b/featurebyte/models/feature_list.py
@@ -554,11 +554,12 @@ class FeatureListModel(FeatureByteCatalogBaseDocumentModel):
             ]
         return self._feature_clusters
 
-    @property
-    def remote_attribute_paths(self) -> List[Path]:
+    @classmethod
+    def _get_remote_attribute_paths(cls, document_dict: Dict[str, Any]) -> List[Path]:
         paths = []
-        if self.feature_clusters_path:
-            paths.append(Path(self.feature_clusters_path))
+        feature_clusters_path = document_dict.get("feature_clusters_path")
+        if feature_clusters_path:
+            paths.append(Path(feature_clusters_path))
         return paths
 
     @property

--- a/featurebyte/models/offline_store_feature_table.py
+++ b/featurebyte/models/offline_store_feature_table.py
@@ -101,11 +101,12 @@ class OfflineStoreFeatureTableModel(FeatureByteCatalogBaseDocumentModel):
             values["feature_store_id"] = values["feature_cluster"].feature_store_id
         return values
 
-    @property
-    def remote_attribute_paths(self) -> List[Path]:
+    @classmethod
+    def _get_remote_attribute_paths(cls, document_dict: Dict[str, Any]) -> List[Path]:
         paths = []
-        if self.feature_cluster_path:
-            paths.append(Path(self.feature_cluster_path))
+        feature_cluster_path = document_dict.get("feature_cluster_path")
+        if feature_cluster_path:
+            paths.append(Path(feature_cluster_path))
         return paths
 
     @property

--- a/featurebyte/service/base_document.py
+++ b/featurebyte/service/base_document.py
@@ -422,7 +422,7 @@ class BaseDocumentService(
         int
             number of records deleted
         """
-        document = await self.get_document(
+        document_dict = await self.get_document_as_dict(
             document_id=document_id,
             exception_detail=exception_detail,
             use_raw_query_filter=use_raw_query_filter,
@@ -432,7 +432,7 @@ class BaseDocumentService(
         )
 
         # check if document is modifiable
-        self._check_document_modifiable(document=document.dict(by_alias=True))
+        self._check_document_modifiable(document=document_dict)
 
         query_filter = self._construct_get_query_filter(
             document_id=document_id, use_raw_query_filter=use_raw_query_filter, **kwargs
@@ -445,7 +445,11 @@ class BaseDocumentService(
         )
 
         # remove remote attributes
-        for remote_path in document.remote_attribute_paths:
+        for (
+            remote_path
+        ) in self.document_class._get_remote_attribute_paths(  # pylint: disable=protected-access
+            document_dict
+        ):
             await self.storage.try_delete_if_exists(remote_path)
         return int(num_of_records_deleted)
 

--- a/tests/util/helper.py
+++ b/tests/util/helper.py
@@ -979,7 +979,7 @@ async def manage_document(doc_service, create_data, storage):
         doc = await doc_service.create_document(data=create_data)
 
         # check remote paths are created
-        for path in doc.remote_attribute_paths:
+        for path in type(doc)._get_remote_attribute_paths(doc.dict(by_alias=True)):
             full_path = os.path.join(storage.base_path, path)
             assert os.path.exists(full_path), f"Remote path {full_path} not created"
 
@@ -990,6 +990,6 @@ async def manage_document(doc_service, create_data, storage):
             await doc_service.delete_document(document_id=doc.id)
 
             # check remote paths are deleted
-            for path in doc.remote_attribute_paths:
+            for path in type(doc)._get_remote_attribute_paths(doc.dict(by_alias=True)):
                 full_path = os.path.join(storage.base_path, path)
                 assert not os.path.exists(full_path), f"Remote path {full_path} not deleted"


### PR DESCRIPTION
## Description

This refactors delete_document to not load document as model. This makes it less strict and allows deletion of documents that are no longer compatible with the current model schema.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
