### PR TITLE
[DEV-3365] Backfill only required tiles for offline store tables on deploying

### DIFF
--- a/.changelog/DEV-3365.yaml
+++ b/.changelog/DEV-3365.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Backfill only required tiles for offline store tables when enabling a deployment"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/feature_manager/model.py
+++ b/featurebyte/feature_manager/model.py
@@ -57,6 +57,7 @@ class ExtendedFeatureModel(FeatureModel):
                 parent_column_name=info.parent,
                 category_column_name=info.value_by_column,
                 feature_store_id=self.tabular_source.feature_store_id,
+                windows=info.windows,
             )
             out.append(tile_spec)
         return out

--- a/featurebyte/models/tile.py
+++ b/featurebyte/models/tile.py
@@ -64,6 +64,7 @@ class TileSpec(FeatureByteBaseModel):
     category_column_name: Optional[str]
     feature_store_id: Optional[ObjectId]
     entity_tracker_table_name: str
+    windows: List[Optional[str]]
 
     class Config:
         """

--- a/featurebyte/models/tile_registry.py
+++ b/featurebyte/models/tile_registry.py
@@ -44,6 +44,16 @@ class LastRunMetadata(BaseModel):
     index: int
 
 
+class BackfillMetadata(BaseModel):
+    """
+    BackfillMetadata class
+
+    Metadata of the tile backfill process when enabling a deployment
+    """
+
+    start_date: datetime
+
+
 class TileModel(FeatureByteCatalogBaseDocumentModel):
     """
     TileModel document
@@ -64,6 +74,7 @@ class TileModel(FeatureByteCatalogBaseDocumentModel):
 
     last_run_metadata_online: Optional[LastRunMetadata]
     last_run_metadata_offline: Optional[LastRunMetadata]
+    backfill_metadata: Optional[BackfillMetadata]
 
     class Settings(FeatureByteCatalogBaseDocumentModel.Settings):
         """
@@ -102,3 +113,4 @@ class TileUpdate(BaseDocumentServiceUpdateSchema):
 
     last_run_metadata_online: Optional[LastRunMetadata]
     last_run_metadata_offline: Optional[LastRunMetadata]
+    backfill_metadata: Optional[BackfillMetadata]

--- a/featurebyte/service/feature_manager.py
+++ b/featurebyte/service/feature_manager.py
@@ -243,11 +243,10 @@ class FeatureManagerService:
         """
         Backfill tiles required to populate internal online store
 
-        This will determine the start and end tile timestamps based on the recorded backfill start
-        date (tiles are already available back to this date due to previous backfills) and latest
-        scheduled task's computed tiles.
-
-        Example:
+        This will determine the tiles that need to be backfilled using information stored in the
+        tile registry collection. Tiles between backfill_start_date and last_run_tile_end_date can
+        be assumed to be available because of previous backfills and on going scheduled tile tasks.
+        See an example below.
 
         Feature: Amount Sum over 48 hours
 
@@ -263,11 +262,11 @@ class FeatureManagerService:
 
         Notes:
 
-        * start_ts: start timestamp of the tile that needs to be computed. This is determined by
+        * start_ts: start timestamp of the tiles that need to be computed. This is determined by
           end_ts and the largest feature derivation window of the feature.
 
-        * end_ts: to the end timestamp of the tile that needs to be computed. This is determined by
-          the feature job settings and the deployment time.
+        * end_ts: end timestamp of the tiles that need to be computed. This is determined by the
+          feature job settings and the deployment time.
 
         * backfill_start_date: start timestamp of the tile that was last backfilled. This is updated
           by tile backfill process during deployment.

--- a/featurebyte/service/feature_manager.py
+++ b/featurebyte/service/feature_manager.py
@@ -32,6 +32,35 @@ from featurebyte.session.databricks_unity import DatabricksUnitySession
 logger = get_logger(__name__)
 
 
+def get_previous_job_datetime(
+    input_dt: datetime, frequency_minutes: int, time_modulo_frequency_seconds: int
+) -> datetime:
+    """
+    Calculate the expected current job datetime give input datetime, frequency_minutes and
+    time_modulo_frequency_seconds.
+
+    Parameters
+    ----------
+    input_dt: datetime
+        input datetime
+    frequency_minutes: int
+        frequency in minutes
+    time_modulo_frequency_seconds: int
+        time_modulo_frequency in seconds
+
+    Returns
+    -------
+    datetime
+    """
+    next_job_time = get_next_job_datetime(
+        input_dt=input_dt,
+        frequency_minutes=frequency_minutes,
+        time_modulo_frequency_seconds=time_modulo_frequency_seconds,
+    )
+    previous_job_time = next_job_time - timedelta(minutes=frequency_minutes)
+    return previous_job_time
+
+
 class FeatureManagerService:
     """
     FeatureManagerService is responsible for orchestrating the materialization of features and tiles
@@ -118,14 +147,10 @@ class FeatureManagerService:
             aggregation_id_to_tile_spec[tile_spec.aggregation_id] = tile_spec
             tile_job_exists = await self.tile_manager_service.tile_job_exists(tile_spec=tile_spec)
             if not tile_job_exists:
-                # generate historical tiles
-                await self._generate_historical_tiles(session=session, tile_spec=tile_spec)
                 tile_specs_to_be_scheduled.append(tile_spec)
-
-            elif is_recreating_schema:
-                # if this is called when recreating the schema, we cannot assume that the historical
-                # tiles are available even if there is an active tile jobs.
-                await self._generate_historical_tiles(session=session, tile_spec=tile_spec)
+            await self._backfill_tiles(
+                session=session, tile_spec=tile_spec, schedule_time=schedule_time
+            )
 
         # populate feature store. if this is called when recreating the schema, we need to run all
         # the online store compute queries since the tables need to be regenerated.
@@ -202,46 +227,158 @@ class FeatureManagerService:
         schedule_time: datetime,
         aggregation_result_name: str,
     ) -> None:
-        next_job_time = get_next_job_datetime(
+        job_schedule_ts = get_previous_job_datetime(
             input_dt=schedule_time,
             frequency_minutes=tile_spec.frequency_minute,
             time_modulo_frequency_seconds=tile_spec.time_modulo_frequency_second,
         )
-        job_schedule_ts = next_job_time - timedelta(minutes=tile_spec.frequency_minute)
         job_schedule_ts_str = job_schedule_ts.strftime("%Y-%m-%d %H:%M:%S")
         await self.tile_manager_service.populate_feature_store(
             session, tile_spec, job_schedule_ts_str, aggregation_result_name
         )
 
-    async def _generate_historical_tiles(self, session: BaseSession, tile_spec: TileSpec) -> None:
-        # generate historical tile_values
-        date_format = "%Y-%m-%dT%H:%M:%S.%fZ"
+    async def _backfill_tiles(
+        self, session: BaseSession, tile_spec: TileSpec, schedule_time: datetime
+    ) -> None:
+        """
+        Backfill tiles required to populate internal online store
 
-        # derive the latest tile_start_date
-        end_ind = date_util.timestamp_utc_to_tile_index(
-            datetime.utcnow(),
-            tile_spec.time_modulo_frequency_second,
-            tile_spec.blind_spot_second,
-            tile_spec.frequency_minute,
-        )
-        end_ts = date_util.tile_index_to_timestamp_utc(
-            end_ind,
-            tile_spec.time_modulo_frequency_second,
-            tile_spec.blind_spot_second,
-            tile_spec.frequency_minute,
-        )
-        end_ts_str = end_ts.strftime(date_format)
+        This will determine the start and end tile timestamps based on the recorded backfill start
+        date (tiles are already available back to this date due to previous backfills) and latest
+        scheduled task's computed tiles.
 
