### PR TITLE
[DEV-3312] Handle offline store feature table bad state when disabling a deployment

### DIFF
--- a/featurebyte/service/exception.py
+++ b/featurebyte/service/exception.py
@@ -1,0 +1,12 @@
+"""
+Exception classes used within services
+"""
+
+
+class OfflineStoreFeatureTableBadStateError(Exception):
+    """
+    OfflineStoreFeatureTableBadStateError
+
+    This exception is raised when an offline store feature table document is being updated but is in
+    a bad state and cannot be recovered. This should only happen rarely and should be investigated.
+    """

--- a/featurebyte/service/offline_store_feature_table_construction.py
+++ b/featurebyte/service/offline_store_feature_table_construction.py
@@ -37,6 +37,7 @@ from featurebyte.query_graph.node.generic import LookupNode
 from featurebyte.query_graph.node.mixin import BaseGroupbyParameters
 from featurebyte.service.entity import EntityService
 from featurebyte.service.entity_serving_names import EntityServingNamesService
+from featurebyte.service.exception import OfflineStoreFeatureTableBadStateError
 from featurebyte.service.offline_store_feature_table import OfflineStoreFeatureTableService
 from featurebyte.service.parent_serving import ParentEntityLookupService
 from featurebyte.storage import Storage
@@ -156,7 +157,7 @@ class OfflineStoreFeatureTableConstructionService:
 
         Raises
         ------
-        AssertionError
+        OfflineStoreFeatureTableBadStateError
             If the entity universe cannot be determined
         """
         ingest_graph_metadata = get_combined_ingest_graph(
@@ -172,7 +173,7 @@ class OfflineStoreFeatureTableConstructionService:
                 source_type=source_type,
                 feature_table_name=feature_table_name,
             )
-        except AssertionError:
+        except OfflineStoreFeatureTableBadStateError:
             # Temporarily save the offline ingest graphs and other information to a file for
             # troubleshooting
             debug_info = {
@@ -237,7 +238,7 @@ class OfflineStoreFeatureTableConstructionService:
 
         Raises
         ------
-        AssertionError
+        OfflineStoreFeatureTableBadStateError
             If the entity universe cannot be determined
         """
         params = []
@@ -278,7 +279,7 @@ class OfflineStoreFeatureTableConstructionService:
         universe_expr = get_combined_universe(params, source_type)
 
         if universe_expr is None:
-            raise AssertionError(
+            raise OfflineStoreFeatureTableBadStateError(
                 f"Failed to create entity universe for offline store feature table {feature_table_name}"
             )
 


### PR DESCRIPTION
## Description

This adds handling for offline stores feature table in a bad state when disabling a deployment. This is to ensure that the process of disabling a deployment can always complete to free up resources.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
