### PR TITLE
[chore] Save debug info for troubleshooting on entity universe creation failure 

### DIFF
--- a/featurebyte/models/entity_universe.py
+++ b/featurebyte/models/entity_universe.py
@@ -427,7 +427,7 @@ def apply_join_steps(universe_expr: Expression, join_steps: List[EntityLookupSte
 def get_combined_universe(
     entity_universe_params: List[EntityUniverseParams],
     source_type: SourceType,
-) -> Expression:
+) -> Optional[Expression]:
     """
     Returns the combined entity universe expression
 
@@ -440,7 +440,7 @@ def get_combined_universe(
 
     Returns
     -------
-    Expression
+    Optional[Expression]
     """
     combined_universe_expr: Optional[Expression] = None
     processed_universe_exprs = set()
@@ -476,7 +476,6 @@ def get_combined_universe(
         # ignored.
         combined_universe_expr = DUMMY_ENTITY_UNIVERSE
 
-    assert combined_universe_expr is not None
     return combined_universe_expr
 
 

--- a/featurebyte/service/deploy.py
+++ b/featurebyte/service/deploy.py
@@ -672,9 +672,7 @@ class FeastIntegrationService:
 
         feature_table_map = {}
         feat_table_service = self.offline_store_feature_table_service
-        async for (
-            source_table
-        ) in feat_table_service.list_source_lookup_feature_tables_for_deployment(
+        async for source_table in feat_table_service.list_source_feature_tables_for_deployment(
             deployment_id=deployment.id
         ):
             if serving_names:

--- a/featurebyte/service/offline_store_feature_table.py
+++ b/featurebyte/service/offline_store_feature_table.py
@@ -4,7 +4,7 @@ OfflineStoreFeatureTableService class
 
 from __future__ import annotations
 
-from typing import Any, AsyncIterator, Dict, Optional
+from typing import Any, AsyncIterator, Dict, List, Optional
 
 from datetime import datetime
 from pathlib import Path
@@ -302,11 +302,11 @@ class OfflineStoreFeatureTableService(
         ):
             yield doc
 
-    async def list_source_lookup_feature_tables_for_deployment(
+    async def list_source_feature_tables_for_deployment(
         self, deployment_id: ObjectId
     ) -> AsyncIterator[OfflineStoreFeatureTableModel]:
         """
-        Retrieve list of source lookup feature tables in the catalog
+        Retrieve list of source feature tables in the catalog
 
         Parameters
         ----------

--- a/featurebyte/service/offline_store_feature_table.py
+++ b/featurebyte/service/offline_store_feature_table.py
@@ -4,7 +4,7 @@ OfflineStoreFeatureTableService class
 
 from __future__ import annotations
 
-from typing import Any, AsyncIterator, Dict, List, Optional
+from typing import Any, AsyncIterator, Dict, Optional
 
 from datetime import datetime
 from pathlib import Path

--- a/featurebyte/service/offline_store_feature_table_construction.py
+++ b/featurebyte/service/offline_store_feature_table_construction.py
@@ -153,6 +153,11 @@ class OfflineStoreFeatureTableConstructionService:
         Returns
         -------
         OfflineStoreFeatureTableModel
+
+        Raises
+        ------
+        AssertionError
+            If the entity universe cannot be determined
         """
         ingest_graph_metadata = get_combined_ingest_graph(
             features=features,

--- a/featurebyte/service/offline_store_feature_table_manager.py
+++ b/featurebyte/service/offline_store_feature_table_manager.py
@@ -307,16 +307,22 @@ class OfflineStoreFeatureTableManagerService:  # pylint: disable=too-many-instan
         feature_ids_to_remove = await self.feature_service.get_online_disabled_feature_ids()
         feature_table_data = await self.offline_store_feature_table_service.list_documents_as_dict(
             query_filter={
-                "$or": [
-                    {"feature_ids": {"$in": list(feature_ids_to_remove)}},
-                    {"feature_ids": {"$size": 0}},
-                ],
-                # Filter out precomputed lookup feature tables since those always have empty
-                # feature_ids
-                "$or": [
-                    {"precomputed_lookup_feature_table_info": None},
-                    {"precomputed_lookup_feature_table_info": {"$exists": False}},
-                ],
+                "$and": [
+                    {
+                        "$or": [
+                            {"feature_ids": {"$in": list(feature_ids_to_remove)}},
+                            {"feature_ids": {"$size": 0}},
+                        ]
+                    },
+                    {
+                        # Filter out precomputed lookup feature tables since those always have empty
+                        # feature_ids
+                        "$or": [
+                            {"precomputed_lookup_feature_table_info": None},
+                            {"precomputed_lookup_feature_table_info": {"$exists": False}},
+                        ],
+                    },
+                ]
             },
         )
         feature_lists = await self._get_online_enabled_feature_lists(

--- a/featurebyte/service/offline_store_feature_table_manager.py
+++ b/featurebyte/service/offline_store_feature_table_manager.py
@@ -306,7 +306,13 @@ class OfflineStoreFeatureTableManagerService:  # pylint: disable=too-many-instan
 
         feature_ids_to_remove = await self.feature_service.get_online_disabled_feature_ids()
         feature_table_data = await self.offline_store_feature_table_service.list_documents_as_dict(
-            query_filter={"feature_ids": {"$in": list(feature_ids_to_remove)}},
+            query_filter={
+                "$or": [
+                    {"feature_ids": {"$in": list(feature_ids_to_remove)}},
+                    {"feature_ids": {"$size": 0}},
+                ],
+                "precomputed_lookup_feature_table_info": None,
+            },
         )
         feature_lists = await self._get_online_enabled_feature_lists(
             feature_list_to_online_disable=feature_list_to_online_disable

--- a/featurebyte/service/offline_store_feature_table_manager.py
+++ b/featurebyte/service/offline_store_feature_table_manager.py
@@ -311,7 +311,12 @@ class OfflineStoreFeatureTableManagerService:  # pylint: disable=too-many-instan
                     {"feature_ids": {"$in": list(feature_ids_to_remove)}},
                     {"feature_ids": {"$size": 0}},
                 ],
-                "precomputed_lookup_feature_table_info": None,
+                # Filter out precomputed lookup feature tables since those always have empty
+                # feature_ids
+                "$or": [
+                    {"precomputed_lookup_feature_table_info": None},
+                    {"precomputed_lookup_feature_table_info": {"$exists": False}},
+                ],
             },
         )
         feature_lists = await self._get_online_enabled_feature_lists(

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -1551,7 +1551,7 @@ async def test_deployment_failure_cleanup(
 
 
 @pytest.mark.asyncio
-async def test_entity_universe_dump(
+async def test_entity_universe_debug_info_dump(
     app_container,
     float_feature,
     transaction_entity,
@@ -1566,6 +1566,7 @@ async def test_entity_universe_dump(
     Test entity universe dump during deployment error for troubleshooting
     """
     _ = mock_update_data_warehouse
+    _ = mock_offline_store_feature_manager_dependencies
 
     with patch(
         "featurebyte.service.offline_store_feature_table_construction.get_combined_universe",

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -1583,9 +1583,11 @@ async def test_entity_universe_dump(
 
     # Check ingest graphs dump for troubleshooting
     feature_table_name = "cat1_cust_id_30m"
-    path = f"catalog/{app_container.catalog_id}/offline_store_feature_table/{feature_table_name}/offline_ingest_graphs.pickle"
-    ingest_graphs_dump_bytes = await storage.get_bytes(path)
-    ingest_graphs_dump = pickle.loads(ingest_graphs_dump_bytes)
+    path = f"catalog/{app_container.catalog_id}/offline_store_feature_table/{feature_table_name}/entity_universe_debug_info.pickle"
+    debug_info_bytes = await storage.get_bytes(path)
+    debug_info = pickle.loads(debug_info_bytes)
+    assert isinstance(debug_info, dict)
+    ingest_graphs_dump = debug_info["offline_ingest_graphs"]
     assert len(ingest_graphs_dump) == 1
     assert isinstance(ingest_graphs_dump[0][0], OfflineStoreIngestQueryGraph)
 

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -2,10 +2,12 @@
 Tests for OfflineStoreFeatureTableManagerService
 """
 
-# pylint: disable=too-many-lines,too-many-arguments,too-many-locals
 from typing import Dict
 
 import os
+
+# pylint: disable=too-many-lines,too-many-arguments,too-many-locals
+import pickle
 from unittest.mock import patch
 
 import pytest
@@ -16,6 +18,7 @@ from featurebyte.common.model_util import get_version
 from featurebyte.exception import DocumentCreationError
 from featurebyte.models.feature import FeatureModel
 from featurebyte.models.offline_store_feature_table import OfflineStoreFeatureTableModel
+from featurebyte.models.offline_store_ingest_query import OfflineStoreIngestQueryGraph
 from featurebyte.models.precomputed_lookup_feature_table import get_lookup_steps_unique_identifier
 from featurebyte.models.relationship import RelationshipType
 from featurebyte.query_graph.model.entity_relationship_info import EntityRelationshipInfo
@@ -1539,6 +1542,52 @@ async def test_deployment_failure_cleanup(
             deployment_id=float_feat_deployment_id,
         )
     assert str(exc_info.value) == "Failed to create deployment"
+
+    # Check that feature tables and tasks are cleaned up
+    feature_tables = await get_all_feature_tables(document_service)
+    scheduled_tasks = await get_all_scheduled_tasks(periodic_task_service)
+    assert not list(feature_tables.keys())
+    assert not list(scheduled_tasks.keys())
+
+
+@pytest.mark.asyncio
+async def test_entity_universe_dump(
+    app_container,
+    float_feature,
+    transaction_entity,
+    float_feat_deployment_id,
+    mock_update_data_warehouse,
+    mock_offline_store_feature_manager_dependencies,
+    document_service,
+    periodic_task_service,
+    storage,
+):
+    """
+    Test entity universe dump during deployment error for troubleshooting
+    """
+    _ = mock_update_data_warehouse
+
+    with patch(
+        "featurebyte.service.offline_store_feature_table_construction.get_combined_universe",
+        return_value=None,
+    ):
+        with pytest.raises(DocumentCreationError) as exc_info:
+            await deploy_feature(
+                app_container,
+                float_feature,
+                context_primary_entity_ids=[transaction_entity.id],
+                return_type="feature_list",
+                deployment_id=float_feat_deployment_id,
+            )
+    assert str(exc_info.value) == "Failed to create deployment"
+
+    # Check ingest graphs dump for troubleshooting
+    feature_table_name = "cat1_cust_id_30m"
+    path = f"catalog/{app_container.catalog_id}/offline_store_feature_table/{feature_table_name}/offline_ingest_graphs.pickle"
+    ingest_graphs_dump_bytes = await storage.get_bytes(path)
+    ingest_graphs_dump = pickle.loads(ingest_graphs_dump_bytes)
+    assert len(ingest_graphs_dump) == 1
+    assert isinstance(ingest_graphs_dump[0][0], OfflineStoreIngestQueryGraph)
 
     # Check that feature tables and tasks are cleaned up
     feature_tables = await get_all_feature_tables(document_service)


### PR DESCRIPTION
## Description

This adds saving of debug info for troubleshooting on entity universe creation failure. The deployment disabling logic is also updated to remove feature tables that do not have any associated feature ids (likely a result of failed deployment).

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