-        start_ts = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        Example:
+
+        Feature: Amount Sum over 48 hours
+
+                 <-------------------------------- 48h ------------------------------->
+                                            (tiles available)
+                                      # # # # # # # # # # # # # # #
+        ---------|-------------------|----------------------------|-------------------|--> (time)
+                 ^                   ^                            ^                   ^
+             start_ts        backfill_start_date      last_run_tile_end_date       end_ts
+                 <------------------->                            <------------------->
+                    required compute                                 required compute
+           (start_ts_1)        (end_ts_1)                 (start_ts_2)           (end_ts_2)
+
+        Notes:
+
+        * start_ts: start timestamp of the tile that needs to be computed. This is determined by
+          end_ts and the largest feature derivation window of the feature.
+
+        * end_ts: to the end timestamp of the tile that needs to be computed. This is determined by
+          the feature job settings and the deployment time.
+
+        * backfill_start_date: start timestamp of the tile that was last backfilled. This is updated
+          by tile backfill process during deployment.
+
+        * last_run_tile_end_date: end timestamp of the tile that was last computed in the scheduled
+          tile task. This is updated by scheduled tile task regularly.
+
+        Parameters
+        ----------
+        session: BaseSession
+            Instance of BaseSession to interact with the data warehouse
+        tile_spec: TileSpec
+            Instance of TileSpec
+        schedule_time: datetime
+            The moment of enabling the feature
+        """
+        # Derive the tile end date based on expected previous job time
+        job_schedule_ts = get_previous_job_datetime(
+            input_dt=schedule_time,
+            frequency_minutes=tile_spec.frequency_minute,
+            time_modulo_frequency_seconds=tile_spec.time_modulo_frequency_second,
+        )
+        end_ts = job_schedule_ts - timedelta(seconds=tile_spec.blind_spot_second)
+
+        # Determine the earliest tiles required to compute the features for offline store. This is
+        # determined by the largest feature derivation window.
+        max_window_seconds: Optional[int] = None
+        for window in tile_spec.windows:
+            if window is None:
+                max_window_seconds = None
+                break
+            window_seconds = int(pd.Timedelta(window).total_seconds())
+            if max_window_seconds is None or window_seconds > max_window_seconds:
+                max_window_seconds = window_seconds
+
+        if max_window_seconds is None:
+            # Need to backfill all the way back for features without a bounded window
+            start_ts = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        else:
+            # For features with a bounded window, backfill only the required tiles
+            start_ts = end_ts - timedelta(seconds=max_window_seconds)
+
+        start_ts_1: Optional[datetime] = None
+        end_ts_1: Optional[datetime] = None
+        start_ts_2: Optional[datetime] = None
+        end_ts_2: Optional[datetime] = None
 
         tile_model = await self.tile_registry_service.get_tile_model(
             tile_spec.tile_id, tile_spec.aggregation_id
         )
-        if tile_model is not None and tile_model.last_run_metadata_offline is not None:
-            start_ts = tile_model.last_run_metadata_offline.tile_end_date
+        if tile_model is not None and tile_model.backfill_metadata is not None:
+            if start_ts.replace(tzinfo=None) < tile_model.backfill_metadata.start_date:
+                # Need to compute tiles up to previous backfill start date
+                start_ts_1 = start_ts
+                end_ts_1 = tile_model.backfill_metadata.start_date
+            if tile_model.last_run_metadata_offline is None:
+                # Note: unlikely to happen as there should already be a tile job running, but we
+                # still need to handle this case in case of bad state / error
+                start_ts_2 = tile_model.backfill_metadata.start_date
+                end_ts_2 = end_ts
+            elif tile_model.last_run_metadata_offline.tile_end_date < end_ts.replace(tzinfo=None):
+                # Need to compute tiles from last run tile end date to end_ts
+                start_ts_2 = tile_model.last_run_metadata_offline.tile_end_date
+                end_ts_2 = end_ts
+            to_init_backfill_metadata = False
+        else:
+            # Need to compute tiles up to end_ts
+            start_ts_2 = start_ts
+            end_ts_2 = end_ts
+            to_init_backfill_metadata = True
 
-        logger.info(f"start_ts: {start_ts}")
+        logger.info(
+            "Determined tile start and end timestamps for online enabling",
+            extra={
+                "start_ts_1": str(start_ts_1),
+                "end_ts_1": str(end_ts_1),
+                "start_ts_2": str(start_ts_2),
+                "end_ts_2": str(end_ts_2),
+            },
+        )
 
+        if start_ts_1 is not None and end_ts_1 is not None:
+            await self._backfill_tiles_with_start_end(
+                session=session,
+                tile_spec=tile_spec,
+                start_ts=start_ts_1,
+                end_ts=end_ts_1,
+                update_last_run_metadata=False,
+                update_backfill_start_date=True,
+            )
+
+        if start_ts_2 is not None and end_ts_2 is not None:
+            await self._backfill_tiles_with_start_end(
+                session=session,
+                tile_spec=tile_spec,
+                start_ts=start_ts_2,
+                end_ts=end_ts_2,
+                update_last_run_metadata=True,
+                update_backfill_start_date=to_init_backfill_metadata,
+            )
+
+    async def _backfill_tiles_with_start_end(
+        self,
+        session: BaseSession,
+        tile_spec: TileSpec,
+        start_ts: datetime,
+        end_ts: datetime,
+        update_last_run_metadata: bool,
+        update_backfill_start_date: bool,
+    ) -> None:
+        # Align the start timestamp to the tile boundary
         start_ind = date_util.timestamp_utc_to_tile_index(
             start_ts,
             tile_spec.time_modulo_frequency_second,
@@ -254,16 +391,23 @@ class FeatureManagerService:
             tile_spec.blind_spot_second,
             tile_spec.frequency_minute,
         )
+        date_format = "%Y-%m-%dT%H:%M:%S.%fZ"
         start_ts_str = start_ts.strftime(date_format)
-
+        end_ts_str = end_ts.strftime(date_format)
         await self.tile_manager_service.generate_tiles(
             session=session,
             tile_spec=tile_spec,
             tile_type=TileType.OFFLINE,
             end_ts_str=end_ts_str,
             start_ts_str=start_ts_str,
-            last_tile_start_ts_str=end_ts_str,
+            last_tile_start_ts_str=end_ts_str if update_last_run_metadata else None,
         )
+        if update_backfill_start_date:
+            await self.tile_registry_service.update_backfill_metadata(
+                tile_id=tile_spec.tile_id,
+                aggregation_id=tile_spec.aggregation_id,
+                backfill_start_date=start_ts,
+            )
 
     async def _update_tile_feature_mapping_table(
         self,

--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -11,7 +11,6 @@ from sqlglot import expressions
 from featurebyte.common.progress import get_ranged_progress_callback
 from featurebyte.common.utils import timer
 from featurebyte.enum import InternalName, MaterializedTableNamePrefix
-from featurebyte.exception import DocumentNotFoundError
 from featurebyte.logging import get_logger
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.feature_store import FeatureStoreModel
@@ -219,7 +218,6 @@ class FeatureTableCacheService:
         nodes: List[Tuple[Node, CachedFeatureDefinition]],
         is_target: bool = False,
         serving_names_mapping: Optional[Dict[str, str]] = None,
-        is_feature_list_deployed: bool = False,
         progress_callback: Optional[
             Callable[[int, Optional[str]], Coroutine[Any, Any, None]]
         ] = None,
@@ -261,7 +259,6 @@ class FeatureTableCacheService:
                 feature_store=feature_store,
                 output_table_details=output_table_details,
                 serving_names_mapping=serving_names_mapping,
-                is_feature_list_deployed=is_feature_list_deployed,
                 parent_serving_preparation=parent_serving_preparation,
                 progress_callback=progress_callback,
             )
@@ -276,7 +273,6 @@ class FeatureTableCacheService:
         nodes: List[Tuple[Node, CachedFeatureDefinition]],
         is_target: bool = False,
         serving_names_mapping: Optional[Dict[str, str]] = None,
-        is_feature_list_deployed: bool = False,
         progress_callback: Optional[
             Callable[[int, Optional[str]], Coroutine[Any, Any, None]]
         ] = None,
@@ -294,7 +290,6 @@ class FeatureTableCacheService:
                 nodes=nodes,
                 is_target=is_target,
                 serving_names_mapping=serving_names_mapping,
-                is_feature_list_deployed=is_feature_list_deployed,
                 progress_callback=progress_callback,
             )
 
@@ -339,7 +334,6 @@ class FeatureTableCacheService:
         non_cached_nodes: List[Tuple[Node, CachedFeatureDefinition]],
         is_target: bool = False,
         serving_names_mapping: Optional[Dict[str, str]] = None,
-        is_feature_list_deployed: bool = False,
         progress_callback: Optional[
             Callable[[int, Optional[str]], Coroutine[Any, Any, None]]
         ] = None,
@@ -362,7 +356,6 @@ class FeatureTableCacheService:
                 nodes=non_cached_nodes,
                 is_target=is_target,
                 serving_names_mapping=serving_names_mapping,
-                is_feature_list_deployed=is_feature_list_deployed,
                 progress_callback=progress_callback,
             )
 
@@ -534,14 +527,6 @@ class FeatureTableCacheService:
             remaining_progress_callback = None
 
         if non_cached_nodes:
-            is_feature_list_deployed = False
-            if feature_list_id:
-                try:
-                    feature_list = await self.feature_list_service.get_document(feature_list_id)
-                    is_feature_list_deployed = feature_list.deployed
-                except DocumentNotFoundError:
-                    is_feature_list_deployed = False
-
             if feature_table_cache_exists:
                 # if feature table cache exists - update existing table with new features
                 await self._update_table(
@@ -553,7 +538,6 @@ class FeatureTableCacheService:
                     non_cached_nodes=non_cached_nodes,
                     is_target=is_target,
                     serving_names_mapping=serving_names_mapping,
-                    is_feature_list_deployed=is_feature_list_deployed,
                     progress_callback=remaining_progress_callback,
                 )
             else:
@@ -567,7 +551,6 @@ class FeatureTableCacheService:
                     nodes=non_cached_nodes,
                     is_target=is_target,
                     serving_names_mapping=serving_names_mapping,
-                    is_feature_list_deployed=is_feature_list_deployed,
                     progress_callback=remaining_progress_callback,
                 )
 

--- a/featurebyte/service/historical_features.py
+++ b/featurebyte/service/historical_features.py
@@ -86,7 +86,6 @@ class HistoricalFeatureExecutor(QueryExecutor[HistoricalFeatureExecutorParams]):
                 observation_set=executor_params.observation_set,
                 serving_names_mapping=executor_params.serving_names_mapping,
                 feature_store=executor_params.feature_store,
-                is_feature_list_deployed=executor_params.is_feature_list_deployed,
                 parent_serving_preparation=executor_params.parent_serving_preparation,
                 output_table_details=executor_params.output_table_details,
                 progress_callback=executor_params.progress_callback,

--- a/featurebyte/service/tile_registry_service.py
+++ b/featurebyte/service/tile_registry_service.py
@@ -10,7 +10,12 @@ from datetime import datetime
 
 from featurebyte.exception import DocumentNotFoundError
 from featurebyte.models.tile import TileType
-from featurebyte.models.tile_registry import LastRunMetadata, TileModel, TileUpdate
+from featurebyte.models.tile_registry import (
+    BackfillMetadata,
+    LastRunMetadata,
+    TileModel,
+    TileUpdate,
+)
 from featurebyte.service.base_document import BaseDocumentService
 
 
@@ -84,4 +89,33 @@ class TileRegistryService(BaseDocumentService[TileModel, TileModel, TileUpdate])
             update_model = TileUpdate(last_run_metadata_online=metadata_model)
         else:
             update_model = TileUpdate(last_run_metadata_offline=metadata_model)
+        await self.update_document(document.id, update_model, document=document)
+
+    async def update_backfill_metadata(
+        self, tile_id: str, aggregation_id: str, backfill_start_date: datetime
+    ) -> None:
+        """
+        Update information about the tile backfill process
+
+        Parameters
+        ----------
+        tile_id: str
+            Tile id
+        aggregation_id: str
+            Aggregation id
+        backfill_start_date: datetime
+            Start date of the backfill process
+
+        Raises
+        ------
+        DocumentNotFoundError
+            If the tile model is not found
+        """
+        document = await self.get_tile_model(tile_id, aggregation_id)
+        if document is None:
+            raise DocumentNotFoundError(
+                f"TileRegistryService: TileModel with tile_id={tile_id} and aggregation_id={aggregation_id} not found"
+            )
+        metadata_model = BackfillMetadata(start_date=backfill_start_date)
+        update_model = TileUpdate(backfill_metadata=metadata_model)
         await self.update_document(document.id, update_model, document=document)

--- a/featurebyte/tile/tile_cache.py
+++ b/featurebyte/tile/tile_cache.py
@@ -192,6 +192,7 @@ class OnDemandTileComputeRequest:
             category_column_name=self.tile_gen_info.value_by_column,
             feature_store_id=feature_store_id,
             entity_tracker_table_name=self.tile_info_key.get_entity_tracker_table_name(),
+            windows=self.tile_gen_info.windows,
         )
         return tile_spec, self.tracker_sql
 

--- a/tests/fixtures/feature_manager/enable_new_feature.sql
+++ b/tests/fixtures/feature_manager/enable_new_feature.sql
@@ -1,0 +1,134 @@
+CREATE TABLE "TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9" AS
+SELECT * FROM (
+            select
+                index,
+                "cust_id", value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9,
+                current_timestamp() as created_at
+            from (SELECT
+  index,
+  "cust_id",
+  COUNT(*) AS value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+FROM (
+  SELECT
+    *,
+    F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "event_timestamp"), 900, 1800, 60) AS index
+  FROM (
+    SELECT
+      *
+    FROM (
+      SELECT
+        "col_int" AS "col_int",
+        "col_float" AS "col_float",
+        "col_char" AS "col_char",
+        "col_text" AS "col_text",
+        "col_binary" AS "col_binary",
+        "col_boolean" AS "col_boolean",
+        "event_timestamp" AS "event_timestamp",
+        "cust_id" AS "cust_id"
+      FROM "sf_database"."sf_schema"."sf_table"
+      WHERE
+        "event_timestamp" >= CAST('2022-05-15T06:45:00.000000Z' AS TIMESTAMPNTZ)
+        AND "event_timestamp" < CAST('2022-05-15T08:45:00.000000Z' AS TIMESTAMPNTZ)
+    )
+    WHERE
+      "event_timestamp" >= CAST('2022-05-15T06:45:00.000000Z' AS TIMESTAMPNTZ)
+      AND "event_timestamp" < CAST('2022-05-15T08:45:00.000000Z' AS TIMESTAMPNTZ)
+  )
+)
+GROUP BY
+  index,
+  "cust_id")
+        );
+
+CREATE TABLE "ONLINE_STORE_377553E5920DD2DB8B17F21DDD52F8B1194A780C" AS
+SELECT * FROM (SELECT "cust_id",
+                      CAST("AGGREGATION_RESULT_NAME" AS STRING) AS "AGGREGATION_RESULT_NAME",
+                      CAST("VALUE" AS FLOAT) AS "VALUE",
+                      CAST(0 AS INT) AS "VERSION",
+                      to_timestamp('2022-05-15 10:00:05') AS UPDATED_AT
+                    FROM (SELECT
+  "cust_id",
+  CAST('_fb_internal_cust_id_window_w7200_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9' AS VARCHAR) AS "AGGREGATION_RESULT_NAME",
+  "_fb_internal_cust_id_window_w7200_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9" AS "VALUE"
+FROM (
+  WITH REQUEST_TABLE AS (
+    SELECT DISTINCT
+      CAST('2022-05-15 09:15:00' AS TIMESTAMPNTZ) AS POINT_IN_TIME,
+      "cust_id" AS "cust_id"
+    FROM TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9
+    WHERE
+      INDEX >= FLOOR(
+        (
+          DATE_PART(EPOCH_SECOND, CAST('2022-05-15 09:15:00' AS TIMESTAMPNTZ)) - 900
+        ) / 3600
+      ) - 2
+      AND INDEX < FLOOR(
+        (
+          DATE_PART(EPOCH_SECOND, CAST('2022-05-15 09:15:00' AS TIMESTAMPNTZ)) - 900
+        ) / 3600
+      )
+  ), "REQUEST_TABLE_W7200_F3600_BS1800_M900_cust_id" AS (
+    SELECT
+      "POINT_IN_TIME",
+      "cust_id",
+      FLOOR((
+        DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 900
+      ) / 3600) AS "__FB_LAST_TILE_INDEX",
+      FLOOR((
+        DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 900
+      ) / 3600) - 2 AS "__FB_FIRST_TILE_INDEX"
+    FROM (
+      SELECT DISTINCT
+        "POINT_IN_TIME",
+        "cust_id"
+      FROM REQUEST_TABLE
+    )
+  ), _FB_AGGREGATED AS (
+    SELECT
+      REQ."POINT_IN_TIME",
+      REQ."cust_id",
+      "T0"."_fb_internal_cust_id_window_w7200_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9" AS "_fb_internal_cust_id_window_w7200_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9"
+    FROM REQUEST_TABLE AS REQ
+    LEFT JOIN (
+      SELECT
+        "POINT_IN_TIME",
+        "cust_id",
+        SUM(value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9) AS "_fb_internal_cust_id_window_w7200_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9"
+      FROM (
+        SELECT
+          REQ."POINT_IN_TIME",
+          REQ."cust_id",
+          TILE.INDEX,
+          TILE.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+        FROM "REQUEST_TABLE_W7200_F3600_BS1800_M900_cust_id" AS REQ
+        INNER JOIN TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 AS TILE
+          ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 2) = FLOOR(TILE.INDEX / 2)
+          AND REQ."cust_id" = TILE."cust_id"
+        WHERE
+          TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+        UNION ALL
+        SELECT
+          REQ."POINT_IN_TIME",
+          REQ."cust_id",
+          TILE.INDEX,
+          TILE.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+        FROM "REQUEST_TABLE_W7200_F3600_BS1800_M900_cust_id" AS REQ
+        INNER JOIN TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 AS TILE
+          ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 2) - 1 = FLOOR(TILE.INDEX / 2)
+          AND REQ."cust_id" = TILE."cust_id"
+        WHERE
+          TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+      )
+      GROUP BY
+        "POINT_IN_TIME",
+        "cust_id"
+    ) AS T0
+      ON REQ."POINT_IN_TIME" = T0."POINT_IN_TIME" AND REQ."cust_id" = T0."cust_id"
+  )
+  SELECT
+    AGG."POINT_IN_TIME",
+    AGG."cust_id",
+    "_fb_internal_cust_id_window_w7200_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9"
+  FROM _FB_AGGREGATED AS AGG
+))
+);

--- a/tests/fixtures/feature_manager/enable_second_feature_later_date.sql
+++ b/tests/fixtures/feature_manager/enable_second_feature_later_date.sql
@@ -1,0 +1,196 @@
+ALTER TABLE TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 ADD COLUMN
+value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9 FLOAT;
+
+
+                merge into TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 a using (
+            select
+                index,
+                "cust_id", value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9,
+                current_timestamp() as created_at
+            from (SELECT
+  index,
+  "cust_id",
+  COUNT(*) AS value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+FROM (
+  SELECT
+    *,
+    F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "event_timestamp"), 900, 1800, 60) AS index
+  FROM (
+    SELECT
+      *
+    FROM (
+      SELECT
+        "col_int" AS "col_int",
+        "col_float" AS "col_float",
+        "col_char" AS "col_char",
+        "col_text" AS "col_text",
+        "col_binary" AS "col_binary",
+        "col_boolean" AS "col_boolean",
+        "event_timestamp" AS "event_timestamp",
+        "cust_id" AS "cust_id"
+      FROM "sf_database"."sf_schema"."sf_table"
+      WHERE
+        "event_timestamp" >= CAST('2022-05-15T05:45:00.000000Z' AS TIMESTAMPNTZ)
+        AND "event_timestamp" < CAST('2022-05-15T06:45:00.000000Z' AS TIMESTAMPNTZ)
+    )
+    WHERE
+      "event_timestamp" >= CAST('2022-05-15T05:45:00.000000Z' AS TIMESTAMPNTZ)
+      AND "event_timestamp" < CAST('2022-05-15T06:45:00.000000Z' AS TIMESTAMPNTZ)
+  )
+)
+GROUP BY
+  index,
+  "cust_id")
+        ) b
+                    on a.INDEX = b.INDEX AND EQUAL_NULL(a."cust_id", b."cust_id")
+                    when matched then
+                        update set a.created_at = current_timestamp(), a.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9 = b.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+                    when not matched then
+                        insert (INDEX, "cust_id", value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9, CREATED_AT)
+                            values (b.INDEX, b."cust_id", b.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9, current_timestamp())
+            ;
+
+ALTER TABLE TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 ADD COLUMN
+value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9 FLOAT;
+
+
+                merge into TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 a using (
+            select
+                index,
+                "cust_id", value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9,
+                current_timestamp() as created_at
+            from (SELECT
+  index,
+  "cust_id",
+  COUNT(*) AS value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+FROM (
+  SELECT
+    *,
+    F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "event_timestamp"), 900, 1800, 60) AS index
+  FROM (
+    SELECT
+      *
+    FROM (
+      SELECT
+        "col_int" AS "col_int",
+        "col_float" AS "col_float",
+        "col_char" AS "col_char",
+        "col_text" AS "col_text",
+        "col_binary" AS "col_binary",
+        "col_boolean" AS "col_boolean",
+        "event_timestamp" AS "event_timestamp",
+        "cust_id" AS "cust_id"
+      FROM "sf_database"."sf_schema"."sf_table"
+      WHERE
+        "event_timestamp" >= CAST('2022-05-15T08:45:00.000000Z' AS TIMESTAMPNTZ)
+        AND "event_timestamp" < CAST('2022-05-15T09:45:00.000000Z' AS TIMESTAMPNTZ)
+    )
+    WHERE
+      "event_timestamp" >= CAST('2022-05-15T08:45:00.000000Z' AS TIMESTAMPNTZ)
+      AND "event_timestamp" < CAST('2022-05-15T09:45:00.000000Z' AS TIMESTAMPNTZ)
+  )
+)
+GROUP BY
+  index,
+  "cust_id")
+        ) b
+                    on a.INDEX = b.INDEX AND EQUAL_NULL(a."cust_id", b."cust_id")
+                    when matched then
+                        update set a.created_at = current_timestamp(), a.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9 = b.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+                    when not matched then
+                        insert (INDEX, "cust_id", value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9, CREATED_AT)
+                            values (b.INDEX, b."cust_id", b.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9, current_timestamp())
+            ;
+
+CREATE TABLE "__SESSION_TEMP_TABLE_000000000000000000000000" AS
+SELECT * FROM (SELECT
+  "cust_id",
+  CAST('_fb_internal_cust_id_window_w14400_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9' AS VARCHAR) AS "AGGREGATION_RESULT_NAME",
+  "_fb_internal_cust_id_window_w14400_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9" AS "VALUE"
+FROM (
+  WITH REQUEST_TABLE AS (
+    SELECT DISTINCT
+      CAST('2022-05-15 10:15:00' AS TIMESTAMPNTZ) AS POINT_IN_TIME,
+      "cust_id" AS "cust_id"
+    FROM TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9
+    WHERE
+      INDEX >= FLOOR(
+        (
+          DATE_PART(EPOCH_SECOND, CAST('2022-05-15 10:15:00' AS TIMESTAMPNTZ)) - 900
+        ) / 3600
+      ) - 4
+      AND INDEX < FLOOR(
+        (
+          DATE_PART(EPOCH_SECOND, CAST('2022-05-15 10:15:00' AS TIMESTAMPNTZ)) - 900
+        ) / 3600
+      )
+  ), "REQUEST_TABLE_W14400_F3600_BS1800_M900_cust_id" AS (
+    SELECT
+      "POINT_IN_TIME",
+      "cust_id",
+      FLOOR((
+        DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 900
+      ) / 3600) AS "__FB_LAST_TILE_INDEX",
+      FLOOR((
+        DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 900
+      ) / 3600) - 4 AS "__FB_FIRST_TILE_INDEX"
+    FROM (
+      SELECT DISTINCT
+        "POINT_IN_TIME",
+        "cust_id"
+      FROM REQUEST_TABLE
+    )
+  ), _FB_AGGREGATED AS (
+    SELECT
+      REQ."POINT_IN_TIME",
+      REQ."cust_id",
+      "T0"."_fb_internal_cust_id_window_w14400_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9" AS "_fb_internal_cust_id_window_w14400_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9"
+    FROM REQUEST_TABLE AS REQ
+    LEFT JOIN (
+      SELECT
+        "POINT_IN_TIME",
+        "cust_id",
+        SUM(value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9) AS "_fb_internal_cust_id_window_w14400_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9"
+      FROM (
+        SELECT
+          REQ."POINT_IN_TIME",
+          REQ."cust_id",
+          TILE.INDEX,
+          TILE.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+        FROM "REQUEST_TABLE_W14400_F3600_BS1800_M900_cust_id" AS REQ
+        INNER JOIN TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 AS TILE
+          ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 4) = FLOOR(TILE.INDEX / 4)
+          AND REQ."cust_id" = TILE."cust_id"
+        WHERE
+          TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+        UNION ALL
+        SELECT
+          REQ."POINT_IN_TIME",
+          REQ."cust_id",
+          TILE.INDEX,
+          TILE.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+        FROM "REQUEST_TABLE_W14400_F3600_BS1800_M900_cust_id" AS REQ
+        INNER JOIN TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 AS TILE
+          ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 4) - 1 = FLOOR(TILE.INDEX / 4)
+          AND REQ."cust_id" = TILE."cust_id"
+        WHERE
+          TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+      )
+      GROUP BY
+        "POINT_IN_TIME",
+        "cust_id"
+    ) AS T0
+      ON REQ."POINT_IN_TIME" = T0."POINT_IN_TIME" AND REQ."cust_id" = T0."cust_id"
+  )
+  SELECT
+    AGG."POINT_IN_TIME",
+    AGG."cust_id",
+    "_fb_internal_cust_id_window_w14400_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9"
+  FROM _FB_AGGREGATED AS AGG
+));
+
+
+INSERT INTO online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c ("cust_id", "AGGREGATION_RESULT_NAME", "VALUE", "VERSION", UPDATED_AT)
+SELECT "cust_id", "AGGREGATION_RESULT_NAME", "VALUE", 0, to_timestamp('2022-05-15 10:00:05')
+FROM __SESSION_TEMP_TABLE_000000000000000000000000
+;

--- a/tests/fixtures/feature_manager/enable_second_feature_much_later_date.sql
+++ b/tests/fixtures/feature_manager/enable_second_feature_much_later_date.sql
@@ -1,0 +1,144 @@
+ALTER TABLE TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 ADD COLUMN
+value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9 FLOAT;
+
+
+                merge into TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 a using (
+            select
+                index,
+                "cust_id", value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9,
+                current_timestamp() as created_at
+            from (SELECT
+  index,
+  "cust_id",
+  COUNT(*) AS value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+FROM (
+  SELECT
+    *,
+    F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "event_timestamp"), 900, 1800, 60) AS index
+  FROM (
+    SELECT
+      *
+    FROM (
+      SELECT
+        "col_int" AS "col_int",
+        "col_float" AS "col_float",
+        "col_char" AS "col_char",
+        "col_text" AS "col_text",
+        "col_binary" AS "col_binary",
+        "col_boolean" AS "col_boolean",
+        "event_timestamp" AS "event_timestamp",
+        "cust_id" AS "cust_id"
+      FROM "sf_database"."sf_schema"."sf_table"
+      WHERE
+        "event_timestamp" >= CAST('2022-05-15T08:45:00.000000Z' AS TIMESTAMPNTZ)
+        AND "event_timestamp" < CAST('2022-06-15T09:45:00.000000Z' AS TIMESTAMPNTZ)
+    )
+    WHERE
+      "event_timestamp" >= CAST('2022-05-15T08:45:00.000000Z' AS TIMESTAMPNTZ)
+      AND "event_timestamp" < CAST('2022-06-15T09:45:00.000000Z' AS TIMESTAMPNTZ)
+  )
+)
+GROUP BY
+  index,
+  "cust_id")
+        ) b
+                    on a.INDEX = b.INDEX AND EQUAL_NULL(a."cust_id", b."cust_id")
+                    when matched then
+                        update set a.created_at = current_timestamp(), a.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9 = b.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+                    when not matched then
+                        insert (INDEX, "cust_id", value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9, CREATED_AT)
+                            values (b.INDEX, b."cust_id", b.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9, current_timestamp())
+            ;
+
+CREATE TABLE "__SESSION_TEMP_TABLE_000000000000000000000000" AS
+SELECT * FROM (SELECT
+  "cust_id",
+  CAST('_fb_internal_cust_id_window_w14400_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9' AS VARCHAR) AS "AGGREGATION_RESULT_NAME",
+  "_fb_internal_cust_id_window_w14400_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9" AS "VALUE"
+FROM (
+  WITH REQUEST_TABLE AS (
+    SELECT DISTINCT
+      CAST('2022-06-15 10:15:00' AS TIMESTAMPNTZ) AS POINT_IN_TIME,
+      "cust_id" AS "cust_id"
+    FROM TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9
+    WHERE
+      INDEX >= FLOOR(
+        (
+          DATE_PART(EPOCH_SECOND, CAST('2022-06-15 10:15:00' AS TIMESTAMPNTZ)) - 900
+        ) / 3600
+      ) - 4
+      AND INDEX < FLOOR(
+        (
+          DATE_PART(EPOCH_SECOND, CAST('2022-06-15 10:15:00' AS TIMESTAMPNTZ)) - 900
+        ) / 3600
+      )
+  ), "REQUEST_TABLE_W14400_F3600_BS1800_M900_cust_id" AS (
+    SELECT
+      "POINT_IN_TIME",
+      "cust_id",
+      FLOOR((
+        DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 900
+      ) / 3600) AS "__FB_LAST_TILE_INDEX",
+      FLOOR((
+        DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 900
+      ) / 3600) - 4 AS "__FB_FIRST_TILE_INDEX"
+    FROM (
+      SELECT DISTINCT
+        "POINT_IN_TIME",
+        "cust_id"
+      FROM REQUEST_TABLE
+    )
+  ), _FB_AGGREGATED AS (
+    SELECT
+      REQ."POINT_IN_TIME",
+      REQ."cust_id",
+      "T0"."_fb_internal_cust_id_window_w14400_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9" AS "_fb_internal_cust_id_window_w14400_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9"
+    FROM REQUEST_TABLE AS REQ
+    LEFT JOIN (
+      SELECT
+        "POINT_IN_TIME",
+        "cust_id",
+        SUM(value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9) AS "_fb_internal_cust_id_window_w14400_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9"
+      FROM (
+        SELECT
+          REQ."POINT_IN_TIME",
+          REQ."cust_id",
+          TILE.INDEX,
+          TILE.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+        FROM "REQUEST_TABLE_W14400_F3600_BS1800_M900_cust_id" AS REQ
+        INNER JOIN TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 AS TILE
+          ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 4) = FLOOR(TILE.INDEX / 4)
+          AND REQ."cust_id" = TILE."cust_id"
+        WHERE
+          TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+        UNION ALL
+        SELECT
+          REQ."POINT_IN_TIME",
+          REQ."cust_id",
+          TILE.INDEX,
+          TILE.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+        FROM "REQUEST_TABLE_W14400_F3600_BS1800_M900_cust_id" AS REQ
+        INNER JOIN TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 AS TILE
+          ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 4) - 1 = FLOOR(TILE.INDEX / 4)
+          AND REQ."cust_id" = TILE."cust_id"
+        WHERE
+          TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+      )
+      GROUP BY
+        "POINT_IN_TIME",
+        "cust_id"
+    ) AS T0
+      ON REQ."POINT_IN_TIME" = T0."POINT_IN_TIME" AND REQ."cust_id" = T0."cust_id"
+  )
+  SELECT
+    AGG."POINT_IN_TIME",
+    AGG."cust_id",
+    "_fb_internal_cust_id_window_w14400_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9"
+  FROM _FB_AGGREGATED AS AGG
+));
+
+
+INSERT INTO online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c ("cust_id", "AGGREGATION_RESULT_NAME", "VALUE", "VERSION", UPDATED_AT)
+SELECT "cust_id", "AGGREGATION_RESULT_NAME", "VALUE", 0, to_timestamp('2022-05-15 10:00:05')
+FROM __SESSION_TEMP_TABLE_000000000000000000000000
+;

--- a/tests/fixtures/feature_manager/enable_with_backfill_metadata.sql
+++ b/tests/fixtures/feature_manager/enable_with_backfill_metadata.sql
@@ -1,0 +1,144 @@
+ALTER TABLE TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 ADD COLUMN
+value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9 FLOAT;
+
+
+                merge into TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 a using (
+            select
+                index,
+                "cust_id", value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9,
+                current_timestamp() as created_at
+            from (SELECT
+  index,
+  "cust_id",
+  COUNT(*) AS value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+FROM (
+  SELECT
+    *,
+    F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "event_timestamp"), 900, 1800, 60) AS index
+  FROM (
+    SELECT
+      *
+    FROM (
+      SELECT
+        "col_int" AS "col_int",
+        "col_float" AS "col_float",
+        "col_char" AS "col_char",
+        "col_text" AS "col_text",
+        "col_binary" AS "col_binary",
+        "col_boolean" AS "col_boolean",
+        "event_timestamp" AS "event_timestamp",
+        "cust_id" AS "cust_id"
+      FROM "sf_database"."sf_schema"."sf_table"
+      WHERE
+        "event_timestamp" >= CAST('2022-05-15T04:45:00.000000Z' AS TIMESTAMPNTZ)
+        AND "event_timestamp" < CAST('2022-05-15T06:45:00.000000Z' AS TIMESTAMPNTZ)
+    )
+    WHERE
+      "event_timestamp" >= CAST('2022-05-15T04:45:00.000000Z' AS TIMESTAMPNTZ)
+      AND "event_timestamp" < CAST('2022-05-15T06:45:00.000000Z' AS TIMESTAMPNTZ)
+  )
+)
+GROUP BY
+  index,
+  "cust_id")
+        ) b
+                    on a.INDEX = b.INDEX AND EQUAL_NULL(a."cust_id", b."cust_id")
+                    when matched then
+                        update set a.created_at = current_timestamp(), a.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9 = b.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+                    when not matched then
+                        insert (INDEX, "cust_id", value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9, CREATED_AT)
+                            values (b.INDEX, b."cust_id", b.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9, current_timestamp())
+            ;
+
+CREATE TABLE "__SESSION_TEMP_TABLE_000000000000000000000000" AS
+SELECT * FROM (SELECT
+  "cust_id",
+  CAST('_fb_internal_cust_id_window_w14400_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9' AS VARCHAR) AS "AGGREGATION_RESULT_NAME",
+  "_fb_internal_cust_id_window_w14400_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9" AS "VALUE"
+FROM (
+  WITH REQUEST_TABLE AS (
+    SELECT DISTINCT
+      CAST('2022-05-15 09:15:00' AS TIMESTAMPNTZ) AS POINT_IN_TIME,
+      "cust_id" AS "cust_id"
+    FROM TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9
+    WHERE
+      INDEX >= FLOOR(
+        (
+          DATE_PART(EPOCH_SECOND, CAST('2022-05-15 09:15:00' AS TIMESTAMPNTZ)) - 900
+        ) / 3600
+      ) - 4
+      AND INDEX < FLOOR(
+        (
+          DATE_PART(EPOCH_SECOND, CAST('2022-05-15 09:15:00' AS TIMESTAMPNTZ)) - 900
+        ) / 3600
+      )
+  ), "REQUEST_TABLE_W14400_F3600_BS1800_M900_cust_id" AS (
+    SELECT
+      "POINT_IN_TIME",
+      "cust_id",
+      FLOOR((
+        DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 900
+      ) / 3600) AS "__FB_LAST_TILE_INDEX",
+      FLOOR((
+        DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 900
+      ) / 3600) - 4 AS "__FB_FIRST_TILE_INDEX"
+    FROM (
+      SELECT DISTINCT
+        "POINT_IN_TIME",
+        "cust_id"
+      FROM REQUEST_TABLE
+    )
+  ), _FB_AGGREGATED AS (
+    SELECT
+      REQ."POINT_IN_TIME",
+      REQ."cust_id",
+      "T0"."_fb_internal_cust_id_window_w14400_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9" AS "_fb_internal_cust_id_window_w14400_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9"
+    FROM REQUEST_TABLE AS REQ
+    LEFT JOIN (
+      SELECT
+        "POINT_IN_TIME",
+        "cust_id",
+        SUM(value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9) AS "_fb_internal_cust_id_window_w14400_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9"
+      FROM (
+        SELECT
+          REQ."POINT_IN_TIME",
+          REQ."cust_id",
+          TILE.INDEX,
+          TILE.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+        FROM "REQUEST_TABLE_W14400_F3600_BS1800_M900_cust_id" AS REQ
+        INNER JOIN TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 AS TILE
+          ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 4) = FLOOR(TILE.INDEX / 4)
+          AND REQ."cust_id" = TILE."cust_id"
+        WHERE
+          TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+        UNION ALL
+        SELECT
+          REQ."POINT_IN_TIME",
+          REQ."cust_id",
+          TILE.INDEX,
+          TILE.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+        FROM "REQUEST_TABLE_W14400_F3600_BS1800_M900_cust_id" AS REQ
+        INNER JOIN TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 AS TILE
+          ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 4) - 1 = FLOOR(TILE.INDEX / 4)
+          AND REQ."cust_id" = TILE."cust_id"
+        WHERE
+          TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+      )
+      GROUP BY
+        "POINT_IN_TIME",
+        "cust_id"
+    ) AS T0
+      ON REQ."POINT_IN_TIME" = T0."POINT_IN_TIME" AND REQ."cust_id" = T0."cust_id"
+  )
+  SELECT
+    AGG."POINT_IN_TIME",
+    AGG."cust_id",
+    "_fb_internal_cust_id_window_w14400_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9"
+  FROM _FB_AGGREGATED AS AGG
+));
+
+
+INSERT INTO online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c ("cust_id", "AGGREGATION_RESULT_NAME", "VALUE", "VERSION", UPDATED_AT)
+SELECT "cust_id", "AGGREGATION_RESULT_NAME", "VALUE", 0, to_timestamp('2022-05-15 10:00:05')
+FROM __SESSION_TEMP_TABLE_000000000000000000000000
+;

--- a/tests/fixtures/feature_manager/enable_with_required_tiles_available.sql
+++ b/tests/fixtures/feature_manager/enable_with_required_tiles_available.sql
@@ -1,0 +1,92 @@
+CREATE TABLE "ONLINE_STORE_377553E5920DD2DB8B17F21DDD52F8B1194A780C" AS
+SELECT * FROM (SELECT "cust_id",
+                      CAST("AGGREGATION_RESULT_NAME" AS STRING) AS "AGGREGATION_RESULT_NAME",
+                      CAST("VALUE" AS FLOAT) AS "VALUE",
+                      CAST(0 AS INT) AS "VERSION",
+                      to_timestamp('2022-05-15 10:00:05') AS UPDATED_AT
+                    FROM (SELECT
+  "cust_id",
+  CAST('_fb_internal_cust_id_window_w7200_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9' AS VARCHAR) AS "AGGREGATION_RESULT_NAME",
+  "_fb_internal_cust_id_window_w7200_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9" AS "VALUE"
+FROM (
+  WITH REQUEST_TABLE AS (
+    SELECT DISTINCT
+      CAST('2022-05-15 09:15:00' AS TIMESTAMPNTZ) AS POINT_IN_TIME,
+      "cust_id" AS "cust_id"
+    FROM TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9
+    WHERE
+      INDEX >= FLOOR(
+        (
+          DATE_PART(EPOCH_SECOND, CAST('2022-05-15 09:15:00' AS TIMESTAMPNTZ)) - 900
+        ) / 3600
+      ) - 2
+      AND INDEX < FLOOR(
+        (
+          DATE_PART(EPOCH_SECOND, CAST('2022-05-15 09:15:00' AS TIMESTAMPNTZ)) - 900
+        ) / 3600
+      )
+  ), "REQUEST_TABLE_W7200_F3600_BS1800_M900_cust_id" AS (
+    SELECT
+      "POINT_IN_TIME",
+      "cust_id",
+      FLOOR((
+        DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 900
+      ) / 3600) AS "__FB_LAST_TILE_INDEX",
+      FLOOR((
+        DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 900
+      ) / 3600) - 2 AS "__FB_FIRST_TILE_INDEX"
+    FROM (
+      SELECT DISTINCT
+        "POINT_IN_TIME",
+        "cust_id"
+      FROM REQUEST_TABLE
+    )
+  ), _FB_AGGREGATED AS (
+    SELECT
+      REQ."POINT_IN_TIME",
+      REQ."cust_id",
+      "T0"."_fb_internal_cust_id_window_w7200_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9" AS "_fb_internal_cust_id_window_w7200_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9"
+    FROM REQUEST_TABLE AS REQ
+    LEFT JOIN (
+      SELECT
+        "POINT_IN_TIME",
+        "cust_id",
+        SUM(value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9) AS "_fb_internal_cust_id_window_w7200_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9"
+      FROM (
+        SELECT
+          REQ."POINT_IN_TIME",
+          REQ."cust_id",
+          TILE.INDEX,
+          TILE.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+        FROM "REQUEST_TABLE_W7200_F3600_BS1800_M900_cust_id" AS REQ
+        INNER JOIN TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 AS TILE
+          ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 2) = FLOOR(TILE.INDEX / 2)
+          AND REQ."cust_id" = TILE."cust_id"
+        WHERE
+          TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+        UNION ALL
+        SELECT
+          REQ."POINT_IN_TIME",
+          REQ."cust_id",
+          TILE.INDEX,
+          TILE.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+        FROM "REQUEST_TABLE_W7200_F3600_BS1800_M900_cust_id" AS REQ
+        INNER JOIN TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 AS TILE
+          ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 2) - 1 = FLOOR(TILE.INDEX / 2)
+          AND REQ."cust_id" = TILE."cust_id"
+        WHERE
+          TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+      )
+      GROUP BY
+        "POINT_IN_TIME",
+        "cust_id"
+    ) AS T0
+      ON REQ."POINT_IN_TIME" = T0."POINT_IN_TIME" AND REQ."cust_id" = T0."cust_id"
+  )
+  SELECT
+    AGG."POINT_IN_TIME",
+    AGG."cust_id",
+    "_fb_internal_cust_id_window_w7200_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9"
+  FROM _FB_AGGREGATED AS AGG
+))
+);

--- a/tests/fixtures/feature_manager/enable_without_last_run_metadata.sql
+++ b/tests/fixtures/feature_manager/enable_without_last_run_metadata.sql
@@ -1,0 +1,144 @@
+ALTER TABLE TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 ADD COLUMN
+value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9 FLOAT;
+
+
+                merge into TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 a using (
+            select
+                index,
+                "cust_id", value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9,
+                current_timestamp() as created_at
+            from (SELECT
+  index,
+  "cust_id",
+  COUNT(*) AS value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+FROM (
+  SELECT
+    *,
+    F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "event_timestamp"), 900, 1800, 60) AS index
+  FROM (
+    SELECT
+      *
+    FROM (
+      SELECT
+        "col_int" AS "col_int",
+        "col_float" AS "col_float",
+        "col_char" AS "col_char",
+        "col_text" AS "col_text",
+        "col_binary" AS "col_binary",
+        "col_boolean" AS "col_boolean",
+        "event_timestamp" AS "event_timestamp",
+        "cust_id" AS "cust_id"
+      FROM "sf_database"."sf_schema"."sf_table"
+      WHERE
+        "event_timestamp" >= CAST('2022-05-15T06:45:00.000000Z' AS TIMESTAMPNTZ)
+        AND "event_timestamp" < CAST('2022-06-15T09:45:00.000000Z' AS TIMESTAMPNTZ)
+    )
+    WHERE
+      "event_timestamp" >= CAST('2022-05-15T06:45:00.000000Z' AS TIMESTAMPNTZ)
+      AND "event_timestamp" < CAST('2022-06-15T09:45:00.000000Z' AS TIMESTAMPNTZ)
+  )
+)
+GROUP BY
+  index,
+  "cust_id")
+        ) b
+                    on a.INDEX = b.INDEX AND EQUAL_NULL(a."cust_id", b."cust_id")
+                    when matched then
+                        update set a.created_at = current_timestamp(), a.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9 = b.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+                    when not matched then
+                        insert (INDEX, "cust_id", value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9, CREATED_AT)
+                            values (b.INDEX, b."cust_id", b.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9, current_timestamp())
+            ;
+
+CREATE TABLE "__SESSION_TEMP_TABLE_000000000000000000000000" AS
+SELECT * FROM (SELECT
+  "cust_id",
+  CAST('_fb_internal_cust_id_window_w7200_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9' AS VARCHAR) AS "AGGREGATION_RESULT_NAME",
+  "_fb_internal_cust_id_window_w7200_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9" AS "VALUE"
+FROM (
+  WITH REQUEST_TABLE AS (
+    SELECT DISTINCT
+      CAST('2022-06-15 10:15:00' AS TIMESTAMPNTZ) AS POINT_IN_TIME,
+      "cust_id" AS "cust_id"
+    FROM TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9
+    WHERE
+      INDEX >= FLOOR(
+        (
+          DATE_PART(EPOCH_SECOND, CAST('2022-06-15 10:15:00' AS TIMESTAMPNTZ)) - 900
+        ) / 3600
+      ) - 2
+      AND INDEX < FLOOR(
+        (
+          DATE_PART(EPOCH_SECOND, CAST('2022-06-15 10:15:00' AS TIMESTAMPNTZ)) - 900
+        ) / 3600
+      )
+  ), "REQUEST_TABLE_W7200_F3600_BS1800_M900_cust_id" AS (
+    SELECT
+      "POINT_IN_TIME",
+      "cust_id",
+      FLOOR((
+        DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 900
+      ) / 3600) AS "__FB_LAST_TILE_INDEX",
+      FLOOR((
+        DATE_PART(EPOCH_SECOND, "POINT_IN_TIME") - 900
+      ) / 3600) - 2 AS "__FB_FIRST_TILE_INDEX"
+    FROM (
+      SELECT DISTINCT
+        "POINT_IN_TIME",
+        "cust_id"
+      FROM REQUEST_TABLE
+    )
+  ), _FB_AGGREGATED AS (
+    SELECT
+      REQ."POINT_IN_TIME",
+      REQ."cust_id",
+      "T0"."_fb_internal_cust_id_window_w7200_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9" AS "_fb_internal_cust_id_window_w7200_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9"
+    FROM REQUEST_TABLE AS REQ
+    LEFT JOIN (
+      SELECT
+        "POINT_IN_TIME",
+        "cust_id",
+        SUM(value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9) AS "_fb_internal_cust_id_window_w7200_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9"
+      FROM (
+        SELECT
+          REQ."POINT_IN_TIME",
+          REQ."cust_id",
+          TILE.INDEX,
+          TILE.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+        FROM "REQUEST_TABLE_W7200_F3600_BS1800_M900_cust_id" AS REQ
+        INNER JOIN TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 AS TILE
+          ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 2) = FLOOR(TILE.INDEX / 2)
+          AND REQ."cust_id" = TILE."cust_id"
+        WHERE
+          TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+        UNION ALL
+        SELECT
+          REQ."POINT_IN_TIME",
+          REQ."cust_id",
+          TILE.INDEX,
+          TILE.value_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9
+        FROM "REQUEST_TABLE_W7200_F3600_BS1800_M900_cust_id" AS REQ
+        INNER JOIN TILE_COUNT_704BC9A2E9FE7B08D6C064FBACD6B3FCB0185DA9 AS TILE
+          ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 2) - 1 = FLOOR(TILE.INDEX / 2)
+          AND REQ."cust_id" = TILE."cust_id"
+        WHERE
+          TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+      )
+      GROUP BY
+        "POINT_IN_TIME",
+        "cust_id"
+    ) AS T0
+      ON REQ."POINT_IN_TIME" = T0."POINT_IN_TIME" AND REQ."cust_id" = T0."cust_id"
+  )
+  SELECT
+    AGG."POINT_IN_TIME",
+    AGG."cust_id",
+    "_fb_internal_cust_id_window_w7200_count_704bc9a2e9fe7b08d6c064fbacd6b3fcb0185da9"
+  FROM _FB_AGGREGATED AS AGG
+));
+
+
+INSERT INTO online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c ("cust_id", "AGGREGATION_RESULT_NAME", "VALUE", "VERSION", UPDATED_AT)
+SELECT "cust_id", "AGGREGATION_RESULT_NAME", "VALUE", 1, to_timestamp('2022-05-15 10:00:05')
+FROM __SESSION_TEMP_TABLE_000000000000000000000000
+;

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -948,6 +948,10 @@ def create_generic_tile_spec():
         tile_id=tile_id,
         aggregation_id=aggregation_id,
         feature_store_id=ObjectId(),
+        # Set a large windows since many tests assume that all the tiles in the tile_data.csv will
+        # be selected, but this is now not necessarily the case since we will only select the tiles
+        # that are within the window.
+        windows=["3650d"],
     )
 
 

--- a/tests/integration/feature_manager/test_feature_manager.py
+++ b/tests/integration/feature_manager/test_feature_manager.py
@@ -3,7 +3,7 @@ This module contains integration tests for FeatureSnowflake
 """
 
 import contextlib
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import PropertyMock, patch
 
 import numpy as np
