### PR TITLE
[chore] Fix create_many error when input is empty list

### DIFF
--- a/featurebyte/service/base_document.py
+++ b/featurebyte/service/base_document.py
@@ -263,6 +263,9 @@ class BaseDocumentService(
         data_list: List[DocumentCreateSchema]
             Document creation payload objects
         """
+        if not data_list:
+            return
+
         documents = []
         for data in data_list:
             document_dict = await self._get_document_dict_to_insert(data)

--- a/tests/unit/service/test_base_document.py
+++ b/tests/unit/service/test_base_document.py
@@ -528,7 +528,7 @@ async def test_create_many(document_service):
 
 
 @pytest.mark.asyncio
-async def test_create_many(document_service):
+async def test_create_many_empty_list(document_service):
     """Test calling create_many with empty list should not error"""
     await document_service.create_many([])
 

--- a/tests/unit/service/test_base_document.py
+++ b/tests/unit/service/test_base_document.py
@@ -527,6 +527,12 @@ async def test_create_many(document_service):
         assert retrieved.id == data.id
 
 
+@pytest.mark.asyncio
+async def test_create_many(document_service):
+    """Test calling create_many with empty list should not error"""
+    await document_service.create_many([])
+
+
 @pytest_asyncio.fixture(name="document_with_block_modification")
 async def document_with_block_modification_fixture(document_service, to_use_create_many):
     """Create a document with block_modification_by"""


### PR DESCRIPTION
## Description

Update BaseDocumentService `create_many` to not error on empty list.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
