### PR TITLE
[DEV-3230] Use precomputed lookup feature tables in online serving

### DIFF
--- a/featurebyte/feast/service/feature_store.py
+++ b/featurebyte/feast/service/feature_store.py
@@ -273,11 +273,6 @@ class FeastFeatureStoreService:
         Optional[FeastFeatureStore]
             Feast feature store used for materialization
         """
-        # Note: This guard is to be removed when feast registry is updated to include precomputed
-        # lookup feature tables
-        if feature_table_model.precomputed_lookup_feature_table_info is not None:
-            return None
-
         feast_stores = []
         first_registry = None
         for deployment_id in feature_table_model.deployment_ids:

--- a/featurebyte/models/deployment.py
+++ b/featurebyte/models/deployment.py
@@ -35,6 +35,7 @@ class DeploymentModel(FeatureByteCatalogBaseDocumentModel):
     context_id: Optional[PydanticObjectId] = Field(default=None)
     use_case_id: Optional[PydanticObjectId] = Field(default=None)
     registry_info: Optional[FeastRegistryInfo] = Field(default=None)
+    serving_entity_ids: Optional[List[PydanticObjectId]] = Field(default=None)
 
     class Settings(FeatureByteCatalogBaseDocumentModel.Settings):
         """

--- a/featurebyte/models/precomputed_lookup_feature_table.py
+++ b/featurebyte/models/precomputed_lookup_feature_table.py
@@ -137,9 +137,10 @@ def get_precomputed_lookup_feature_tables(
     ] = {}
     for feature_list in feature_lists:
         for full_serving_entity_ids in feature_list.enabled_serving_entity_ids:
