### PR TITLE
[chore] Revise `update_document` by setting `by_alias=True`

### DIFF
--- a/featurebyte/service/base_document.py
+++ b/featurebyte/service/base_document.py
@@ -1057,7 +1057,11 @@ class BaseDocumentService(
             )
 
         # perform validation first before actual update
-        update_dict = data.dict(exclude_none=exclude_none, by_alias=True)
+        update_dict = data.dict(
+            exclude_none=exclude_none,
+            exclude={"id": True},  # exclude id to avoid updating original document ID
+            by_alias=True,  # use alias when getting update data dictionary
+        )
 
         # update document to persistent
         await self._update_document(

--- a/featurebyte/service/base_document.py
+++ b/featurebyte/service/base_document.py
@@ -1057,7 +1057,7 @@ class BaseDocumentService(
             )
 
         # perform validation first before actual update
-        update_dict = data.dict(exclude_none=exclude_none)
+        update_dict = data.dict(exclude_none=exclude_none, by_alias=True)
 
         # update document to persistent
         await self._update_document(


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
This PR updates `update_document` method of base document service so that it behaves properly when the update document object contains field with alias.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
