### PR TITLE
[chore] Cast entity column type based on dtype in entity universe

### DIFF
--- a/tests/fixtures/feature_materialize/initialize_new_columns_existing_table.sql
+++ b/tests/fixtures/feature_materialize/initialize_new_columns_existing_table.sql
@@ -6,7 +6,7 @@ ALTER TABLE "cat1_cust_id_30m" ADD COLUMN "sum_30m_V220101" FLOAT;
 
 CREATE TABLE "sf_db"."sf_schema"."TEMP_REQUEST_TABLE_000000000000000000000000" AS
 SELECT DISTINCT
-  "cust_id"
+  CAST("cust_id" AS BIGINT) AS "cust_id"
 FROM online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c
 WHERE
   "AGGREGATION_RESULT_NAME" = '_fb_internal_cust_id_window_w1800_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295'

--- a/tests/fixtures/feature_materialize/initialize_new_columns_existing_table_empty.sql
+++ b/tests/fixtures/feature_materialize/initialize_new_columns_existing_table_empty.sql
@@ -6,7 +6,7 @@ ALTER TABLE "cat1_cust_id_30m" ADD COLUMN "sum_30m_V220101" FLOAT;
 
 CREATE TABLE "sf_db"."sf_schema"."TEMP_REQUEST_TABLE_000000000000000000000000" AS
 SELECT DISTINCT
-  "cust_id"
+  CAST("cust_id" AS BIGINT) AS "cust_id"
 FROM online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c
 WHERE
   "AGGREGATION_RESULT_NAME" = '_fb_internal_cust_id_window_w1800_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295'

--- a/tests/fixtures/feature_materialize/initialize_new_columns_new_table.sql
+++ b/tests/fixtures/feature_materialize/initialize_new_columns_new_table.sql
@@ -4,7 +4,7 @@ FROM "cat1_cust_id_30m";
 
 CREATE TABLE "sf_db"."sf_schema"."TEMP_REQUEST_TABLE_000000000000000000000000" AS
 SELECT DISTINCT
-  "cust_id"
+  CAST("cust_id" AS BIGINT) AS "cust_id"
 FROM online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c
 WHERE
   "AGGREGATION_RESULT_NAME" = '_fb_internal_cust_id_window_w1800_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295'

--- a/tests/fixtures/feature_materialize/initialize_new_columns_new_table_databricks.sql
+++ b/tests/fixtures/feature_materialize/initialize_new_columns_new_table_databricks.sql
@@ -10,7 +10,7 @@ TBLPROPERTIES (
   'delta.minWriterVersion'='5'
 ) AS
 SELECT DISTINCT
-  `cust_id`
+  CAST(`cust_id` AS LONG) AS `cust_id`
 FROM online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c
 WHERE
   `AGGREGATION_RESULT_NAME` = '_fb_internal_cust_id_window_w1800_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295'

--- a/tests/fixtures/feature_materialize/materialize_features_queries.sql
+++ b/tests/fixtures/feature_materialize/materialize_features_queries.sql
@@ -1,6 +1,6 @@
 CREATE TABLE "sf_db"."sf_schema"."TEMP_REQUEST_TABLE_000000000000000000000000" AS
 SELECT DISTINCT
-  "cust_id"
+  CAST("cust_id" AS BIGINT) AS "cust_id"
 FROM online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c
 WHERE
   "AGGREGATION_RESULT_NAME" = '_fb_internal_cust_id_window_w1800_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295'

--- a/tests/fixtures/feature_materialize/materialize_features_queries_composite_entity.sql
+++ b/tests/fixtures/feature_materialize/materialize_features_queries_composite_entity.sql
@@ -1,6 +1,6 @@
 CREATE TABLE "sf_db"."sf_schema"."TEMP_REQUEST_TABLE_000000000000000000000000" AS
 SELECT DISTINCT