@@ -441,6 +441,10 @@ async def test_online_enable__re_deploy_from_latest_tile_start(
     with patch(
         "featurebyte.service.tile_manager.TileManagerService.generate_tiles"
     ) as mock_generate_tiles:
-        await feature_manager_service.online_enable(session, online_feature_spec)
+        with patch("featurebyte.service.feature_manager.datetime") as mock_datetime:
+            # simulate re-deploy at a later date; otherwise this will be a no-op since no new tiles
+            # need to be generated and generate_tiles won't be called
+            mock_datetime.utcnow.return_value = last_tile_start_ts + timedelta(days=1)
+            await feature_manager_service.online_enable(session, online_feature_spec)
         _, kwargs = mock_generate_tiles.call_args
         assert kwargs["start_ts_str"] == last_tile_start_ts.strftime("%Y-%m-%dT%H:%M:%S.%fZ")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1985,6 +1985,7 @@ def mock_snowflake_session_fixture():
     )
     session.clone_if_not_threadsafe.return_value = session
     session.create_table_as = partial(SnowflakeSession.create_table_as, session)
+    session.retry_sql = partial(SnowflakeSession.retry_sql, session)
     return session
 
 
@@ -2010,6 +2011,7 @@ def mock_snowflake_tile():
         value_column_types=["FLOAT"],
         entity_column_names=["col1"],
         feature_store_id=ObjectId(),
