### PR TITLE
[chore] Refactor base document service to support soft-delete

### DIFF
--- a/featurebyte/models/base.py
+++ b/featurebyte/models/base.py
@@ -294,6 +294,10 @@ class FeatureByteBaseDocumentModel(FeatureByteBaseModel):
         description="List of reference information that blocks modifications to the document",
     )
     description: Optional[StrictStr] = Field(default=None, description="Record description")
+    is_deleted: bool = Field(
+        default=False,
+        description="Flag to indicate if the record is deleted.",
+    )
 
     @validator("id", pre=True)
     @classmethod

--- a/featurebyte/models/catalog.py
+++ b/featurebyte/models/catalog.py
@@ -57,13 +57,6 @@ class CatalogModel(FeatureByteBaseDocumentModel):
         default=None,
         description="Online store ID that is associated with the catalog.",
     )
-    is_deleted: bool = Field(
-        default=False,
-        description=(
-            "Flag to indicate if the catalog is deleted. "
-            "If true, the catalog will not be returned in any API calls."
-        ),
-    )
 
     # pydantic validators
     _sort_ids_validator = validator("default_feature_store_ids", allow_reuse=True)(

--- a/featurebyte/routes/catalog/controller.py
+++ b/featurebyte/routes/catalog/controller.py
@@ -159,7 +159,7 @@ class CatalogController(
                 f"Catalog cannot be deleted because it still has active deployment: {doc['name']}"
             )
 
-        await self.service.soft_delete(document_id=catalog_id)
+        await self.service.soft_delete_document(document_id=catalog_id)
 
     async def get_info(
         self,

--- a/featurebyte/schema/catalog.py
+++ b/featurebyte/schema/catalog.py
@@ -61,7 +61,6 @@ class CatalogServiceUpdate(BaseDocumentServiceUpdateSchema):
     """
 
     name: Optional[NameStr]
-    is_deleted: Optional[bool]
 
     class Settings(BaseDocumentServiceUpdateSchema.Settings):
         """

--- a/featurebyte/schema/common/base.py
+++ b/featurebyte/schema/common/base.py
@@ -44,6 +44,14 @@ class BaseDocumentServiceUpdateSchema(FeatureByteBaseModel):
         unique_constraints: List[UniqueValuesConstraint] = []
 
 
+class DocumentSoftDeleteUpdate(BaseDocumentServiceUpdateSchema):
+    """
+    Document soft delete update schema
+    """
+
+    is_deleted: bool
+
+
 class PaginationMixin(FeatureByteBaseModel):
     """
     Add page and page_size

--- a/featurebyte/service/base_document.py
+++ b/featurebyte/service/base_document.py
@@ -44,7 +44,11 @@ from featurebyte.models.persistent import (
 )
 from featurebyte.persistent.base import Persistent, SortDir
 from featurebyte.routes.block_modification_handler import BlockModificationHandler
-from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema, BaseInfo
+from featurebyte.schema.common.base import (
+    BaseDocumentServiceUpdateSchema,
+    BaseInfo,
+    DocumentSoftDeleteUpdate,
+)
 from featurebyte.service.mixin import (
     DEFAULT_PAGE_SIZE,
     Document,
@@ -329,6 +333,10 @@ class BaseDocumentService(
             if not self._allow_to_use_raw_query_filter:
                 raise NotImplementedError(RAW_QUERY_FILTER_WARNING)
             return kwargs
+
+        # filter out soft deleted documents
+        kwargs["is_deleted"] = {"$ne": True}
+
         # inject catalog_id into filter if document is catalog specific
         if self.is_catalog_specific:
             kwargs = {**kwargs, "catalog_id": self.catalog_id}
@@ -532,6 +540,40 @@ class BaseDocumentService(
         ):
             await self.storage.try_delete_if_exists(remote_path)
 
+    async def soft_delete_document(self, document_id: ObjectId) -> None:
+        """
+        Soft delete document at persistent
+
+        Parameters
+        ----------
+        document_id: ObjectId
+            Document ID
+        """
+        await self.update_document(
+            document_id=document_id,
+            data=DocumentSoftDeleteUpdate(is_deleted=True),  # type: ignore[arg-type]
+            return_document=False,
+        )
+
+    async def soft_delete_documents(self, query_filter: QueryFilter) -> int:
+        """
+        Soft delete multiple documents at persistent
+
+        Parameters
+        ----------
+        query_filter: QueryFilter
+            Query filter to apply on documents
+
+        Returns
+        -------
+        int
+            Number of soft-deleted documents
+        """
+        return await self.update_documents(
+            query_filter=query_filter,
+            update={"$set": {"is_deleted": True}},
+        )
+
     def construct_list_query_filter(
         self,
         query_filter: Optional[QueryFilter] = None,
@@ -570,6 +612,8 @@ class BaseDocumentService(
             if not self._allow_to_use_raw_query_filter:
                 raise NotImplementedError(RAW_QUERY_FILTER_WARNING)
             return output
+
+        output["is_deleted"] = {"$ne": True}  # exclude soft-deleted documents
         if kwargs.get("name"):
             output["name"] = kwargs["name"]
         if kwargs.get("version"):

--- a/featurebyte/service/catalog.py
+++ b/featurebyte/service/catalog.py
@@ -4,12 +4,11 @@ CatalogService class
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Optional
 
 from bson import ObjectId
 
 from featurebyte.models.catalog import CatalogModel
-from featurebyte.models.persistent import QueryFilter
 from featurebyte.schema.catalog import CatalogCreate, CatalogOnlineStoreUpdate, CatalogServiceUpdate
 from featurebyte.schema.worker.task.online_store_initialize import (
     CatalogOnlineStoreInitializeTaskPayload,
@@ -23,47 +22,6 @@ class CatalogService(BaseDocumentService[CatalogModel, CatalogCreate, CatalogSer
     """
 
     document_class = CatalogModel
-
-    def _construct_get_query_filter(
-        self, document_id: ObjectId, use_raw_query_filter: bool = False, **kwargs: Any
-    ) -> QueryFilter:
-        query_filter = super()._construct_get_query_filter(
-            document_id=document_id, use_raw_query_filter=use_raw_query_filter, **kwargs
-        )
-        if not use_raw_query_filter:
-            query_filter["is_deleted"] = {"$ne": True}
-        return query_filter
-
-    def construct_list_query_filter(
-        self,
-        query_filter: Optional[QueryFilter] = None,
-        use_raw_query_filter: bool = False,
-        **kwargs: Any,
-    ) -> QueryFilter:
-        query_filter = super().construct_list_query_filter(
-            query_filter=query_filter, use_raw_query_filter=use_raw_query_filter, **kwargs
-        )
-        if not use_raw_query_filter:
-            query_filter["is_deleted"] = {"$ne": True}
-        return query_filter
-
-    async def soft_delete(
-        self,
-        document_id: ObjectId,
-    ) -> None:
-        """
-        Soft delete document
-
-        Parameters
-        ----------
-        document_id: ObjectId
-            ID of document to delete
-        """
-        await self.update_document(
-            document_id=document_id,
-            data=CatalogServiceUpdate(is_deleted=True),
-            return_document=False,
-        )
 
     async def update_online_store(
         self,

--- a/tests/unit/api/test_credential.py
+++ b/tests/unit/api/test_credential.py
@@ -211,6 +211,7 @@ async def test_credential_update(credential, snowflake_feature_store, persistent
                 np.nan,
                 str(snowflake_feature_store.id),
             ),
+            ("INSERT", 'insert: "sf_featurestore"', "is_deleted", np.nan, False),
             ("INSERT", 'insert: "sf_featurestore"', "name", np.nan, "sf_featurestore"),
             ("INSERT", 'insert: "sf_featurestore"', "storage_credential", np.nan, None),
             ("INSERT", 'insert: "sf_featurestore"', "updated_at", np.nan, None),
@@ -290,6 +291,7 @@ def test_get_credentials(credential):
         "storage_credential",
         "block_modification_by",
         "description",
+        "is_deleted",
     }
 
 

--- a/tests/unit/api/test_dimension_table.py
+++ b/tests/unit/api/test_dimension_table.py
@@ -171,6 +171,7 @@ def dimension_table_dict_fixture(snowflake_database_table):
         "created_at": None,
         "updated_at": None,
         "user_id": None,
+        "is_deleted": False,
     }
 
 

--- a/tests/unit/api/test_entity.py
+++ b/tests/unit/api/test_entity.py
@@ -153,6 +153,7 @@ def test_entity_update_name(entity, catalog):
             ("INSERT", 'insert: "customer"', "catalog_id", np.nan, str(catalog.id)),
             ("INSERT", 'insert: "customer"', "created_at", np.nan, entity.created_at.isoformat()),
             ("INSERT", 'insert: "customer"', "description", np.nan, None),
+            ("INSERT", 'insert: "customer"', "is_deleted", np.nan, False),
             ("INSERT", 'insert: "customer"', "name", np.nan, "customer"),
             ("INSERT", 'insert: "customer"', "parents", np.nan, []),
             ("INSERT", 'insert: "customer"', "primary_table_ids", np.nan, []),

--- a/tests/unit/api/test_event_table.py
+++ b/tests/unit/api/test_event_table.py
@@ -133,6 +133,7 @@ def event_table_dict_fixture(snowflake_database_table):
         "user_id": None,
         "event_timestamp_timezone_offset": None,
         "event_timestamp_timezone_offset_column": None,
+        "is_deleted": False,
     }
 
 