-  "cust_id",
+  CAST("cust_id" AS BIGINT) AS "cust_id",
   "another_key"
 FROM online_store_39866085bbe5ca4054c0978e965930d2f26cc229
 WHERE

--- a/tests/fixtures/feature_materialize/materialize_features_queries_composite_entity_batch.sql
+++ b/tests/fixtures/feature_materialize/materialize_features_queries_composite_entity_batch.sql
@@ -1,6 +1,6 @@
 CREATE TABLE "sf_db"."sf_schema"."TEMP_REQUEST_TABLE_000000000000000000000000" AS
 SELECT DISTINCT
-  "cust_id",
+  CAST("cust_id" AS BIGINT) AS "cust_id",
   "another_key"
 FROM online_store_39866085bbe5ca4054c0978e965930d2f26cc229
 WHERE

--- a/tests/fixtures/feature_materialize/scheduled_materialize_features_precomputed_lookup_ttl.sql
+++ b/tests/fixtures/feature_materialize/scheduled_materialize_features_precomputed_lookup_ttl.sql
@@ -1,6 +1,6 @@
 CREATE TABLE "sf_db"."sf_schema"."TEMP_REQUEST_TABLE_000000000000000000000000" AS
 SELECT DISTINCT
-  "cust_id"
+  CAST("cust_id" AS BIGINT) AS "cust_id"
 FROM online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c
 WHERE
   "AGGREGATION_RESULT_NAME" = '_fb_internal_cust_id_window_w86400_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295'

--- a/tests/fixtures/feature_materialize/scheduled_materialize_features_queries.sql
+++ b/tests/fixtures/feature_materialize/scheduled_materialize_features_queries.sql
@@ -1,6 +1,6 @@
 CREATE TABLE "sf_db"."sf_schema"."TEMP_REQUEST_TABLE_000000000000000000000000" AS
 SELECT DISTINCT
-  "cust_id"
+  CAST("cust_id" AS BIGINT) AS "cust_id"
 FROM online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c
 WHERE
   "AGGREGATION_RESULT_NAME" = '_fb_internal_cust_id_window_w1800_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295'

--- a/tests/fixtures/offline_store_feature_table/latest_aggregation_with_window_universe.sql
+++ b/tests/fixtures/offline_store_feature_table/latest_aggregation_with_window_universe.sql
@@ -1,5 +1,5 @@
 SELECT DISTINCT
-  "cust_id"
+  CAST("cust_id" AS BIGINT) AS "cust_id"
 FROM online_store_1d1bc6c6b7e37001082cdc2f77e909b292fa4e50
 WHERE
   "AGGREGATION_RESULT_NAME" = '_fb_internal_cust_id_window_w7776000_latest_d9b2a8ebb02e7a6916ae36e9cc223759433c01e2'

--- a/tests/fixtures/offline_store_feature_table/latest_aggregation_without_window_universe.sql
+++ b/tests/fixtures/offline_store_feature_table/latest_aggregation_without_window_universe.sql
@@ -1,5 +1,5 @@
 SELECT DISTINCT
