### PR TITLE
[chore] Disable feast usage before feast imports

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,9 @@ from mongomock_motor import AsyncMongoMockClient
 
 from featurebyte.persistent.mongo import MongoDB
 
+# Need to disable early here before any feast imports (too late to patch this in an autouse fixture)
+os.environ["FEAST_USAGE"] = "False"
+
 
 def pytest_addoption(parser):
     """Set up additional pytest options"""
@@ -112,12 +115,3 @@ def index_to_timestamp_fixture(request):
     Parameterized fixture for index to timestamp conversion
     """
     return request.param
-
-
-@pytest.fixture(autouse=True)
-def disable_feast_usage():
-    """
-    Enable feast usage reporting
-    """
-    with patch.dict(os.environ, {"FEAST_USAGE": "False"}):
-        yield


### PR DESCRIPTION
## Description

For this environment variable to have effect, it has to be set before any feast imports.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
