### PR TITLE
[DEV-3538] Do not convert keys to string in value counts

### DIFF
--- a/featurebyte/query_graph/sql/interpreter/preview.py
+++ b/featurebyte/query_graph/sql/interpreter/preview.py
@@ -981,6 +981,7 @@ class PreviewMixin(BaseGraphInterpreter):
         num_rows: int,
         num_categories_limit: int,
         seed: int = 1234,
+        convert_keys_to_string: bool = True,
     ) -> str:
         """
         Construct SQL to get value counts for a given node.
@@ -994,6 +995,8 @@ class PreviewMixin(BaseGraphInterpreter):
         num_categories_limit : int
             Maximum number of categories to include in the result. If there are more categories in
             the data, the result will include the most frequent categories up to this number.
+        convert_keys_to_string: bool
+            Whether to convert keys to string
         seed: int
             Random seed to use for sampling
 
@@ -1009,6 +1012,10 @@ class PreviewMixin(BaseGraphInterpreter):
         cte_statements: List[CteStatement] = [
             ("data", sql_tree),
         ]
+        if convert_keys_to_string:
+            cte_statements.append(
+                self._get_cte_with_casted_data(sql_tree),
+            )
         # It's expected that this function is called on a node that is associated with a column and
         # not a frame, so here we simply take the first column.
         col_expr = sql_tree.expressions[0]
@@ -1016,7 +1023,7 @@ class PreviewMixin(BaseGraphInterpreter):
         cat_counts = self._get_cat_counts(
             quoted_identifier(col_name),
             num_categories_limit=num_categories_limit,
-            use_casted_data=False,
+            use_casted_data=convert_keys_to_string,
         )
         output_expr = (
             construct_cte_sql(cte_statements)

--- a/featurebyte/service/preview.py
+++ b/featurebyte/service/preview.py
@@ -331,9 +331,7 @@ class PreviewService:
                 return cast_type(key)
             return key
 
-        if cast_type:
-            output = {_cast_key(key): value for (key, value) in output.items()}
-
+        output = {_cast_key(key): value for (key, value) in output.items()}
         return output  # type: ignore
 
     @staticmethod

--- a/featurebyte/service/preview.py
+++ b/featurebyte/service/preview.py
@@ -273,6 +273,7 @@ class PreviewService:
         preview: FeatureStorePreview,
         num_rows: int,
         num_categories_limit: int,
+        convert_keys_to_string: bool = True,
         seed: int = 1234,
     ) -> dict[Any, int]:
         """
@@ -287,6 +288,8 @@ class PreviewService:
         num_categories_limit : int
             Maximum number of categories to include in the result. If there are more categories in
             the data, the result will include the most frequent categories up to this number.
+        convert_keys_to_string : bool
+            Whether to convert keys to string
         seed: int
             Random seed to use for sampling
 
@@ -304,6 +307,7 @@ class PreviewService:
             node_name=preview.node_name,
             num_rows=num_rows,
             num_categories_limit=num_categories_limit,
+            convert_keys_to_string=convert_keys_to_string,
             seed=seed,
         )
 
@@ -311,6 +315,9 @@ class PreviewService:
         assert df_result.columns.tolist() == ["key", "count"]  # type: ignore
         df_result.loc[df_result["key"].isnull(), "key"] = None  # type: ignore
         output = df_result.set_index("key")["count"].to_dict()  # type: ignore