-  "cust_id" AS "cust_id"
+  CAST("cust_id" AS BIGINT) AS "cust_id"
 FROM (
   SELECT
     "col_int" AS "col_int",

--- a/tests/unit/models/test_entity_universe.py
+++ b/tests/unit/models/test_entity_universe.py
@@ -247,7 +247,7 @@ def test_item_aggregate_universe(catalog, item_aggregate_graph_and_node):
     expected = textwrap.dedent(
         """
         SELECT DISTINCT
-          "event_id_col" AS "transaction_id"
+          CAST("event_id_col" AS BIGINT) AS "transaction_id"
         FROM (
           SELECT
             L."event_id_col" AS "event_id_col",
@@ -519,7 +519,7 @@ def test_combined_universe__exclude_dummy_entity_universe(
     expected = textwrap.dedent(
         """
         SELECT DISTINCT
-          "cust_id"
+          CAST("cust_id" AS BIGINT) AS "cust_id"
         FROM online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c
         WHERE
           "AGGREGATION_RESULT_NAME" = '_fb_internal_cust_id_window_w86400_sum_420f46a4414d6fc926c85a1349835967a96bf4c2'
@@ -559,21 +559,21 @@ def test_combined_universe__window_aggregate_multiple_windows(
     expected = textwrap.dedent(
         """
         SELECT DISTINCT
-          "cust_id"
+          CAST("cust_id" AS BIGINT) AS "cust_id"
         FROM online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c
         WHERE
           "AGGREGATION_RESULT_NAME" = '_fb_internal_cust_id_window_w86400_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295'
           AND "cust_id" IS NOT NULL
         UNION
         SELECT DISTINCT
-          "cust_id"
+          CAST("cust_id" AS BIGINT) AS "cust_id"
         FROM online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c
         WHERE
           "AGGREGATION_RESULT_NAME" = '_fb_internal_cust_id_window_w7200_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295'
           AND "cust_id" IS NOT NULL
         UNION
         SELECT DISTINCT
-          "cust_id"
+          CAST("cust_id" AS BIGINT) AS "cust_id"
         FROM online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c
         WHERE
           "AGGREGATION_RESULT_NAME" = '_fb_internal_cust_id_window_w86400_sum_420f46a4414d6fc926c85a1349835967a96bf4c2'

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -695,7 +695,7 @@ async def test_feature_table_one_feature_deployed(
                 "formatted_expression": textwrap.dedent(
                     """
                     SELECT DISTINCT
-                      "cust_id"
+                      CAST("cust_id" AS BIGINT) AS "cust_id"
                     FROM online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c
                     WHERE
                       "AGGREGATION_RESULT_NAME" = '_fb_internal_cust_id_window_w86400_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295'
@@ -838,7 +838,7 @@ async def test_feature_table_two_features_deployed(
                 "formatted_expression": textwrap.dedent(
                     """
                     SELECT DISTINCT
-                      "cust_id"
+                      CAST("cust_id" AS BIGINT) AS "cust_id"
                     FROM online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c
                     WHERE
                       "AGGREGATION_RESULT_NAME" = '_fb_internal_cust_id_window_w86400_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295'
@@ -938,7 +938,7 @@ async def test_feature_table_undeploy(
                 "formatted_expression": textwrap.dedent(
                     """
                     SELECT DISTINCT
-                      "cust_id"
+                      CAST("cust_id" AS BIGINT) AS "cust_id"
                     FROM online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c
                     WHERE
                       "AGGREGATION_RESULT_NAME" = '_fb_internal_cust_id_window_w86400_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295'
@@ -1076,7 +1076,7 @@ async def test_feature_table_two_features_different_feature_job_settings_deploye
                 "formatted_expression": textwrap.dedent(
                     """
                     SELECT DISTINCT
-                      "cust_id"
+                      CAST("cust_id" AS BIGINT) AS "cust_id"
                     FROM online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c
                     WHERE
                       "AGGREGATION_RESULT_NAME" = '_fb_internal_cust_id_window_w86400_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295'
@@ -1127,7 +1127,7 @@ async def test_feature_table_two_features_different_feature_job_settings_deploye
                 "formatted_expression": textwrap.dedent(
                     """
                     SELECT DISTINCT
-                      "cust_id"
+                      CAST("cust_id" AS BIGINT) AS "cust_id"
                     FROM online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c
                     WHERE
                       "AGGREGATION_RESULT_NAME" = '_fb_internal_cust_id_window_w86400_sum_420f46a4414d6fc926c85a1349835967a96bf4c2'


### PR DESCRIPTION
## Description

This applies casting for entity columns based on the dtype information when constructing the entity universe. This is necessary to avoid schema mismatch when looking up feature tables externally in databricks.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