@@ -895,6 +896,7 @@ def test_default_feature_job_setting_history(saved_event_table):
         "event_timestamp_timezone_offset",
         "event_timestamp_timezone_offset_column",
         "block_modification_by",
+        "is_deleted",
     }
 
 

--- a/tests/unit/api/test_feature.py
+++ b/tests/unit/api/test_feature.py
@@ -552,6 +552,7 @@ def test_get_feature(saved_feature):
         "description",
         "online_store_table_names",
         "last_updated_by_scheduled_task_at",
+        "is_deleted",
     }
 
     with pytest.raises(RecordRetrievalException) as exc:

--- a/tests/unit/api/test_feature_list.py
+++ b/tests/unit/api/test_feature_list.py
@@ -88,6 +88,7 @@ def test_feature_list_creation__success(
         "catalog_id": catalog.id,
         "block_modification_by": [],
         "description": None,
+        "is_deleted": False,
     }
     for obj in flist.feature_objects.values():
         assert isinstance(obj, Feature)
@@ -153,6 +154,7 @@ def test_feature_list_creation__feature_and_group(production_ready_feature, feat
         "catalog_id": catalog.id,
         "block_modification_by": [],
         "description": None,
+        "is_deleted": False,
     }
     for obj in flist.feature_objects.values():
         assert isinstance(obj, Feature)
