### PR TITLE
[DEV-3230] Fix precomputed lookup feature table universe for ttl features 

### DIFF
--- a/featurebyte/service/feature_materialize.py
+++ b/featurebyte/service/feature_materialize.py
@@ -376,7 +376,9 @@ class FeatureMaterializeService:  # pylint: disable=too-many-instance-attributes
                 column_names=column_names,
                 column_dtypes=column_dtypes,
                 source_feature_table_serving_names=feature_table_model.serving_names,
-                use_last_materialized_timestamp=use_last_materialized_timestamp,
+                use_last_materialized_timestamp=(
+                    use_last_materialized_timestamp and not feature_table_model.has_ttl
+                ),
                 lookup_feature_table=lookup_feature_table,
             )
             result.append((lookup_feature_table, lookup_materialized_features))

--- a/tests/fixtures/feature_materialize/scheduled_materialize_features_precomputed_lookup_ttl.sql
+++ b/tests/fixtures/feature_materialize/scheduled_materialize_features_precomputed_lookup_ttl.sql
@@ -1,0 +1,167 @@
+CREATE TABLE "sf_db"."sf_schema"."TEMP_REQUEST_TABLE_000000000000000000000000" AS
+SELECT DISTINCT
+  "cust_id"
+FROM online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c
+WHERE
+  "AGGREGATION_RESULT_NAME" = '_fb_internal_cust_id_window_w86400_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295';
+
+CREATE OR REPLACE TABLE "sf_db"."sf_schema"."TEMP_REQUEST_TABLE_000000000000000000000000" AS
+SELECT
+  ROW_NUMBER() OVER (ORDER BY 1) AS "__FB_TABLE_ROW_INDEX",
+  *
+FROM "TEMP_REQUEST_TABLE_000000000000000000000000";
+
+CREATE TABLE "sf_db"."sf_schema"."TEMP_FEATURE_TABLE_000000000000000000000000" AS
+WITH ONLINE_REQUEST_TABLE AS (
+  SELECT
+    REQ."cust_id",
+    CAST('2022-01-06 00:00:00' AS TIMESTAMPNTZ) AS POINT_IN_TIME
+  FROM "sf_db"."sf_schema"."TEMP_REQUEST_TABLE_000000000000000000000000" AS REQ
+), _FB_AGGREGATED AS (
+  SELECT
+    REQ."cust_id",
+    REQ."POINT_IN_TIME",
+    "T0"."_fb_internal_cust_id_window_w86400_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295" AS "_fb_internal_cust_id_window_w86400_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295"
+  FROM ONLINE_REQUEST_TABLE AS REQ
+  LEFT JOIN (
+    SELECT
+      "cust_id" AS "cust_id",
+      "_fb_internal_cust_id_window_w86400_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295" AS "_fb_internal_cust_id_window_w86400_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295"
+    FROM (
+      SELECT
+        """cust_id""" AS "cust_id",
+        "'_fb_internal_cust_id_window_w86400_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295'" AS "_fb_internal_cust_id_window_w86400_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295"
+      FROM (
+        SELECT
+          "cust_id",
+          "AGGREGATION_RESULT_NAME",
+          "VALUE"
+        FROM (
+          SELECT
+            R.*
+          FROM (
+            SELECT
+              "AGGREGATION_RESULT_NAME",
+              "LATEST_VERSION"
+            FROM (VALUES
+              ('_fb_internal_cust_id_window_w86400_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295', _fb_internal_cust_id_window_w86400_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295_VERSION_PLACEHOLDER)) AS version_table("AGGREGATION_RESULT_NAME", "LATEST_VERSION")
+          ) AS L
+          INNER JOIN online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c AS R
+            ON R."AGGREGATION_RESULT_NAME" = L."AGGREGATION_RESULT_NAME"
+            AND R."VERSION" = L."LATEST_VERSION"
+        )
+        WHERE
+          "AGGREGATION_RESULT_NAME" IN ('_fb_internal_cust_id_window_w86400_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295')
+      )   PIVOT(  MAX("VALUE") FOR "AGGREGATION_RESULT_NAME" IN ('_fb_internal_cust_id_window_w86400_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295'))
+    )
+  ) AS T0
+    ON REQ."cust_id" = T0."cust_id"
+)
+SELECT
+  AGG."cust_id",
+  CAST("_fb_internal_cust_id_window_w86400_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295" AS DOUBLE) AS "__feature_requiring_parent_serving_ttl_V220101__part0"
+FROM _FB_AGGREGATED AS AGG;
+
+CREATE TABLE "sf_db"."sf_schema"."TEMP_LOOKUP_UNIVERSE_TABLE_000000000000000000000000" AS
+WITH ENTITY_UNIVERSE AS (
+  SELECT
+    CAST('2022-01-06 00:00:00' AS TIMESTAMPNTZ) AS "POINT_IN_TIME",
+    "transaction_id"
+  FROM (
+    SELECT DISTINCT
+      "col_int" AS "transaction_id"
+    FROM (
+      SELECT
+        "col_int" AS "col_int",
+        "col_float" AS "col_float",
+        "col_char" AS "col_char",
+        "col_text" AS "col_text",
+        "col_binary" AS "col_binary",
+        "col_boolean" AS "col_boolean",
+        "event_timestamp" AS "event_timestamp",
+        "created_at" AS "created_at",
+        "cust_id" AS "cust_id"
+      FROM "sf_database"."sf_schema"."sf_table"
+      WHERE
+        "event_timestamp" >= CAST('2022-01-05 00:00:00' AS TIMESTAMPNTZ)
+        AND "event_timestamp" < CAST('2022-01-06 00:00:00' AS TIMESTAMPNTZ)
+    )
+  )
+), JOINED_PARENTS_ENTITY_UNIVERSE AS (
+  SELECT
+    REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
+    REQ."transaction_id" AS "transaction_id",
+    REQ."cust_id" AS "cust_id"
+  FROM (
+    SELECT
+      REQ."POINT_IN_TIME",
+      REQ."transaction_id",
+      CASE
+        WHEN REQ."POINT_IN_TIME" < "T0"."event_timestamp"
+        THEN NULL
+        ELSE "T0"."cust_id"
+      END AS "cust_id"
+    FROM ENTITY_UNIVERSE AS REQ
+    LEFT JOIN (
+      SELECT
+        "transaction_id",
+        ANY_VALUE("cust_id") AS "cust_id",
+        ANY_VALUE("event_timestamp") AS "event_timestamp"
+      FROM (
+        SELECT
+          "col_int" AS "transaction_id",
+          "cust_id" AS "cust_id",
+          "event_timestamp"
+        FROM (
+          SELECT
+            "col_int" AS "col_int",
+            "col_float" AS "col_float",
+            "col_char" AS "col_char",
+            "col_text" AS "col_text",
+            "col_binary" AS "col_binary",
+            "col_boolean" AS "col_boolean",
+            "event_timestamp" AS "event_timestamp",
+            "created_at" AS "created_at",
+            "cust_id" AS "cust_id"
+          FROM "sf_database"."sf_schema"."sf_table"
+        )
+      )
+      GROUP BY
+        "transaction_id"
+    ) AS T0
+      ON REQ."transaction_id" = T0."transaction_id"
+  ) AS REQ
+)
+SELECT
+  "POINT_IN_TIME",
+  "transaction_id",
+  "cust_id"
+FROM JOINED_PARENTS_ENTITY_UNIVERSE;
+
+CREATE TABLE "sf_db"."sf_schema"."TEMP_LOOKUP_FEATURE_TABLE_000000000000000000000000" AS
+SELECT
+  L."transaction_id",
+  R."__feature_requiring_parent_serving_ttl_V220101__part0"
+FROM "TEMP_LOOKUP_UNIVERSE_TABLE_000000000000000000000000" AS L
+LEFT JOIN "TEMP_FEATURE_TABLE_000000000000000000000000" AS R
+  ON L."cust_id" = R."cust_id";
+
+INSERT INTO "cat1_cust_id_30m" (
+  "__feature_timestamp",
+  "cust_id",
+  "__feature_requiring_parent_serving_ttl_V220101__part0"
+) SELECT
+  CAST('2022-01-06T00:00:00' AS TIMESTAMPNTZ) AS "__feature_timestamp",
+  "cust_id",
+  "__feature_requiring_parent_serving_ttl_V220101__part0"
+FROM "TEMP_FEATURE_TABLE_000000000000000000000000";
+
+INSERT INTO "cat1_cust_id_30m_via_transaction_id_000000" (
+  "__feature_timestamp",
+  "transaction_id",
+  "__feature_requiring_parent_serving_ttl_V220101__part0"
+) SELECT
+  CAST('2022-01-06T00:00:00' AS TIMESTAMPNTZ) AS "__feature_timestamp",
+  "transaction_id",
+  "__feature_requiring_parent_serving_ttl_V220101__part0"
+FROM "TEMP_LOOKUP_FEATURE_TABLE_000000000000000000000000";