+
+        if convert_keys_to_string:
+            return output  # type: ignore
 
         # Cast int and float to native types
         column_dtype = (

--- a/tests/fixtures/query_graph/expected_value_counts.sql
+++ b/tests/fixtures/query_graph/expected_value_counts.sql
@@ -5,10 +5,6 @@ WITH data AS (
   ORDER BY
     RANDOM(1234)
   LIMIT 50000
-), casted_data AS (
-  SELECT
-    CAST("a" AS STRING) AS "a"
-  FROM data
 )
 SELECT
   "a" AS "key",
@@ -17,7 +13,7 @@ FROM (
   SELECT
     "a",
     COUNT(*) AS "__FB_COUNTS"
-  FROM casted_data
+  FROM data
   GROUP BY
     "a"
   ORDER BY

--- a/tests/fixtures/query_graph/expected_value_counts_no_casting.sql
+++ b/tests/fixtures/query_graph/expected_value_counts_no_casting.sql
@@ -5,10 +5,6 @@ WITH data AS (
   ORDER BY
     RANDOM(1234)
   LIMIT 50000
-), casted_data AS (
-  SELECT
-    CAST("a" AS STRING) AS "a"
-  FROM data
 )
 SELECT
   "a" AS "key",
@@ -17,7 +13,7 @@ FROM (
   SELECT
     "a",
     COUNT(*) AS "__FB_COUNTS"
-  FROM casted_data
+  FROM data
   GROUP BY
     "a"
   ORDER BY

--- a/tests/unit/query_graph/interpreter/test_preview.py
+++ b/tests/unit/query_graph/interpreter/test_preview.py
@@ -196,3 +196,17 @@ def test_value_counts_sql(project_from_simple_graph, update_fixtures):
     )
     expected_filename = f"tests/fixtures/query_graph/expected_value_counts.sql"
     assert_equal_with_expected_fixture(sql_code, expected_filename, update_fixtures)
+
+
+def test_value_counts_sql_no_casting(project_from_simple_graph, update_fixtures):
+    """Test value counts sql"""
+    graph, node = project_from_simple_graph
+    interpreter = GraphInterpreter(graph, SourceType.SNOWFLAKE)
+    sql_code = interpreter.construct_value_counts_sql(
+        node.name,
+        num_rows=50000,
+        num_categories_limit=1000,
+        convert_keys_to_string=False,
+    )
+    expected_filename = f"tests/fixtures/query_graph/expected_value_counts_no_casting.sql"
+    assert_equal_with_expected_fixture(sql_code, expected_filename, update_fixtures)

--- a/tests/unit/service/test_preview.py
+++ b/tests/unit/service/test_preview.py
@@ -242,6 +242,29 @@ async def test_preview_featurelist__missing_entity(
     assert str(exc.value) == expected
 
 
+async def test_value_counts(
+    preview_service,
+    feature_store_preview,
+    mock_snowflake_session,
+):
+    """
+    Test value counts
+    """
+    mock_snowflake_session.execute_query.return_value = pd.DataFrame(
+        {
+            "key": ["1", "2", None],
+            "count": [100, 50, 3],
+        }
+    )
+    result = await preview_service.value_counts(
+        feature_store_preview,
+        num_rows=100000,
+        num_categories_limit=500,
+        convert_keys_to_string=True,
+    )
+    assert result == {"1": 100, "2": 50, None: 3}
+
+
 @pytest.mark.parametrize(
     "project_column,keys,expected",
     [
@@ -263,7 +286,7 @@ async def test_preview_featurelist__missing_entity(
     ],
 )
 @pytest.mark.asyncio
-async def test_value_counts(
+async def test_value_counts_not_convert_keys_to_string(
     preview_service,
     feature_store_preview_project_column,
     keys,
@@ -283,5 +306,6 @@ async def test_value_counts(
         feature_store_preview_project_column,
         num_rows=100000,
         num_categories_limit=500,
+        convert_keys_to_string=False,
     )
     assert result == expected

--- a/tests/unit/service/test_preview.py
+++ b/tests/unit/service/test_preview.py
@@ -240,8 +240,8 @@ async def test_value_counts(
     """
     mock_snowflake_session.execute_query.return_value = pd.DataFrame(
         {
-            "key": ["a", "b"],
-            "count": [100, 50],
+            "key": [1, 2, None],
+            "count": [100, 50, 3],
         }
     )
     result = await preview_service.value_counts(
@@ -249,4 +249,4 @@ async def test_value_counts(
         num_rows=100000,
         num_categories_limit=500,
     )
-    assert result == {"a": 100, "b": 50}
+    assert result == {1: 100, 2: 50, None: 3}

--- a/tests/unit/service/test_preview.py
+++ b/tests/unit/service/test_preview.py
@@ -88,6 +88,9 @@ def feature_store_preview_fixture(feature_store):
 
 @pytest.fixture(name="feature_store_preview_project_column")
 def feature_store_preview_project_column_fixture(feature_store_preview, project_column):
+    """
+    Fixture for a FeatureStorePreview with a project column
+    """
     project_node = next(
         node for node in feature_store_preview.graph.nodes if node.type == "project"
     )


### PR DESCRIPTION
## Description

This updates the value counts query to not convert keys to string as we need to preserve the original type.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
