### PR TITLE
[DEV-3539] Fix error when using request column as key in dictionary feature operations 

### DIFF
--- a/.changelog/DEV-3539.yaml
+++ b/.changelog/DEV-3539.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix error when using request column as key in dictionary feature operations"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/core/accessor/count_dict.py
+++ b/featurebyte/core/accessor/count_dict.py
@@ -14,12 +14,17 @@ from featurebyte.core.util import SeriesBinaryOperator, series_unary_operation
 from featurebyte.enum import DBVarType
 from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.node.count_dict import GetValueFromDictionaryNode
-from featurebyte.typing import Scalar
+from featurebyte.typing import Scalar, is_scalar
 
 if TYPE_CHECKING:
     from featurebyte.api.feature import Feature
+    from featurebyte.api.request_column import RequestColumn
 else:
     Feature = TypeVar("Feature")
+    RequestColumn = TypeVar("RequestColumn")
+
+
+KeyType = Union[Union[Scalar, Feature, RequestColumn]]
 
 
 class CdAccessorMixin:
@@ -349,14 +354,14 @@ class CountDictAccessor:
             output_var_type=DBVarType.FLOAT,
         )
 
-    def get_value(self, key: Union[Scalar, Feature]) -> Feature:
+    def get_value(self, key: KeyType) -> Feature:
         """
         Retrieves the value of a specific key in the Cross Aggregate feature. The key may either be a
         lookup feature or a scalar value.
 
         Parameters
         ----------
-        key: Union[Scalar, Feature]
+        key: KeyType
             key to lookup the value for
 
         Returns
@@ -391,7 +396,7 @@ class CountDictAccessor:
         1
         """
         additional_node_params = {}
-        if not isinstance(key, type(self._feature_obj)):
+        if is_scalar(key):
             # We only need to assign value if we have been passed in a single scalar value.
             additional_node_params["value"] = key
         # construct operation structure of the get value node output
@@ -407,7 +412,7 @@ class CountDictAccessor:
             additional_node_params=additional_node_params,
         )
 
-    def get_rank(self, key: Union[Scalar, Feature], descending: bool = False) -> Feature:
+    def get_rank(self, key: KeyType, descending: bool = False) -> Feature:
         """
         Computes the rank of a specific key in the Cross Aggregate feature. If there are multiple keys with the same
         value, those keys will have the same rank, which equals the smallest rank among those keys. The key that is
@@ -415,7 +420,7 @@ class CountDictAccessor:
 
         Parameters
         ----------
-        key: Union[Scalar, Feature]
+        key: KeyType
             Key to lookup the value for.
         descending: bool
             Defaults to ranking in ascending order. Set to true to rank in descending order.
@@ -454,7 +459,7 @@ class CountDictAccessor:
         additional_node_params: Dict[str, Any] = {
             "descending": descending,
         }
-        if not isinstance(key, type(self._feature_obj)):
+        if is_scalar(key):
             # We only need to assign value if we have been passed in a single scalar value.
             additional_node_params["value"] = key
 
@@ -465,7 +470,7 @@ class CountDictAccessor:
             additional_node_params=additional_node_params,
         )
 
-    def get_relative_frequency(self, key: Union[Scalar, Feature]) -> Feature:
+    def get_relative_frequency(self, key: KeyType) -> Feature:
         """
         Computes the relative frequency of a specific key in the Cross Aggregate feature. The key
         may either be a lookup feature or a scalar value. If the key does not exist, the relative
@@ -473,7 +478,7 @@ class CountDictAccessor:
 
         Parameters
         ----------
-        key: Union[Scalar, Feature]
+        key: KeyType
             Key to lookup the value for.
 
         Returns
@@ -509,7 +514,7 @@ class CountDictAccessor:
         0.14285714285714302
         """
         additional_node_params = {}
-        if not isinstance(key, type(self._feature_obj)):
+        if is_scalar(key):
             # We only need to assign value if we have been passed in a single scalar value.
             additional_node_params["value"] = key
 

--- a/featurebyte/query_graph/sql/ast/util.py
+++ b/featurebyte/query_graph/sql/ast/util.py
@@ -13,7 +13,7 @@ from featurebyte.query_graph.sql.ast.literal import make_literal_value
 
 def prepare_binary_op_input_nodes(
     context: SQLNodeContext,
-) -> tuple[TableNode, ExpressionNode, ExpressionNode]:
+) -> tuple[Optional[TableNode], ExpressionNode, ExpressionNode]:
     """
     Perform common preparation on binary ops input nodes, such as constructing literal value
     expression and swapping left right operands when applicable
