### PR TITLE
[DEV-3585] Track aggregation_ids in offline store feature table documents

### DIFF
--- a/featurebyte/models/offline_store_feature_table.py
+++ b/featurebyte/models/offline_store_feature_table.py
@@ -115,6 +115,7 @@ class OfflineStoreFeatureTableModel(FeatureByteCatalogBaseDocumentModel):
     precomputed_lookup_feature_table_info: Optional[PrecomputedLookupFeatureTableInfo]
     feature_store_id: Optional[PydanticObjectId] = Field(default=None)
     deployment_ids: List[PydanticObjectId] = Field(default_factory=list)
+    aggregation_ids: List[str] = Field(default_factory=list)
 
     @root_validator
     @classmethod
@@ -346,6 +347,7 @@ class OfflineStoreFeatureTableModel(FeatureByteCatalogBaseDocumentModel):
                 "precomputed_lookup_feature_table_info.source_feature_table_id"
             ),
             pymongo.operations.IndexModel("deployment_ids"),
+            pymongo.operations.IndexModel("aggregation_ids"),
         ]
         auditable = False
 
@@ -361,6 +363,7 @@ class FeaturesUpdate(BaseDocumentServiceUpdateSchema):
     output_column_names: List[str]
     output_dtypes: List[DBVarType]
     entity_universe: EntityUniverseModel
+    aggregation_ids: List[str]
 
 
 class OfflineLastMaterializedAtUpdate(BaseDocumentServiceUpdateSchema):

--- a/featurebyte/service/offline_store_feature_table.py
+++ b/featurebyte/service/offline_store_feature_table.py
@@ -378,3 +378,24 @@ class OfflineStoreFeatureTableService(
             }
         ):
             yield doc
+
+    async def list_feature_tables_for_aggregation_id(
+        self, aggregation_id: str
+    ) -> AsyncIterator[OfflineStoreFeatureTableModel]:
+        """
+        Retrieve list of offline store feature tables associated with an aggregation_id
+
+        Parameters
+        ----------
+        aggregation_id: str
+            Aggregation id of interest
+
+        Yields
+        ------
+        AsyncIterator[OfflineStoreFeatureTableModel]
+            List query output
+        """
+        async for doc in self.list_documents_iterator(
+            query_filter={"aggregation_ids": aggregation_id}
+        ):
+            yield doc

--- a/featurebyte/service/offline_store_feature_table_construction.py
+++ b/featurebyte/service/offline_store_feature_table_construction.py
@@ -198,6 +198,10 @@ class OfflineStoreFeatureTableConstructionService:
                 await self.storage.put(Path(file_path), Path(path))
             raise
 
+        aggregation_ids = set()
+        for feature_model in features:
+            aggregation_ids.update(feature_model.aggregation_ids)
+
         return OfflineStoreFeatureTableModel(
             name=feature_table_name,
             feature_ids=[feature.id for feature in features],
@@ -210,6 +214,7 @@ class OfflineStoreFeatureTableConstructionService:
             entity_universe=entity_universe,
             has_ttl=has_ttl,
             feature_job_setting=feature_job_setting.normalize() if feature_job_setting else None,
+            aggregation_ids=list(aggregation_ids),
         )
 
     async def get_entity_universe_model(

--- a/tests/unit/service/test_offline_store_feature_table.py
+++ b/tests/unit/service/test_offline_store_feature_table.py
@@ -50,6 +50,7 @@ def offline_store_feature_table_dict_fixture(test_dir, service, user_id):
         "primary_entity_ids": [],
         "serving_names": ["cust_id"],
         "user_id": user_id,
+        "aggregation_ids": ["agg_id_1"],
     }
 
 
@@ -168,6 +169,7 @@ async def test_update_document(
             output_column_names=["col1", "col2"],
             output_dtypes=["FLOAT", "FLOAT"],
             entity_universe=offline_store_feature_table.entity_universe,
+            aggregation_ids=[],
         ),
         populate_remote_attributes=True,
     )
@@ -204,6 +206,7 @@ async def test_update_document__with_failure(
         output_column_names=["col1", "col2"],
         output_dtypes=["FLOAT", "FLOAT"],
         entity_universe=offline_store_feature_table.entity_universe,
+        aggregation_ids=[],
     )
 
     assert os.path.exists(cluster_path)
