### PR TITLE
[chore] Update online store update task to be cpu task

### DIFF
--- a/featurebyte/schema/worker/task/online_store_initialize.py
+++ b/featurebyte/schema/worker/task/online_store_initialize.py
@@ -7,7 +7,7 @@ from typing import Optional
 from featurebyte.enum import WorkerCommand
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.catalog import CatalogModel
-from featurebyte.schema.worker.task.base import BaseTaskPayload
+from featurebyte.schema.worker.task.base import BaseTaskPayload, TaskType
 
 
 class CatalogOnlineStoreInitializeTaskPayload(BaseTaskPayload):
@@ -18,3 +18,4 @@ class CatalogOnlineStoreInitializeTaskPayload(BaseTaskPayload):
     command = WorkerCommand.CATALOG_ONLINE_STORE_UPDATE
     online_store_id: Optional[PydanticObjectId]
     output_collection_name = CatalogModel.collection_name()
+    task_type = TaskType.CPU_TASK


### PR DESCRIPTION
## Description

The `CATALOG_ONLINE_STORE_UPDATE` task should be a cpu task since it involves features materialization, similar to the `SCHEDULED_FEATURE_MATERIALIZE` task.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
