### PR TITLE
[chore] Fix deployment's sample entity serving names

### DIFF
--- a/featurebyte/routes/deployment/controller.py
+++ b/featurebyte/routes/deployment/controller.py
@@ -51,7 +51,7 @@ from featurebyte.service.online_serving import OnlineServingService
 from featurebyte.service.use_case import UseCaseService
 
 
-class DeploymentController(
+class DeploymentController(  # pylint: disable=too-many-instance-attributes, too-many-arguments
     BaseDocumentController[DeploymentModel, DeploymentService, DeploymentList]
 ):
     """
@@ -337,11 +337,13 @@ class DeploymentController(
             Sample entity serving names
         """
         deployment: DeploymentModel = await self.service.get_document(deployment_id)
-        entity_serving_names = (
-            await self.entity_serving_names_service.get_sample_entity_serving_names(
-                entity_ids=deployment.serving_entity_ids, table_ids=None, count=count
+        entity_serving_names = []
+        if deployment.serving_entity_ids:
+            entity_serving_names = (
+                await self.entity_serving_names_service.get_sample_entity_serving_names(
+                    entity_ids=deployment.serving_entity_ids, table_ids=None, count=count
+                )
             )
-        )
         return SampleEntityServingNames(entity_serving_names=entity_serving_names)
 
 

--- a/featurebyte/routes/deployment/controller.py
+++ b/featurebyte/routes/deployment/controller.py
@@ -44,6 +44,7 @@ from featurebyte.service.batch_feature_table import BatchFeatureTableService
 from featurebyte.service.catalog import AllCatalogService, CatalogService
 from featurebyte.service.context import ContextService
 from featurebyte.service.deployment import AllDeploymentService, DeploymentService
+from featurebyte.service.entity_serving_names import EntityServingNamesService
 from featurebyte.service.feature_list import AllFeatureListService, FeatureListService
 from featurebyte.service.mixin import DEFAULT_PAGE_SIZE
 from featurebyte.service.online_serving import OnlineServingService
@@ -70,6 +71,7 @@ class DeploymentController(
         use_case_service: UseCaseService,
         batch_feature_table_service: BatchFeatureTableService,
         feast_feature_store_service: FeastFeatureStoreService,
+        entity_serving_names_service: EntityServingNamesService,
     ):
         super().__init__(deployment_service)
         self.catalog_service = catalog_service
@@ -80,6 +82,7 @@ class DeploymentController(
         self.use_case_service = use_case_service
         self.batch_feature_table_service = batch_feature_table_service
         self.feast_feature_store_service = feast_feature_store_service
+        self.entity_serving_names_service = entity_serving_names_service
 
     async def create_deployment(self, data: DeploymentCreate) -> Task:
         """
@@ -334,8 +337,10 @@ class DeploymentController(
             Sample entity serving names
         """
         deployment: DeploymentModel = await self.service.get_document(deployment_id)
-        entity_serving_names = await self.feature_list_service.get_sample_entity_serving_names(
-            feature_list_id=deployment.feature_list_id, count=count
+        entity_serving_names = (
+            await self.entity_serving_names_service.get_sample_entity_serving_names(
+                entity_ids=deployment.serving_entity_ids, table_ids=None, count=count
+            )
         )
         return SampleEntityServingNames(entity_serving_names=entity_serving_names)
 

--- a/featurebyte/service/entity_serving_names.py
+++ b/featurebyte/service/entity_serving_names.py
@@ -75,7 +75,7 @@ class EntityServingNamesService:
         return unique_values
 
     async def get_sample_entity_serving_names(  # pylint: disable=too-many-locals
-        self, entity_ids: Sequence[ObjectId], table_ids: Sequence[ObjectId], count: int
+        self, entity_ids: Sequence[ObjectId], table_ids: Optional[Sequence[ObjectId]], count: int
     ) -> List[Dict[str, str]]:
         """
         Get sample entity serving names for a list of entities and tables
@@ -84,7 +84,7 @@ class EntityServingNamesService:
         ----------
         entity_ids: Sequence[ObjectId]
             List of entity ids
-        table_ids: Sequence[ObjectId]
+        table_ids: Optional[Sequence[ObjectId]]
             List of table ids
         count: int
             Number of sample entity serving names to return
@@ -104,6 +104,14 @@ class EntityServingNamesService:
         entities: Dict[ObjectId, Dict[str, List[str]]] = {
             entity.id: {"serving_name": entity.serving_names} for entity in primary_entity
         }
+        if table_ids is None:
+            table_ids = []
+            for entity in primary_entity:
+                if entity.primary_table_ids:
+                    table_ids.append(entity.primary_table_ids[0])
+                else:
+                    table_ids.append(entity.table_ids[0])
+
         tables = self.table_service.list_documents_iterator(
             query_filter={"_id": {"$in": table_ids}}
         )


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
Update deployment's sample entity serving names logic to rely on `serving_entity_ids` but not feature list's primary entity ids.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
