### PR TITLE
[DEV-3028] Update item table lookup universe to filter by event timestamps

### DIFF
--- a/featurebyte/models/entity_lookup_feature_table.py
+++ b/featurebyte/models/entity_lookup_feature_table.py
@@ -78,7 +78,6 @@ def get_entity_lookup_graph(
             }
         }
     else:
-        # TODO: handle ITEM_TABLE which also needs event_parameters
         additional_params = {}
     lookup_node = graph.add_operation(
         node_type=NodeType.LOOKUP,

--- a/featurebyte/models/entity_universe.py
+++ b/featurebyte/models/entity_universe.py
@@ -15,7 +15,9 @@ from sqlglot.expressions import Expression, Select, Subqueryable, select
 
 from featurebyte.enum import InternalName, SourceType
 from featurebyte.models.base import FeatureByteBaseModel
+from featurebyte.models.item_table import ItemTableModel
 from featurebyte.models.parent_serving import EntityLookupStep
+from featurebyte.models.proxy_table import ProxyTableModel
 from featurebyte.models.sqlglot_expression import SqlglotExpressionModel
 from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.model.graph import QueryGraphModel
@@ -509,6 +511,53 @@ def get_combined_universe(
         combined_universe_expr = DUMMY_ENTITY_UNIVERSE
 
     return combined_universe_expr
+
+
+def get_item_relation_table_lookup_universe(
+    item_table_model: ProxyTableModel,
+) -> expressions.Select:
+    assert isinstance(item_table_model, ItemTableModel)
+    event_table_model = item_table_model.event_table_model
+    assert event_table_model is not None
+    filtered_event_table_expr = (
+        expressions.select(quoted_identifier(event_table_model.event_id_column))
+        .from_(
+            get_fully_qualified_table_name((event_table_model.tabular_source.table_details.dict()))
+        )
+        .where(
+            expressions.and_(
+                expressions.GTE(
+                    this=quoted_identifier(event_table_model.event_timestamp_column),
+                    expression=LAST_MATERIALIZED_TIMESTAMP_PLACEHOLDER,
+                ),
+                expressions.LT(
+                    this=quoted_identifier(event_table_model.event_timestamp_column),
+                    expression=CURRENT_FEATURE_TIMESTAMP_PLACEHOLDER,
+                ),
+            )
+        )
+    )
+    universe = (
+        expressions.select(quoted_identifier(item_table_model.item_id_column))
+        .from_(
+            expressions.Table(
+                this=get_fully_qualified_table_name(
+                    item_table_model.tabular_source.table_details.dict()
+                ),
+                alias="ITEM",
+            ),
+        )
+        .join(
+            filtered_event_table_expr.subquery(alias="EVENT"),
+            on=expressions.EQ(
+                this=get_qualified_column_identifier(item_table_model.event_id_column, "ITEM"),
+                expression=get_qualified_column_identifier(
+                    event_table_model.event_id_column, "EVENT"
+                ),
+            ),
+        )
+    )
+    return universe
 
 
 class EntityUniverseModel(FeatureByteBaseModel):

--- a/featurebyte/models/entity_universe.py
+++ b/featurebyte/models/entity_universe.py
@@ -515,7 +515,8 @@ def get_combined_universe(
 
 def get_item_relation_table_lookup_universe(item_table_model: TableModel) -> expressions.Select:
     """
-    Get the entity universe for a relation table that is an ItemTable
+    Get the entity universe for a relation table that is an ItemTable. This is used when looking up
+    a parent entity using a child entity (item id column) in an ItemTable.
 
     Parameters
     ----------
@@ -549,6 +550,7 @@ def get_item_relation_table_lookup_universe(item_table_model: TableModel) -> exp
     )
     universe = (
         expressions.select(quoted_identifier(item_table_model.item_id_column))
+        .distinct()
         .from_(
             expressions.Table(
                 this=get_fully_qualified_table_name(
@@ -565,6 +567,7 @@ def get_item_relation_table_lookup_universe(item_table_model: TableModel) -> exp
                     event_table_model.event_id_column, "EVENT"
                 ),
             ),
+            join_type="INNER",
         )
     )
     return universe

--- a/featurebyte/models/entity_universe.py
+++ b/featurebyte/models/entity_universe.py
@@ -17,7 +17,7 @@ from featurebyte.enum import InternalName, SourceType
 from featurebyte.models.base import FeatureByteBaseModel
 from featurebyte.models.item_table import ItemTableModel
 from featurebyte.models.parent_serving import EntityLookupStep
-from featurebyte.models.proxy_table import ProxyTableModel
+from featurebyte.models.proxy_table import ProxyTableModel, TableModel
 from featurebyte.models.sqlglot_expression import SqlglotExpressionModel
 from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.model.graph import QueryGraphModel
@@ -513,9 +513,7 @@ def get_combined_universe(
     return combined_universe_expr
 
 
-def get_item_relation_table_lookup_universe(
-    item_table_model: ProxyTableModel,
-) -> expressions.Select:
+def get_item_relation_table_lookup_universe(item_table_model: TableModel) -> expressions.Select:
     assert isinstance(item_table_model, ItemTableModel)
     event_table_model = item_table_model.event_table_model
     assert event_table_model is not None

--- a/featurebyte/models/entity_universe.py
+++ b/featurebyte/models/entity_universe.py
@@ -17,7 +17,7 @@ from featurebyte.enum import InternalName, SourceType
 from featurebyte.models.base import FeatureByteBaseModel
 from featurebyte.models.item_table import ItemTableModel
 from featurebyte.models.parent_serving import EntityLookupStep
-from featurebyte.models.proxy_table import ProxyTableModel, TableModel
+from featurebyte.models.proxy_table import TableModel
 from featurebyte.models.sqlglot_expression import SqlglotExpressionModel
 from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.model.graph import QueryGraphModel
@@ -514,6 +514,18 @@ def get_combined_universe(
 
 
 def get_item_relation_table_lookup_universe(item_table_model: TableModel) -> expressions.Select:
+    """
+    Get the entity universe for a relation table that is an ItemTable
+
+    Parameters
+    ----------
+    item_table_model: TableModel
+        Item table model
+
+    Returns
+    -------
+    expressions.Select
+    """
     assert isinstance(item_table_model, ItemTableModel)
     event_table_model = item_table_model.event_table_model
     assert event_table_model is not None

--- a/featurebyte/models/item_table.py
+++ b/featurebyte/models/item_table.py
@@ -4,12 +4,13 @@ This module contains ItemTable related models
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, List, Tuple, Type
+from typing import Any, ClassVar, List, Optional, Tuple, Type
 
-from pydantic import root_validator
+from pydantic import Field, root_validator
 
 from featurebyte.common.validator import construct_data_model_root_validator
 from featurebyte.enum import DBVarType
+from featurebyte.models.event_table import EventTableModel
 from featurebyte.models.feature_store import TableModel
 from featurebyte.query_graph.graph_node.base import GraphNode
 from featurebyte.query_graph.model.column_info import ColumnInfo
@@ -57,6 +58,8 @@ class ItemTableModel(ItemTableData, TableModel):
             ],
         )
     )
+
+    event_table_model: Optional[EventTableModel] = Field(default=None, exclude=True)
 
     @property
     def primary_key_columns(self) -> List[str]:

--- a/featurebyte/models/parent_serving.py
+++ b/featurebyte/models/parent_serving.py
@@ -11,7 +11,7 @@ from pydantic import root_validator
 
 from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
 from featurebyte.models.entity import EntityModel
-from featurebyte.models.proxy_table import ProxyTableModel
+from featurebyte.models.proxy_table import ProxyTableModel, TableModel
 from featurebyte.query_graph.model.entity_relationship_info import EntityRelationshipInfo
 from featurebyte.query_graph.node.schema import FeatureStoreDetails
 
@@ -51,7 +51,7 @@ class EntityLookupStep(FeatureByteBaseModel):
     """
 
     id: PydanticObjectId
-    table: ProxyTableModel
+    table: TableModel
     parent: EntityLookupInfo
     child: EntityLookupInfo
 
@@ -64,7 +64,7 @@ class EntityLookupStepCreator(FeatureByteBaseModel):
 
     entity_relationships_info: List[EntityRelationshipInfo]
     entities_by_id: Dict[PydanticObjectId, EntityModel]
-    tables_by_id: Dict[PydanticObjectId, ProxyTableModel]
+    tables_by_id: Dict[PydanticObjectId, TableModel]
     default_entity_lookup_steps: Dict[PydanticObjectId, EntityLookupStep]
 
     @root_validator(pre=True)

--- a/featurebyte/models/parent_serving.py
+++ b/featurebyte/models/parent_serving.py
@@ -98,7 +98,7 @@ class EntityLookupStepCreator(FeatureByteBaseModel):
 
             default_entity_lookup_steps[info.id] = EntityLookupStep(
                 id=info.id,
-                table=relation_table.dict(by_alias=True),
+                table=relation_table,
                 parent=EntityLookupInfo(
                     key=parent_column_name,
                     serving_name=parent_entity.serving_names[0],

--- a/featurebyte/models/parent_serving.py
+++ b/featurebyte/models/parent_serving.py
@@ -11,7 +11,7 @@ from pydantic import root_validator
 
 from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
 from featurebyte.models.entity import EntityModel
-from featurebyte.models.proxy_table import ProxyTableModel, TableModel
+from featurebyte.models.proxy_table import TableModel
 from featurebyte.query_graph.model.entity_relationship_info import EntityRelationshipInfo
 from featurebyte.query_graph.node.schema import FeatureStoreDetails
 

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -111,7 +111,7 @@ from featurebyte.service.historical_features import (
     HistoricalFeaturesService,
     HistoricalFeaturesValidationParametersService,
 )
-from featurebyte.service.item_table import ItemTableService
+from featurebyte.service.item_table import ExtendedItemTableService, ItemTableService
 from featurebyte.service.namespace_handler import NamespaceHandler
 from featurebyte.service.observation_table import ObservationTableService
 from featurebyte.service.offline_store_feature_table import OfflineStoreFeatureTableService
@@ -251,6 +251,7 @@ app_container_config.register_class(EntityRelationshipExtractorService)
 app_container_config.register_class(EntityLookupFeatureTableService)
 app_container_config.register_class(EventTableController)
 app_container_config.register_class(EventTableService)
+app_container_config.register_class(ExtendedItemTableService)
 app_container_config.register_class(FeatureController)
 app_container_config.register_class(FeatureService)
 app_container_config.register_class(FeatureFacadeService)

--- a/featurebyte/service/item_table.py
+++ b/featurebyte/service/item_table.py
@@ -4,9 +4,12 @@ ItemTableService class
 
 from __future__ import annotations
 
+from bson import ObjectId
+
 from featurebyte.models.item_table import ItemTableModel
 from featurebyte.schema.item_table import ItemTableCreate, ItemTableServiceUpdate
 from featurebyte.service.base_table_document import BaseTableDocumentService
+from featurebyte.service.event_table import EventTableService
 
 
 class ItemTableService(
@@ -22,3 +25,34 @@ class ItemTableService(
     @property
     def class_name(self) -> str:
         return "ItemTable"
+
+
+class ExtendedItemTableService:
+    """
+    ExtendedItemTableService class
+    """
+
+    def __init__(
+        self, item_table_service: ItemTableService, event_table_service: EventTableService
+    ):
+        self.item_table_service = item_table_service
+        self.event_table_service = event_table_service
+
+    async def get_document_with_event_table_model(self, document_id: ObjectId) -> ItemTableModel:
+        """
+        Get ItemTableModel with the event_table_model field populated
+
+        Parameters
+        ----------
+        document_id: ObjectId
+            Document ID
+
+        Returns
+        -------
+        ItemTableModel
+        """
+        item_table = await self.item_table_service.get_document(document_id=document_id)
+        item_table.event_table_model = await self.event_table_service.get_document(
+            document_id=item_table.event_table_id
+        )
+        return item_table

--- a/tests/fixtures/offline_store_feature_table/item_id_to_item_type_universe.sql
+++ b/tests/fixtures/offline_store_feature_table/item_id_to_item_type_universe.sql
@@ -3,10 +3,10 @@ WITH ENTITY_UNIVERSE AS (
     __fb_current_feature_timestamp AS "POINT_IN_TIME",
     "item_id"
   FROM (
-    SELECT
+    SELECT DISTINCT
       "item_id_col"
     FROM "sf_database"."sf_schema"."items_table" AS ITEM
-    JOIN (
+    INNER JOIN (
       SELECT
         "col_int"
       FROM "sf_database"."sf_schema"."sf_table"

--- a/tests/fixtures/offline_store_feature_table/item_id_to_item_type_universe.sql
+++ b/tests/fixtures/offline_store_feature_table/item_id_to_item_type_universe.sql
@@ -1,0 +1,59 @@
+WITH ENTITY_UNIVERSE AS (
+  SELECT
+    __fb_current_feature_timestamp AS "POINT_IN_TIME",
+    "item_id"
+  FROM (
+    SELECT
+      "item_id_col"
+    FROM "sf_database"."sf_schema"."items_table" AS ITEM
+    JOIN (
+      SELECT
+        "col_int"
+      FROM "sf_database"."sf_schema"."sf_table"
+      WHERE
+        "event_timestamp" >= __fb_last_materialized_timestamp
+        AND "event_timestamp" < __fb_current_feature_timestamp
+    ) AS EVENT
+      ON ITEM."event_id_col" = EVENT."col_int"
+  )
+), JOINED_PARENTS_ENTITY_UNIVERSE AS (
+  SELECT
+    REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
+    REQ."item_id" AS "item_id",
+    REQ."item_type" AS "item_type"
+  FROM (
+    SELECT
+      REQ."POINT_IN_TIME",
+      REQ."item_id",
+      "T0"."item_type" AS "item_type"
+    FROM ENTITY_UNIVERSE AS REQ
+    LEFT JOIN (
+      SELECT
+        "item_id",
+        ANY_VALUE("item_type") AS "item_type"
+      FROM (
+        SELECT
+          "item_id_col" AS "item_id",
+          "item_type" AS "item_type"
+        FROM (
+          SELECT
+            "event_id_col" AS "event_id_col",
+            "item_id_col" AS "item_id_col",
+            "item_type" AS "item_type",
+            "item_amount" AS "item_amount",
+            "created_at" AS "created_at",
+            "event_timestamp" AS "event_timestamp"
+          FROM "sf_database"."sf_schema"."items_table"
+        )
+      )
+      GROUP BY
+        "item_id"
+    ) AS T0
+      ON REQ."item_id" = T0."item_id"
+  ) AS REQ
+)
+SELECT
+  "POINT_IN_TIME",
+  "item_id",
+  "item_type"
+FROM JOINED_PARENTS_ENTITY_UNIVERSE

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1132,6 +1132,19 @@ def item_entity_fixture(catalog):
     return entity
 
 
+@pytest.fixture(name="item_type_entity", scope="session")
+def item_type_entity_fixture(catalog):
+    """
+    Fixture for an Entity "ItemType"
+    """
+    _ = catalog
+    entity = Entity(
+        _id=ObjectId("664ac92379c46110f9275db1"), name="ItemType", serving_names=["item_type"]
+    )
+    entity.save()
+    return entity
+
+
 @pytest.fixture(name="status_entity", scope="session")
 def status_entity_fixture(catalog):
     """
@@ -1275,6 +1288,7 @@ def tag_entities_for_item_table(item_table):
     """
     item_table["order_id"].as_entity("Order")
     item_table["item_id"].as_entity("Item")
+    item_table["item_type"].as_entity("ItemType")
 
 
 @pytest.fixture(name="item_table", scope="session")
@@ -1285,6 +1299,7 @@ def item_table_fixture(
     event_table,
     order_entity,
     item_entity,
+    item_type_entity,
     catalog,
 ):
     """
@@ -1293,6 +1308,7 @@ def item_table_fixture(
     _ = catalog
     _ = order_entity
     _ = item_entity
+    _ = item_type_entity
     database_table = data_source.get_source_table(
         database_name=session.database_name,
         schema_name=session.schema_name,

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -1495,13 +1495,10 @@ def test_online_features__patch_feast(config, deployed_feature_list):
 
 
 @pytest.mark.order(11)
-def test_item_view_feature_online_serving(
-    session, config, deployed_feature_list_item_use_case, source_type
-):
+def test_item_view_feature_online_serving(config, deployed_feature_list_item_use_case):
     """
     Test item view feature with parent serving
     """
-    _ = session
     client = config.get_client()
     deployment = deployed_feature_list_item_use_case
 

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -320,6 +320,7 @@ async def saved_feature_list_composite_entities_fixture(features):
 def removed_relationships_fixture(
     saved_feature_list_all,
     saved_feature_list_composite_entities,
+    saved_feature_list_item_type_feature,
     event_table,
     item_table,
     scd_table,
@@ -338,6 +339,7 @@ def removed_relationships_fixture(
     """
     _ = saved_feature_list_all
     _ = saved_feature_list_composite_entities
+    _ = saved_feature_list_item_type_feature
 
     def untag_entities(table):
         for column_info in table.columns_info:
@@ -492,6 +494,78 @@ async def deployed_features_list_composite_entities_order_use_case_fixture(
     ):
         deployment = feature_list.deploy(
             "deployment order use case", use_case_name=order_use_case.name
+        )
+        with patch(
+            "featurebyte.service.feature_materialize.datetime", autospec=True
+        ) as mock_datetime:
+            mock_datetime.utcnow.return_value = datetime(2001, 1, 2, 12)
+            await deploy_service.update_deployment(
+                deployment_id=deployment.id,
+                to_enable_deployment=True,
+            )
+
+    yield deployment
+    await deploy_service.update_deployment(
+        deployment_id=deployment.id,
+        to_enable_deployment=False,
+    )
+
+
+@pytest.fixture(name="item_use_case", scope="module")
+def item_use_case_fixture(item_entity):
+    """
+    Fixture for item level use case
+    """
+    target = fb.TargetNamespace.create(
+        "item_target",
+        primary_entity=[item_entity.name],
+        dtype=DBVarType.FLOAT,
+    )
+    context = fb.Context.create(
+        name="item_context",
+        primary_entity=[item_entity.name],
+    )
+    use_case = fb.UseCase.create("item_use_case", target.name, context.name, "item_description")
+    return use_case
+
+
+@pytest_asyncio.fixture(name="saved_feature_list_item_type_feature", scope="module")
+async def saved_feature_list_item_type_feature_fixture(item_table):
+    """
+    Fixture for a saved feature list with item type feature
+    """
+    item_view = item_table.get_view()
+    feature = item_view.groupby("item_type").aggregate_over(
+        value_column=None,
+        method="count",
+        windows=["7d"],
+        feature_names=["Count 7d by Item Type"],
+    )["Count 7d by Item Type"]
+    feature.save()
+    feature.update_readiness("PRODUCTION_READY")
+
+    feature_list = fb.FeatureList([feature], name=f"{feature.name} Feature List")
+    feature_list.save()
+    return feature_list
+
+
+@pytest_asyncio.fixture(name="deployed_feature_list_item_use_case", scope="module")
+async def deployed_feature_list_item_use_case_fixture(
+    app_container,
+    saved_feature_list_item_type_feature,
+    item_use_case,
+):
+    """
+    Fixture for a deployed feature list with a ItemType feature to be served by Item entity (child
+    of ItemType)
+    """
+    deploy_service = app_container.deploy_service
+    with patch(
+        "featurebyte.service.feature_manager.get_next_job_datetime",
+        return_value=pd.Timestamp("2001-01-02 12:00:00").to_pydatetime(),
+    ):
+        deployment = saved_feature_list_item_type_feature.deploy(
+            "deployment item use case", use_case_name=item_use_case.name
         )
         with patch(
             "featurebyte.service.feature_materialize.datetime", autospec=True
@@ -1418,3 +1492,34 @@ def test_online_features__patch_feast(config, deployed_feature_list):
             json=data.json_dict(),
         ).json()
         assert res3 == {"features": res2["features"] + res1["features"]}
+
+
+@pytest.mark.order(11)
+def test_item_view_feature_online_serving(
+    session, config, deployed_feature_list_item_use_case, source_type
+):
+    """
+    Test item view feature with parent serving
+    """
+    _ = session
+    client = config.get_client()
+    deployment = deployed_feature_list_item_use_case
+
+    entity_serving_names = [
+        {
+            "item_id": "item_60",
+        }
+    ]
+    data = OnlineFeaturesRequestPayload(entity_serving_names=entity_serving_names)
+
+    with patch("featurebyte.service.online_serving.datetime", autospec=True) as mock_datetime:
+        mock_datetime.utcnow.return_value = datetime(2001, 1, 2, 12)
+        res = client.post(
+            f"/deployment/{deployment.id}/online_features",
+            json=data.json_dict(),
+        )
+    assert res.status_code == 200
+
+    feat_dict = res.json()["features"][0]
+    expected = {"item_id": "item_60", "Count 7d by Item Type": 11}
+    assert_dict_approx_equal(feat_dict, expected)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1150,6 +1150,32 @@ def group_entity_fixture(catalog):
     yield entity
 
 
+@pytest.fixture(name="item_entity")
+def item_entity_fixture(catalog):
+    """
+    Item entity fixture
+    """
+    _ = catalog
+    entity = Entity(
+        name="item", serving_names=["item_id"], _id=ObjectId("664a3e617ac430c2ae37aede")
+    )
+    entity.save()
+    yield entity
+
+
+@pytest.fixture(name="item_type_entity")
+def item_type_entity_fixture(catalog):
+    """
+    Item type entity fixture
+    """
+    _ = catalog
+    entity = Entity(
+        name="item_type", serving_names=["item_type"], _id=ObjectId("664a3e7d7ac430c2ae37aedf")
+    )
+    entity.save()
+    yield entity
+
+
 @pytest.fixture(name="snowflake_event_table_with_entity")
 def snowflake_event_table_with_entity_fixture(
     snowflake_event_table,
@@ -1235,11 +1261,15 @@ def snowflake_event_view_entity_feature_job_fixture(
 
 
 @pytest.fixture(name="snowflake_item_view_with_entity")
-def snowflake_item_view_with_entity_fixture(snowflake_item_table, transaction_entity):
+def snowflake_item_view_with_entity_fixture(
+    snowflake_item_table, transaction_entity, item_entity, item_type_entity
+):
     """
     Snowflake item view with entity
     """
     snowflake_item_table["event_id_col"].as_entity(transaction_entity.name)
+    snowflake_item_table["item_id_col"].as_entity(item_entity.name)
+    snowflake_item_table["item_type"].as_entity(item_type_entity.name)
     item_view = snowflake_item_table.get_view(event_suffix="_event")
     return item_view
 
@@ -1928,6 +1958,24 @@ def aggregate_asat_composite_entity_fixture(snowflake_scd_table_with_entity):
         feature_name="asat_gender_x_other_count",
     )
     return feature
+
+
+@pytest.fixture(name="item_view_window_aggregate_feature")
+def item_view_window_aggregate_feature_fixture(snowflake_item_view_with_entity):
+    """
+    Fixture to get a window aggregate feature from an item view
+    """
+    return snowflake_item_view_with_entity.groupby(["item_type"]).aggregate_over(
+        value_column="item_amount",
+        method="sum",
+        windows=["1d"],
+        feature_names=["sum_1d"],
+        feature_job_setting=FeatureJobSetting(
+            blind_spot="10m",
+            frequency="30m",
+            time_modulo_frequency="5m",
+        ),
+    )["sum_1d"]
 
 
 @pytest.fixture(name="descendant_of_gender_feature")

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -1720,12 +1720,10 @@ async def test_undeploy_bad_state_error_handling(
 async def test_item_view_window_aggregate(
     app_container,
     document_service,
-    periodic_task_service,
     deployed_item_view_window_aggregate_feature,
     item_id_to_item_type_relationship_info,
     float_feat_deployment_id,
     item_entity,
-    expected_feast_registry_mapping,
     update_fixtures,
 ):
     """

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -309,6 +309,28 @@ async def deployed_item_aggregate_feature(
 
 
 @pytest_asyncio.fixture
+async def deployed_item_view_window_aggregate_feature(
+    app_container,
+    item_view_window_aggregate_feature,
+    item_entity,
+    float_feat_deployment_id,
+    mock_update_data_warehouse,
+    mock_offline_store_feature_manager_dependencies,
+):
+    """
+    Fixture for deployed item view window aggregate feature
+    """
+    _ = mock_update_data_warehouse
+    _ = mock_offline_store_feature_manager_dependencies
+    return await deploy_feature(
+        app_container,
+        item_view_window_aggregate_feature,
+        context_primary_entity_ids=[item_entity.id],
+        deployment_id=float_feat_deployment_id,
+    )
+
+
+@pytest_asyncio.fixture
 async def deployed_complex_feature(
     app_container,
     non_time_based_feature,
@@ -542,6 +564,22 @@ async def customer_to_gender_relationship_info(
         app_container,
         child_entity_id=cust_id_entity.id,
         parent_entity_id=gender_entity.id,
+    )
+
+
+@pytest_asyncio.fixture
+async def item_id_to_item_type_relationship_info(
+    app_container,
+    item_entity,
+    item_type_entity,
+):
+    """
+    Fixture for the relationship info id between item and item type entities
+    """
+    return await get_relationship_info(
+        app_container,
+        child_entity_id=item_entity.id,
+        parent_entity_id=item_type_entity.id,
     )
 
 
@@ -1676,3 +1714,120 @@ async def test_undeploy_bad_state_error_handling(
     scheduled_tasks = await get_all_scheduled_tasks(periodic_task_service)
     assert not list(feature_tables.keys())
     assert not list(scheduled_tasks.keys())
+
+
+@pytest.mark.asyncio
+async def test_item_view_window_aggregate(
+    app_container,
+    document_service,
+    periodic_task_service,
+    deployed_item_view_window_aggregate_feature,
+    item_id_to_item_type_relationship_info,
+    float_feat_deployment_id,
+    item_entity,
+    expected_feast_registry_mapping,
+    update_fixtures,
+):
+    """
+    Test feature table creation for a feature with item view window aggregate
+    """
+    catalog_id = app_container.catalog_id
+    feature_tables = await get_all_feature_tables(document_service)
+    expected_suffix = get_lookup_steps_unique_identifier([item_id_to_item_type_relationship_info])
+    assert set(feature_tables.keys()) == {
+        "cat1_item_type_30m",
+        f"cat1_item_type_30m_via_item_id_{expected_suffix}",
+    }
+    feature_table = feature_tables["cat1_item_type_30m"]
+
+    feature_table_dict = feature_table.dict(by_alias=True, exclude={"created_at", "updated_at"})
+    feature_table_id = feature_table_dict.pop("_id")
+    feature_table_dict.pop("feature_cluster")
+    assert feature_table_dict == {
+        "base_name": "item_type_30m",
+        "block_modification_by": [],
+        "catalog_id": catalog_id,
+        "deployment_ids": [float_feat_deployment_id],
+        "description": None,
+        "entity_lookup_info": None,
+        "entity_universe": {
+            "query_template": {
+                "formatted_expression": textwrap.dedent(
+                    """
+                    SELECT DISTINCT
+                      "item_type"
+                    FROM online_store_22f02bbc16545d0e730d39effc50176c1d1f6299
+                    WHERE
+                      "AGGREGATION_RESULT_NAME" = '_fb_internal_item_type_window_w86400_sum_2e4057b32df81d547bde013cd755a1189af7e615'
+                      AND "item_type" IS NOT NULL
+                    """
+                ).strip()
+            }
+        },
+        "feature_cluster_path": feature_table_dict["feature_cluster_path"],
+        "feature_ids": [deployed_item_view_window_aggregate_feature.id],
+        "feature_job_setting": {
+            "blind_spot": "600s",
+            "frequency": "1800s",
+            "time_modulo_frequency": "300s",
+        },
+        "feature_store_id": feature_table_dict["feature_store_id"],
+        "has_ttl": True,
+        "last_materialized_at": None,
+        "name": "cat1_item_type_30m",
+        "name_prefix": "cat1",
+        "name_suffix": None,
+        "online_stores_last_materialized_at": [],
+        "output_column_names": ["sum_1d_V231227"],
+        "output_dtypes": ["FLOAT"],
+        "precomputed_lookup_feature_table_info": None,
+        "primary_entity_ids": [ObjectId("664a3e7d7ac430c2ae37aedf")],
+        "serving_names": ["item_type"],
+        "user_id": ObjectId("63f9506dd478b94127123456"),
+    }
+
+    # check precomputed lookup feature table
+    feature_table = feature_tables[f"cat1_item_type_30m_via_item_id_{expected_suffix}"]
+    feature_table_dict = feature_table.dict(
+        by_alias=True, exclude={"created_at", "updated_at", "id"}
+    )
+    entity_universe = feature_table_dict.pop("entity_universe")
+    assert feature_table_dict == {
+        "block_modification_by": [],
+        "catalog_id": catalog_id,
+        "description": None,
+        "entity_lookup_info": None,
+        "feature_cluster": None,
+        "feature_cluster_path": None,
+        "feature_ids": [],
+        "feature_job_setting": None,
+        "feature_store_id": deployed_item_view_window_aggregate_feature.tabular_source.feature_store_id,
+        "has_ttl": True,
+        "last_materialized_at": None,
+        "name": f"cat1_item_type_30m_via_item_id_{expected_suffix}",
+        "base_name": None,
+        "name_prefix": None,
+        "name_suffix": None,
+        "online_stores_last_materialized_at": [],
+        "output_column_names": [],
+        "output_dtypes": [],
+        "precomputed_lookup_feature_table_info": {
+            "lookup_steps": [item_id_to_item_type_relationship_info.dict(by_alias=True)],
+            "lookup_mapping": [
+                {
+                    "lookup_feature_table_serving_name": "item_id",
+                    "source_feature_table_serving_name": "item_type",
+                }
+            ],
+            "source_feature_table_id": feature_table_id,
+        },
+        "primary_entity_ids": [item_entity.id],
+        "serving_names": item_entity.serving_names,
+        "user_id": ObjectId("63f9506dd478b94127123456"),
+        "deployment_ids": [float_feat_deployment_id],
+    }
+    assert_equal_with_expected_fixture(
+        entity_universe["query_template"]["formatted_expression"],
+        "tests/fixtures/offline_store_feature_table/item_id_to_item_type_universe.sql",
+        update_fixture=update_fixtures,
+    )

--- a/tests/unit/service/test_parent_serving.py
+++ b/tests/unit/service/test_parent_serving.py
@@ -36,7 +36,7 @@ async def test_get_join_steps__one_step(
     assert join_steps == [
         EntityLookupStep(
             id=relationship_info.id,
-            table=data.dict(by_alias=True),
+            table=data,
             parent=EntityLookupInfo(
                 key="b",
                 serving_name="B",
@@ -72,7 +72,7 @@ async def test_get_join_steps__two_steps(
     assert join_steps == [
         EntityLookupStep(
             id=rel_a_to_b.id,
-            table=data_a_to_b.dict(by_alias=True),
+            table=data_a_to_b,
             parent=EntityLookupInfo(
                 entity_id=entity_b.id,
                 key="b",
@@ -86,7 +86,7 @@ async def test_get_join_steps__two_steps(
         ),
         EntityLookupStep(
             id=rel_b_to_c.id,
-            table=data_b_to_c.dict(by_alias=True),
+            table=data_b_to_c,
             parent=EntityLookupInfo(
                 entity_id=entity_c.id,
                 key="c",
@@ -142,7 +142,7 @@ async def test_get_join_steps__two_branches(
         ),
         EntityLookupStep(
             id=rel_b_to_d.id,
-            table=data_b_to_d.dict(by_alias=True),
+            table=data_b_to_d,
             parent=EntityLookupInfo(
                 key="d",
                 serving_name="D",
@@ -156,7 +156,7 @@ async def test_get_join_steps__two_branches(
         ),
         EntityLookupStep(
             id=rel_b_to_c.id,
-            table=data_b_to_c.dict(by_alias=True),
+            table=data_b_to_c,
             parent=EntityLookupInfo(
                 key="c",
                 serving_name="C",
@@ -200,7 +200,7 @@ async def test_get_join_steps__serving_names_mapping(
     assert join_steps == [
         EntityLookupStep(
             id=rel_a_to_b.id,
-            table=data_a_to_b.dict(by_alias=True),
+            table=data_a_to_b,
             parent=EntityLookupInfo(
                 key="b",
                 serving_name="B",
@@ -214,7 +214,7 @@ async def test_get_join_steps__serving_names_mapping(
         ),
         EntityLookupStep(
             id=rel_b_to_d.id,
-            table=data_b_to_d.dict(by_alias=True),
+            table=data_b_to_d,
             parent=EntityLookupInfo(
                 key="d",
                 serving_name="D",
@@ -228,7 +228,7 @@ async def test_get_join_steps__serving_names_mapping(
         ),
         EntityLookupStep(
             id=rel_b_to_c.id,
-            table=data_b_to_c.dict(by_alias=True),
+            table=data_b_to_c,
             parent=EntityLookupInfo(
                 key="c",
                 serving_name="C",
@@ -295,7 +295,7 @@ async def test_get_join_steps__multiple_provided(
     assert join_steps == [
         EntityLookupStep(
             id=rel_b_to_c.id,
-            table=data_b_to_c.dict(by_alias=True),
+            table=data_b_to_c,
             parent=EntityLookupInfo(
                 key="c",
                 serving_name="C",
@@ -309,7 +309,7 @@ async def test_get_join_steps__multiple_provided(
         ),
         EntityLookupStep(
             id=rel_c_to_d.id,
-            table=data_c_to_d.dict(by_alias=True),
+            table=data_c_to_d,
             parent=EntityLookupInfo(
                 key="d",
                 serving_name="D",
@@ -346,7 +346,7 @@ async def test_get_join_steps__use_provided_relationships(
     assert join_steps == [
         EntityLookupStep(
             id=relationship_info_1.id,
-            table=data.dict(by_alias=True),
+            table=data,
             parent=EntityLookupInfo(
                 key="b",
                 serving_name="B",
@@ -390,7 +390,7 @@ async def test_required_entity__complex_and_should_not_error(
     assert join_steps == [
         EntityLookupStep(
             id=rel_a_to_b.id,
-            table=data_a_to_b.dict(by_alias=True),
+            table=data_a_to_b,
             parent=EntityLookupInfo(
                 key="b",
                 serving_name="B",


### PR DESCRIPTION
## Description

This updates the item table lookup universe to filter by event timestamps using previous materialization timestamp. This prevents unnecessary materialization for item ids that have already been materialized.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