@@ -528,6 +530,7 @@ def test_get_feature_list(
                 _get_new_value_from_audit_history("features_entity_lookup_info"),
             ),
             ("features_primary_entity_ids", [[str(cust_id_entity.id)]]),
+            ("is_deleted", False),
             ("name", "my_feature_list"),
             ("online_enabled_feature_ids", []),
             ("primary_entity_ids", [str(cust_id_entity.id)]),

--- a/tests/unit/api/test_feature_store.py
+++ b/tests/unit/api/test_feature_store.py
@@ -221,6 +221,7 @@ def test_get(saved_snowflake_feature_store):
             ("details.role_name", "TESTING"),
             ("details.schema_name", "sf_schema"),
             ("details.warehouse", "sf_warehouse"),
+            ("is_deleted", False),
             ("name", "sf_featurestore"),
             ("type", "snowflake"),
             ("updated_at", None),

--- a/tests/unit/api/test_item_table.py
+++ b/tests/unit/api/test_item_table.py
@@ -99,6 +99,7 @@ def item_table_dict_fixture(snowflake_database_table_item_table):
         "type": "item_table",
         "updated_at": None,
         "user_id": None,
+        "is_deleted": False,
     }
 
 

--- a/tests/unit/api/test_online_store.py
+++ b/tests/unit/api/test_online_store.py
@@ -143,6 +143,7 @@ async def test_get(saved_mysql_online_store, persistent):
             ("details.host", "mysql_host"),
             ("details.port", 3306),
             ("details.type", "mysql"),
