### PR TITLE
[chore] Split snowflake integration tests and run tests sequentially

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -126,8 +126,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
+      fail-fast: false
       matrix:
-        fail-fast: false
         python-version:
           - 3.10.14
         pytest-group:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -129,6 +129,11 @@ jobs:
       matrix:
         python-version:
           - 3.10.14
+        pytest-group:
+          - 1
+          - 2
+    env:
+      PYTEST_SPLITS: 2  # This needs to be EQ the count of strategy.matrix.pytest-group
     steps:
       - uses: actions/checkout@v4
       - uses: arduino/setup-task@v2
@@ -160,10 +165,13 @@ jobs:
           name: hive-udf
           path: featurebyte/sql/spark/
       - name: Run tests
+        env:
+          PYTEST_GROUP: ${{ matrix.pytest-group }}
         run: task test-integration-snowflake
       - name: Renaming test assets
         run: |
-          mv .coverage .coverage.1
+          mv .coverage .coverage.1.${{ matrix.pytest-group }}
+          mv pytest.xml.1 pytest.xml.1.${{ matrix.pytest-group }}
       - name: Upload test results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -127,6 +127,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
+        fail-fast: false
         python-version:
           - 3.10.14
         pytest-group:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -266,7 +266,7 @@ tasks:
       - task: install
     cmds:
       - task: test-setup
-      - poetry run pytest --timeout=240 --timeout-method=thread --junitxml=pytest.xml.1 -n auto --cov=featurebyte tests/integration --source-types none,snowflake
+      - poetry run pytest --timeout=240 --timeout-method=thread --junitxml=pytest.xml.1 --cov=featurebyte tests/integration --source-types none,snowflake --splits={{.PYTEST_SPLITS}} --group={{.PYTEST_GROUP}}
       - task: test-teardown
 
   test-reset:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -266,7 +266,7 @@ tasks:
       - task: install
     cmds:
       - task: test-setup
-      - poetry run pytest --timeout=240 --timeout-method=thread --junitxml=pytest.xml.1 --cov=featurebyte tests/integration --source-types none,snowflake --splits={{.PYTEST_SPLITS}} --group={{.PYTEST_GROUP}}
+      - poetry run pytest --timeout=360 --timeout-method=thread --junitxml=pytest.xml.1 --cov=featurebyte tests/integration --source-types none,snowflake --splits={{.PYTEST_SPLITS}} --group={{.PYTEST_GROUP}}
       - task: test-teardown
 
   test-reset:


### PR DESCRIPTION
## Description

`pytest-xdist` worker in snowflake integration tests is crashing very often:

```
...
[gw0] node down: Not properly terminated
[gw0] [ 21%] FAILED tests/integration/feature_store_integration/test_feature_materialize.py::test_feature_tables_expected[snowflake] 

replacing crashed worker gw0
...
```

This splits snowflake integration tests into two jobs and within each job runs tests sequentially.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