@@ -25,7 +25,7 @@ def prepare_binary_op_input_nodes(
 
     Returns
     -------
-    tuple[TableNode, ExpressionNode, ExpressionNode]
+    tuple[Optional[TableNode], ExpressionNode, ExpressionNode]
     """
     input_sql_nodes = context.input_sql_nodes
     parameters = context.parameters
@@ -48,9 +48,7 @@ def prepare_binary_op_input_nodes(
         left_node, right_node = right_node, left_node
 
     if table_node is None:
-        # In this case, the left node is a column from the request data. The right node must be from
-        # a feature and has a valid table node.
-        assert right_node.table_node is not None, "Right node must have a table node"
+        # Table node can be None if both sides are derived from request column
         table_node = right_node.table_node
 
     return table_node, left_node, right_node

--- a/featurebyte/query_graph/sql/ast/util.py
+++ b/featurebyte/query_graph/sql/ast/util.py
@@ -4,7 +4,7 @@ Utilities for building SQLNode
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 from featurebyte.query_graph.sql.ast.base import ExpressionNode, SQLNodeContext, TableNode
 from featurebyte.query_graph.sql.ast.generic import ParsedExpressionNode
@@ -58,7 +58,7 @@ def prepare_binary_op_input_nodes(
 
 def prepare_unary_input_nodes(
     context: SQLNodeContext,
-) -> tuple[TableNode, ExpressionNode, dict[str, Any]]:
+) -> tuple[Optional[TableNode], ExpressionNode, dict[str, Any]]:
     """Extract TableNode and ExpressionNode in a unary operation
 
     Parameters
@@ -73,5 +73,4 @@ def prepare_unary_input_nodes(
     input_expr_node = context.input_sql_nodes[0]
     assert isinstance(input_expr_node, ExpressionNode), "Input node must be an expression node"
     table_node = input_expr_node.table_node
-    assert table_node is not None
     return table_node, input_expr_node, context.parameters

--- a/featurebyte/typing.py
+++ b/featurebyte/typing.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Optional, Sequence, Type, Union, cast
 from typing_extensions import Literal
 
 import pandas as pd
-from pandas.api.types import is_scalar
+from pandas.api.types import is_scalar as pd_is_scalar
 from pydantic import StrictFloat, StrictInt, StrictStr
 
 DatetimeSupportedPropertyType = Literal[
@@ -38,6 +38,22 @@ Timestamp = Union[pd.Timestamp]
 AllSupportedValueTypes = Union[Scalar, ScalarSequence, Timestamp]
 
 Func = Callable[..., Any]
+
+
+def is_scalar(value: Any) -> bool:
+    """
+    Returns whether the provided value is a Scalar value
+
+    Parameters
+    ----------
+    value : Any
+        Value to check
+
+    Returns
+    -------
+    bool
+    """
+    return cast(bool, pd_is_scalar(value))
 
 
 def is_scalar_nan(value: Any) -> bool:

--- a/tests/integration/api/test_dimension_view_operations.py
+++ b/tests/integration/api/test_dimension_view_operations.py
@@ -270,6 +270,9 @@ def test_get_value_in_dictionary__target_derived_from_request_column(event_table
     feature_name = "get_value_in_dictionary"
     get_value_feature.name = feature_name
 
+    # Check feature can be saved
+    get_value_feature.save()
+
     # Check output
     preview_params = [{"POINT_IN_TIME": "2001-01-02 12:00:00", "cust_id": "350"}]
     get_value_feature_preview = get_value_feature.preview(pd.DataFrame(preview_params))

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -41,6 +41,7 @@ from featurebyte.api.feature_store import FeatureStore
 from featurebyte.api.groupby import GroupBy
 from featurebyte.api.item_table import ItemTable
 from featurebyte.api.online_store import OnlineStore
+from featurebyte.api.request_column import RequestColumn
 from featurebyte.app import User, app, get_celery
 from featurebyte.enum import AggFunc, InternalName, SourceType
 from featurebyte.exception import DuplicatedRecordException, ObjectHasBeenSavedError
@@ -2028,6 +2029,14 @@ def latest_event_timestamp_unbounded_feature_fixture(
         feature_job_setting=feature_group_feature_job_setting,
     )["latest_event_timestamp"]
     return feature
+
+
+@pytest.fixture(name="request_column_point_in_time")
+def request_column_point_in_time():
+    """
+    Fixture for a RequestColumn object for the point in time
+    """
+    return RequestColumn.point_in_time()
 
 
 @pytest.fixture(name="session_manager")


### PR DESCRIPTION
## Description

Before this fix, using a request column derived key in dictionary feature operations triggers an error that looks like this:
```
ValidationError: 4 validation errors for GetValueFromDictionaryNode
parameters -> value
  value is not a valid integer (type=type_error.integer)
parameters -> value
  value is not a valid float (type=type_error.float)
parameters -> value
  str type expected (type=type_error.str)
parameters -> value
  value could not be parsed to a boolean (type=type_error.bool)
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