-            serving_entity_ids = EntityAncestorDescendantMapper.create(
+            relationships_mapper = EntityAncestorDescendantMapper.create(
                 feature_lists_relationships_info[feature_list.id],
-            ).keep_related_entity_ids(
+            )
+            serving_entity_ids = relationships_mapper.keep_related_entity_ids(
                 entity_ids_to_filter=full_serving_entity_ids,
                 filter_by=primary_entity_ids,
             )

--- a/featurebyte/routes/deployment/controller.py
+++ b/featurebyte/routes/deployment/controller.py
@@ -262,6 +262,7 @@ class DeploymentController(
             if feast_store and feature_list.versioned_name in feast_feature_services:
                 result = await self.online_serving_service.get_online_features_by_feast(
                     feature_list=feature_list,
+                    deployment=document,
                     feast_store=feast_store,
                     request_data=data.entity_serving_names,
                 )

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -72,6 +72,7 @@ from featurebyte.service.credential import CredentialService
 from featurebyte.service.deploy import (
     DeployFeatureListManagementService,
     DeployFeatureManagementService,
+    DeploymentServingEntityService,
     DeployService,
     FeastIntegrationService,
 )
@@ -233,6 +234,7 @@ app_container_config.register_class(FeastIntegrationService)
 app_container_config.register_class(DeployService)
 app_container_config.register_class(DeploymentController)
 app_container_config.register_class(DeploymentService)
+app_container_config.register_class(DeploymentServingEntityService)
 app_container_config.register_class(DerivePrimaryEntityHelper)
 app_container_config.register_class(DimensionTableController)
 app_container_config.register_class(DimensionTableService)

--- a/featurebyte/service/feature_materialize.py
+++ b/featurebyte/service/feature_materialize.py
@@ -616,6 +616,9 @@ class FeatureMaterializeService:  # pylint: disable=too-many-instance-attributes
         lookup_feature_tables: List[OfflineStoreFeatureTableModel]
             Precomputed lookup feature tables to be initialized
         """
+        if not lookup_feature_tables:
+            return
+
         source_feature_table = await self.offline_store_feature_table_service.get_document(
             source_feature_table_id
         )
@@ -938,10 +941,6 @@ class FeatureMaterializeService:  # pylint: disable=too-many-instance-attributes
         # noqa: DAR101
         """
         if not columns:
-            return
-        # Note: This guard is to be removed when feast registry is updated to include precomputed
-        # lookup feature tables
-        if feature_table.precomputed_lookup_feature_table_info is not None:
             return
         await materialize_partial(
             feature_store=feature_store,

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -682,7 +682,7 @@ async def test_databricks_udf_created(session, offline_store_feature_tables, sou
 @pytest.mark.usefixtures("deployed_feature_list", "deployed_feature_list_composite_entities")
 async def test_feast_registry(
     app_container,
-    expected_feature_table_names,
+    offline_store_feature_tables_all,
     source_type,
     deployment_name,
 ):
@@ -707,7 +707,7 @@ async def test_feast_registry(
     assert {
         fv.name
         for fv in feature_store._list_feature_views(allow_cache=False, hide_dummy_entity=False)
-    } == expected_feature_table_names
+    } == {table.name for table in offline_store_feature_tables_all.values()}
 
     # Check feature services
     feature_service_name = f"EXTERNAL_FS_FEATURE_LIST_{get_version()}"
@@ -722,13 +722,8 @@ async def test_feast_registry(
     feature_service = feature_store.get_feature_service(feature_service_name)
     version = get_version()
     entity_row = {
-        "üser id": 5,
-        "cust_id": 761,
-        "user_status": "STÀTUS_CODE_37",
-        "PRODUCT_ACTION": "detail",
-        "order_id": "T1230",
+        "order_id": "T3850",
         "POINT_IN_TIME": pd.Timestamp("2001-01-02 12:00:00"),
-        "üser id x PRODUCT_ACTION": "detail::761",
     }
     with patch.object(
         feature_store,
@@ -756,47 +751,42 @@ async def test_feast_registry(
             )
         ]
     expected = {
-        f"Amount Sum by Customer x Product Action 24d_{version}": [None],
-        f"Current Number of Users With This Status_{version}": [1.0],
+        f"Amount Sum by Customer x Product Action 24d_{version}": [169.77000427246094],
+        f"Current Number of Users With This Status_{version}": [1],
         f"EXTERNAL_CATEGORY_AMOUNT_SUM_BY_USER_ID_7d_{version}": [
             {
-                "__MISSING__": 240.76,
-                "detail": 254.23,
-                "purchase": 216.87,
-                "rëmove": 98.34,
-                "àdd": 146.22,
+                "__MISSING__": 174.39,
+                "detail": 169.77,
+                "purchase": 473.31,
+                "rëmove": 102.37,
+                "àdd": 27.1,
             }
         ],
-        f"EXTERNAL_FS_AMOUNT_SUM_BY_USER_ID_24h_{version}": [683.55],
-        f"EXTERNAL_FS_AMOUNT_SUM_BY_USER_ID_24h_TIMES_100_{version}": [68355.0],
+        f"EXTERNAL_FS_AMOUNT_SUM_BY_USER_ID_24h_{version}": [623.1500244140625],
+        f"EXTERNAL_FS_AMOUNT_SUM_BY_USER_ID_24h_TIMES_100_{version}": [62315.0],
         f"EXTERNAL_FS_ARRAY_AVG_BY_USER_ID_24h_{version}": [
             [
-                0.6807108071969569,
-                0.41463276624595335,
-                0.4432548634609973,
-                0.6828628340472915,
-                0.5967769997569004,
-                0.5210525989755145,
-                0.4687023396052305,
-                0.35638918237609585,
-                0.42879787416376725,
-                0.548615163058392,
+                0.5365338952415342,
+                0.4908373917748641,
+                0.42408493050514906,
+                0.5512648363475837,
+                0.5269536439690168,
+                0.4490616290417775,
+                0.41383692828120605,
+                0.4543201999832706,
+                0.5041296835615285,
+                0.4379877816657862,
             ]
         ],
-        f"EXTERNAL_FS_COMPLEX_USER_X_PRODUCTION_ACTION_FEATURE_{version}": [727.4592974268256],
+        f"EXTERNAL_FS_COMPLEX_USER_X_PRODUCTION_ACTION_FEATURE_{version}": [667.059326171875],
         f"EXTERNAL_FS_COSINE_SIMILARITY_{version}": [0.0],
-        f"EXTERNAL_FS_COSINE_SIMILARITY_VEC_{version}": [0.8578220571057548],
-        f"EXTERNAL_FS_COUNT_BY_PRODUCT_ACTION_7d_{version}": [43.0],
-        f"EXTERNAL_FS_COUNT_OVERALL_7d_{version}": [149.0],
-        f"Most Frequent Item Type by Order_{version}": ["type_12"],
-        "PRODUCT_ACTION": ["detail"],
-        f"User Status Feature_{version}": ["STÀTUS_CODE_37"],
-        f"Complex Feature by User_{version}": ["STÀTUS_CODE_37_1"],
-        "cust_id": ["761"],
-        "order_id": ["T1230"],
-        "user_status": ["STÀTUS_CODE_37"],
-        "üser id": ["5"],
-        "üser id x PRODUCT_ACTION": ["detail::761"],
+        f"EXTERNAL_FS_COSINE_SIMILARITY_VEC_{version}": [0.9171356558799744],
+        f"EXTERNAL_FS_COUNT_BY_PRODUCT_ACTION_7d_{version}": [43],
+        f"EXTERNAL_FS_COUNT_OVERALL_7d_{version}": [149],
+        f"Most Frequent Item Type by Order_{version}": ["type_24"],
+        f"User Status Feature_{version}": ["STÀTUS_CODE_26"],
+        f"Complex Feature by User_{version}": ["STÀTUS_CODE_26_1"],
+        "order_id": ["T3850"],
     }
     if source_type == SourceType.DATABRICKS_UNITY:
         expected.pop(f"EXTERNAL_FS_ARRAY_AVG_BY_USER_ID_24h_{version}")
@@ -816,17 +806,12 @@ async def test_feast_registry(
             entity_rows=[entity_row],
         ).to_dict()
     expected = {
-        "üser id": ["5"],
-        "cust_id": ["761"],
-        "PRODUCT_ACTION": ["detail"],
-        "user_status": ["STÀTUS_CODE_37"],
-        "order_id": ["T1230"],
-        "üser id x PRODUCT_ACTION": ["detail::761"],
+        "order_id": ["T3850"],
         f"Amount Sum by Customer x Product Action 24d_{version}": [None],
-        f"User Status Feature_{version}": ["STÀTUS_CODE_37"],
+        f"User Status Feature_{version}": ["STÀTUS_CODE_26"],
         f"Current Number of Users With This Status_{version}": [1],
-        f"Complex Feature by User_{version}": ["STÀTUS_CODE_37_1"],
-        f"Most Frequent Item Type by Order_{version}": ["type_12"],
+        f"Complex Feature by User_{version}": ["STÀTUS_CODE_26_1"],
+        f"Most Frequent Item Type by Order_{version}": ["type_24"],
         f"EXTERNAL_FS_COUNT_OVERALL_7d_{version}": [None],
         f"EXTERNAL_FS_COUNT_BY_PRODUCT_ACTION_7d_{version}": [None],
         f"EXTERNAL_FS_AMOUNT_SUM_BY_USER_ID_24h_{version}": [None],
@@ -868,6 +853,8 @@ def test_online_features__all_entities_provided(config, deployed_feature_list, s
     client = config.get_client()
     deployment = deployed_feature_list
 
+    # Note that the serving key for the deployment is order_id. The additional entities provided
+    # will not be used.
     entity_serving_names = [
         {
             "üser id": 5,
@@ -901,38 +888,38 @@ def test_online_features__all_entities_provided(config, deployed_feature_list, s
             feat_dict["EXTERNAL_FS_ARRAY_AVG_BY_USER_ID_24h"]
         )
     expected = {
-        "Amount Sum by Customer x Product Action 24d": 254.23000000000002,
-        "Complex Feature by User": "STÀTUS_CODE_37_1",
-        "Current Number of Users With This Status": 1.0,
+        "Amount Sum by Customer x Product Action 24d": None,
+        "Complex Feature by User": None,
+        "Current Number of Users With This Status": None,
         "EXTERNAL_CATEGORY_AMOUNT_SUM_BY_USER_ID_7d": {
-            "__MISSING__": 240.76,
-            "detail": 254.23,
-            "purchase": 216.87,
-            "rëmove": 98.34,
-            "àdd": 146.22,
+            "__MISSING__": 234.77,
+            "detail": 235.24,
+            "purchase": 225.78,
+            "rëmove": 11.39,
+            "àdd": 338.51,
         },
-        "EXTERNAL_FS_AMOUNT_SUM_BY_USER_ID_24h": 683.55,
-        "EXTERNAL_FS_AMOUNT_SUM_BY_USER_ID_24h_TIMES_100": 68355.0,
+        "EXTERNAL_FS_AMOUNT_SUM_BY_USER_ID_24h": 475.3800048828125,
+        "EXTERNAL_FS_AMOUNT_SUM_BY_USER_ID_24h_TIMES_100": 47538.0,
         "EXTERNAL_FS_ARRAY_AVG_BY_USER_ID_24h": [
-            0.6807108071969569,
-            0.41463276624595335,
-            0.4432548634609973,
-            0.6828628340472915,
-            0.5967769997569004,
-            0.5210525989755145,
-            0.4687023396052305,
-            0.35638918237609585,
-            0.42879787416376725,
-            0.548615163058392,
+            0.41825654595626777,
+            0.3459365542614712,
+            0.5725510296687925,
+            0.424307035963231,
+            0.4930920411475925,
+            0.4502761817462119,
+            0.3192654242159094,
+            0.40611594238301874,
+            0.6493784232675229,
+            0.38572185913993623,
         ],
-        "EXTERNAL_FS_COMPLEX_USER_X_PRODUCTION_ACTION_FEATURE": 727.4592974268256,
+        "EXTERNAL_FS_COMPLEX_USER_X_PRODUCTION_ACTION_FEATURE": 476.289306640625,
         "EXTERNAL_FS_COSINE_SIMILARITY": 0.0,
-        "EXTERNAL_FS_COSINE_SIMILARITY_VEC": 0.8578220571057548,
-        "EXTERNAL_FS_COUNT_BY_PRODUCT_ACTION_7d": 43.0,
-        "EXTERNAL_FS_COUNT_OVERALL_7d": 149.0,
+        "EXTERNAL_FS_COSINE_SIMILARITY_VEC": 0.895897626876831,
+        "EXTERNAL_FS_COUNT_BY_PRODUCT_ACTION_7d": None,
+        "EXTERNAL_FS_COUNT_OVERALL_7d": 149,
         "Most Frequent Item Type by Order": "type_12",
         "PRODUCT_ACTION": "detail",
-        "User Status Feature": "STÀTUS_CODE_37",
+        "User Status Feature": None,
         "cust_id": 761,
         "order_id": "T1230",
         "user_status": "STÀTUS_CODE_37",

--- a/tests/unit/feast/utils/test_registry_construction.py
+++ b/tests/unit/feast/utils/test_registry_construction.py
@@ -10,7 +10,7 @@ from google.protobuf.json_format import MessageToDict
 from featurebyte import FeatureList, RequestColumn
 from featurebyte.common.model_util import get_version
 from featurebyte.feast.utils.registry_construction import FeastRegistryBuilder
-from tests.util.helper import assert_lists_of_dicts_equal, deploy_features_through_api
+from tests.util.helper import assert_lists_of_dicts_equal
 
 
 def test_feast_registry_construction__missing_asset(
@@ -29,6 +29,7 @@ def test_feast_registry_construction__missing_asset(
             features=[float_feature.cached_model],
             feature_lists=[],
             entity_lookup_steps_mapping={},
+            serving_entity_ids=None,
         )
 
     with pytest.raises(ValueError, match="Missing features: "):
@@ -39,11 +40,12 @@ def test_feast_registry_construction__missing_asset(
             features=[],
             feature_lists=[feature_list],
             entity_lookup_steps_mapping={},
+            serving_entity_ids=None,
         )
 
 
 @pytest.mark.asyncio
-async def test_feast_registry_construction__with_post_processing_features(  # pylint: disable=too-many-locals
+async def test_feast_registry_construction__with_post_processing_features(  # pylint: disable=too-many-locals,too-many-arguments
     snowflake_feature_store,
     mysql_online_store,
     cust_id_entity,
@@ -54,6 +56,7 @@ async def test_feast_registry_construction__with_post_processing_features(  # py
     mock_pymysql_connect,
     mock_deployment_flow,
     app_container,
+    expected_cust_id_via_transaction_id_table_name,
 ):
     """Test the construction of the feast register (with post processing features)"""
     _ = mock_deployment_flow
@@ -68,7 +71,8 @@ async def test_feast_registry_construction__with_post_processing_features(  # py
 
     feature_list = FeatureList([feature_requires_post_processing], name="test_feature_list")
     feature_list.save()
-    deploy_features_through_api([feature_requires_post_processing])
+    deployment = feature_list.deploy(make_production_ready=True, ignore_guardrails=True)
+    deployment.enable()
 
     helper_service = app_container.entity_lookup_feature_table_service
     entity_lookup_steps_mapping = await helper_service.get_entity_lookup_steps_mapping(
@@ -81,6 +85,7 @@ async def test_feast_registry_construction__with_post_processing_features(  # py
         features=[feature_requires_post_processing.cached_model],
         feature_lists=[feature_list.cached_model],  # type: ignore
         entity_lookup_steps_mapping=entity_lookup_steps_mapping,
+        serving_entity_ids=feature_list.cached_model.primary_entity_ids,
     )
     feast_registry_dict = MessageToDict(feast_registry_proto)
     on_demand_feature_views = feast_registry_dict["onDemandFeatureViews"]
@@ -91,8 +96,8 @@ async def test_feast_registry_construction__with_post_processing_features(  # py
     assert odfv_spec["features"] == [{"name": f"feature_{get_version()}", "valueType": "FLOAT"}]
     assert odfv_spec["sources"].keys() == {
         "POINT_IN_TIME",
-        "cat1_cust_id_30m",
         "cat1_transaction_id_1d",
+        expected_cust_id_via_transaction_id_table_name,
     }
 
     data_sources = feast_registry_dict["dataSources"]
@@ -177,7 +182,9 @@ def expected_data_sources_fixture(expected_data_source_names):
 
 
 @pytest.fixture(name="expected_feature_view_specs")
-def expected_feature_view_specs_fixture(feature_list):
+def expected_feature_view_specs_fixture(
+    feature_list, expected_cust_id_via_transaction_id_table_name
+):
     """Expected feature view specs"""
     relationship_info_id = feature_list.cached_model.relationships_info[0].id
     common_snowflake_options = {"database": "sf_database", "schema": "sf_schema"}
@@ -245,6 +252,33 @@ def expected_feature_view_specs_fixture(feature_list):
             },
             "entities": ["cust_id"],
             "entityColumns": [{"name": "cust_id", "valueType": "STRING"}],
+            "features": [
+                {"name": "__feature_timestamp", "valueType": "UNIX_TIMESTAMP"},
+                {"name": f"sum_1d_{version}", "valueType": "FLOAT"},
+                {
+                    "name": f"__composite_feature_ttl_req_col_{version}__part0",
+                    "valueType": "UNIX_TIMESTAMP",
+                },
+                {
+                    "name": f"__composite_feature_ttl_req_col_{version}__part1",
+                    "valueType": "FLOAT",
+                },
+            ],
+            "ttl": "3600s",
+        },
+        {
+            **common_params,
+            "name": expected_cust_id_via_transaction_id_table_name,
+            "batchSource": {
+                **common_batch_source,
+                "name": expected_cust_id_via_transaction_id_table_name,
+                "snowflakeOptions": {
+                    **common_snowflake_options,
+                    "table": expected_cust_id_via_transaction_id_table_name,
+                },
+            },
+            "entities": ["transaction_id"],
+            "entityColumns": [{"name": "transaction_id", "valueType": "STRING"}],
             "features": [
                 {"name": "__feature_timestamp", "valueType": "UNIX_TIMESTAMP"},
                 {"name": f"sum_1d_{version}", "valueType": "FLOAT"},

--- a/tests/unit/routes/test_deployment.py
+++ b/tests/unit/routes/test_deployment.py
@@ -140,6 +140,7 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
                     "use_case_id": None,
                     "context_id": None,
                     "registry_info": None,
+                    "serving_entity_ids": ["63f94ed6ea1f050131379214"],
                 },
                 {
                     "_id": response_dict["data"][1]["_id"],
@@ -158,6 +159,7 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
                     "use_case_id": None,
                     "context_id": None,
                     "registry_info": None,
+                    "serving_entity_ids": ["63f94ed6ea1f050131379214"],
                 },
                 {
                     "_id": response_dict["data"][2]["_id"],
@@ -176,6 +178,7 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
                     "use_case_id": None,
                     "context_id": None,
                     "registry_info": None,
+                    "serving_entity_ids": ["63f94ed6ea1f050131379214"],
                 },
             ],
             "page": 1,
@@ -218,6 +221,7 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
                     "use_case_id": None,
                     "user_id": response_dict["data"][0]["user_id"],
                     "registry_info": None,
+                    "serving_entity_ids": ["63f94ed6ea1f050131379214"],
                 }
             ],
             "page": 1,

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -124,7 +124,6 @@ async def deployed_float_feature_list(
     app_container,
     float_feature,
     transaction_entity,
-    cust_id_entity,
     float_feat_deployment_id,
     mock_update_data_warehouse,
     mock_offline_store_feature_manager_dependencies,
@@ -140,7 +139,7 @@ async def deployed_float_feature_list(
         return_type="feature_list",
         deployment_id=float_feat_deployment_id,
     )
-    assert feature_list.enabled_serving_entity_ids == [[transaction_entity.id], [cust_id_entity.id]]
+    assert feature_list.enabled_serving_entity_ids == [[transaction_entity.id]]
     assert mock_offline_store_feature_manager_dependencies["initialize_new_columns"].call_count == 2
     assert mock_offline_store_feature_manager_dependencies["apply_comments"].call_count == 1
     return feature_list

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -385,11 +385,19 @@ def expected_feast_registry_mapping_fixture(
     fl_version = get_version()
     return {
         float_feat_deployment_id: {
-            "feature_views": {"cat1_cust_id_30m", "fb_entity_lookup_{entity_rel_id1}"},
+            "feature_views": {
+                "cat1_cust_id_30m",
+                "cat1_cust_id_30m_via_transaction_id_{expected_suffix}",
+                "fb_entity_lookup_{entity_rel_id1}",
+            },
             "feature_services": {f"sum_1d_list_{fl_version}"},
         },
         float_feat_post_processed_deployment_id: {
-            "feature_views": {"cat1_cust_id_30m", "fb_entity_lookup_{entity_rel_id1}"},
+            "feature_views": {
+                "cat1_cust_id_30m",
+                "cat1_cust_id_30m_via_transaction_id_{expected_suffix}",
+                "fb_entity_lookup_{entity_rel_id1}",
+            },
             "feature_services": {f"sum_1d_plus_123_list_{fl_version}"},
         },
         float_feat_diff_fjs_deployment_id: {
@@ -405,7 +413,11 @@ def expected_feast_registry_mapping_fixture(
             "feature_services": {f"some_lookup_feature_list_{fl_version}"},
         },
         aggregate_asat_deployment_id: {
-            "feature_views": {"cat1_gender_1d", "fb_entity_lookup_{entity_rel_id1}"},
+            "feature_views": {
+                "cat1_gender_1d",
+                "cat1_gender_1d_via_cust_id_{expected_suffix}",
+                "fb_entity_lookup_{entity_rel_id1}",
+            },
             "feature_services": {f"asat_gender_count_list_{fl_version}"},
         },
         complex_feat_deployment_id: {
@@ -605,6 +617,7 @@ async def test_feature_table_one_feature_deployed(
         expected_feast_registry_mapping=expected_feast_registry_mapping,
         enabled_deployment=True,
         entity_rel_id1=transaction_to_customer_relationship_info.id,
+        expected_suffix=expected_suffix,
     )
 
     # check that feature cluster file exists
@@ -740,6 +753,7 @@ async def test_feature_table_two_features_deployed(
             expected_feast_registry_mapping=expected_feast_registry_mapping,
             enabled_deployment=True,
             entity_rel_id1=transaction_to_customer_relationship_info.id,
+            expected_suffix=expected_suffix,
         )
 
 
@@ -848,6 +862,7 @@ async def test_feature_table_undeploy(
             expected_feast_registry_mapping=expected_feast_registry_mapping,
             enabled_deployment=enabled_deployment,
             entity_rel_id1=transaction_to_customer_relationship_info.id,
+            expected_suffix=expected_suffix,
         )
 
     # Check online disabling the last feature deletes the feature table
@@ -874,6 +889,7 @@ async def test_feature_table_undeploy(
             expected_feast_registry_mapping=expected_feast_registry_mapping,
             enabled_deployment=False,
             entity_rel_id1=transaction_to_customer_relationship_info.id,
+            expected_suffix=expected_suffix,
         )
 
 
@@ -1003,6 +1019,7 @@ async def test_feature_table_two_features_different_feature_job_settings_deploye
             expected_feast_registry_mapping=expected_feast_registry_mapping,
             enabled_deployment=True,
             entity_rel_id1=transaction_to_customer_relationship_info.id,
+            expected_suffix=expected_suffix,
         )
 
 
@@ -1196,6 +1213,7 @@ async def test_aggregate_asat_feature(
         expected_feast_registry_mapping=expected_feast_registry_mapping,
         enabled_deployment=True,
         entity_rel_id1=customer_to_gender_relationship_info.id,
+        expected_suffix=expected_suffix,
     )
 
     # check precomputed lookup feature table

--- a/tests/unit/service/test_registry.py
+++ b/tests/unit/service/test_registry.py
@@ -72,7 +72,12 @@ async def test_registry_service__project_name_creation(registry_service_map):
     for (_, catalog_name), registry_service in registry_service_map.items():
         deployment.id = ObjectId()
         catalog = Catalog.get(name=catalog_name)
-        feast_registry = await registry_service.get_or_create_feast_registry(deployment=deployment)
+        with patch(
+            "featurebyte.service.deployment.DeploymentService.get_document", return_value=deployment
+        ):
+            feast_registry = await registry_service.get_or_create_feast_registry(
+                deployment=deployment
+            )
         expected_table_prefix = catalog_name_to_table_prefix[catalog_name]
         existing_catalog_ids.add(catalog.id)
         existing_project_names.add(feast_registry.name)


### PR DESCRIPTION
## Description

This updates online serving service to use precomputed lookup feature tables instead of dynamically looking up parent features.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