+        windows=["1d"],
     )
 
     return tile_spec

--- a/tests/unit/feature_manager/test_model.py
+++ b/tests/unit/feature_manager/test_model.py
@@ -64,6 +64,7 @@ def test_extended_feature_model__float_feature(float_feature, snowflake_feature_
             feature_store_id=snowflake_feature_store.id,
             parent_column_name="col_float",
             aggregation_function_name="sum",
+            windows=["30m", "2h", "1d"],
         )
     ]
     assert model.tile_specs == expected_tile_specs
@@ -133,6 +134,7 @@ def test_extended_feature_model__agg_per_category_feature(
             feature_store_id=snowflake_feature_store.id,
             parent_column_name="col_float",
             aggregation_function_name="sum",
+            windows=["30m", "2h", "1d"],
         )
     ]
     assert model.tile_specs == expected_tile_specs

--- a/tests/unit/service/test_feature_manager.py
+++ b/tests/unit/service/test_feature_manager.py
@@ -1,0 +1,452 @@
+"""
+Test FeatureManagerService
+"""
+
+from datetime import datetime
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+from bson import ObjectId
+
+from featurebyte.feature_manager.model import ExtendedFeatureModel
+from featurebyte.models.online_store_spec import OnlineFeatureSpec
+from featurebyte.models.tile_registry import BackfillMetadata, LastRunMetadata, TileUpdate
+from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
+from tests.util.helper import assert_equal_with_expected_fixture, extract_session_executed_queries
+
+
+@pytest.fixture(autouse=True)
+def mock_schedule_online_store_current_ts():
+    """
+    Fixture to mock datetime.now() to a fixed time in TileScheduleOnlineStore
+    """
+    with patch("featurebyte.sql.tile_schedule_online_store.datetime") as mock_datetime:
+        mock_datetime.now.return_value = datetime(2022, 5, 15, 10, 0, 5)
+        yield
+
+
+@pytest.fixture(autouse=True)
+def mock_temp_table_objectid():
+    """
+    Fixture to mock ObjectId to a fixed value in TileScheduleOnlineStore
+    """
+    with patch("featurebyte.sql.common.ObjectId", return_value=ObjectId("0" * 24)):
+        yield
+
+
+@pytest.fixture
+def feature_manager_service(app_container):
+    """
+    Fixture for a FeatureManagerService
+    """
+    return app_container.feature_manager_service
+
+
+@pytest.fixture
+def feature_2h(snowflake_event_view_with_entity):
+    """
+    Fixture for a feature with 2h derivation window
+    """
+    feature = snowflake_event_view_with_entity.groupby("cust_id").aggregate_over(
+        method="count",
+        windows=["2h"],
+        feature_names=["COUNT_2h"],
+        feature_job_setting=FeatureJobSetting(
+            blind_spot="30m",
+            frequency="1h",
+            time_modulo_frequency="15m",
+        ),
+    )["COUNT_2h"]
+    feature.save()
+    return feature
+
+
+@pytest.fixture
+def feature_4h(snowflake_event_view_with_entity):
+    """
+    Fixture for a feature with 4h derivation window
+    """
+    feature = snowflake_event_view_with_entity.groupby("cust_id").aggregate_over(
+        method="count",
+        windows=["4h"],
+        feature_names=["COUNT_4h"],
+        feature_job_setting=FeatureJobSetting(
+            blind_spot="30m",
+            frequency="1h",
+            time_modulo_frequency="15m",
+        ),
+    )["COUNT_4h"]
+    feature.save()
+    return feature
+
+
+def get_online_feature_spec(feature_model):
+    """
+    Helper function to get an OnlineFeatureSpec from a feature
+    """
+    extended_feature_model = ExtendedFeatureModel(**feature_model.dict(by_alias=True))
+    online_feature_spec = OnlineFeatureSpec(feature=extended_feature_model)
+    return online_feature_spec
+
+
+async def get_tile_model(app_container, feature_model):
+    """
+    Helper function to get a tile model for a feature
+    """
+    tile_specs = ExtendedFeatureModel(**feature_model.dict(by_alias=True)).tile_specs
+    assert len(tile_specs) == 1
+    return await app_container.tile_registry_service.get_tile_model(
+        tile_specs[0].tile_id, tile_specs[0].aggregation_id
+    )
+
+
+@pytest.mark.asyncio
+async def test_enable_new_feature(
+    app_container,
+    feature_manager_service,
+    mock_snowflake_session,
+    feature_2h,
+    update_fixtures,
+):
+    """
+    Test enabling one feature without any existing backfill metadata
+    """
+    feature_model = feature_2h.cached_model
+
+    tile_model = await get_tile_model(app_container, feature_model)
+    assert tile_model is None
+
+    mock_snowflake_session.table_exists.return_value = False
+    await feature_manager_service.online_enable(
+        session=mock_snowflake_session,
+        feature_spec=get_online_feature_spec(feature_model),
+        schedule_time=pd.Timestamp("2022-05-15 10:00:00"),
+    )
+
+    # Check tile registry metadata updated
+    tile_model = await get_tile_model(app_container, feature_model)
+    assert tile_model.backfill_metadata == BackfillMetadata(start_date=datetime(2022, 5, 15, 6, 45))
+    assert tile_model.last_run_metadata_offline == LastRunMetadata(
+        tile_end_date=datetime(2022, 5, 15, 8, 45), index=459057
+    )
+
+    # Check executed queries
+    executed_queries = extract_session_executed_queries(mock_snowflake_session)
+    assert_equal_with_expected_fixture(
+        executed_queries,
+        "tests/fixtures/feature_manager/enable_new_feature.sql",
+        update_fixtures,
+    )
+
+
+@pytest.mark.asyncio
+async def test_enable_feature_with_existing_backfill_metadata(
+    app_container,
+    feature_manager_service,
+    mock_snowflake_session,
+    feature_2h,
+    feature_4h,
+    update_fixtures,
+):
+    """
+    Test enabling two features with shared tile
+    """
+    tile_model = await get_tile_model(app_container, feature_2h.cached_model)
+    assert tile_model is None
+
+    # Enable feature_2h. This sets up the tile registry metadata
+    mock_snowflake_session.table_exists.return_value = False
+    await feature_manager_service.online_enable(
+        session=mock_snowflake_session,
+        feature_spec=get_online_feature_spec(feature_2h.cached_model),
+        schedule_time=pd.Timestamp("2022-05-15 10:00:00"),
+    )
+
+    # Enable feature_4h. This should use the existing tile registry metadata to determine what
+    # should be backfilled
+    mock_snowflake_session.list_table_schema.return_value = {
+        "tile_col_1": "some_info",
+        "tile_col_2": "some_info",
+    }
+    mock_snowflake_session.reset_mock()
+    mock_snowflake_session.table_exists.return_value = True
+    await feature_manager_service.online_enable(
+        session=mock_snowflake_session,
+        feature_spec=get_online_feature_spec(feature_4h.cached_model),
+        schedule_time=pd.Timestamp("2022-05-15 10:00:00"),
+    )
+
+    # Check tile registry metadata updated
+    tile_model = await get_tile_model(app_container, feature_4h.cached_model)
+    assert tile_model.backfill_metadata == BackfillMetadata(start_date=datetime(2022, 5, 15, 4, 45))
+    assert tile_model.last_run_metadata_offline == LastRunMetadata(
+        tile_end_date=datetime(2022, 5, 15, 8, 45), index=459057
+    )
+
+    # Check executed queries
+    executed_queries = extract_session_executed_queries(mock_snowflake_session)
+    assert_equal_with_expected_fixture(
+        executed_queries,
+        "tests/fixtures/feature_manager/enable_with_backfill_metadata.sql",
+        update_fixtures,
+    )
+
+
+@pytest.mark.asyncio
+async def test_enable_feature_with_required_tiles_available(
+    app_container,
+    feature_manager_service,
+    mock_snowflake_session,
+    feature_2h,
+    feature_4h,
+    update_fixtures,
+):
+    """
+    Test enabling a feature when its required tiles are already generated
+    """
+    tile_model = await get_tile_model(app_container, feature_4h.cached_model)
+    assert tile_model is None
+
+    # Enable feature_4h. This sets up the tile registry metadata
+    mock_snowflake_session.table_exists.return_value = False
+    await feature_manager_service.online_enable(
+        session=mock_snowflake_session,
+        feature_spec=get_online_feature_spec(feature_4h.cached_model),
+        schedule_time=pd.Timestamp("2022-05-15 10:00:00"),
+    )
+
+    # Check tile registry metadata updated
+    tile_model = await get_tile_model(app_container, feature_4h.cached_model)
+    assert tile_model.backfill_metadata == BackfillMetadata(start_date=datetime(2022, 5, 15, 4, 45))
+    assert tile_model.last_run_metadata_offline == LastRunMetadata(
+        tile_end_date=datetime(2022, 5, 15, 8, 45), index=459057
+    )
+
+    # Enable feature_2h. No tiles need to be generated again because feature_4h has already
+    # generated the required tiles
+    mock_snowflake_session.reset_mock()
+    await feature_manager_service.online_enable(
+        session=mock_snowflake_session,
+        feature_spec=get_online_feature_spec(feature_2h.cached_model),
+        schedule_time=pd.Timestamp("2022-05-15 10:00:00"),
+    )
+
+    # Check tile registry metadata remains the same
+    tile_model = await get_tile_model(app_container, feature_4h.cached_model)
+    assert tile_model.backfill_metadata == BackfillMetadata(start_date=datetime(2022, 5, 15, 4, 45))
+    assert tile_model.last_run_metadata_offline == LastRunMetadata(
+        tile_end_date=datetime(2022, 5, 15, 8, 45), index=459057
+    )
+
+    # Check executed queries. There shouldn't be any tile compute queries but only the feature
+    # compute query using existing tiles.
+    executed_queries = extract_session_executed_queries(mock_snowflake_session)
+    assert_equal_with_expected_fixture(
+        executed_queries,
+        "tests/fixtures/feature_manager/enable_with_required_tiles_available.sql",
+        update_fixtures,
+    )
+
+
+@pytest.mark.asyncio
+async def test_enable_second_feature_later_date(
+    app_container,
+    feature_manager_service,
+    mock_snowflake_session,
+    feature_2h,
+    feature_4h,
+    update_fixtures,
+):
+    """
+    Test enabling a feature with a later schedule date. This requires two queries for the tile
+    backfill.
+    """
+    tile_model = await get_tile_model(app_container, feature_2h.cached_model)
+    assert tile_model is None
+
+    # Enable feature_2h. This sets up the tile registry metadata
+    mock_snowflake_session.table_exists.return_value = False
+    await feature_manager_service.online_enable(
+        session=mock_snowflake_session,
+        feature_spec=get_online_feature_spec(feature_2h.cached_model),
+        schedule_time=pd.Timestamp("2022-05-15 10:00:00"),
+    )
+
+    # Check tile registry metadata updated
+    tile_model = await get_tile_model(app_container, feature_4h.cached_model)
+    assert tile_model.backfill_metadata == BackfillMetadata(start_date=datetime(2022, 5, 15, 6, 45))
+    assert tile_model.last_run_metadata_offline == LastRunMetadata(
+        tile_end_date=datetime(2022, 5, 15, 8, 45), index=459057
+    )
+
+    # Enable feature_4h at a later schedule time
+    mock_snowflake_session.list_table_schema.return_value = {
+        "tile_col_1": "some_info",
+        "tile_col_2": "some_info",
+    }
+    mock_snowflake_session.reset_mock()
+    mock_snowflake_session.table_exists.return_value = True
+    await feature_manager_service.online_enable(
+        session=mock_snowflake_session,
+        feature_spec=get_online_feature_spec(feature_4h.cached_model),
+        schedule_time=pd.Timestamp("2022-05-15 11:00:00"),
+    )
+
+    # Check tile registry metadata updated
+    tile_model = await get_tile_model(app_container, feature_4h.cached_model)
+    assert tile_model.backfill_metadata == BackfillMetadata(start_date=datetime(2022, 5, 15, 5, 45))
+    assert tile_model.last_run_metadata_offline == LastRunMetadata(
+        tile_end_date=datetime(2022, 5, 15, 9, 45), index=459058
+    )
+
+    # Check executed queries. This requires two tile compute queries for the backfill.
+    executed_queries = extract_session_executed_queries(mock_snowflake_session)
+    assert_equal_with_expected_fixture(
+        executed_queries,
+        "tests/fixtures/feature_manager/enable_second_feature_later_date.sql",
+        update_fixtures,
+    )
+
+
+@pytest.mark.asyncio
+async def test_enable_second_feature_much_later_date(
+    app_container,
+    feature_manager_service,
+    mock_snowflake_session,
+    feature_2h,
+    feature_4h,
+    update_fixtures,
+):
+    """
+    Test enabling a feature with a much later schedule date. This requires computation of recent
+    tiles, and should not update backfill metadata start date.
+    """
+    tile_model = await get_tile_model(app_container, feature_2h.cached_model)
+    assert tile_model is None
+
+    # Enable feature_2h. This sets up the tile registry metadata
+    mock_snowflake_session.table_exists.return_value = False
+    await feature_manager_service.online_enable(
+        session=mock_snowflake_session,
+        feature_spec=get_online_feature_spec(feature_2h.cached_model),
+        schedule_time=pd.Timestamp("2022-05-15 10:00:00"),
+    )
+
+    # Check tile registry metadata updated
+    tile_model = await get_tile_model(app_container, feature_4h.cached_model)
+    assert tile_model.backfill_metadata == BackfillMetadata(start_date=datetime(2022, 5, 15, 6, 45))
+    assert tile_model.last_run_metadata_offline == LastRunMetadata(
+        tile_end_date=datetime(2022, 5, 15, 8, 45), index=459057
+    )
+
+    # Enable feature_4h at a much later schedule time when last_run_metadata_offline remains the
+    # same. This simulates the scenario where feature_2h is no longer enabled so no scheduled tile
+    # job has been running.
+    mock_snowflake_session.list_table_schema.return_value = {
+        "tile_col_1": "some_info",
+        "tile_col_2": "some_info",
+    }
+    mock_snowflake_session.reset_mock()
+    mock_snowflake_session.table_exists.return_value = True
+    await feature_manager_service.online_enable(
+        session=mock_snowflake_session,
+        feature_spec=get_online_feature_spec(feature_4h.cached_model),
+        schedule_time=pd.Timestamp("2022-06-15 11:00:00"),
+    )
+
+    # Check tile registry metadata. backfill_metadata start date should remain the same as before.
+    tile_model = await get_tile_model(app_container, feature_4h.cached_model)
+    assert tile_model.backfill_metadata == BackfillMetadata(start_date=datetime(2022, 5, 15, 6, 45))
+    assert tile_model.last_run_metadata_offline == LastRunMetadata(
+        tile_end_date=datetime(2022, 6, 15, 9, 45), index=459802
+    )
+
+    # Check executed queries. This requires two tile compute queries for the backfill.
+    executed_queries = extract_session_executed_queries(mock_snowflake_session)
+    assert_equal_with_expected_fixture(
+        executed_queries,
+        "tests/fixtures/feature_manager/enable_second_feature_much_later_date.sql",
+        update_fixtures,
+    )
+
+
+@pytest.mark.asyncio
+async def test_enable_with_backfill_metadata_but_not_last_run_metadata(
+    app_container,
+    feature_manager_service,
+    mock_snowflake_session,
+    feature_2h,
+    update_fixtures,
+):
+    """
+    Test enabling a feature when backfill metadata is available but last run metadata is not (less
+    likely case).
+    """
+    tile_model = await get_tile_model(app_container, feature_2h.cached_model)
+    assert tile_model is None
+
+    # Enable feature_2h. This sets up the tile registry metadata
+    mock_snowflake_session.table_exists.return_value = False
+    await feature_manager_service.online_enable(
+        session=mock_snowflake_session,
+        feature_spec=get_online_feature_spec(feature_2h.cached_model),
+        schedule_time=pd.Timestamp("2022-05-15 10:00:00"),
+    )
+
+    # Check tile registry metadata updated
+    tile_model = await get_tile_model(app_container, feature_2h.cached_model)
+    assert tile_model.backfill_metadata == BackfillMetadata(start_date=datetime(2022, 5, 15, 6, 45))
+    assert tile_model.last_run_metadata_offline == LastRunMetadata(
+        tile_end_date=datetime(2022, 5, 15, 8, 45), index=459057
+    )
+
+    # Online disable the feature
+    await feature_manager_service.online_disable(
+        session=mock_snowflake_session,
+        feature_spec=get_online_feature_spec(feature_2h.cached_model),
+    )
+
+    # Simulate missing last run metadata by unsetting it
+    update_schema = TileUpdate(
+        last_run_metadata_offline=None,
+        backfill_metadata=tile_model.backfill_metadata,
+    )
+    await app_container.tile_registry_service.update_document(
+        document_id=tile_model.id,
+        data=update_schema,
+        exclude_none=False,
+        document=tile_model,
+    )
+    tile_model = await get_tile_model(app_container, feature_2h.cached_model)
+    assert tile_model.backfill_metadata is not None
+    assert tile_model.last_run_metadata_offline is None
+
+    # Enable feature_2h at a much later schedule time. This requires tiles computation.
+    mock_snowflake_session.list_table_schema.return_value = {
+        "tile_col_1": "some_info",
+        "tile_col_2": "some_info",
+    }
+    mock_snowflake_session.reset_mock()
+    mock_snowflake_session.table_exists.return_value = True
+    await feature_manager_service.online_enable(
+        session=mock_snowflake_session,
+        feature_spec=get_online_feature_spec(feature_2h.cached_model),
+        schedule_time=pd.Timestamp("2022-06-15 11:00:00"),
+    )
+
+    # Check tile registry metadata. backfill_metadata start date should remain the same as before.
+    # last_run_metadata_offline should be set again.
+    tile_model = await get_tile_model(app_container, feature_2h.cached_model)
+    assert tile_model.backfill_metadata == BackfillMetadata(start_date=datetime(2022, 5, 15, 6, 45))
+    assert tile_model.last_run_metadata_offline == LastRunMetadata(
+        tile_end_date=datetime(2022, 6, 15, 9, 45), index=459802
+    )
+
+    # Check executed queries. This requires two tile compute queries for the backfill.
+    executed_queries = extract_session_executed_queries(mock_snowflake_session)
+    assert_equal_with_expected_fixture(
+        executed_queries,
+        "tests/fixtures/feature_manager/enable_without_last_run_metadata.sql",
+        update_fixtures,
+    )

