### PR TITLE
[chore] Make sdk version check less stringent

### DIFF
--- a/featurebyte/__init__.py
+++ b/featurebyte/__init__.py
@@ -8,6 +8,7 @@ import sys
 
 import pandas as pd
 import yaml
+from packaging.version import Version
 
 from featurebyte.api.api_object_util import iterate_api_object_using_paginated_routes
 from featurebyte.api.batch_feature_table import BatchFeatureTable
@@ -118,6 +119,27 @@ def list_profiles() -> pd.DataFrame:
     return pd.DataFrame([profile.dict() for profile in profiles] if profiles else [])
 
 
+def _versions_compatible(first_version: str, second_version: str) -> bool:
+    """
+    Check if two versions are compatible.
+
+    Parameters
+    ----------
+    first_version: str
+        First version
+    second_version: str
+        Second version
+
+    Returns
+    -------
+    bool
+        True if versions are compatible, False otherwise
+    """
+    _version_a = Version(first_version)
+    _version_b = Version(second_version)
+    return _version_a.major == _version_b.major and _version_a.minor == _version_b.minor
+
+
 def get_active_profile() -> Profile:
     """
     Get active profile from configuration file.
@@ -141,7 +163,7 @@ def get_active_profile() -> Profile:
 
     logger.info(f"Active profile: {conf.profile.name} ({conf.profile.api_url})")
     versions = Configurations().check_sdk_versions()
-    if versions["remote sdk"] != versions["local sdk"]:
+    if not _versions_compatible(versions["remote sdk"], versions["local sdk"]):
         logger.warning(
             f"Remote SDK version ({versions['remote sdk']}) is different from local ({versions['local sdk']}). "
             "Update local SDK to avoid unexpected behavior."

--- a/scripts/enforce_import_rules.py
+++ b/scripts/enforce_import_rules.py
@@ -117,6 +117,7 @@ if __name__ == "__main__":
         "json",
         "operator",
         "os",
+        "packaging.version",
         "pathlib",
         "re",
         "shutil",

--- a/tests/unit/api/test_feature_store.py
+++ b/tests/unit/api/test_feature_store.py
@@ -20,7 +20,6 @@ from featurebyte.exception import (
     RecordRetrievalException,
 )
 from featurebyte.query_graph.node.schema import SnowflakeDetails
-from featurebyte.schema.feature_store import DatabaseDetailsUpdate
 from featurebyte.session.manager import SessionManager
 
 

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -148,3 +148,22 @@ def test_register_profile(noop_check_sdk_versions, noop_log_env_summary, config)
     finally:
         # Reset back to original profile
         config.use_profile(original_profile_name)
+
+
+@pytest.mark.parametrize(
+    "first_version,second_version,expected",
+    [
+        ("1.1.0", "1.1.1", True),
+        ("1.1.0", "1.1.0", True),
+        ("1.1.0", "1.1.0.dev7", True),
+        ("1.1.0", "1.0.0", False),
+        ("1.1.0", "1.2.0.dev7", False),
+    ],
+)
+def test_versions_compatible(first_version, second_version, expected):
+    """
+    Test versions_compatible function
+    """
+    assert (
+        fb._versions_compatible(first_version, second_version) is expected
+    )  # pylint: disable=protected-access


### PR DESCRIPTION
## Description

Make sdk version check less stringent, only display warning on minor version mismatch.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