--- a/tests/fixtures/feature_materialize/scheduled_materialize_features_precomputed_lookup_ttl.sql
+++ b/tests/fixtures/feature_materialize/scheduled_materialize_features_precomputed_lookup_ttl.sql
@@ -83,7 +83,7 @@ WITH ENTITY_UNIVERSE AS (
         "cust_id" AS "cust_id"
       FROM "sf_database"."sf_schema"."sf_table"
       WHERE
-        "event_timestamp" >= CAST('2022-01-05 00:00:00' AS TIMESTAMPNTZ)
+        "event_timestamp" >= CAST('1970-01-01 00:00:00' AS TIMESTAMPNTZ)
         AND "event_timestamp" < CAST('2022-01-06 00:00:00' AS TIMESTAMPNTZ)
     )
   )

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -1169,3 +1169,61 @@ async def deployed_feature_list_requiring_parent_serving_fixture(
     ]
 
     return feature_list
+
+
+@pytest_asyncio.fixture(name="deployed_feature_list_requiring_parent_serving_ttl")
+async def deployed_feature_list_requiring_parent_serving_ttl_fixture(
+    app_container,
+    float_feature,
+    non_time_based_feature,
+    cust_id_entity,
+    transaction_entity,
+    fl_requiring_parent_serving_deployment_id,
+    mock_offline_store_feature_manager_dependencies,
+    mock_update_data_warehouse,
+):
+    """
+    Fixture a deployed feature list that require serving parent features with ttl
+
+    float_feature: customer entity feature (ttl)
+    non_time_based_feature: transaction entity feature (non-ttl)
+
+    Customer is a parent of transaction.
+
+    Primary entity of the combined feature is transaction.
+
+    Combined feature requires serving two feature tables (one transaction, one customer) using
+    transaction as the serving entity.
+    """
+    _ = mock_offline_store_feature_manager_dependencies
+    _ = mock_update_data_warehouse
+
+    new_feature = float_feature + non_time_based_feature
+    new_feature.name = "feature_requiring_parent_serving_ttl"
+    new_feature.save()
+
+    feature_list = await deploy_feature_ids(
+        app_container,
+        feature_list_name="fl_requiring_parent_serving_ttl",
+        feature_ids=[
+            new_feature.id,
+        ],
+        deployment_id=fl_requiring_parent_serving_deployment_id,
+    )
+
+    expected_relationship_info = await get_relationship_info(
+        app_container,
+        child_entity_id=transaction_entity.id,
+        parent_entity_id=cust_id_entity.id,
+    )
+    assert feature_list.features_entity_lookup_info == [
+        FeatureEntityLookupInfo(
+            feature_id=new_feature.id,
+            feature_list_to_feature_primary_entity_join_steps=[],
+            feature_internal_entity_join_steps=[
+                EntityRelationshipInfo(**expected_relationship_info.dict(by_alias=True))
+            ],
+        ),
+    ]
+
+    return feature_list

