### PR TITLE
[DEV-3383] Apply casting for features with int dtype in feature query

### DIFF
--- a/.changelog/DEV-3383.yaml
+++ b/.changelog/DEV-3383.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Cast features with integer dtype BIGINT explicitly in feature queries"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/query_graph/node/binary.py
+++ b/featurebyte/query_graph/node/binary.py
@@ -150,6 +150,10 @@ class DivideNode(BinaryArithmeticOpNode):
 
     type: Literal[NodeType.DIV] = Field(NodeType.DIV, const=True)
 
+    def derive_var_type(self, inputs: List[OperationStructure]) -> DBVarType:
+        _ = inputs
+        return DBVarType.FLOAT
+
     def generate_expression(self, left_operand: str, right_operand: str) -> str:
         return f"{left_operand} / {right_operand}"
 

--- a/tests/fixtures/expected_feature_sql_combined_simple_aggregate_and_window_aggregate.sql
+++ b/tests/fixtures/expected_feature_sql_combined_simple_aggregate_and_window_aggregate.sql
@@ -104,7 +104,7 @@ WITH "REQUEST_TABLE_W604800_F360_BS90_M180_cust_id" AS (
     ON REQ."transaction_id" = T1."transaction_id"
 )
 SELECT
-  (
+  CAST((
     "_fb_internal_cust_id_window_w604800_sum_32c30411c654d6ad110110ed16543be7a7cefaaa" + CASE
       WHEN (
         "_fb_internal_transaction_id_item_count_None_event_id_col_None_join_1" IS NULL
@@ -112,5 +112,5 @@ SELECT
       THEN 0
       ELSE "_fb_internal_transaction_id_item_count_None_event_id_col_None_join_1"
     END
-  ) AS "combined_feature"
+  ) AS BIGINT) AS "combined_feature"
 FROM _FB_AGGREGATED AS AGG

--- a/tests/fixtures/expected_get_online_features_multiple_queries_batch_request_table.sql
+++ b/tests/fixtures/expected_get_online_features_multiple_queries_batch_request_table.sql
@@ -46,13 +46,13 @@ WITH ONLINE_REQUEST_TABLE AS (
 SELECT
   AGG."__FB_TABLE_ROW_INDEX",
   AGG."cust_id",
-  CASE
+  CAST(CASE
     WHEN (
       "_fb_internal_window_w86400_count_3178e5d8142ed182c5db45462cb780d18205bd64" IS NULL
     )
     THEN 0
     ELSE "_fb_internal_window_w86400_count_3178e5d8142ed182c5db45462cb780d18205bd64"
-  END AS "count_1d"
+  END AS BIGINT) AS "count_1d"
 FROM _FB_AGGREGATED AS AGG;
 
 SELECT

--- a/tests/fixtures/expected_get_online_features_multiple_queries_dataframe.sql
+++ b/tests/fixtures/expected_get_online_features_multiple_queries_dataframe.sql
@@ -50,13 +50,13 @@ WITH ONLINE_REQUEST_TABLE AS (
 SELECT
   AGG."__FB_TABLE_ROW_INDEX",
   AGG."cust_id",
-  CASE
+  CAST(CASE
     WHEN (
       "_fb_internal_window_w86400_count_3178e5d8142ed182c5db45462cb780d18205bd64" IS NULL
     )
     THEN 0
     ELSE "_fb_internal_window_w86400_count_3178e5d8142ed182c5db45462cb780d18205bd64"
-  END AS "count_1d"
+  END AS BIGINT) AS "count_1d"
 FROM _FB_AGGREGATED AS AGG;
 
 SELECT

--- a/tests/fixtures/expected_historical_requests_multiple_batches_feature_set_0.sql
+++ b/tests/fixtures/expected_historical_requests_multiple_batches_feature_set_0.sql
@@ -70,6 +70,6 @@ SELECT
   AGG."__FB_TABLE_ROW_INDEX",
   AGG."POINT_IN_TIME",
   AGG."CUSTOMER_ID",
-  "_fb_internal_MEMBERSHIP_STATUS_as_at_count_None_membership_status_None_input_3" AS "asat_feature",
-  "_fb_internal_order_id_item_count_None_order_id_None_input_4" AS "order_size"
+  CAST("_fb_internal_MEMBERSHIP_STATUS_as_at_count_None_membership_status_None_input_3" AS BIGINT) AS "asat_feature",
+  CAST("_fb_internal_order_id_item_count_None_order_id_None_input_4" AS BIGINT) AS "order_size"
 FROM _FB_AGGREGATED AS AGG

--- a/tests/fixtures/expected_online_feature_retrieval_filled_versions.sql
+++ b/tests/fixtures/expected_online_feature_retrieval_filled_versions.sql
@@ -76,5 +76,5 @@ SELECT
   AGG."CUSTOMER_ID",
   AGG."order_id",
   CAST("_fb_internal_CUSTOMER_ID_window_w172800_avg_f37862722c21105449ad882409cf62a1ff7f5b35" AS DOUBLE) AS "a_48h_average",
-  "_fb_internal_order_id_item_count_None_order_id_None_input_2" AS "order_size"
+  CAST("_fb_internal_order_id_item_count_None_order_id_None_input_2" AS BIGINT) AS "order_size"
 FROM _FB_AGGREGATED AS AGG

--- a/tests/fixtures/expected_online_feature_retrieval_filled_versions_multiple_groups.sql
+++ b/tests/fixtures/expected_online_feature_retrieval_filled_versions_multiple_groups.sql
@@ -102,7 +102,7 @@ SELECT
   AGG."__FB_TABLE_ROW_INDEX",
   AGG."CUSTOMER_ID",
   AGG."order_id",
-  "_fb_internal_order_id_item_count_None_order_id_None_input_2" AS "order_size"
+  CAST("_fb_internal_order_id_item_count_None_order_id_None_input_2" AS BIGINT) AS "order_size"
 FROM _FB_AGGREGATED AS AGG;
 
 SELECT

--- a/tests/fixtures/expected_online_feature_retrieval_mixed.sql
+++ b/tests/fixtures/expected_online_feature_retrieval_mixed.sql
@@ -76,5 +76,5 @@ SELECT
   AGG."CUSTOMER_ID",
   AGG."order_id",
   CAST("_fb_internal_CUSTOMER_ID_window_w172800_avg_f37862722c21105449ad882409cf62a1ff7f5b35" AS DOUBLE) AS "a_48h_average",
-  "_fb_internal_order_id_item_count_None_order_id_None_input_2" AS "order_size"
+  CAST("_fb_internal_order_id_item_count_None_order_id_None_input_2" AS BIGINT) AS "order_size"
 FROM _FB_AGGREGATED AS AGG

--- a/tests/fixtures/expected_online_feature_retrieval_request_subquery.sql
+++ b/tests/fixtures/expected_online_feature_retrieval_request_subquery.sql
@@ -82,5 +82,5 @@ WITH ONLINE_REQUEST_TABLE AS (
 SELECT
   AGG."CUSTOMER_ID",
   CAST("_fb_internal_CUSTOMER_ID_window_w172800_avg_f37862722c21105449ad882409cf62a1ff7f5b35" AS DOUBLE) AS "a_48h_average",
-  "_fb_internal_order_id_item_count_None_order_id_None_input_2" AS "order_size"
+  CAST("_fb_internal_order_id_item_count_None_order_id_None_input_2" AS BIGINT) AS "order_size"
 FROM _FB_AGGREGATED AS AGG

--- a/tests/fixtures/expected_preview_sql_aggregate_asat.sql
+++ b/tests/fixtures/expected_preview_sql_aggregate_asat.sql
@@ -48,5 +48,5 @@ WITH REQUEST_TABLE AS (
 SELECT
   AGG."POINT_IN_TIME",
   AGG."CUSTOMER_ID",
-  "_fb_internal_MEMBERSHIP_STATUS_as_at_count_None_membership_status_None_input_1" AS "asat_feature"
+  CAST("_fb_internal_MEMBERSHIP_STATUS_as_at_count_None_membership_status_None_input_1" AS BIGINT) AS "asat_feature"
 FROM _FB_AGGREGATED AS AGG

--- a/tests/fixtures/expected_preview_sql_aggregate_asat_offset.sql
+++ b/tests/fixtures/expected_preview_sql_aggregate_asat_offset.sql
@@ -49,5 +49,5 @@ WITH REQUEST_TABLE AS (
 SELECT
   AGG."POINT_IN_TIME",
   AGG."CUSTOMER_ID",
-  "_fb_internal_MEMBERSHIP_STATUS_as_at_count_None_membership_status_None_7d_input_1" AS "asat_feature_offset_7d"
+  CAST("_fb_internal_MEMBERSHIP_STATUS_as_at_count_None_membership_status_None_7d_input_1" AS BIGINT) AS "asat_feature_offset_7d"
 FROM _FB_AGGREGATED AS AGG

--- a/tests/fixtures/expected_preview_sql_all_types.sql
+++ b/tests/fixtures/expected_preview_sql_all_types.sql
@@ -597,12 +597,12 @@ SELECT
   AGG."CUSTOMER_ID",
   CAST("_fb_internal_CUSTOMER_ID_window_w7200_avg_f37862722c21105449ad882409cf62a1ff7f5b35" AS DOUBLE) AS "a_2h_average",
   CAST("_fb_internal_CUSTOMER_ID_window_w172800_avg_f37862722c21105449ad882409cf62a1ff7f5b35" AS DOUBLE) AS "a_48h_average",
-  "_fb_internal_order_id_item_count_None_order_id_None_input_4" AS "order_size",
+  CAST("_fb_internal_order_id_item_count_None_order_id_None_input_4" AS BIGINT) AS "order_size",
   CAST((
     "_fb_internal_CUSTOMER_ID_lookup_cust_value_1_input_2" + "_fb_internal_CUSTOMER_ID_lookup_cust_value_2_input_2"
   ) AS DOUBLE) AS "MY FEATURE",
   "_fb_internal_CUSTOMER_ID_lookup_membership_status_input_3" AS "Current Membership Status",
   CAST("_fb_internal_CUSTOMER_ID_window_w7776000_latest_414e1c5ab2e329a43aabe6dc95bd30d1d9c311b0" AS DOUBLE) AS "a_latest_value_past_90d",
   CAST("_fb_internal_CUSTOMER_ID_BUSINESS_ID_latest_b4a6546e024f3a059bd67f454028e56c5a37826e" AS DOUBLE) AS "a_latest_value",
-  "_fb_internal_MEMBERSHIP_STATUS_as_at_count_None_membership_status_None_input_3" AS "asat_feature"
+  CAST("_fb_internal_MEMBERSHIP_STATUS_as_at_count_None_membership_status_None_input_3" AS BIGINT) AS "asat_feature"
 FROM _FB_AGGREGATED AS AGG

--- a/tests/fixtures/expected_preview_sql_item_groupby.sql
+++ b/tests/fixtures/expected_preview_sql_item_groupby.sql
@@ -209,5 +209,5 @@ SELECT
   AGG."CUSTOMER_ID",
   CAST("_fb_internal_CUSTOMER_ID_window_w7200_avg_f37862722c21105449ad882409cf62a1ff7f5b35" AS DOUBLE) AS "a_2h_average",
   CAST("_fb_internal_CUSTOMER_ID_window_w172800_avg_f37862722c21105449ad882409cf62a1ff7f5b35" AS DOUBLE) AS "a_48h_average",
-  "_fb_internal_order_id_item_count_None_order_id_None_input_2" AS "order_size"
+  CAST("_fb_internal_order_id_item_count_None_order_id_None_input_2" AS BIGINT) AS "order_size"
 FROM _FB_AGGREGATED AS AGG

--- a/tests/fixtures/feature_materialize/initialize_features_no_entity_databricks_unity.sql
+++ b/tests/fixtures/feature_materialize/initialize_features_no_entity_databricks_unity.sql
@@ -72,13 +72,13 @@ WITH ONLINE_REQUEST_TABLE AS (
     ON TRUE
 )
 SELECT
-  CASE
+  CAST(CASE
     WHEN (
       `_fb_internal_window_w86400_count_3178e5d8142ed182c5db45462cb780d18205bd64` IS NULL
     )
     THEN 0
     ELSE `_fb_internal_window_w86400_count_3178e5d8142ed182c5db45462cb780d18205bd64`
-  END AS `count_1d_V220101`,
+  END AS LONG) AS `count_1d_V220101`,
   '0' AS `__featurebyte_dummy_entity`
 FROM _FB_AGGREGATED AS AGG;
 

--- a/tests/fixtures/feature_materialize/initialize_new_columns_precomputed_lookup.sql
+++ b/tests/fixtures/feature_materialize/initialize_new_columns_precomputed_lookup.sql
@@ -81,20 +81,20 @@ WITH ONLINE_REQUEST_TABLE AS (
 )
 SELECT
   AGG."gender",
-  CASE
+  CAST(CASE
     WHEN (
       "_fb_internal_gender_as_at_count_None_col_boolean_None_project_1" IS NULL
     )
     THEN 0
     ELSE "_fb_internal_gender_as_at_count_None_col_boolean_None_project_1"
-  END AS "__feature_requiring_parent_serving_V220101__part1",
-  CASE
+  END AS BIGINT) AS "__feature_requiring_parent_serving_V220101__part1",
+  CAST(CASE
     WHEN (
       "_fb_internal_gender_as_at_count_None_col_boolean_None_project_1" IS NULL
     )
     THEN 0
     ELSE "_fb_internal_gender_as_at_count_None_col_boolean_None_project_1"
-  END AS "__feature_requiring_parent_serving_plus_123_V220101__part1"
+  END AS BIGINT) AS "__feature_requiring_parent_serving_plus_123_V220101__part1"
 FROM _FB_AGGREGATED AS AGG;
 
 CREATE TABLE "sf_db"."sf_schema"."TEMP_LOOKUP_UNIVERSE_TABLE_000000000000000000000000" AS

--- a/tests/fixtures/feature_materialize/scheduled_materialize_features_precomputed_lookup.sql
+++ b/tests/fixtures/feature_materialize/scheduled_materialize_features_precomputed_lookup.sql
@@ -77,20 +77,20 @@ WITH ONLINE_REQUEST_TABLE AS (
 )
 SELECT
   AGG."gender",
-  CASE
+  CAST(CASE
     WHEN (
       "_fb_internal_gender_as_at_count_None_col_boolean_None_project_1" IS NULL
     )
     THEN 0
     ELSE "_fb_internal_gender_as_at_count_None_col_boolean_None_project_1"
-  END AS "__feature_requiring_parent_serving_V220101__part1",
-  CASE
+  END AS BIGINT) AS "__feature_requiring_parent_serving_V220101__part1",
+  CAST(CASE
     WHEN (
       "_fb_internal_gender_as_at_count_None_col_boolean_None_project_1" IS NULL
     )
     THEN 0
     ELSE "_fb_internal_gender_as_at_count_None_col_boolean_None_project_1"
-  END AS "__feature_requiring_parent_serving_plus_123_V220101__part1"
+  END AS BIGINT) AS "__feature_requiring_parent_serving_plus_123_V220101__part1"
 FROM _FB_AGGREGATED AS AGG;
 
 CREATE TABLE "sf_db"."sf_schema"."TEMP_LOOKUP_UNIVERSE_TABLE_000000000000000000000000" AS


### PR DESCRIPTION
## Description

This applies explicit casting for features with integer dtype to BIGINT. This is to ensure predictable data types for the columns in the feature table and facilitate code generation for databricks on demand functions.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
