### PR TITLE
[DEV-3284] Make dtype mandatory during target namespace creation

### DIFF
--- a/.changelog/DEV-3284.yaml
+++ b/.changelog/DEV-3284.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: api
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Make dtype mandatory when create a target namespace"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/target_namespace.py
+++ b/featurebyte/api/target_namespace.py
@@ -15,6 +15,7 @@ from featurebyte.api.entity import Entity
 from featurebyte.api.feature_or_target_namespace_mixin import FeatureOrTargetNamespaceMixin
 from featurebyte.api.savable_api_object import DeletableApiObject, SavableApiObject
 from featurebyte.common.doc_util import FBAutoDoc
+from featurebyte.enum import DBVarType
 from featurebyte.exception import RecordRetrievalException
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.target_namespace import TargetNamespaceModel
@@ -30,6 +31,7 @@ class TargetNamespace(FeatureOrTargetNamespaceMixin, DeletableApiObject, Savable
     __fbautodoc__ = FBAutoDoc(proxy_class="featurebyte.TargetNamespace")
 
     internal_window: Optional[str] = Field(alias="window")
+    internal_dtype: DBVarType = Field(alias="dtype")
 
     # class variables
     _route = "/target_namespace"
@@ -48,7 +50,7 @@ class TargetNamespace(FeatureOrTargetNamespaceMixin, DeletableApiObject, Savable
 
     @classmethod
     def create(
-        cls, name: str, primary_entity: List[str], window: Optional[str] = None
+        cls, name: str, primary_entity: List[str], dtype: DBVarType, window: Optional[str] = None
     ) -> TargetNamespace:
         """
         Create a new TargetNamespace.
@@ -59,6 +61,8 @@ class TargetNamespace(FeatureOrTargetNamespaceMixin, DeletableApiObject, Savable
             Name of the TargetNamespace
         primary_entity: List[str]
             List of entities.
+        dtype: DBVarType
+            Data type of the TargetNamespace
         window: Optional[str]
             Window of the TargetNamespace
 
@@ -72,13 +76,30 @@ class TargetNamespace(FeatureOrTargetNamespaceMixin, DeletableApiObject, Savable
         >>> target_namespace = fb.TargetNamespace.create(  # doctest: +SKIP
         ...     name="amount_7d_target",
         ...     window="7d",
+        ...     dtype=DBVarType.FLOAT,
         ...     primary_entity=["customer"]
         ... )
         """
         entity_ids = [Entity.get(entity_name).id for entity_name in primary_entity]
-        target_namespace = TargetNamespace(name=name, entity_ids=entity_ids, window=window)
+        target_namespace = TargetNamespace(
+            name=name, entity_ids=entity_ids, dtype=dtype, window=window
+        )
         target_namespace.save()
         return target_namespace
+
+    @property
+    def dtype(self) -> DBVarType:
+        """
+        Database variable type of the target namespace.
+
+        Returns
+        -------
+        DBVarType
+        """
+        try:
+            return self.cached_model.dtype
+        except RecordRetrievalException:
+            return self.internal_dtype
 
     @property
     def window(self) -> Optional[str]:
@@ -138,6 +159,7 @@ class TargetNamespace(FeatureOrTargetNamespaceMixin, DeletableApiObject, Savable
         >>> target_namespace = fb.TargetNamespace.create(  # doctest: +SKIP
         ...     name="amount_7d_target",
         ...     window="7d",
+        ...     dtype=DBVarType.FLOAT,
         ...     primary_entity=["customer"]
         ... )
         >>> target_namespace.delete()  # doctest: +SKIP

--- a/featurebyte/enum.py
+++ b/featurebyte/enum.py
@@ -117,7 +117,7 @@ class StrEnum(str, Enum):
 
 class DBVarType(StrEnum):
     """
-    The DBVarType enum class provides a way to represetn various Dababase variable types supported by FeatureByte.
+    The DBVarType enum class provides a way to represent various Database variable types supported by FeatureByte.
     """
 
     __fbautodoc__ = FBAutoDoc(proxy_class="featurebyte.enum.DBVarType")

--- a/featurebyte/schema/target_namespace.py
+++ b/featurebyte/schema/target_namespace.py
@@ -25,7 +25,7 @@ class TargetNamespaceCreate(FeatureByteBaseModel):
 
     id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
     name: NameStr
-    dtype: Optional[DBVarType]
+    dtype: DBVarType
     target_ids: List[PydanticObjectId] = Field(default_factory=list)
     default_target_id: Optional[PydanticObjectId]
     default_version_mode: DefaultVersionMode = Field(default=DefaultVersionMode.AUTO)

--- a/tests/fixtures/request_payloads/target_namespace.json
+++ b/tests/fixtures/request_payloads/target_namespace.json
@@ -7,7 +7,7 @@
     "_id": "64ae4be43a93459ede8c383b",
     "default_target_id": "64a80107d667dd0c2b13d8cd",
     "default_version_mode": "AUTO",
-    "dtype": null,
+    "dtype": "FLOAT",
     "entity_ids": [
         "63f94ed6ea1f050131379214"
     ],

--- a/tests/integration/api/test_serving_parent_features.py
+++ b/tests/integration/api/test_serving_parent_features.py
@@ -16,6 +16,7 @@ from featurebyte import (
     TargetNamespace,
     UseCase,
 )
+from featurebyte.enum import DBVarType
 from featurebyte.schema.feature_list import OnlineFeaturesRequestPayload
 from tests.util.helper import tz_localize_if_needed
 
@@ -215,7 +216,9 @@ def event_use_case_fixture(event_entity):
     Fixture for an event use case. To be specified when creating deployment, so that the deployment
     can be served by providing serving_event_id
     """
-    target = TargetNamespace.create(name="dummy_target", primary_entity=[event_entity.name])
+    target = TargetNamespace.create(
+        name="dummy_target", primary_entity=[event_entity.name], dtype=DBVarType.FLOAT
+    )
     context = Context.create(name="event_context", primary_entity=[event_entity.name])
     use_case = UseCase.create(
         name="event_use_case", target_name=target.name, context_name=context.name
@@ -295,7 +298,9 @@ def test_use_case_list_filtering_by_feature_list(feature_list_with_parent_child_
 
     # create another use case with different primary entity
     entity = Entity.create(name="another_entity", serving_names=["another_serving_id"])
-    target = TargetNamespace.create(name="another_target", primary_entity=[entity.name])
+    target = TargetNamespace.create(
+        name="another_target", primary_entity=[entity.name], dtype=DBVarType.FLOAT
+    )
     context = Context.create(name="another_context", primary_entity=[entity.name])
     another_use_case = UseCase.create(
         name="another_use_case", target_name=target.name, context_name=context.name

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -18,7 +18,7 @@ from sqlglot import parse_one
 
 import featurebyte as fb
 from featurebyte.common.model_util import get_version
-from featurebyte.enum import InternalName, SourceType
+from featurebyte.enum import DBVarType, InternalName, SourceType
 from featurebyte.feast.patch import augment_response_with_on_demand_transforms
 from featurebyte.logging import get_logger
 from featurebyte.query_graph.sql.common import sql_to_string
@@ -401,6 +401,7 @@ def order_use_case_fixture(order_entity):
     target = fb.TargetNamespace.create(
         "order_target",
         primary_entity=[order_entity.name],
+        dtype=DBVarType.FLOAT,
     )
     context = fb.Context.create(
         name="order_context",

--- a/tests/unit/api/test_observation_table.py
+++ b/tests/unit/api/test_observation_table.py
@@ -10,6 +10,7 @@ import pytest
 
 from featurebyte import TargetNamespace
 from featurebyte.api.observation_table import ObservationTable
+from featurebyte.enum import DBVarType
 from featurebyte.exception import RecordCreationException
 from featurebyte.models.observation_table import Purpose
 from tests.unit.api.base_materialize_table_test import BaseMaterializedTableApiTest
@@ -178,7 +179,9 @@ def test_create_observation_table_with_target_column_from_source_table(
     _ = catalog
     _ = patched_observation_table_service
 
-    target_namespace = TargetNamespace.create("target", primary_entity=[cust_id_entity.name])
+    target_namespace = TargetNamespace.create(
+        "target", primary_entity=[cust_id_entity.name], dtype=DBVarType.FLOAT
+    )
     observation_table = snowflake_database_table.create_observation_table(
         "observation_table_from_source_table",
         columns_rename_mapping={"event_timestamp": "POINT_IN_TIME", "col_float": "target"},

--- a/tests/unit/api/test_target.py
+++ b/tests/unit/api/test_target.py
@@ -8,6 +8,7 @@ import pytest
 import featurebyte
 from featurebyte.api.target import Target
 from featurebyte.api.target_namespace import TargetNamespace
+from featurebyte.enum import DBVarType
 from tests.unit.api.base_feature_or_target_test import FeatureOrTargetBaseTestSuite, TestItemType
 from tests.util.helper import fb_assert_frame_equal
 
@@ -111,7 +112,10 @@ class TestTargetTestSuite(FeatureOrTargetBaseTestSuite):
         float_target.save()
         # Persist a target that has no recipe.
         TargetNamespace.create(
-            name="target_without_recipe", primary_entity=[cust_id_entity.name], window="7d"
+            name="target_without_recipe",
+            primary_entity=[cust_id_entity.name],
+            dtype=DBVarType.FLOAT,
+            window="7d",
         )
 
         # List out the targets
@@ -121,7 +125,7 @@ class TestTargetTestSuite(FeatureOrTargetBaseTestSuite):
         expected_df = pd.DataFrame(
             {
                 "name": ["float_target", "target_without_recipe"],
-                "dtype": ["FLOAT", None],
+                "dtype": ["FLOAT", "FLOAT"],
                 "entities": [["customer"], ["customer"]],
             }
         )

--- a/tests/unit/api/test_target_namespace.py
+++ b/tests/unit/api/test_target_namespace.py
@@ -3,6 +3,7 @@ Test target namespace module
 """
 
 from featurebyte.api.target_namespace import TargetNamespace
+from featurebyte.enum import DBVarType
 
 
 def test_target_namespace_create_and_delete(item_entity):
@@ -10,7 +11,7 @@ def test_target_namespace_create_and_delete(item_entity):
     Test target namespace create
     """
     target_namespace = TargetNamespace.create(
-        "target_namespace_1", primary_entity=["item"], window="7d"
+        "target_namespace_1", primary_entity=["item"], dtype=DBVarType.FLOAT, window="7d"
     )
     assert target_namespace.name == "target_namespace_1"
     assert target_namespace.window == "7d"

--- a/tests/unit/api/test_use_case.py
+++ b/tests/unit/api/test_use_case.py
@@ -3,6 +3,7 @@ Unit test for UseCase class
 """
 
 from featurebyte import ObservationTable, TargetNamespace, UseCase
+from featurebyte.enum import DBVarType
 
 
 def test_create_use_case_with_descriptive_target(catalog, cust_id_entity, context):
@@ -17,6 +18,7 @@ def test_create_use_case_with_descriptive_target(catalog, cust_id_entity, contex
         name=target_name,
         window="28d",
         primary_entity=[cust_id_entity.name],
+        dtype=DBVarType.FLOAT,
     )
     assert namespace.name == target_name
     use_case = UseCase.create(

--- a/tests/unit/test_generate_payload_fixtures.py
+++ b/tests/unit/test_generate_payload_fixtures.py
@@ -196,6 +196,7 @@ def test_save_payload_fixtures(  # pylint: disable=too-many-arguments
         default_target_id=float_target.id,
         entity_ids=[cust_id_entity.id],
         window="7d",
+        dtype=DBVarType.FLOAT,
     )
     target_table = TargetTableCreate(
         _id="646f6c1c0ed28a5271fb32da",


### PR DESCRIPTION
## Description

A descriptive target without specific definition can be created using `TargetNamespace.create` but the dtype specified is not mandatory. When the dtype is not specified there is no way to validate the dtype of a target column provided in an observation table. This can result in different observation table associating a column of the same target but with inconsistent dtypes.

To avoid this issue, the changes made here will make dtype mandatory during the creation of a descriptive target.


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
