### PR TITLE
query_graph/node: Avoid calling transform_info in a loop

### DIFF
--- a/featurebyte/query_graph/node/generic.py
+++ b/featurebyte/query_graph/node/generic.py
@@ -231,11 +231,12 @@ class FilterNode(BaseNode):
             ]
         else:
             node_kwargs["columns"] = input_operation_info.columns
+            transform_info = self.transform_info
             node_kwargs["aggregations"] = [
                 PostAggregationColumn.create(
                     name=col.name,
                     columns=[col] + mask_operation_info.aggregations,
-                    transform=self.transform_info,
+                    transform=transform_info,
                     node_name=self.name,
                     other_node_names=mask_operation_info.all_node_names,
                     dtype=col.dtype,
@@ -1384,6 +1385,7 @@ class JoinNode(BasePrunableNode):
         right_on_col = next(
             col for col in inputs[1].columns if col.name == self.parameters.right_on
         )
+        transform_info = self.transform_info
         for col in inputs[1].columns:
             if col.name in right_col_map:
                 if global_state.keep_all_source_columns:
@@ -1395,7 +1397,7 @@ class JoinNode(BasePrunableNode):
                         # this is used to decide the timestamp column source table in
                         # `iterate_group_by_node_and_table_id_pairs`
                         columns=[left_on_col, right_on_col, col],
-                        transform=self.transform_info,
+                        transform=transform_info,
                         node_name=self.name,
                         dtype=col.dtype,
                         other_node_names=col.node_names,
@@ -1718,6 +1720,7 @@ class TrackChangesNode(BaseNode):
         columns = [natural_key_source_column]
         track_dtype = tracked_source_column.dtype
         valid_dtype = effective_timestamp_source_column.dtype
+        transform_info = self.transform_info
         for column_name, dtype in [
             (self.parameters.previous_tracked_column_name, track_dtype),
             (self.parameters.new_tracked_column_name, track_dtype),
@@ -1727,7 +1730,7 @@ class TrackChangesNode(BaseNode):
             derived_column = DerivedDataColumn.create(
                 name=column_name,
                 columns=[effective_timestamp_source_column, tracked_source_column],
-                transform=self.transform_info,
+                transform=transform_info,
                 node_name=self.name,
                 dtype=dtype,
             )


### PR DESCRIPTION
## Description

This avoids calling the `transform_info` property in a loop which is unnecessary and can be expensive.

Before:
<img width="941" alt="image" src="https://github.com/featurebyte/featurebyte/assets/2175543/0b93a86e-fe29-4f9e-aee7-2b15566fd66c">

After:
<img width="956" alt="image" src="https://github.com/featurebyte/featurebyte/assets/2175543/3b8c04ab-50f3-49eb-8b19-bc2c365d6ec2">


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
