### PR TITLE
[DEV-3232] Make online disable handling more robust to unexpected failures

### DIFF
--- a/featurebyte/service/feature.py
+++ b/featurebyte/service/feature.py
@@ -372,3 +372,19 @@ class FeatureService(BaseFeatureService[FeatureModel, FeatureServiceCreate]):
             table_ids=feature.table_ids,
             count=count,
         )
+
+    async def get_online_disabled_feature_ids(self) -> List[ObjectId]:
+        """
+        Get the ids of the features that are online disabled
+
+        Returns
+        -------
+        List[ObjectId]
+        """
+        disabled_feature_ids = []
+        async for doc in self.list_documents_as_dict_iterator(
+            query_filter={"online_enabled": False},
+            projection={"_id": 1},
+        ):
+            disabled_feature_ids.append(doc["_id"])
+        return disabled_feature_ids

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -1265,7 +1265,7 @@ async def deployed_feature_list_requiring_parent_serving_composite_entity_fixtur
     descendant_of_gender_feature: group entity feature (non-ttl)
     aggregate_asat_composite_entity_feature: gender X another_entity feature (non-ttl)
 
-    Group is a parent of gender.
+    Gender is a parent of Group.
 
     Primary entity of the combined feature is group X another_entity.
 


### PR DESCRIPTION
## Description

This updates the online disable handling for offline feature store tables to be more robust to unexpected / previous errors. 

Changes:

1. When updating offline store feature table documents, obtain the most up to date features that should have been offline disabled, instead of just the current list of features to be disabled. This way it can correct the states if a previous online disabling action failed unexpectedly.

2. When cleaning up offline store feature tables in the data warehouse, handle and log unexpected errors to allow the disabling process to continue instead of being terminated.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
