### PR TITLE
[chore] Simplify creation of table from parquet file in BaseSparkSession

### DIFF
--- a/featurebyte/session/base_spark.py
+++ b/featurebyte/session/base_spark.py
@@ -245,18 +245,10 @@ class BaseSparkSession(BaseSession, ABC):
                     f"CACHE TABLE `{table_name}` OPTIONS ('storageLevel' 'DISK_ONLY')"
                 )
             else:
-                # register a permanent table from uncached temp view
-                request_id = self.generate_session_unique_id()
-                temp_view_name = f"__TEMP_TABLE_{request_id}"
-                await self.execute_query(
-                    f"CREATE OR REPLACE TEMPORARY VIEW `{temp_view_name}` USING parquet OPTIONS "
-                    f"(path '{self.storage_path}/{temp_filename}')"
-                )
-
                 await self.execute_query(
                     f"CREATE OR REPLACE TABLE `{table_name}` USING DELTA "
                     f"TBLPROPERTIES('delta.columnMapping.mode' = 'name', 'delta.minReaderVersion' = '2', 'delta.minWriterVersion' = '5') "
-                    f"AS SELECT * FROM `{temp_view_name}`"
+                    f"AS SELECT * FROM PARQUET.`{self.storage_path}/{temp_filename}`"
                 )
         finally:
             # clean up staging file


### PR DESCRIPTION
## Description

This updates `register_table` method in `BaseSparkSession` to use a simpler select from parquet syntax.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