--- a/tests/unit/service/test_feature_materialize.py
+++ b/tests/unit/service/test_feature_materialize.py
@@ -236,7 +236,7 @@ async def offline_store_feature_table_with_precomputed_lookup_fixture(
 
 
 @pytest_asyncio.fixture(name="offline_store_feature_table_with_precomputed_lookup_ttl")
-async def offline_store_feature_table_with_precomputed_lookup_fixture(
+async def offline_store_feature_table_with_precomputed_lookup_ttl_fixture(
     app_container,
     deployed_feature_list_requiring_parent_serving_ttl,
     cust_id_entity,
@@ -245,12 +245,6 @@ async def offline_store_feature_table_with_precomputed_lookup_fixture(
     Fixture for offline store feature table that requires precomputed lookup (this returns the
     source feature table)
     """
-    models = []
-    async for model in app_container.offline_store_feature_table_service.list_documents_iterator(
-        query_filter={}
-    ):
-        models.append(model)
-
     _ = deployed_feature_list_requiring_parent_serving_ttl
     async for model in app_container.offline_store_feature_table_service.list_documents_iterator(
         query_filter={"primary_entity_ids": cust_id_entity.id}


### PR DESCRIPTION
## Description

This fixes the precomputed lookup feature table entity universe for ttl features. Without this, the features are precomputed for only new entities between feature materialization intervals, but this should be done for all entities regardless of the intervals for ttl features.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
