### PR TITLE
Overwrite debug info file if exists to prevent error

### DIFF
--- a/featurebyte/service/offline_store_feature_table_construction.py
+++ b/featurebyte/service/offline_store_feature_table_construction.py
@@ -186,6 +186,10 @@ class OfflineStoreFeatureTableConstructionService:
             path = self.offline_store_feature_table_service.get_full_remote_file_path(
                 f"offline_store_feature_table/{feature_table_name}/entity_universe_debug_info.pickle"
             )
+            try:
+                await self.storage.delete(Path(path))
+            except FileNotFoundError:
+                pass
             async with aiofiles.tempfile.TemporaryDirectory() as tempdir_path:
                 file_path = os.path.join(tempdir_path, "data.pickle")
                 with open(file_path, "wb") as file_obj:


### PR DESCRIPTION
## Description

The dumping of debug info file can error if there is an existing file with the same name. This fix prevents the error.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
