### PR TITLE
[chore] Add drop_all_null_stats option to PreviewService describe method

### DIFF
--- a/featurebyte/service/preview.py
+++ b/featurebyte/service/preview.py
@@ -222,7 +222,7 @@ class PreviewService:
             be described in multiple queries. If None, a default value will be used. If 0, batching
             will be disabled.
         drop_all_null_stats: bool
-            Whether to drop the result of a statisticss if all values across all columns are null
+            Whether to drop the result of a statistics if all values across all columns are null
 
         Returns
         -------

--- a/featurebyte/service/preview.py
+++ b/featurebyte/service/preview.py
@@ -204,6 +204,7 @@ class PreviewService:
         size: int,
         seed: int,
         columns_batch_size: Optional[int] = None,
+        drop_all_null_stats: bool = True,
     ) -> dict[str, Any]:
         """
         Sample a QueryObject that is not a Feature (e.g. SourceTable, EventTable, EventView, etc)
@@ -220,6 +221,8 @@ class PreviewService:
             Maximum number of columns to describe in a single query. More columns in the data will
             be described in multiple queries. If None, a default value will be used. If 0, batching
             will be disabled.
+        drop_all_null_stats: bool
+            Whether to drop the result of a statisticss if all values across all columns are null
 
         Returns
         -------
@@ -265,7 +268,9 @@ class PreviewService:
                 columns=[str(column.name) for column in columns],
             )
             df_queries.append(df_query)
-        results = pd.concat(df_queries, axis=1).dropna(axis=0, how="all")
+        results = pd.concat(df_queries, axis=1)
+        if drop_all_null_stats:
+            results = results.dropna(axis=0, how="all")
         return dataframe_to_json(results, describe_queries.type_conversions, skip_prepare=True)
 
     async def value_counts(

--- a/tests/unit/service/test_preview.py
+++ b/tests/unit/service/test_preview.py
@@ -9,6 +9,7 @@ from bson import ObjectId
 from sqlglot import parse_one
 
 from featurebyte import FeatureStore
+from featurebyte.common.utils import dataframe_from_json
 from featurebyte.exception import MissingPointInTimeColumnError, RequiredEntityNotProvidedError
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.feature_list import FeatureCluster
@@ -263,35 +264,28 @@ async def test_describe_drop_all_null_stats(
     Test describe
     """
 
+    # pylint: disable=no-member
     async def mock_execute_query(query):
         if "%missing" not in query:
             return pd.DataFrame({"count": [100]})
-        stats_names = [col.alias_or_name for col in parse_one(query, read="snowflake").expressions]
-        column_names = [
-            "col_int",
-            "col_float",
-            "col_char",
-            "col_text",
-            "col_binary",
-            "col_boolean",
-            "event_timestamp",
-            "created_at",
-            "cust_id",
+        result_column_names = [
+            col.alias_or_name for col in parse_one(query, read="snowflake").expressions
         ]
-        result = pd.DataFrame(
-            {col: ["some_val"] * len(stats_names) for col in column_names},
-            index=stats_names,
-        )
-        result.loc["%missing"] = None
-        return result.T
+        # Make %missing stats null in all columns
+        data = {
+            col: ["some_value"] if "%missing" not in col else [None] for col in result_column_names
+        }
+        return pd.DataFrame(data)
 
     mock_snowflake_session.execute_query.side_effect = mock_execute_query
     mock_snowflake_session.execute_query_long_running.side_effect = mock_execute_query
-    result = await preview_service.describe(
-        feature_store_sample,
-        size=5000,
-        seed=0,
-        drop_all_null_stats=drop_all_null_stats,
+    result = dataframe_from_json(
+        await preview_service.describe(
+            feature_store_sample,
+            size=5000,
+            seed=0,
+            drop_all_null_stats=drop_all_null_stats,
+        )
     )
     if drop_all_null_stats:
         assert "%missing" not in result.index


### PR DESCRIPTION
## Description

This adds a `drop_all_null_stats` option to the describe method which disables dropping statistics will all null values. This behaviour is for producing human readable output in interactive usage, but can be inconvenient when the service is used internally for other purposes.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
