### PR TITLE
[chore] Remove temporary parameter in register_table

### DIFF
--- a/featurebyte/query_graph/sql/feature_historical.py
+++ b/featurebyte/query_graph/sql/feature_historical.py
@@ -111,7 +111,7 @@ class DataFrameObservationSet(ObservationSet):
     ) -> None:
         if add_row_index:
             self.dataframe[InternalName.TABLE_ROW_INDEX] = np.arange(self.dataframe.shape[0])
-        await session.register_table(request_table_name, self.dataframe, temporary=False)
+        await session.register_table(request_table_name, self.dataframe)
 
 
 class MaterializedTableObservationSet(ObservationSet):

--- a/featurebyte/query_graph/sql/online_serving.py
+++ b/featurebyte/query_graph/sql/online_serving.py
@@ -553,7 +553,7 @@ async def get_online_features(  # pylint: disable=too-many-locals,too-many-branc
         # table beforehand.
         if isinstance(request_data, pd.DataFrame):
             request_table_name = f"{REQUEST_TABLE_NAME}_{session.generate_session_unique_id()}"
-            await session.register_table(request_table_name, request_data, temporary=False)
+            await session.register_table(request_table_name, request_data)
         else:
             assert request_table_details is not None
             request_table_name = request_table_details.table_name

--- a/featurebyte/session/base.py
+++ b/featurebyte/session/base.py
@@ -652,27 +652,6 @@ class BaseSession(BaseModel):
             return pd.DataFrame(all_rows, columns=columns)
         return None
 
-    async def register_table_with_query(
-        self, table_name: str, query: str, temporary: bool = True
-    ) -> None:
-        """
-        Register a temporary table using a Select query
-
-        Parameters
-        ----------
-        table_name : str
-            Temp table name
-        query : str
-            SQL query for the table
-        temporary : bool
-            If True, register a temporary table
-        """
-        if temporary:
-            create_command = "CREATE OR REPLACE TEMPORARY TABLE"
-        else:
-            create_command = "CREATE OR REPLACE TABLE"
-        await self.execute_query_long_running(f"{create_command} {table_name} AS {query}")
-
     async def drop_table(
         self,
         table_name: str,

--- a/featurebyte/session/base.py
+++ b/featurebyte/session/base.py
@@ -324,12 +324,7 @@ class BaseSession(BaseModel):
         """
 
     @abstractmethod
-    async def register_table(
-        self,
-        table_name: str,
-        dataframe: pd.DataFrame,
-        temporary: bool = True,
-    ) -> None:
+    async def register_table(self, table_name: str, dataframe: pd.DataFrame) -> None:
         """
         Register a table
 
@@ -339,8 +334,6 @@ class BaseSession(BaseModel):
             Temp table name
         dataframe : pd.DataFrame
             DataFrame to register
-        temporary : bool
-            If True, register a temporary table
         """
 
     @classmethod

--- a/featurebyte/session/base_spark.py
+++ b/featurebyte/session/base_spark.py
@@ -224,7 +224,7 @@ class BaseSparkSession(BaseSession, ABC):
         try:
             await self.execute_query(
                 f"CREATE OR REPLACE TABLE `{table_name}` USING DELTA "
-                f"TBLPROPERTIES('delta.columnMapping.mode' = 'name', 'delta.minReaderVersion' = '2', 'delta.minWriterVersion' = '5', 'delta.feature.timestampNtz' = 'supported')"  # pylint: disable=line-too-long
+                f"TBLPROPERTIES('delta.columnMapping.mode' = 'name', 'delta.minReaderVersion' = '2', 'delta.minWriterVersion' = '5') "
                 f"AS SELECT * FROM PARQUET.`{self.storage_path}/{temp_filename}`"
             )
         finally:

--- a/featurebyte/session/base_spark.py
+++ b/featurebyte/session/base_spark.py
@@ -208,16 +208,6 @@ class BaseSparkSession(BaseSession, ABC):
             logger.warning(f"Spark: Not supported data type '{spark_type}'")
         return db_vartype
 
-    async def register_table_with_query(
-        self, table_name: str, query: str, temporary: bool = True
-    ) -> None:
-        if temporary:
-            create_command = "CREATE OR REPLACE TEMPORARY VIEW"
-        else:
-            create_command = "CREATE OR REPLACE VIEW"
-        await self.execute_query_long_running(f"{create_command} `{table_name}` AS {query}")
-        await self.execute_query_long_running(f"CACHE TABLE `{table_name}`")
-
     async def register_table(self, table_name: str, dataframe: pd.DataFrame) -> None:
         # truncate timestamps to microseconds to avoid parquet and Spark issues
         if dataframe.shape[0] > 0:

--- a/featurebyte/session/base_spark.py
+++ b/featurebyte/session/base_spark.py
@@ -224,7 +224,7 @@ class BaseSparkSession(BaseSession, ABC):
         try:
             await self.execute_query(
                 f"CREATE OR REPLACE TABLE `{table_name}` USING DELTA "
-                f"TBLPROPERTIES('delta.columnMapping.mode' = 'name', 'delta.minReaderVersion' = '2', 'delta.minWriterVersion' = '5') "
+                f"TBLPROPERTIES('delta.columnMapping.mode' = 'name', 'delta.minReaderVersion' = '2', 'delta.minWriterVersion' = '5', 'delta.feature.timestampNtz' = 'supported')"  # pylint: disable=line-too-long
                 f"AS SELECT * FROM PARQUET.`{self.storage_path}/{temp_filename}`"
             )
         finally:

--- a/featurebyte/session/databricks_unity.py
+++ b/featurebyte/session/databricks_unity.py
@@ -149,13 +149,10 @@ class DatabricksUnitySession(DatabricksSession):
         """
         await self.execute_query(f"ALTER {kind} {name} OWNER TO `{self.group_name}`")
 
-    async def register_table(
-        self, table_name: str, dataframe: pd.DataFrame, temporary: bool = True
-    ) -> None:
-        await super().register_table(table_name, dataframe, temporary)
-        if not temporary:
-            # grant ownership of the table or view to the group
-            await self.set_owner("TABLE", table_name)
+    async def register_table(self, table_name: str, dataframe: pd.DataFrame) -> None:
+        await super().register_table(table_name, dataframe)
+        # grant ownership of the table or view to the group
+        await self.set_owner("TABLE", table_name)
 
     async def list_schemas(self, database_name: str | None = None) -> list[str]:
         schemas = await self.execute_query_interactive(

--- a/featurebyte/session/snowflake.py
+++ b/featurebyte/session/snowflake.py
@@ -255,14 +255,9 @@ class SnowflakeSession(BaseSession):
                 else:
                     yield pa.record_batch(batch.to_pandas(), schema=schema)
 
-    async def register_table(
-        self, table_name: str, dataframe: pd.DataFrame, temporary: bool = True
-    ) -> None:
+    async def register_table(self, table_name: str, dataframe: pd.DataFrame) -> None:
         schema = self.get_columns_schema_from_dataframe(dataframe)
-        if temporary:
-            create_command = "CREATE OR REPLACE TEMP TABLE"
-        else:
-            create_command = "CREATE OR REPLACE TABLE"
+        create_command = "CREATE OR REPLACE TABLE"
         await self.execute_query(
             f"""
             {create_command} "{table_name}"(

--- a/featurebyte/session/sqlite.py
+++ b/featurebyte/session/sqlite.py
@@ -106,9 +106,7 @@ class SQLiteSession(BaseSession):
                 )
         return column_name_type_map
 
-    async def register_table(
-        self, table_name: str, dataframe: pd.DataFrame, temporary: bool = True
-    ) -> None:
+    async def register_table(self, table_name: str, dataframe: pd.DataFrame) -> None:
         raise NotImplementedError()
 
     async def execute_query(

--- a/featurebyte/worker/task/observation_table_upload.py
+++ b/featurebyte/worker/task/observation_table_upload.py
@@ -74,9 +74,7 @@ class ObservationTableUploadTask(DataWarehouseMixin, BaseTask[ObservationTableUp
         )
 
         # Write the file to the warehouse
-        await db_session.register_table(
-            location.table_details.table_name, uploaded_dataframe, temporary=False
-        )
+        await db_session.register_table(location.table_details.table_name, uploaded_dataframe)
         await self.observation_table_service.add_row_index_column(
             db_session, location.table_details
         )

--- a/tests/integration/api/test_change_view_operations.py
+++ b/tests/integration/api/test_change_view_operations.py
@@ -154,7 +154,7 @@ async def test_change_view_correctness(session, data_source):
     df_expected.insert(0, "cust_id", "c1")
 
     table_name = "test_change_view_correctness_table"
-    await session.register_table(table_name, df, temporary=False)
+    await session.register_table(table_name, df)
 
     scd_source_table = data_source.get_source_table(
         table_name=table_name,

--- a/tests/integration/api/test_distance_operations.py
+++ b/tests/integration/api/test_distance_operations.py
@@ -54,7 +54,7 @@ async def register_table_with_array_column(
     """
     _ = catalog
     table_name = "event_table_with_distances"
-    await session.register_table(table_name, distance_event_data, temporary=False)
+    await session.register_table(table_name, distance_event_data)
 
     database_table = data_source.get_source_table(
         database_name=session.database_name,

--- a/tests/integration/api/test_observation_table.py
+++ b/tests/integration/api/test_observation_table.py
@@ -93,7 +93,7 @@ async def test_observation_table_min_interval_between_entities(
         df[SpecialColumnName.POINT_IN_TIME].astype(str)
     )
     table_name = "observation_table_time_interval"
-    await session.register_table(table_name, df, temporary=False)
+    await session.register_table(table_name, df)
 
     database_table = data_source.get_source_table(
         database_name=session.database_name,

--- a/tests/integration/api/test_scd_view_operations.py
+++ b/tests/integration/api/test_scd_view_operations.py
@@ -125,14 +125,14 @@ async def test_scd_join_small(session, data_source, source_type):
 
     # Register event table
     table_name = f"{table_prefix}_EVENT"
-    await session.register_table(table_name, df_events, temporary=False)
+    await session.register_table(table_name, df_events)
     await session.execute_query(
         f'UPDATE {table_name} SET {_quote("ts")} = NULL WHERE {_quote("event_id")} = 4'
     )
 
     # Register scd table
     table_name = f"{table_prefix}_SCD"
-    await session.register_table(table_name, df_scd, temporary=False)
+    await session.register_table(table_name, df_scd)
     await session.execute_query(
         f'UPDATE {table_name} SET {_quote("effective_ts")} = NULL WHERE {_quote("scd_value")} = 3'
     )
@@ -199,9 +199,9 @@ async def test_feature_derived_from_multiple_scd_joins(session, data_source, sou
         }
     )
     table_prefix = str(ObjectId())
-    await session.register_table(f"{table_prefix}_EVENT", df_events, temporary=False)
-    await session.register_table(f"{table_prefix}_SCD", df_scd, temporary=False)
-    await session.register_table(f"{table_prefix}_SCD_2", df_scd_2, temporary=False)
+    await session.register_table(f"{table_prefix}_EVENT", df_events)
+    await session.register_table(f"{table_prefix}_SCD", df_scd)
+    await session.register_table(f"{table_prefix}_SCD_2", df_scd_2)
     event_source_table = data_source.get_source_table(
         table_name=f"{table_prefix}_EVENT",
         database_name=session.database_name,

--- a/tests/integration/api/test_serving_parent_features.py
+++ b/tests/integration/api/test_serving_parent_features.py
@@ -84,10 +84,10 @@ async def tables_fixture(session, data_source, customer_entity, event_entity):
             "country": ["france", "japan"],
         }
     )
-    await session.register_table(f"{table_prefix}_EVENT", df_events, temporary=False)
-    await session.register_table(f"{table_prefix}_SCD_1", df_scd_1, temporary=False)
-    await session.register_table(f"{table_prefix}_SCD_2", df_scd_2, temporary=False)
-    await session.register_table(f"{table_prefix}_DIMENSION_1", df_dimension_1, temporary=False)
+    await session.register_table(f"{table_prefix}_EVENT", df_events)
+    await session.register_table(f"{table_prefix}_SCD_1", df_scd_1)
+    await session.register_table(f"{table_prefix}_SCD_2", df_scd_2)
+    await session.register_table(f"{table_prefix}_DIMENSION_1", df_dimension_1)
 
     city_entity = Entity(name=f"{table_prefix}_city", serving_names=["serving_city_id"])
     city_entity.save()

--- a/tests/integration/api/test_vector_aggregation_operations.py
+++ b/tests/integration/api/test_vector_aggregation_operations.py
@@ -153,7 +153,7 @@ async def register_table_with_array_column(
     """
     _ = catalog
     table_name = "event_table_with_vector"
-    await session.register_table(table_name, event_data_with_array, temporary=False)
+    await session.register_table(table_name, event_data_with_array)
 
     database_table = data_source.get_source_table(
         database_name=session.database_name,
@@ -186,7 +186,7 @@ async def register_item_table_with_array_column(
     Register a table with an array column
     """
     table_name = "item_table_with_vector"
-    await session.register_table(table_name, item_data_with_array, temporary=False)
+    await session.register_table(table_name, item_data_with_array)
 
     database_table = data_source.get_source_table(
         database_name=session.database_name,
@@ -212,7 +212,7 @@ async def register_scd_table_with_array_column(
     Register a table with an array column
     """
     table_name = "scd_table_with_vector"
-    await session.register_table(table_name, scd_data_with_array, temporary=False)
+    await session.register_table(table_name, scd_data_with_array)
 
     database_table = data_source.get_source_table(
         database_name=session.database_name,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -853,7 +853,7 @@ async def datasets_registration_helper_fixture(
                 Session object
             """
             for table_name, df in self.datasets.items():
-                await session.register_table(table_name, df, temporary=False)
+                await session.register_table(table_name, df)
 
         @property
         def table_names(self) -> List[str]:

--- a/tests/integration/session/test_base.py
+++ b/tests/integration/session/test_base.py
@@ -42,7 +42,7 @@ async def setup_module(session):
     """
     Setup module
     """
-    await session.register_table("TEST_DATA_TABLE", sample_dataframe(), temporary=True)
+    await session.register_table("TEST_DATA_TABLE", sample_dataframe())
 
 
 @pytest.mark.asyncio

--- a/tests/integration/session/test_comment.py
+++ b/tests/integration/session/test_comment.py
@@ -23,7 +23,7 @@ async def registered_table(session):
             "b": [4, 5, 6],
         }
     )
-    await session.register_table(table_name, df, temporary=False)
+    await session.register_table(table_name, df)
     yield table_name
     await session.drop_table(
         table_name=table_name,

--- a/tests/integration/session/test_spark.py
+++ b/tests/integration/session/test_spark.py
@@ -108,6 +108,7 @@ async def test_register_table(session):
             "üser id": [1, 2, 3, 4, 5],
         }
     )
-    await session.register_table(table_name="test_table", dataframe=df_training_events)
-    df_retrieve = await session.execute_query("SELECT * FROM test_table")
+    table_name = "test_table_test_register_table"
+    await session.register_table(table_name=table_name, dataframe=df_training_events)
+    df_retrieve = await session.execute_query(f"SELECT * FROM {table_name}")
     assert_frame_equal(df_retrieve, df_training_events, check_dtype=False)

--- a/tests/integration/tile/test_tile_cache.py
+++ b/tests/integration/tile/test_tile_cache.py
@@ -106,7 +106,7 @@ async def test_tile_cache(session, tile_cache, feature_for_tile_cache_tests, gro
 
     request_id = session.generate_session_unique_id()
     request_table_name = f"{REQUEST_TABLE_NAME}_{request_id}"
-    await session.register_table(request_table_name, df_training_events, temporary=False)
+    await session.register_table(request_table_name, df_training_events)
 
     # No cache existed before for this feature. Check that one tile table needs to be computed
     request_id = session.generate_session_unique_id()
@@ -154,7 +154,7 @@ async def test_tile_cache(session, tile_cache, feature_for_tile_cache_tests, gro
             "üser id": [1, 2, 3, 4, np.nan],
         }
     )
-    await session.register_table(request_table_name, df_training_events, temporary=False)
+    await session.register_table(request_table_name, df_training_events)
     request_id = session.generate_session_unique_id()
     requests = await tile_cache.get_required_computation(
         request_id=request_id,
@@ -201,7 +201,7 @@ async def test_tile_cache(session, tile_cache, feature_for_tile_cache_tests, gro
 
     request_id = session.generate_session_unique_id()
     request_table_name = f"{REQUEST_TABLE_NAME}_{request_id}"
-    await session.register_table(request_table_name, df_training_events, temporary=False)
+    await session.register_table(request_table_name, df_training_events)
     requests = await tile_cache.get_required_computation(
         request_id=request_id,
         graph=feature.graph,

--- a/tests/integration/udf/test_object_agg.py
+++ b/tests/integration/udf/test_object_agg.py
@@ -23,7 +23,11 @@ async def setup_test_data_fixture(session):
             "val_col": [None, -1.5],
         }
     )
-    await session.register_table(table_name="test_table", dataframe=table, temporary=True)
+    await session.register_table(table_name="test_table", dataframe=table)
+    yield
+    await session.drop_table(
+        "test_table", schema_name=session.schema_name, database_name=session.database_name
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/test_databricks_session.py
+++ b/tests/unit/session/test_databricks_session.py
@@ -211,9 +211,8 @@ async def test_databricks_session(databricks_session_dict):
     pd.testing.assert_frame_equal(df_result, df_expected)
 
 
-@pytest.mark.parametrize("temporary", [True, False])
 @pytest.mark.asyncio
-async def test_databricks_register_table(databricks_session_dict, databricks_connection, temporary):
+async def test_databricks_register_table(databricks_session_dict, databricks_connection):
     """
     Test Databricks session register_table
     """
@@ -232,16 +231,9 @@ async def test_databricks_register_table(databricks_session_dict, databricks_con
                     "cust_id": [1, 2, 3],
                 },
             )
-            if temporary:
-                expected = "CREATE OR REPLACE TEMPORARY VIEW"
-            else:
-                expected = "CREATE OR REPLACE TABLE"
-            await session.register_table("my_view", df, temporary)
-
-            if temporary:
-                assert mock_execute_query.call_args_list[0][0][0].startswith(expected)
-            else:
-                assert mock_execute_query.call_args_list[-1][0][0].startswith(expected)
+            expected = "CREATE OR REPLACE TABLE"
+            await session.register_table("my_view", df)
+            assert mock_execute_query.call_args_list[-1][0][0].startswith(expected)
 
 
 def test_databricks_sql_connector_not_available(databricks_session_dict):

--- a/tests/util/helper.py
+++ b/tests/util/helper.py
@@ -434,7 +434,7 @@ async def create_observation_table_from_dataframe(
     """
     unique_id = ObjectId()
     db_table_name = f"df_{unique_id}"
-    await session.register_table(db_table_name, df, temporary=False)
+    await session.register_table(db_table_name, df)
     return data_source.get_source_table(
         db_table_name,
         database_name=session.database_name,
@@ -450,7 +450,7 @@ async def create_batch_request_table_from_dataframe(session, df, data_source):
     """
     unique_id = ObjectId()
     db_table_name = f"df_{unique_id}"
-    await session.register_table(db_table_name, df, temporary=False)
+    await session.register_table(db_table_name, df)
     return data_source.get_source_table(
         db_table_name,
         database_name=session.database_name,


### PR DESCRIPTION
## Description

This removes a few unused options in BaseSession:

1. `temporary` flag in `register_table()` which is always set to False in non-test code paths
2. `register_table_with_query()` which is unused

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