+            ("is_deleted", False),
             ("name", "mysql_online_store"),
             ("updated_at", None),
             ("user_id", None),

--- a/tests/unit/api/test_scd_table.py
+++ b/tests/unit/api/test_scd_table.py
@@ -207,6 +207,7 @@ def scd_table_dict_fixture(snowflake_database_table_scd_table):
         "created_at": None,
         "updated_at": None,
         "user_id": None,
+        "is_deleted": False,
     }
 
 

--- a/tests/unit/models/test_dimension_table.py
+++ b/tests/unit/models/test_dimension_table.py
@@ -91,6 +91,7 @@ def get_base_expected_dimension_table_model(dimension_table_model, dimension_col
         "catalog_id": DEFAULT_CATALOG_ID,
         "block_modification_by": [],
         "description": None,
+        "is_deleted": False,
     }
 
 

--- a/tests/unit/models/test_entity.py
+++ b/tests/unit/models/test_entity.py
@@ -34,6 +34,7 @@ def test_entity_model():
         "catalog_id",
         "block_modification_by",
         "description",
+        "is_deleted",
     }
     assert isinstance(entity_dict["_id"], ObjectId)
     assert isinstance(entity_dict["user_id"], ObjectId)

--- a/tests/unit/models/test_event_table.py
+++ b/tests/unit/models/test_event_table.py
@@ -104,6 +104,7 @@ def test_event_table_model(snowflake_feature_store, feature_job_setting):
         "event_timestamp_timezone_offset_column": None,
         "block_modification_by": [],
         "description": None,
+        "is_deleted": False,
     }
     assert event_table.dict() == expected_event_table_dict
     event_table_json = event_table.json(by_alias=True)

--- a/tests/unit/models/test_feature.py
+++ b/tests/unit/models/test_feature.py
@@ -38,6 +38,7 @@ def feature_name_space_dict_fixture():
         "catalog_id": DEFAULT_CATALOG_ID,
         "block_modification_by": [],
         "description": None,
+        "is_deleted": False,
     }
 
 
@@ -133,6 +134,7 @@ def test_feature_model(feature_model_dict, api_object_to_id):
         "definition_hash": None,
         "online_store_table_names": ["online_store_377553e5920dd2db8b17f21ddd52f8b1194a780c"],
         "last_updated_by_scheduled_task_at": None,
+        "is_deleted": False,
     }
 
 

--- a/tests/unit/models/test_feature_list.py
+++ b/tests/unit/models/test_feature_list.py
@@ -40,6 +40,7 @@ def feature_list_model_dict_fixture():
         "supported_serving_entity_ids": [],
         "block_modification_by": [],
         "description": None,
+        "is_deleted": False,
     }
 
 
@@ -64,6 +65,7 @@ def feature_list_namespace_model_dict_fixture():
         "catalog_id": DEFAULT_CATALOG_ID,
         "block_modification_by": [],
         "description": None,
+        "is_deleted": False,
     }
 
 

--- a/tests/unit/models/test_scd_table.py
+++ b/tests/unit/models/test_scd_table.py
@@ -132,6 +132,7 @@ def get_base_expected_scd_table_model(scd_table_model, scd_columns_info):
         "catalog_id": DEFAULT_CATALOG_ID,
         "block_modification_by": [],
         "description": None,
+        "is_deleted": False,
     }
 
 

--- a/tests/unit/routes/test_deployment.py
+++ b/tests/unit/routes/test_deployment.py
@@ -141,6 +141,7 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
                     "context_id": None,
                     "registry_info": None,
                     "serving_entity_ids": ["63f94ed6ea1f050131379214"],
+                    "is_deleted": False,
                 },
                 {
                     "_id": response_dict["data"][1]["_id"],
@@ -160,6 +161,7 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
                     "context_id": None,
                     "registry_info": None,
                     "serving_entity_ids": ["63f94ed6ea1f050131379214"],
+                    "is_deleted": False,
                 },
                 {
                     "_id": response_dict["data"][2]["_id"],
@@ -179,6 +181,7 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
                     "context_id": None,
                     "registry_info": None,
                     "serving_entity_ids": ["63f94ed6ea1f050131379214"],
+                    "is_deleted": False,
                 },
             ],
             "page": 1,
