### PR TITLE
[DEV-3583] Fix validation when latest aggregation method is not supported

### DIFF
--- a/.changelog/DEV-3583.yaml
+++ b/.changelog/DEV-3583.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Validate aggregation method is supported in more aggregation methods"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/aggregator/base_aggregator.py
+++ b/featurebyte/api/aggregator/base_aggregator.py
@@ -102,7 +102,9 @@ class BaseAggregator(ABC):
 
         unsupported_methods = self.not_supported_aggregation_methods
         if unsupported_methods is not None and method in unsupported_methods:
-            raise ValueError(f"{method} is not supported for {self.aggregation_method_name}")
+            raise ValueError(
+                f"{method} aggregation method is not supported for {self.aggregation_method_name}"
+            )
 
         validate_vector_aggregate_parameters(self.view.columns_info, value_column, method)
 

--- a/featurebyte/api/aggregator/base_aggregator.py
+++ b/featurebyte/api/aggregator/base_aggregator.py
@@ -68,6 +68,17 @@ class BaseAggregator(ABC):
         str
         """
 
+    @property
+    def not_supported_aggregation_methods(self) -> Optional[List[AggFunc]]:
+        """
+        Aggregators can override this to indicate aggregation methods that are not supported
+
+        Returns
+        -------
+        Optional[List[AggFunc]]
+        """
+        return None
+
     def _validate_method_and_value_column(
         self, method: Optional[str], value_column: Optional[str]
     ) -> None:
@@ -88,6 +99,10 @@ class BaseAggregator(ABC):
                 raise ValueError("value_column is required")
             if value_column not in self.view.columns:
                 raise KeyError(f'Column "{value_column}" not found in {self.view}!')
+
+        unsupported_methods = self.not_supported_aggregation_methods
+        if unsupported_methods is not None and method in unsupported_methods:
+            raise ValueError(f"{method} is not supported for {self.aggregation_method_name}")
 
         validate_vector_aggregate_parameters(self.view.columns_info, value_column, method)
 

--- a/featurebyte/api/aggregator/base_asat_aggregator.py
+++ b/featurebyte/api/aggregator/base_asat_aggregator.py
@@ -36,6 +36,10 @@ class BaseAsAtAggregator(BaseAggregator):
         str
         """
 
+    @property
+    def not_supported_aggregation_methods(self) -> Optional[List[AggFunc]]:
+        return [AggFunc.LATEST]
+
     def _validate_parameters(
         self,
         method: Optional[str],
@@ -47,9 +51,6 @@ class BaseAsAtAggregator(BaseAggregator):
     ) -> None:
         self._validate_method_and_value_column(method=method, value_column=value_column)
         self._validate_fill_value_and_skip_fill_na(fill_value=fill_value, skip_fill_na=skip_fill_na)
-
-        if method == AggFunc.LATEST:
-            raise ValueError("latest aggregation method is not supported for aggregated_asat")
 
         if output_name is None:
             raise ValueError(f"{self.output_name_parameter} is required")

--- a/featurebyte/api/aggregator/forward_aggregator.py
+++ b/featurebyte/api/aggregator/forward_aggregator.py
@@ -33,6 +33,10 @@ class ForwardAggregator(BaseAggregator):
     def aggregation_method_name(self) -> str:
         return "forward_aggregate"
 
+    @property
+    def not_supported_aggregation_methods(self) -> Optional[List[AggFunc]]:
+        return [AggFunc.LATEST]
+
     def forward_aggregate(
         self,
         value_column: str,

--- a/featurebyte/api/aggregator/simple_aggregator.py
+++ b/featurebyte/api/aggregator/simple_aggregator.py
@@ -33,6 +33,10 @@ class SimpleAggregator(BaseAggregator):
     def aggregation_method_name(self) -> str:
         return "aggregate"
 
+    @property
+    def not_supported_aggregation_methods(self) -> Optional[List[AggFunc]]:
+        return [AggFunc.LATEST]
+
     def aggregate(
         self,
         value_column: Optional[str] = None,

--- a/scripts/test-docs-setup.py
+++ b/scripts/test-docs-setup.py
@@ -222,7 +222,7 @@ def setup() -> None:
         "GroceryCustomerGuid"
     ).forward_aggregate(
         value_column="Timestamp",
-        method="latest",
+        method="max",
         window="7d",
         target_name="target_latest_invoice_timestamp",
     )

--- a/tests/unit/api/aggregator/test_forward_aggregator.py
+++ b/tests/unit/api/aggregator/test_forward_aggregator.py
@@ -151,6 +151,7 @@ def test_prepare_node_parameters(forward_aggregator):
         ("col_float", AggFunc.SUM, "random", "target", ValueError),
         (None, AggFunc.COUNT, "7d", "target", None),
         (None, AggFunc.SUM, "7d", "target", ValueError),
+        ("col_float", AggFunc.LATEST, "7d", "target", ValueError),
     ],
 )
 def test_validate_parameters(

--- a/tests/unit/api/test_aggregate_asat.py
+++ b/tests/unit/api/test_aggregate_asat.py
@@ -161,3 +161,17 @@ def test_aggregate_asat_with_category(
             "window": None,
         }
     }