--- a/tests/unit/service/test_feature_table_cache.py
+++ b/tests/unit/service/test_feature_table_cache.py
@@ -270,7 +270,6 @@ async def test_create_feature_table_cache(
     assert params["output_table_details"].database_name == "sf_db"
     assert params["output_table_details"].schema_name == "sf_schema"
     assert params["output_table_details"].table_name == "__TEMP__FEATURE_TABLE_CACHE_ObjectId"
-    assert params["is_feature_list_deployed"] == feature_list.deployed
 
     assert mock_snowflake_session.execute_query_long_running.await_count == 2
 
@@ -366,7 +365,6 @@ async def test_update_feature_table_cache(
     assert params["output_table_details"].database_name == "sf_db"
     assert params["output_table_details"].schema_name == "sf_schema"
     assert params["output_table_details"].table_name == "__TEMP__FEATURE_TABLE_CACHE_ObjectId"
-    assert params["is_feature_list_deployed"] == feature_list.deployed
 
     assert mock_snowflake_session.execute_query_long_running.await_count == 3
 
@@ -453,7 +451,6 @@ async def test_update_feature_table_cache__mix_cached_and_non_cached_features(
     assert params["output_table_details"].database_name == "sf_db"
     assert params["output_table_details"].schema_name == "sf_schema"
     assert params["output_table_details"].table_name == "__TEMP__FEATURE_TABLE_CACHE_ObjectId"
-    assert params["is_feature_list_deployed"] == feature_list.deployed
 
     assert mock_snowflake_session.execute_query_long_running.await_count == 3
 

--- a/tests/unit/service/test_historical_features.py
+++ b/tests/unit/service/test_historical_features.py
@@ -64,8 +64,6 @@ async def test_get_historical_features__feature_list_not_deployed(
         output_table_details=output_table_details,
     )
     assert mock_get_historical_features.assert_called_once
-    call_args = mock_get_historical_features.call_args
-    assert call_args[1]["is_feature_list_deployed"] is False
 
 
 @pytest.mark.asyncio
@@ -93,8 +91,6 @@ async def test_get_historical_features__feature_list_not_saved(
         output_table_details=output_table_details,
     )
     assert mock_get_historical_features.assert_called_once
-    call_args = mock_get_historical_features.call_args
-    assert call_args[1]["is_feature_list_deployed"] is False
 
 
 @pytest.mark.asyncio
@@ -119,8 +115,6 @@ async def test_get_historical_features__feature_list_deployed(
         output_table_details=output_table_details,
     )
     assert mock_get_historical_features.assert_called_once
-    call_args = mock_get_historical_features.call_args
-    assert call_args[1]["is_feature_list_deployed"] is True
 
 
 @pytest.mark.asyncio
@@ -144,8 +138,6 @@ async def test_get_historical_features__feature_clusters_not_set(
         output_table_details=output_table_details,
     )
     assert mock_get_historical_features.assert_called_once
-    call_args = mock_get_historical_features.call_args
-    assert call_args[1]["is_feature_list_deployed"] is True
 
 
 @pytest.mark.asyncio
@@ -252,38 +244,6 @@ async def test_get_historical_features__point_in_time_dtype_conversion(
     assert df_observation_set_registered.dtypes["POINT_IN_TIME"] == "datetime64[ns]"
 
     mocked_compute_tiles_on_demand.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_get_historical_features__skip_tile_cache_if_deployed(
-    float_feature,
-    mock_snowflake_session,
-    mocked_compute_tiles_on_demand,
-    output_table_details,
-    tile_cache_service,
-    snowflake_feature_store,
-):
-    """
-    Test that for with is_feature_list_deployed=True on demand tile computation is skipped
-    """
-    df_request = pd.DataFrame(
-        {
-            "POINT_IN_TIME": ["2022-01-01", "2022-02-01"],
-            "cust_id": ["C1", "C2"],
-        }
-    )
-    mock_snowflake_session.generate_session_unique_id.return_value = "1"
-    await get_historical_features(
-        session=mock_snowflake_session,
-        tile_cache_service=tile_cache_service,
-        graph=float_feature.graph,
-        nodes=[float_feature.node],
-        observation_set=df_request,
-        feature_store=snowflake_feature_store,
-        is_feature_list_deployed=True,
-        output_table_details=output_table_details,
-    )
-    mocked_compute_tiles_on_demand.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tile/test_unit_snowflake_tile.py
+++ b/tests/unit/tile/test_unit_snowflake_tile.py
@@ -27,6 +27,7 @@ def test_construct_snowflaketile_time_modulo_error():
             value_column_types=["FLOAT"],
             entity_column_names=["col1"],
             feature_store_id=ObjectId(),
+            windows=["1d"],
         )
     assert "time_modulo_frequency_second must be less than 180" in str(excinfo.value)
 
@@ -47,6 +48,7 @@ def test_construct_snowflaketile_frequency_minute_error():
             value_column_types=["FLOAT"],
             entity_column_names=["col1"],
             feature_store_id=ObjectId(),
+            windows=["1d"],
         )
     assert "frequency_minute should be a multiple of 60 if it is more than 60" in str(excinfo.value)
 
@@ -66,6 +68,7 @@ def test_construct_snowflaketile_zero_time_modulo_frequency():
         tile_id="some_tile_id",
         aggregation_id="some_agg_id",
         feature_store_id=ObjectId(),
+        windows=["1d"],
     )
     assert tile_spec.time_modulo_frequency_second == 0
     assert tile_spec.blind_spot_second == 3


### PR DESCRIPTION
## Description

This updates the tiles backfill process when enabling a deployment to reduce unnecessary tiles computation. Changes:

1. When enabling a deployment, backfill only the tiles that are required to compute the current features for the offline store tables. This is determined by a combination of feature job settings and feature derivation window.

2. When computing historical features, always run on-demand tiles generation regardless of whether the feature list is deployed.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