@@ -222,6 +225,7 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
                     "user_id": response_dict["data"][0]["user_id"],
                     "registry_info": None,
                     "serving_entity_ids": ["63f94ed6ea1f050131379214"],
+                    "is_deleted": False,
                 }
             ],
             "page": 1,

--- a/tests/unit/routes/test_target.py
+++ b/tests/unit/routes/test_target.py
@@ -115,6 +115,7 @@ class TestTargetApi(BaseCatalogApiTestSuite):
             "user_id": str(user_id),
             "block_modification_by": [],
             "description": None,
+            "is_deleted": False,
         }
 
     def test_create_target__entity_parent_id_in_the_list(

--- a/tests/unit/routes/test_target_table.py
+++ b/tests/unit/routes/test_target_table.py
@@ -137,6 +137,7 @@ class TestTargetTableApi(BaseMaterializedTableTestSuite):
             "updated_at": None,
             "use_case_ids": [],
             "user_id": str(user_id),
+            "is_deleted": False,
         }
 
     @pytest.mark.parametrize(

--- a/tests/unit/service/test_catalog.py
+++ b/tests/unit/service/test_catalog.py
@@ -13,7 +13,7 @@ async def test_catalog_get_and_list_raw_query_filter(app_container, catalog):
     Test catalog service get query filter
     """
     catalog_service = app_container.catalog_service
-    await catalog_service.soft_delete(document_id=catalog.id)
+    await catalog_service.soft_delete_document(document_id=catalog.id)
 
     with pytest.raises(DocumentNotFoundError):
         await catalog_service.get_document(document_id=catalog.id)

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -761,6 +761,7 @@ async def test_feature_table_one_feature_deployed(
         "feature_store_id": feature_table_dict["feature_store_id"],
         "feature_cluster_path": feature_table_dict["feature_cluster_path"],
         "deployment_ids": [float_feat_deployment_id],
+        "is_deleted": False,
     }
     assert_equal_json_fixture(
         feature_cluster,
@@ -824,6 +825,7 @@ async def test_feature_table_one_feature_deployed(
         "serving_names": ["transaction_id"],
         "user_id": ObjectId("63f9506dd478b94127123456"),
         "deployment_ids": [float_feat_deployment_id],
+        "is_deleted": False,
     }
     assert_equal_with_expected_fixture(
         entity_universe["query_template"]["formatted_expression"],
@@ -906,6 +908,7 @@ async def test_feature_table_two_features_deployed(
         "deployment_ids": sorted(
             [float_feat_deployment_id, float_feat_post_processed_deployment_id]
         ),
+        "is_deleted": False,
     }
     assert_equal_json_fixture(
         feature_cluster,
@@ -1004,6 +1007,7 @@ async def test_feature_table_undeploy(
         "feature_store_id": feature_table_dict["feature_store_id"],
         "feature_cluster_path": feature_table_dict["feature_cluster_path"],
         "deployment_ids": [float_feat_post_processed_deployment_id],
+        "is_deleted": False,
     }
     assert_equal_json_fixture(
         feature_cluster,
@@ -1142,6 +1146,7 @@ async def test_feature_table_two_features_different_feature_job_settings_deploye
         "feature_store_id": feature_table_dict["feature_store_id"],
         "feature_cluster_path": feature_table_dict["feature_cluster_path"],
         "deployment_ids": [float_feat_deployment_id],
+        "is_deleted": False,
     }
     assert await has_scheduled_task(periodic_task_service, feature_table)
 
@@ -1193,6 +1198,7 @@ async def test_feature_table_two_features_different_feature_job_settings_deploye
         "feature_store_id": feature_table_dict["feature_store_id"],
         "feature_cluster_path": feature_table_dict["feature_cluster_path"],
         "deployment_ids": [float_feat_diff_fjs_deployment_id],
+        "is_deleted": False,
     }
     assert await has_scheduled_task(periodic_task_service, feature_table)
 
@@ -1259,6 +1265,7 @@ async def test_feature_table_without_entity(
         "feature_store_id": feature_table_dict["feature_store_id"],
         "feature_cluster_path": feature_table_dict["feature_cluster_path"],
         "deployment_ids": [feat_without_entity_deployment_id],
+        "is_deleted": False,
     }
     assert await has_scheduled_task(periodic_task_service, feature_table)
     await check_feast_registry(
@@ -1324,6 +1331,7 @@ async def test_lookup_feature(
         "feature_store_id": feature_table_dict["feature_store_id"],
         "feature_cluster_path": feature_table_dict["feature_cluster_path"],
         "deployment_ids": [scd_lookup_deployment_id],
+        "is_deleted": False,
     }
     assert await has_scheduled_task(periodic_task_service, feature_table)
     await check_feast_registry(
@@ -1394,6 +1402,7 @@ async def test_aggregate_asat_feature(
         "feature_store_id": feature_table_dict["feature_store_id"],
         "feature_cluster_path": feature_table_dict["feature_cluster_path"],
         "deployment_ids": [aggregate_asat_deployment_id],
+        "is_deleted": False,
     }
     assert await has_scheduled_task(periodic_task_service, feature_table)
     await check_feast_registry(
@@ -1444,6 +1453,7 @@ async def test_aggregate_asat_feature(
         "serving_names": ["cust_id"],
         "user_id": ObjectId("63f9506dd478b94127123456"),
         "deployment_ids": [aggregate_asat_deployment_id],
+        "is_deleted": False,
     }
     assert_equal_with_expected_fixture(
         entity_universe["query_template"]["formatted_expression"],
@@ -1662,6 +1672,7 @@ async def test_feature_with_internal_parent_child_relationships(
         "serving_names": ["cust_id"],
         "user_id": ObjectId("63f9506dd478b94127123456"),
         "deployment_ids": [feat_with_internal_parent_child_relationships_deployment_id],
+        "is_deleted": False,
     }
     assert_equal_json_fixture(
         feature_cluster,
@@ -1871,6 +1882,7 @@ async def test_item_view_window_aggregate(
         "primary_entity_ids": [ObjectId("664a3e7d7ac430c2ae37aedf")],
         "serving_names": ["item_type"],
         "user_id": ObjectId("63f9506dd478b94127123456"),
+        "is_deleted": False,
     }
 
     # check precomputed lookup feature table
@@ -1912,6 +1924,7 @@ async def test_item_view_window_aggregate(
         "serving_names": item_entity.serving_names,
         "user_id": ObjectId("63f9506dd478b94127123456"),
         "deployment_ids": [float_feat_deployment_id],
+        "is_deleted": False,
     }
     assert_equal_with_expected_fixture(
         entity_universe["query_template"]["formatted_expression"],
@@ -1976,6 +1989,7 @@ async def test_latest_aggregation_features(
         "primary_entity_ids": [ObjectId("63f94ed6ea1f050131379214")],
         "serving_names": ["cust_id"],
         "user_id": ObjectId("63f9506dd478b94127123456"),
+        "is_deleted": False,
     }
     assert await has_scheduled_task(periodic_task_service, feature_table)
     await check_feast_registry(
@@ -2024,6 +2038,7 @@ async def test_latest_aggregation_features(
         "primary_entity_ids": [ObjectId("63f94ed6ea1f050131379214")],
         "serving_names": ["cust_id"],
         "user_id": ObjectId("63f9506dd478b94127123456"),
+        "is_deleted": False,
     }
     assert await has_scheduled_task(periodic_task_service, feature_table)
     await check_feast_registry(
@@ -2089,6 +2104,7 @@ async def test_count_distinct_window_aggregate_feature(
         "primary_entity_ids": [ObjectId("63f94ed6ea1f050131379214")],
         "serving_names": ["cust_id"],
         "user_id": ObjectId("63f9506dd478b94127123456"),
+        "is_deleted": False,
     }
     assert await has_scheduled_task(periodic_task_service, feature_table)
     await check_feast_registry(


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
This PR moves soft-delete implementation from catalog service to base document service.


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
