### PR TITLE
[chore] Use compatible cmds syntax for test-teardown task

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -403,7 +403,8 @@ tasks:
     preconditions:
       - sh: docker compose ls | grep 'featurebyte_docker'
         msg: "Test environment is not running."
-    cmd: docker compose -p featurebyte_docker -f docker/docker-compose.yml down
+    cmds:
+      - docker compose -p featurebyte_docker -f docker/docker-compose.yml down
 
   docs:
     desc: "Build the documentation and reload the browser"


### PR DESCRIPTION
## Description

The new cmd syntax doesn't work for older versions of task.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
