### PR TITLE
[DEV-3331] Fix feast get online features error for composite entities

### DIFF
--- a/featurebyte/service/online_serving.py
+++ b/featurebyte/service/online_serving.py
@@ -307,8 +307,8 @@ class OnlineServingService:  # pylint: disable=too-many-instance-attributes
         # Get required serving names and composite serving names that need further processing
         offline_store_table_docs = (
             await self.offline_store_feature_table_service.list_documents_as_dict(
-                query_filter={"feature_ids": {"$in": list(feature_id_to_versioned_name.keys())}},
-                project_name={"serving_names"},
+                query_filter={},
+                projection={"serving_names": 1},
             )
         )
         composite_serving_names = set()

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -1246,7 +1246,7 @@ async def deployed_feature_list_requiring_parent_serving_ttl_fixture(
 
 
 @pytest_asyncio.fixture(name="deployed_feature_list_requiring_parent_serving_composite_entity")
-async def deployed_feature_list_requiring_parent_serving_composite_entity_fixture(
+async def deployed_feature_list_requiring_parent_serving_composite_entity_fixture(  # pylint: disable=too-many-arguments
     app_container,
     descendant_of_gender_feature,
     aggregate_asat_composite_entity_feature,

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -1269,8 +1269,9 @@ async def deployed_feature_list_requiring_parent_serving_composite_entity_fixtur
 
     Primary entity of the combined feature is group X another_entity.
 
-    Combined feature requires serving two feature tables (1. customer, 2. gender X another_entity
-    via group X another_entity) using group X another_entity as the serving entity.
+    Combined feature requires serving two feature tables (1. group entity, 2. gender entity X
+    another_entity via group X another_entity) using group entity X another_entity as the serving
+    entity.
     """
     _ = mock_offline_store_feature_manager_dependencies
     _ = mock_update_data_warehouse

--- a/tests/unit/service/test_online_serving_feast.py
+++ b/tests/unit/service/test_online_serving_feast.py
@@ -214,3 +214,37 @@ async def test_feature_requiring_parent_serving(
             }
         ]
     }
+
+
+@pytest.mark.asyncio
+async def test_feature_requiring_parent_serving_composite_entity(
+    app_container,
+    online_serving_service,
+    deployed_feature_list_requiring_parent_serving_composite_entity,
+    fl_requiring_parent_serving_deployment_id,
+):
+    """
+    Test online serving feast with feature requiring parent serving
+    """
+    feast_feature_store = await get_feast_feature_store(
+        app_container, fl_requiring_parent_serving_deployment_id
+    )
+    request_data = [{"another_key": "a", "group_key": "b"}]
+    deployment = await get_deployment_from_feature_list(
+        app_container, deployed_feature_list_requiring_parent_serving_composite_entity.id
+    )
+    result = await online_serving_service.get_online_features_by_feast(
+        deployed_feature_list_requiring_parent_serving_composite_entity,
+        deployment,
+        feast_feature_store,
+        request_data,
+    )
+    assert result.dict() == {
+        "features": [
+            {
+                "another_key": "a",
+                "group_key": "b",
+                "feature_requiring_parent_serving": None,
+            }
+        ]
+    }


### PR DESCRIPTION
## Description

This fixes a ValueError that is raised by feast get_online_features method in some cases. The error is triggered when a feature uses a feature table with composite entity that undergoes precomputed entity lookup (e.g. state x product to customer x product, where state is a parent of customer). 

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