@@ -226,3 +229,20 @@ async def test_update_document__with_failure(
     assert updated_doc.feature_cluster == feature_cluster_two_features
     cluster_path = os.path.join(service.storage.base_path, updated_doc.feature_cluster_path)
     assert os.path.exists(cluster_path)
+
+
+@pytest.mark.asyncio
+async def test_list_feature_tables_for_aggregation_id(service, offline_store_feature_table):
+    """
+    Test listing documents given an aggregation_id
+    """
+    docs = []
+    async for doc in service.list_feature_tables_for_aggregation_id("agg_id_1"):
+        docs.append(doc)
+    assert len(docs) == 1
+    assert docs[0].id == offline_store_feature_table.id
+
+    docs = []
+    async for doc in service.list_feature_tables_for_aggregation_id("agg_id_unknown"):
+        docs.append(doc)
+    assert len(docs) == 0

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -720,6 +720,7 @@ async def test_feature_table_one_feature_deployed(
     feature_table_id = feature_table_dict.pop("_id")
     feature_cluster = feature_table_dict.pop("feature_cluster")
     assert feature_table_dict == {
+        "aggregation_ids": ["sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295"],
         "block_modification_by": [],
         "catalog_id": catalog_id,
         "description": None,
@@ -793,6 +794,7 @@ async def test_feature_table_one_feature_deployed(
     )
     entity_universe = feature_table_dict.pop("entity_universe")
     assert feature_table_dict == {
+        "aggregation_ids": [],
         "block_modification_by": [],
         "catalog_id": catalog_id,
         "description": None,
@@ -865,6 +867,7 @@ async def test_feature_table_two_features_deployed(
     )
     feature_cluster = feature_table_dict.pop("feature_cluster")
     assert feature_table_dict == {
+        "aggregation_ids": ["sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295"],
         "block_modification_by": [],
         "catalog_id": ObjectId("646f6c1c0ed28a5271fb02db"),
         "description": None,
@@ -966,6 +969,7 @@ async def test_feature_table_undeploy(
     )
     feature_cluster = feature_table_dict.pop("feature_cluster")
     assert feature_table_dict == {
+        "aggregation_ids": ["sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295"],
         "block_modification_by": [],
         "catalog_id": ObjectId("646f6c1c0ed28a5271fb02db"),
         "description": None,
@@ -1105,6 +1109,7 @@ async def test_feature_table_two_features_different_feature_job_settings_deploye
     )
     _ = feature_table_dict.pop("feature_cluster")
     assert feature_table_dict == {
+        "aggregation_ids": ["sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295"],
         "block_modification_by": [],
         "catalog_id": ObjectId("646f6c1c0ed28a5271fb02db"),
         "description": None,
@@ -1157,6 +1162,7 @@ async def test_feature_table_two_features_different_feature_job_settings_deploye
     )
     _ = feature_table_dict.pop("feature_cluster")
     assert feature_table_dict == {
+        "aggregation_ids": ["sum_420f46a4414d6fc926c85a1349835967a96bf4c2"],
         "block_modification_by": [],
         "catalog_id": ObjectId("646f6c1c0ed28a5271fb02db"),
         "description": None,
@@ -1235,6 +1241,7 @@ async def test_feature_table_without_entity(
     )
     _ = feature_table_dict.pop("feature_cluster")
     assert feature_table_dict == {
+        "aggregation_ids": ["count_3178e5d8142ed182c5db45462cb780d18205bd64"],
         "block_modification_by": [],
         "catalog_id": ObjectId("646f6c1c0ed28a5271fb02db"),
         "description": None,
@@ -1304,6 +1311,7 @@ async def test_lookup_feature(
         update_fixtures,
     )
     assert feature_table_dict == {
+        "aggregation_ids": [],
         "block_modification_by": [],
         "catalog_id": ObjectId("646f6c1c0ed28a5271fb02db"),
         "description": None,
@@ -1375,6 +1383,7 @@ async def test_aggregate_asat_feature(
     )
 
     assert feature_table_dict == {
+        "aggregation_ids": [],
         "block_modification_by": [],
         "catalog_id": ObjectId("646f6c1c0ed28a5271fb02db"),
         "description": None,
@@ -1421,6 +1430,7 @@ async def test_aggregate_asat_feature(
     )
     entity_universe = feature_table_dict.pop("entity_universe")
     assert feature_table_dict == {
+        "aggregation_ids": [],
         "block_modification_by": [],
         "catalog_id": ObjectId("646f6c1c0ed28a5271fb02db"),
         "description": None,
@@ -1645,6 +1655,7 @@ async def test_feature_with_internal_parent_child_relationships(
 
     _ = feature_table_dict.pop("entity_universe")  # covered in service/test_feature_materialize.py
     assert feature_table_dict == {
+        "aggregation_ids": [],
         "block_modification_by": [],
         "catalog_id": catalog_id,
         "description": None,
@@ -1841,6 +1852,7 @@ async def test_item_view_window_aggregate(
     feature_table_id = feature_table_dict.pop("_id")
     feature_table_dict.pop("feature_cluster")
     assert feature_table_dict == {
+        "aggregation_ids": ["sum_2e4057b32df81d547bde013cd755a1189af7e615"],
         "base_name": "item_type_30m",
         "block_modification_by": [],
         "catalog_id": catalog_id,
@@ -1892,6 +1904,7 @@ async def test_item_view_window_aggregate(
     )
     entity_universe = feature_table_dict.pop("entity_universe")
     assert feature_table_dict == {
+        "aggregation_ids": [],
         "block_modification_by": [],
         "catalog_id": catalog_id,
         "description": None,
@@ -1962,6 +1975,7 @@ async def test_latest_aggregation_features(
         update_fixtures,
     )
     assert feature_table_dict == {
+        "aggregation_ids": ["latest_d9b2a8ebb02e7a6916ae36e9cc223759433c01e2"],
         "base_name": "cust_id_30m",
         "block_modification_by": [],
         "catalog_id": ObjectId("646f6c1c0ed28a5271fb02db"),
@@ -2011,6 +2025,7 @@ async def test_latest_aggregation_features(
         update_fixtures,
     )
     assert feature_table_dict == {
+        "aggregation_ids": ["latest_d9b2a8ebb02e7a6916ae36e9cc223759433c01e2"],
         "base_name": "cust_id_30m",
         "block_modification_by": [],
         "catalog_id": ObjectId("646f6c1c0ed28a5271fb02db"),
@@ -2077,6 +2092,7 @@ async def test_count_distinct_window_aggregate_feature(
         update_fixtures,
     )
     assert feature_table_dict == {
+        "aggregation_ids": [],
         "base_name": "cust_id_30m",
         "block_modification_by": [],
         "catalog_id": ObjectId("646f6c1c0ed28a5271fb02db"),


### PR DESCRIPTION
## Description

This updates `OfflineStoreFeatureTableModel` to track `aggregation_ids` associated with the features in the feature table. This is needed to support tile tasks and feature materialization tasks coordination.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
