### PR TITLE
[chore] Disallow targets with definition to be specified for target column in observation tables

### DIFF
--- a/featurebyte/exception.py
+++ b/featurebyte/exception.py
@@ -513,6 +513,12 @@ class ObservationTableInvalidTargetNameError(BaseUnprocessableEntityError):
     """
 
 
+class ObservationTableTargetDefinitionExistsError(BaseUnprocessableEntityError):
+    """
+    Raise when observation table specifies a target name that already has a definition
+    """
+
+
 class TaskNotRevocableError(BaseUnprocessableEntityError):
     """
     Raise when task is not revocable

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -30,6 +30,7 @@ from featurebyte.exception import (
     ObservationTableInvalidTargetNameError,
     ObservationTableInvalidUseCaseError,
     ObservationTableMissingColumnsError,
+    ObservationTableTargetDefinitionExistsError,
     UnsupportedPointInTimeColumnTypeError,
 )
 from featurebyte.models.base import FeatureByteBaseDocumentModel, PydanticObjectId
@@ -316,6 +317,13 @@ class ObservationTableService(
                     f'Target "{target_column}" does not have matching primary entity ids.'
                 )
             target_namespace_id = ObjectId(target_namespace["_id"])
+
+            # check if target namespace already has a definition
+            if target_namespace["target_ids"]:
+                raise ObservationTableTargetDefinitionExistsError(
+                    f'Target "{target_column}" already has a definition.'
+                )
+
         else:
             target_namespace_id = None
 

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -220,7 +220,10 @@ def validate_columns_info(
         if target_namespace is not None:
             if target_namespace.name not in columns_info_mapping:
                 raise ValueError(f'Target column "{target_namespace.name}" not found.')
-            if columns_info_mapping[target_namespace.name].dtype != target_namespace.dtype:
+            if (
+                target_namespace.dtype is not None
+                and columns_info_mapping[target_namespace.name].dtype != target_namespace.dtype
+            ):
                 raise ValueError(
                     f'Target column "{target_namespace.name}" should have dtype "{target_namespace.dtype}"'
                 )


### PR DESCRIPTION
## Description

Update the validation logic for specifying target column during observation table creation to disallow using targets with definitions. 

Observation table with  target values for such targets should be computed instead. E.g. :
```
observation_table_with_tgt = target.compute_target_table(
    observation_table_without_tgt, 
    "training obs for 30d spend projection"
)
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
