### PR TITLE
[chore] Patch `typechecked` in Feast

### DIFF
--- a/featurebyte/_overrides/typechecked_override.py
+++ b/featurebyte/_overrides/typechecked_override.py
@@ -40,7 +40,7 @@ def custom_typechecked(
         return functools.partial(custom_typechecked, always=always, _localns=_localns)
 
     module = inspect.getmodule(func)
-    if module and module.__name__.startswith("feast."):
+    if module and module.__name__.startswith("feast.feature_view"):
         return func
 
     return original_typechecked(func, always=always, _localns=_localns)  # type: ignore

--- a/featurebyte/_overrides/typechecked_override.py
+++ b/featurebyte/_overrides/typechecked_override.py
@@ -1,0 +1,50 @@
+"""
+This module overrides the `typechecked` decorator from the `typeguard` package to customize
+type checking behavior based on the module where the function is defined.
+"""
+
+from typing import Any, Dict, Optional
+
+import functools
+import inspect
+
+import typeguard
+from typeguard import typechecked as original_typechecked
+
+
+def custom_typechecked(
+    func: Any = None,
+    *,
+    always: bool = False,
+    _localns: Optional[Dict[str, Any]] = None,
+) -> Any:
+    """
+    Customize the `typechecked` decorator to selectively enable or disable type checking
+    based on the defining module of the function or class.
+
+    Parameters
+    ----------
+    func : Any
+        The function or class to enable type checking for.
+    always : bool
+        True to enable type checks even in optimized mode.
+    _localns : Optional[Dict[str, Any]]
+        Local namespace used for resolving type annotations.
+
+    Returns
+    -------
+    Any
+        Either the decorated function or a partial object, depending on whether `func` is provided.
+    """
+    if func is None:
+        return functools.partial(custom_typechecked, always=always, _localns=_localns)
+
+    module = inspect.getmodule(func)
+    if module and module.__name__.startswith("feast."):
+        return func
+
+    return original_typechecked(func, always=always, _localns=_localns)  # type: ignore
+
+
+# Override the typechecked function in the typeguard module
+typeguard.typechecked = custom_typechecked

--- a/featurebyte/app.py
+++ b/featurebyte/app.py
@@ -9,6 +9,7 @@ import uvicorn
 from fastapi import Depends, FastAPI, Header, Request
 from starlette.websockets import WebSocket
 
+from featurebyte._overrides.typechecked_override import custom_typechecked
 from featurebyte.common.utils import get_version
 from featurebyte.logging import configure_featurebyte_logger, get_logger
 from featurebyte.middleware import ExceptionMiddleware
@@ -57,6 +58,9 @@ from featurebyte.worker import get_celery, get_redis
 
 configure_featurebyte_logger()
 logger = get_logger(__name__)
+
+# import to override typechecked decorator
+_ = custom_typechecked
 
 
 def _dep_injection_func(

--- a/featurebyte/feast/patch.py
+++ b/featurebyte/feast/patch.py
@@ -112,7 +112,7 @@ class DataFrameWrapper(pd.DataFrame):
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
-        self._alias: Dict[str, str] = {}
+        self.attrs["_alias"] = {}
 
     def add_column_alias(self, column_name: str, alias: str) -> None:
         """
@@ -125,14 +125,14 @@ class DataFrameWrapper(pd.DataFrame):
         alias: str
             Alias name of the column
         """
-        self._alias[alias] = column_name
+        self.attrs["_alias"][alias] = column_name
 
     def __getitem__(self, key: Any) -> Union[pd.Series, pd.DataFrame]:
         if not isinstance(key, str) and isinstance(key, Iterable):
             return pd.DataFrame({_key: self.__getitem__(_key) for _key in key})
 
-        if isinstance(key, str) and key in self._alias:
-            key = self._alias[key]
+        if isinstance(key, str) and key in self.attrs["_alias"]:
+            key = self.attrs["_alias"][key]
 
         return super().__getitem__(key)
 


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
This PR patches `typechecked` in `Feast` package to improve online features retrieval performance.

### Runtime Performance Comparison

Settings: 
* Deployment of a feature list of ~750 features
* Online store: Redis

Time to retrieve online features (`Feast get_online_features`, after Feast feature store is cached)
Before: 5s
After: 3.8s

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
