### PR TITLE
[chore] Use workspace home as default config path in databricks environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.1.1 (2024-06-10)
+
+### 💡 Enhancements
+
++ `sdk-api` Use workspace home as default config path in databricks environment.
+
 ## v1.1.0 (2024-06-08)
 
 ### 🛑 Breaking Changes

--- a/featurebyte/__init__.py
+++ b/featurebyte/__init__.py
@@ -133,36 +133,6 @@ def get_active_profile() -> Profile:
     """
     conf = Configurations()
 
-    # check if we are in DataBricks environment and valid secrets are present create a profile automatically
-    try:
-        from databricks.sdk.runtime import dbutils  # pylint: disable=import-outside-toplevel
-
-        if len(conf.profiles) == 1 and conf.profiles[0].name == "local":
-            api_url = None
-            api_token = None
-            try:
-                api_url = dbutils.secrets.get(scope="featurebyte", key="api-url")
-                api_token = dbutils.secrets.get(scope="featurebyte", key="api-token")
-            except Exception as databricks_exc:  # pylint: disable=broad-exception-caught
-                # use a more generic exception to avoid dependency on databricks sdk blocking
-                # the rest of the code
-                logger.warning(f"Failed to get secrets from Databricks: {databricks_exc}")
-                logger.info(
-                    "Add the secrets (featurebyte.api-url, featurebyte.api-token) for auto profile creation:\n"
-                    "databricks secrets create-scope --scope featurebyte\n"
-                    "databricks secrets put --scope featurebyte --key api-url --string-value <api-url>\n"
-                    "databricks secrets put --scope featurebyte --key api-token --string-value <api-token>"
-                )
-            if api_url and api_token:
-                register_profile(
-                    profile_name="databricks-auto-profile",
-                    api_url=api_url,
-                    api_token=api_token,
-                    make_default=True,
-                )
-    except (ModuleNotFoundError, ImportError, ValueError):
-        pass
-
     if not conf.profile:
         logger.error(
             "No profile found. Please update your configuration file at {conf.config_file_path}"

--- a/featurebyte/config.py
+++ b/featurebyte/config.py
@@ -53,7 +53,7 @@ def get_home_path() -> Path:
 
         db_user = dbutils.notebook.entry_point.getDbutils().notebook().getContext().userName().get()  # type: ignore
         default_home_path = Path(f"/Workspace/Users/{db_user}")
-    except (ModuleNotFoundError, ImportError, ValueError):
+    except (ModuleNotFoundError, ImportError, ValueError, AttributeError):
         pass
     return Path(os.environ.get("FEATUREBYTE_HOME", str(default_home_path.joinpath(".featurebyte"))))
 

--- a/featurebyte/config.py
+++ b/featurebyte/config.py
@@ -36,9 +36,6 @@ HTTP_REQUEST_BACKOFF_FACTOR: float = 0.3
 FEATURE_PREVIEW_ROW_LIMIT: int = 50
 ONLINE_FEATURE_REQUEST_ROW_LIMIT: int = 50
 
-# default local location
-DEFAULT_HOME_PATH: Path = Path.home().joinpath(".featurebyte")
-
 
 def get_home_path() -> Path:
     """
@@ -49,7 +46,16 @@ def get_home_path() -> Path:
     Path
         Featurebyte Home path
     """
-    return Path(os.environ.get("FEATUREBYTE_HOME", str(DEFAULT_HOME_PATH)))
+    default_home_path: Path = Path.home()
+    try:
+        # check if we are in DataBricks environment and valid secrets are present create a profile automatically
+        from databricks.sdk.runtime import dbutils  # pylint: disable=import-outside-toplevel
+
+        db_user = dbutils.notebook.entry_point.getDbutils().notebook().getContext().userName().get()  # type: ignore
+        default_home_path = Path(f"/Workspace/Users/{db_user}")
+    except (ModuleNotFoundError, ImportError, ValueError):
+        pass
+    return Path(os.environ.get("FEATUREBYTE_HOME", str(default_home_path.joinpath(".featurebyte"))))
 
 
 class LogLevel(StrEnum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ license = "Elastic License 2.0"
 name = "featurebyte"
 readme = "README.md"
 repository = "https://github.com/featurebyte/featurebyte"
-version = "1.1.0"
+version = "1.1.1"
 
 [tool.poetry.dependencies]
 PyYAML = "^6.0"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,7 +2,6 @@
 Test config parser
 """
 
-import os
 import tempfile
 import time
 from pathlib import Path
@@ -18,13 +17,13 @@ from websocket import (
 )
 
 from featurebyte.config import (
-    DEFAULT_HOME_PATH,
     APIClient,
     Configurations,
     LocalStorageSettings,
     LoggingSettings,
     Profile,
     WebsocketClient,
+    get_home_path,
 )
 from featurebyte.exception import InvalidSettingsError
 from featurebyte.logging import get_logger
@@ -151,9 +150,7 @@ def test_default_local_storage():
     Test default local storage location if not specified
     """
     config = Configurations("tests/fixtures/config/config_no_profile.yaml")
-    assert config.storage.local_path == Path(
-        os.environ.get("FEATUREBYTE_HOME", str(DEFAULT_HOME_PATH))
-    ).joinpath("data/files")
+    assert config.storage.local_path == get_home_path().joinpath("data/files")
 
 
 @patch("httpx._client.Client.send")


### PR DESCRIPTION
## Description

Use workspace home as default config path in databricks environment.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
