### PR TITLE
[DEV-3506] Set default feature job setting during SCDTable registration

### DIFF
--- a/featurebyte/schema/scd_table.py
+++ b/featurebyte/schema/scd_table.py
@@ -27,7 +27,9 @@ class SCDTableCreate(TableCreate):
     effective_timestamp_column: StrictStr
     end_timestamp_column: Optional[StrictStr]
     current_flag_column: Optional[StrictStr]
-    default_feature_job_setting: Optional[FeatureJobSetting]
+    default_feature_job_setting: Optional[FeatureJobSetting] = Field(
+        default=FeatureJobSetting(blind_spot="0h", offset="0h", period="24h")
+    )
 
     # pydantic validators
     _special_columns_validator = validator(

--- a/tests/unit/api/test_change_view.py
+++ b/tests/unit/api/test_change_view.py
@@ -283,18 +283,13 @@ def test_get_change_view__no_default_job_setting(snowflake_scd_table):
     """
     Test get_change_view - no default job setting provided
     """
-    datetime_mock = Mock(wraps=datetime)
-    mocked_hour = 11
-    mocked_minute = 15
-    datetime_mock.now.return_value = datetime(1999, 1, 1, mocked_hour, mocked_minute, 0)
-    with patch("featurebyte.api.change_view.datetime", new=datetime_mock):
-        change_view = snowflake_scd_table.get_change_view("col_int")
-        assert change_view.default_feature_job_setting == FeatureJobSetting(
-            blind_spot="0",
-            offset=f"{mocked_hour}h{mocked_minute}m",
-            period="24h",
-        )
-        change_view_test_helper(snowflake_scd_table, change_view)
+    change_view = snowflake_scd_table.get_change_view("col_int")
+    assert change_view.default_feature_job_setting == FeatureJobSetting(
+        blind_spot="0",
+        offset="0",
+        period="24h",
+    )
+    change_view_test_helper(snowflake_scd_table, change_view)
 
 
 def test_get_change_view__with_default_job_setting(snowflake_scd_table):
@@ -400,7 +395,7 @@ def test_aggregate_over_feature_tile_sql(feature_from_change_view):
         FROM (
           SELECT
             *,
-            F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "new_effective_timestamp"), 40500, 0, 1440) AS index
+            F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "new_effective_timestamp"), 0, 0, 1440) AS index
           FROM (
             SELECT
               *

--- a/tests/unit/api/test_scd_table.py
+++ b/tests/unit/api/test_scd_table.py
@@ -11,6 +11,7 @@ from featurebyte.api.scd_table import SCDTable
 from featurebyte.enum import TableDataType
 from featurebyte.exception import DuplicatedRecordException, RecordRetrievalException
 from featurebyte.models.scd_table import SCDTableModel
+from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
 from tests.unit.api.base_table_test import BaseTableTestSuite, DataType
 from tests.util.helper import check_sdk_code_generation
 
@@ -240,6 +241,12 @@ def test_create_scd_table(snowflake_database_table_scd_table, scd_table_dict, ca
     scd_table_dict["created_at"] = scd_table.created_at
     scd_table_dict["updated_at"] = scd_table.updated_at
     scd_table_dict["block_modification_by"] = []
+    scd_table_dict["default_feature_job_setting"] = {
+        "blind_spot": "0s",
+        "offset": "0s",
+        "period": "86400s",
+        "execution_buffer": "0s",
+    }
     for column_idx in [0, 2, 3, 6, 7, 9]:
         scd_table_dict["columns_info"][column_idx]["semantic_id"] = scd_table.columns_info[
             column_idx
@@ -440,7 +447,9 @@ def test_sdk_code_generation_on_saved_data(saved_scd_table, update_fixtures):
 
 def test_update_default_feature_job_setting(saved_scd_table, feature_group_feature_job_setting):
     """Test update feature job setting"""
-    assert saved_scd_table.default_feature_job_setting is None
+    assert saved_scd_table.default_feature_job_setting == FeatureJobSetting(
+        blind_spot="0h", offset="0h", period="24h"
+    )
     saved_scd_table.update_default_feature_job_setting(
         feature_job_setting=feature_group_feature_job_setting
     )

--- a/tests/unit/test_generate_payload_fixtures.py
+++ b/tests/unit/test_generate_payload_fixtures.py
@@ -284,6 +284,10 @@ def test_save_payload_fixtures(  # pylint: disable=too-many-arguments
                 col_info.pop("semantic_id")
             json_payload["columns_info"] = columns_info
 
+        if name == "scd_table":
+            # do not include default_feature_job_setting for SCD table
+            json_payload["default_feature_job_setting"] = None
+
         json_payload["_COMMENT"] = generated_comment
         update_or_check_payload_fixture(request_payload_dir, name, json_payload, update_fixtures)
 


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
This PR updates SCDTable registration logic to set default feature job setting during table registration.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
