### PR TITLE
[chore] Fix extraction of aggregation ids for offline store feature table

### DIFF
--- a/featurebyte/models/offline_store_feature_table.py
+++ b/featurebyte/models/offline_store_feature_table.py
@@ -504,6 +504,9 @@ def _extract_aggregation_ids(offline_ingest_graph: OfflineStoreIngestQueryGraph)
     aggregation_ids = []
     for info in offline_ingest_graph.aggregation_nodes_info:
         node = offline_ingest_graph.graph.get_node_by_name(info.node_name)
-        if isinstance(node.parameters, GroupByNodeParameters):
+        if (
+            isinstance(node.parameters, GroupByNodeParameters)
+            and node.parameters.aggregation_id is not None
+        ):
             aggregation_ids.append(node.parameters.aggregation_id)
     return aggregation_ids

--- a/featurebyte/models/offline_store_feature_table.py
+++ b/featurebyte/models/offline_store_feature_table.py
@@ -32,6 +32,7 @@ from featurebyte.models.parent_serving import FeatureNodeRelationshipsInfo
 from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.query_graph.model.entity_relationship_info import EntityRelationshipInfo
 from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
+from featurebyte.query_graph.node.generic import GroupByNodeParameters
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema
 
 
@@ -400,6 +401,7 @@ class OfflineIngestGraphMetadata:
     feature_cluster: FeatureCluster
     output_column_names: List[str]
     output_dtypes: List[DBVarType]
+    aggregation_ids: List[str]
     offline_ingest_graphs: List[Tuple[OfflineStoreIngestQueryGraph, List[EntityRelationshipInfo]]]
 
 
@@ -432,6 +434,7 @@ def get_combined_ingest_graph(
     output_nodes = []
     output_column_names = []
     output_dtypes = []
+    aggregation_ids = set()
     all_offline_ingest_graphs = []
 
     primary_entity_ids = sorted([entity.id for entity in primary_entities])
@@ -464,6 +467,7 @@ def get_combined_ingest_graph(
             )
             output_column_names.append(offline_ingest_graph.output_column_name)
             output_dtypes.append(offline_ingest_graph.output_dtype)
+            aggregation_ids.update(_extract_aggregation_ids(offline_ingest_graph))
             all_offline_ingest_graphs.append(
                 (offline_ingest_graph, feature.relationships_info or [])
             )
@@ -479,5 +483,27 @@ def get_combined_ingest_graph(
         feature_cluster=feature_cluster,
         output_column_names=output_column_names,
         output_dtypes=output_dtypes,
+        aggregation_ids=list(aggregation_ids),
         offline_ingest_graphs=all_offline_ingest_graphs,
     )
+
+
+def _extract_aggregation_ids(offline_ingest_graph: OfflineStoreIngestQueryGraph) -> list[str]:
+    """
+    Extract all aggregation_id from groupby nodes in OfflineStoreIngestQueryGraph
+
+    Parameters
+    ----------
+    offline_ingest_graph: OfflineStoreIngestQueryGraph
+        Offline store ingest query graph
+
+    Returns
+    -------
+    list[str]
+    """
+    aggregation_ids = []
+    for info in offline_ingest_graph.aggregation_nodes_info:
+        node = offline_ingest_graph.graph.get_node_by_name(info.node_name)
+        if isinstance(node.parameters, GroupByNodeParameters):
+            aggregation_ids.append(node.parameters.aggregation_id)
+    return aggregation_ids

--- a/featurebyte/service/offline_store_feature_table_construction.py
+++ b/featurebyte/service/offline_store_feature_table_construction.py
@@ -198,10 +198,6 @@ class OfflineStoreFeatureTableConstructionService:
                 await self.storage.put(Path(file_path), Path(path))
             raise
 
-        aggregation_ids = set()
-        for feature_model in features:
-            aggregation_ids.update(feature_model.aggregation_ids)
-
         return OfflineStoreFeatureTableModel(
             name=feature_table_name,
             feature_ids=[feature.id for feature in features],
@@ -214,7 +210,7 @@ class OfflineStoreFeatureTableConstructionService:
             entity_universe=entity_universe.dict(by_alias=True),
             has_ttl=has_ttl,
             feature_job_setting=feature_job_setting.normalize() if feature_job_setting else None,
-            aggregation_ids=list(aggregation_ids),
+            aggregation_ids=ingest_graph_metadata.aggregation_ids,
         )
 
     async def get_entity_universe_model(

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -1424,6 +1424,7 @@ async def test_simulated_materialize__non_ttl_feature_table(
     Test simulating scheduled feature materialization for a feature table without TTL
     """
     feature_table_model = user_entity_non_ttl_feature_table
+    assert feature_table_model.aggregation_ids == []
     service = app_container.feature_materialize_service
 
     df_0 = await session.execute_query(


### PR DESCRIPTION
## Description

The `aggregation_ids` of an offline store feature table should be determined from the offline ingest graphs instead of from the features directly.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
