### PR TITLE
[DEV-3382] Fix describe error on timestamp columns with invalid values

### DIFF
--- a/.changelog/DEV-3382.yaml
+++ b/.changelog/DEV-3382.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix view and table describe method error on invalid datetime values"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/tests/fixtures/query_graph/expected_describe_batches_0.sql
+++ b/tests/fixtures/query_graph/expected_describe_batches_0.sql
@@ -19,8 +19,22 @@ WITH data AS (
   FROM data
 ), stats AS (
   SELECT
-    MIN("ts") AS "min__0",
-    MAX("ts") AS "max__0",
+    MIN(
+      IFF(
+        "ts" < CAST('1900-01-01' AS TIMESTAMPNTZ)
+        OR "ts" > CAST('2200-01-01' AS TIMESTAMPNTZ),
+        NULL,
+        "ts"
+      )
+    ) AS "min__0",
+    MAX(
+      IFF(
+        "ts" < CAST('1900-01-01' AS TIMESTAMPNTZ)
+        OR "ts" > CAST('2200-01-01' AS TIMESTAMPNTZ),
+        NULL,
+        "ts"
+      )
+    ) AS "max__0",
     NULL AS "min__1",
     NULL AS "max__1",
     MIN("a") AS "min__2",

--- a/tests/fixtures/query_graph/expected_describe_databricks.sql
+++ b/tests/fixtures/query_graph/expected_describe_databricks.sql
@@ -151,11 +151,23 @@ WITH data AS (
     NULL AS `%empty__0`,
     NULL AS `mean__0`,
     NULL AS `std__0`,
-    MIN(`ts`) AS `min__0`,
+    MIN(
+      IF(
+        `ts` < CAST('1900-01-01' AS TIMESTAMP) OR `ts` > CAST('2200-01-01' AS TIMESTAMP),
+        NULL,
+        `ts`
+      )
+    ) AS `min__0`,
     NULL AS `25%__0`,
     NULL AS `50%__0`,
     NULL AS `75%__0`,
-    MAX(`ts`) AS `max__0`,
+    MAX(
+      IF(
+        `ts` < CAST('1900-01-01' AS TIMESTAMP) OR `ts` > CAST('2200-01-01' AS TIMESTAMP),
+        NULL,
+        `ts`
+      )
+    ) AS `max__0`,
     NULL AS `min TZ offset__0`,
     NULL AS `max TZ offset__0`,
     COUNT(DISTINCT `cust_id`) AS `unique__1`,

--- a/tests/fixtures/query_graph/expected_describe_snowflake.sql
+++ b/tests/fixtures/query_graph/expected_describe_snowflake.sql
@@ -128,11 +128,25 @@ WITH data AS (
     NULL AS "%empty__0",
     NULL AS "mean__0",
     NULL AS "std__0",
-    MIN("ts") AS "min__0",
+    MIN(
+      IFF(
+        "ts" < CAST('1900-01-01' AS TIMESTAMPNTZ)
+        OR "ts" > CAST('2200-01-01' AS TIMESTAMPNTZ),
+        NULL,
+        "ts"
+      )
+    ) AS "min__0",
     NULL AS "25%__0",
     NULL AS "50%__0",
     NULL AS "75%__0",
-    MAX("ts") AS "max__0",
+    MAX(
+      IFF(
+        "ts" < CAST('1900-01-01' AS TIMESTAMPNTZ)
+        OR "ts" > CAST('2200-01-01' AS TIMESTAMPNTZ),
+        NULL,
+        "ts"
+      )
+    ) AS "max__0",
     NULL AS "min TZ offset__0",
     NULL AS "max TZ offset__0",
     COUNT(DISTINCT "cust_id") AS "unique__1",

--- a/tests/fixtures/query_graph/expected_describe_spark.sql
+++ b/tests/fixtures/query_graph/expected_describe_spark.sql
@@ -151,11 +151,23 @@ WITH data AS (
     NULL AS `%empty__0`,
     NULL AS `mean__0`,
     NULL AS `std__0`,
-    MIN(`ts`) AS `min__0`,
+    MIN(
+      IF(
+        `ts` < CAST('1900-01-01' AS TIMESTAMP) OR `ts` > CAST('2200-01-01' AS TIMESTAMP),
+        NULL,
+        `ts`
+      )
+    ) AS `min__0`,
     NULL AS `25%__0`,
     NULL AS `50%__0`,
     NULL AS `75%__0`,
-    MAX(`ts`) AS `max__0`,
+    MAX(
+      IF(
+        `ts` < CAST('1900-01-01' AS TIMESTAMP) OR `ts` > CAST('2200-01-01' AS TIMESTAMP),
+        NULL,
+        `ts`
+      )
+    ) AS `max__0`,
     NULL AS `min TZ offset__0`,
     NULL AS `max TZ offset__0`,
     COUNT(DISTINCT `cust_id`) AS `unique__1`,

--- a/tests/fixtures/query_graph/expected_describe_stats_names.sql
+++ b/tests/fixtures/query_graph/expected_describe_stats_names.sql
@@ -19,8 +19,22 @@ WITH data AS (
   FROM data
 ), stats AS (
   SELECT
-    MIN("ts") AS "min__0",
-    MAX("ts") AS "max__0",
+    MIN(
+      IFF(
+        "ts" < CAST('1900-01-01' AS TIMESTAMPNTZ)
+        OR "ts" > CAST('2200-01-01' AS TIMESTAMPNTZ),
+        NULL,
+        "ts"
+      )
+    ) AS "min__0",
+    MAX(
+      IFF(
+        "ts" < CAST('1900-01-01' AS TIMESTAMPNTZ)
+        OR "ts" > CAST('2200-01-01' AS TIMESTAMPNTZ),
+        NULL,
+        "ts"
+      )
+    ) AS "max__0",
     NULL AS "min__1",
     NULL AS "max__1",
     MIN("a") AS "min__2",

--- a/tests/integration/api/test_view_describe.py
+++ b/tests/integration/api/test_view_describe.py
@@ -272,7 +272,7 @@ async def test_describe_invalid_dates(session, feature_store, catalog):
 
     await session.execute_query(
         """
-        CREATE OR REPLACE TABLE TABLE_INVALID_DATES AS
+        CREATE TABLE TABLE_INVALID_DATES AS
         SELECT CAST('2021-01-01 10:00:00' AS TIMESTAMP) AS date_col
         UNION ALL
         SELECT CAST('0019-01-01 10:00:00' AS TIMESTAMP) AS date_col
@@ -294,12 +294,16 @@ async def test_describe_invalid_dates(session, feature_store, catalog):
     )
     describe_df = source_table.describe()
     assert describe_df.shape[0] > 0
-    result_dict = describe_df["DATE_COL"].to_dict()
+    result_dict = describe_df.iloc[:, 0].to_dict()
     assert result_dict == {
         "dtype": "TIMESTAMP",
         "unique": 4,
         "%missing": 0.0,
-        "top": "0019-01-01 10:00:00.000",
+        "top": (
+            "0019-01-01 10:00:00.000"
+            if session.source_type == "snowflake"
+            else "0019-01-01 10:00:00"
+        ),
         "freq": 3.0,
         "min": "2021-01-01T10:00:00.000000000",
         "max": "2023-01-01T10:00:00.000000000",

--- a/tests/integration/api/test_view_describe.py
+++ b/tests/integration/api/test_view_describe.py
@@ -277,6 +277,12 @@ async def test_describe_invalid_dates(session, feature_store, catalog):
         UNION ALL
         SELECT CAST('0019-01-01 10:00:00' AS TIMESTAMP) AS date_col
         UNION ALL
+        SELECT CAST('0019-01-01 10:00:00' AS TIMESTAMP) AS date_col
+        UNION ALL
+        SELECT CAST('0019-01-01 10:00:00' AS TIMESTAMP) AS date_col
+        UNION ALL
+        SELECT CAST('9019-01-01 10:00:00' AS TIMESTAMP) AS date_col
+        UNION ALL
         SELECT CAST('2023-01-01 10:00:00' AS TIMESTAMP) AS date_col
         """
     )
@@ -288,3 +294,13 @@ async def test_describe_invalid_dates(session, feature_store, catalog):
     )
     describe_df = source_table.describe()
     assert describe_df.shape[0] > 0
+    result_dict = describe_df["DATE_COL"].to_dict()
+    assert result_dict == {
+        "dtype": "TIMESTAMP",
+        "unique": 4,
+        "%missing": 0.0,
+        "top": "0019-01-01 10:00:00.000",
+        "freq": 3.0,
+        "min": "2021-01-01T10:00:00.000000000",
+        "max": "2023-01-01T10:00:00.000000000",
+    }

--- a/tests/unit/service/test_observation_table.py
+++ b/tests/unit/service/test_observation_table.py
@@ -206,8 +206,22 @@ async def test_validate__most_recent_point_in_time(
                 (
                   1.0 - COUNT("POINT_IN_TIME") / NULLIF(COUNT(*), 0)
                 ) * 100 AS "%missing__0",
-                MIN("POINT_IN_TIME") AS "min__0",
-                MAX("POINT_IN_TIME") AS "max__0",
+                MIN(
+                  IFF(
+                    "POINT_IN_TIME" < CAST('1900-01-01' AS TIMESTAMPNTZ)
+                    OR "POINT_IN_TIME" > CAST('2200-01-01' AS TIMESTAMPNTZ),
+                    NULL,
+                    "POINT_IN_TIME"
+                  )
+                ) AS "min__0",
+                MAX(
+                  IFF(
+                    "POINT_IN_TIME" < CAST('1900-01-01' AS TIMESTAMPNTZ)
+                    OR "POINT_IN_TIME" > CAST('2200-01-01' AS TIMESTAMPNTZ),
+                    NULL,
+                    "POINT_IN_TIME"
+                  )
+                ) AS "max__0",
                 COUNT(DISTINCT "cust_id") AS "unique__1",
                 (
                   1.0 - COUNT("cust_id") / NULLIF(COUNT(*), 0)


### PR DESCRIPTION
## Description

This fixes an error when attempting to run describe on timestamp columns with invalid values. Longer term, there should be validation to inform users on such issues but for now this should prevent the error from occurring.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