+
+
+def test_aggregate_as_at_latest(snowflake_scd_view_with_entity):
+    """
+    Test unsupported aggregation method
+    """
+    with pytest.raises(ValueError) as exc_info:
+        snowflake_scd_view_with_entity.groupby("col_boolean").aggregate_asat(
+            value_column="col_float",
+            method="latest",
+            feature_name="asat_feature",
+            offset="7d",
+        )
+    assert str(exc_info.value) == "latest is not supported for aggregate_asat"

--- a/tests/unit/api/test_aggregate_asat.py
+++ b/tests/unit/api/test_aggregate_asat.py
@@ -174,4 +174,4 @@ def test_aggregate_as_at_latest(snowflake_scd_view_with_entity):
             feature_name="asat_feature",
             offset="7d",
         )
-    assert str(exc_info.value) == "latest is not supported for aggregate_asat"
+    assert str(exc_info.value) == "latest aggregation method is not supported for aggregate_asat"

--- a/tests/unit/api/test_aggregate_asat_common.py
+++ b/tests/unit/api/test_aggregate_asat_common.py
@@ -69,7 +69,13 @@ def test_aggregate_asat__latest_not_supported(snowflake_scd_view_with_entity, is
             ["col_boolean"],
             dict(value_column="col_float", method="latest", name="asat_feature"),
         )
-    assert str(exc.value) == "latest aggregation method is not supported for aggregated_asat"
+    if is_forward:
+        assert (
+            str(exc.value)
+            == "latest aggregation method is not supported for forward_aggregate_asat"
+        )
+    else:
+        assert str(exc.value) == "latest aggregation method is not supported for aggregate_asat"
 
 
 @pytest.mark.parametrize("is_forward", [False, True])

--- a/tests/unit/api/test_forward_aggregate_asat.py
+++ b/tests/unit/api/test_forward_aggregate_asat.py
@@ -129,4 +129,7 @@ def test_forward_aggregate_as_at_latest(snowflake_scd_view_with_entity):
             target_name="asat_feature",
             offset="7d",
         )
-    assert str(exc_info.value) == "latest is not supported for forward_aggregate_asat"
+    assert (
+        str(exc_info.value)
+        == "latest aggregation method is not supported for forward_aggregate_asat"
+    )

--- a/tests/unit/api/test_forward_aggregate_asat.py
+++ b/tests/unit/api/test_forward_aggregate_asat.py
@@ -2,6 +2,8 @@
 Test forward_aggregate_asat
 """
 
+import pytest
+
 from featurebyte.api.target import Target
 from tests.util.helper import check_sdk_code_generation, get_node
 
@@ -114,3 +116,17 @@ def test_aggregate_asat__offset(snowflake_scd_view_with_entity, gender_entity_id
         },
         "type": "forward_aggregate_as_at",
     }
+
+
+def test_forward_aggregate_as_at_latest(snowflake_scd_view_with_entity):
+    """
+    Test unsupported aggregation method
+    """
+    with pytest.raises(ValueError) as exc_info:
+        snowflake_scd_view_with_entity.groupby("col_boolean").forward_aggregate_asat(
+            value_column="col_float",
+            method="latest",
+            target_name="asat_feature",
+            offset="7d",
+        )
+    assert str(exc_info.value) == "latest is not supported for forward_aggregate_asat"


### PR DESCRIPTION
## Description

This adds more validation to raise proper error message when using the latest method in unsupported aggregation types.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
