### PR TITLE
[chore] Use a different test table name to avoid collision

### DIFF
--- a/tests/integration/udf/test_object_agg.py
+++ b/tests/integration/udf/test_object_agg.py
@@ -10,6 +10,8 @@ from sqlglot import expressions
 from featurebyte.query_graph.sql.adapter import get_sql_adapter
 from featurebyte.query_graph.sql.common import quoted_identifier, sql_to_string
 
+TEST_TABLE_NAME = "OBJECT_AGG_TEST_TABLE"
+
 
 @pytest_asyncio.fixture(name="setup_test_data", scope="module")
 async def setup_test_data_fixture(session):
@@ -23,10 +25,10 @@ async def setup_test_data_fixture(session):
             "val_col": [None, -1.5],
         }
     )
-    await session.register_table(table_name="test_table", dataframe=table)
+    await session.register_table(table_name=TEST_TABLE_NAME, dataframe=table)
     yield
     await session.drop_table(
-        "test_table", schema_name=session.schema_name, database_name=session.database_name
+        TEST_TABLE_NAME, schema_name=session.schema_name, database_name=session.database_name
     )
 
 
@@ -44,7 +46,7 @@ async def test_object_agg_udf(source_type, session, setup_test_data):
             alias="OUT",
             quoted=True,
         )
-    ).from_(quoted_identifier("test_table"))
+    ).from_(quoted_identifier(TEST_TABLE_NAME))
     df = await session.execute_query(sql_to_string(select_expr, source_type))
     actual = df.iloc[0]["OUT"]
     assert actual == {"2": -1.5}


### PR DESCRIPTION
## Description

Seeing some strange flaky tests recently:

E.g. https://github.com/featurebyte/featurebyte/actions/runs/9475724079/job/26107489803

This could be a possible source of flakiness (same table name was used for event table in integration tests) though I was not able to reproduce the same error locally.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
