### PR TITLE
[chore] Use global async loop for io workers

### DIFF
--- a/featurebyte/worker/start.py
+++ b/featurebyte/worker/start.py
@@ -3,8 +3,13 @@ Start worker
 """
 
 from featurebyte.worker import get_celery
-from featurebyte.worker.task_executor import CPUBoundTask, IOBoundTask
+from featurebyte.worker.task_executor import (
+    CPUBoundTask,
+    IOBoundTask,
+    initialize_asyncio_event_loop,
+)
 
 celery = get_celery()
 celery.register_task(CPUBoundTask())
 celery.register_task(IOBoundTask())
+initialize_asyncio_event_loop()

--- a/tests/unit/worker/test_task_executor.py
+++ b/tests/unit/worker/test_task_executor.py
@@ -6,7 +6,7 @@ import datetime
 from multiprocessing import Array, Process, Value
 from uuid import uuid4
 
-import greenlet
+import gevent
 import pytest
 from bson.objectid import ObjectId
 
@@ -139,8 +139,8 @@ def run_process_task(state: Value, exception_value: Value, timeout: int):
             for idx, byte in enumerate(error_message[:100]):
                 exception_value[idx] = byte
 
-    # execute task in greenlet thread
-    greenlet.greenlet(run_greenlet_task).switch()
+    # execute multiple tasks in greenlet thread
+    gevent.joinall([gevent.spawn(run_greenlet_task), gevent.spawn(run_greenlet_task)])
 
 
 @pytest.mark.parametrize("timeout", [10, 1])

--- a/tests/unit/worker/test_task_executor.py
+++ b/tests/unit/worker/test_task_executor.py
@@ -14,7 +14,7 @@ from featurebyte.models.base import DEFAULT_CATALOG_ID, User
 from featurebyte.schema.worker.task.base import TaskType
 from featurebyte.worker.registry import TASK_REGISTRY_MAP
 from featurebyte.worker.task_executor import TaskExecutor as WorkerTaskExecutor
-from featurebyte.worker.task_executor import run_async
+from featurebyte.worker.task_executor import initialize_asyncio_event_loop, run_async
 from featurebyte.worker.test_util.random_task import RandomTask, RandomTaskPayload, TestCommand
 
 
@@ -123,6 +123,8 @@ def run_process_task(state: Value, exception_value: Value, timeout: int):
     monkey.patch_all()
     import time  # pylint: disable=import-outside-toplevel
 
+    initialize_asyncio_event_loop()
+
     async def async_task(state: Value):
         """Async task that blocks for 2 seconds and update state to 2"""
         time.sleep(2)
@@ -155,7 +157,8 @@ def test_run_async(timeout):
         process.join()
         # state should be updated by async task in greenlet thread
         assert state.value == 2
-        assert exception_value[:].decode("utf-8").strip("\x00") == ""
+        output = exception_value[:].decode("utf-8").strip("\x00")
+        assert output == "", output
     else:
         # expect celery SoftTimeLimitExceeded error
         # with pytest.raises(SoftTimeLimitExceeded) as exc:
@@ -163,7 +166,5 @@ def test_run_async(timeout):
         process.join()
         # state should remain unchanged
         assert state.value == 1
-        assert (
-            exception_value[:].decode("utf-8").strip("\x00")
-            == f"SoftTimeLimitExceeded('Task timed out after {timeout}s',)"
-        )
+        output = exception_value[:].decode("utf-8").strip("\x00")
+        assert output == f"SoftTimeLimitExceeded('Task timed out after {timeout}s',)", output


### PR DESCRIPTION
## Description

- Use a global event loop for executing asyncio functions in gevent pool workers to avoid issues of shared loop being closed occasionally
- Set asyncio default event loop to the global loop only in child thread to avoid the loop being used in main process which may potentially cause some issues in some asyncio operations that do not specify loop explicitly

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
