### PR TITLE
[DEV-3588] Schedule FeatureMaterializeSyncTask on deployment

### DIFF
--- a/featurebyte/service/feature_materialize_scheduler.py
+++ b/featurebyte/service/feature_materialize_scheduler.py
@@ -11,8 +11,8 @@ from featurebyte.models.base import User
 from featurebyte.models.offline_store_feature_table import OfflineStoreFeatureTableModel
 from featurebyte.models.periodic_task import Interval, PeriodicTask
 from featurebyte.persistent import DuplicateDocumentError
-from featurebyte.schema.worker.task.scheduled_feature_materialize import (
-    ScheduledFeatureMaterializeTaskPayload,
+from featurebyte.schema.worker.task.feature_materialize_sync import (
+    FeatureMaterializeSyncTaskPayload,
 )
 from featurebyte.service.task_manager import TaskManager
 
@@ -47,7 +47,8 @@ class FeatureMaterializeSchedulerService:
         offline_store_feature_table: OfflineStoreFeatureTableModel
             Offline store feature table
         """
-        payload = ScheduledFeatureMaterializeTaskPayload(
+        await self._stop_deprecated_job(offline_store_feature_table.id)
+        payload = FeatureMaterializeSyncTaskPayload(
             user_id=self.user.id,
             catalog_id=self.catalog_id,
             offline_store_feature_table_name=offline_store_feature_table.name,
@@ -90,6 +91,7 @@ class FeatureMaterializeSchedulerService:
         offline_store_feature_table_id: ObjectId
             Offline store feature table id
         """
+        await self._stop_deprecated_job(offline_store_feature_table_id)
         job_id = self._get_job_id(offline_store_feature_table_id)
         await self.task_manager.delete_periodic_task_by_name(job_id)
 
@@ -112,5 +114,17 @@ class FeatureMaterializeSchedulerService:
             self._get_job_id(offline_store_feature_table_id)
         )
 
-    def _get_job_id(self, offline_store_feature_table_id: ObjectId) -> str:
+    @classmethod
+    def _get_job_id(cls, offline_store_feature_table_id: ObjectId) -> str:
+        return f"feature_materialize_{offline_store_feature_table_id}"
+
+    @classmethod
+    def _get_deprecated_job_id(cls, offline_store_feature_table_id: ObjectId) -> str:
+        # For backward compatibility. Before we schedule SCHEDULED_FEATURE_MATERIALIZE task
+        # directly, but now we schedule FEATURE_MATERIALIZE_SYNC. Can be removed once all
+        # deprecated jobs are stopped.
         return f"scheduled_feature_materialize_{offline_store_feature_table_id}"
+
+    async def _stop_deprecated_job(self, offline_store_feature_table_id: ObjectId) -> None:
+        job_id = self._get_deprecated_job_id(offline_store_feature_table_id)
+        await self.task_manager.delete_periodic_task_by_name(job_id)

--- a/featurebyte/service/feature_materialize_scheduler.py
+++ b/featurebyte/service/feature_materialize_scheduler.py
@@ -116,7 +116,7 @@ class FeatureMaterializeSchedulerService:
 
     @classmethod
     def _get_job_id(cls, offline_store_feature_table_id: ObjectId) -> str:
-        return f"feature_materialize_{offline_store_feature_table_id}"
+        return f"feature_materialize_sync_{offline_store_feature_table_id}"
 
     @classmethod
     def _get_deprecated_job_id(cls, offline_store_feature_table_id: ObjectId) -> str:

--- a/featurebyte/service/feature_materialize_sync.py
+++ b/featurebyte/service/feature_materialize_sync.py
@@ -204,7 +204,7 @@ class FeatureMaterializeSyncService:
             catalog_id=self.offline_store_feature_table_service.catalog_id,
             user_id=self.offline_store_feature_table_service.user.id,
         )
-        await self.task_manager.submit(payload)
+        await self.task_manager.submit(payload, mark_as_scheduled_task=True)
 
     async def _get_scheduled_job_ts_for_feature_table(
         self, offline_store_feature_table_id: ObjectId

--- a/featurebyte/service/feature_materialize_sync.py
+++ b/featurebyte/service/feature_materialize_sync.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from typing import Optional
 
 import asyncio
-import time
 from datetime import datetime
 
 from bson import ObjectId
@@ -116,6 +115,14 @@ class FeatureMaterializeSyncService:
         status: PrerequisiteTileTaskStatusType
             Status of the tile task
         """
+        logger.info(
+            "Updating tile prerequisite",
+            extra={
+                "tile_tasks_ts": str(tile_task_ts),
+                "aggregation_id": aggregation_id,
+                "status": status,
+            },
+        )
         async for (
             feature_table_model
         ) in self.offline_store_feature_table_service.list_feature_tables_for_aggregation_id(
@@ -166,11 +173,15 @@ class FeatureMaterializeSyncService:
 
         tic = prerequisite.scheduled_job_ts.timestamp()
         prerequisite_met = False
-        logger.debug(
+        logger.info(
             "Waiting for prerequisites for feature materialize task",
-            extra={"offline_store_feature_table_id": feature_table.id},
+            extra={
+                "offline_store_feature_table_id": feature_table.id,
+                "scheduled_job_ts": str(prerequisite.scheduled_job_ts),
+            },
         )
-        while time.time() - tic < get_allowed_waiting_time_seconds(feature_job_setting):
+        allowed_waiting_time_seconds = get_allowed_waiting_time_seconds(feature_job_setting)
+        while datetime.utcnow().timestamp() - tic < allowed_waiting_time_seconds:
             prerequisite_model = await self.feature_materialize_prerequisite_service.get_document(
                 prerequisite.id
             )
@@ -178,7 +189,7 @@ class FeatureMaterializeSyncService:
                 item.aggregation_id for item in prerequisite_model.completed
             ]
             if set(feature_table.aggregation_ids).issubset(set(completed_aggregation_ids)):
-                logger.debug(
+                logger.info(
                     "Prerequisites for feature materialize task met",
                     extra={"offline_store_feature_table_id": feature_table.id},
                 )

--- a/featurebyte/service/task_manager.py
+++ b/featurebyte/service/task_manager.py
@@ -397,7 +397,7 @@ class TaskManager:
 
         data = result["data"]
         if not data:
-            logger.error(f"Document with name {name} not found")
+            logger.warning(f"Periodic task with name {name} not found; nothing to delete")
         else:
             await self.periodic_task_service.delete_document(document_id=data[0]["_id"])
 

--- a/featurebyte/service/task_manager.py
+++ b/featurebyte/service/task_manager.py
@@ -67,7 +67,7 @@ class TaskManager:
             redis=self.redis,
         )
 
-    async def submit(self, payload: BaseTaskPayload) -> str:
+    async def submit(self, payload: BaseTaskPayload, mark_as_scheduled_task: bool = False) -> str:
         """
         Submit task to celery
 
@@ -75,6 +75,8 @@ class TaskManager:
         ----------
         payload: BaseTaskPayload
             Payload to submit
+        mark_as_scheduled_task: bool
+            Whether to make the submitted task as scheduled task
 
         Returns
         -------
@@ -84,6 +86,8 @@ class TaskManager:
         assert self.user.id == payload.user_id
         kwargs = payload.json_dict()
         kwargs["task_output_path"] = payload.task_output_path
+        if mark_as_scheduled_task:
+            kwargs["is_scheduled_task"] = True
         task = self.celery.send_task(payload.task, kwargs=kwargs)
         return str(task.id)
 

--- a/featurebyte/service/tile/tile_task_executor.py
+++ b/featurebyte/service/tile/tile_task_executor.py
@@ -65,7 +65,7 @@ class TileTaskExecutor:
         params: TileScheduledJobParameters
             Parameters for the scheduled task
         """
-        used_job_schedule_ts = params.job_schedule_ts or datetime.now().strftime(DATE_FORMAT)
+        used_job_schedule_ts = params.job_schedule_ts or datetime.utcnow().strftime(DATE_FORMAT)
         final_status: PrerequisiteTileTaskStatusType = "failure"
         try:
             await self._execute(session, params, used_job_schedule_ts)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1445,7 +1445,7 @@ def mock_task_manager(request, persistent, storage):
         task_status = {}
         with patch("featurebyte.service.task_manager.TaskManager.submit") as mock_submit:
 
-            async def submit(payload: BaseTaskPayload):
+            async def submit(payload: BaseTaskPayload, **kwargs):
                 kwargs = payload.json_dict()
                 kwargs["task_output_path"] = payload.task_output_path
                 task_id = str(uuid4())

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2321,7 +2321,7 @@ def mock_task_manager(request, persistent, storage, temp_storage):
         task_status = {}
         with patch("featurebyte.service.task_manager.TaskManager.submit") as mock_submit:
 
-            async def submit(payload: BaseTaskPayload):
+            async def submit(payload: BaseTaskPayload, **kwargs):
                 kwargs = payload.json_dict()
                 kwargs["task_output_path"] = payload.task_output_path
                 task_id = str(uuid4())

--- a/tests/unit/service/test_feature_materialize_scheduler.py
+++ b/tests/unit/service/test_feature_materialize_scheduler.py
@@ -7,12 +7,24 @@ import pytest_asyncio
 from bson import ObjectId
 
 from featurebyte import FeatureJobSetting
+from featurebyte.enum import WorkerCommand
 from featurebyte.models.entity_universe import EntityUniverseModel
 from featurebyte.models.feature_list import FeatureCluster
 from featurebyte.models.offline_store_feature_table import OfflineStoreFeatureTableModel
 from featurebyte.models.periodic_task import Interval
 from featurebyte.models.sqlglot_expression import SqlglotExpressionModel
 from featurebyte.query_graph.graph import QueryGraph
+from featurebyte.schema.worker.task.scheduled_feature_materialize import (
+    ScheduledFeatureMaterializeTaskPayload,
+)
+
+
+@pytest.fixture(name="feature_job_setting")
+def feature_job_setting_fixture():
+    """
+    Fixture for a feature job setting
+    """
+    return FeatureJobSetting(period="1h", blind_spot="0s", offset="5m")
 
 
 @pytest_asyncio.fixture(name="offline_store_feature_table")
@@ -51,6 +63,30 @@ def service_fixture(app_container):
     return app_container.feature_materialize_scheduler_service
 
 
+@pytest_asyncio.fixture(name="deprecated_scheduled_task")
+async def deprecated_scheduled_feature_materialize_task(service, offline_store_feature_table):
+    """
+    Fixture for a deprecated scheduled job
+    """
+    payload = ScheduledFeatureMaterializeTaskPayload(
+        user_id=service.user.id,
+        catalog_id=service.catalog_id,
+        offline_store_feature_table_name=offline_store_feature_table.name,
+        offline_store_feature_table_id=offline_store_feature_table.id,
+    )
+    task_name = service._get_deprecated_job_id(offline_store_feature_table.id)
+    task_id = await service.task_manager.schedule_interval_task(
+        name=task_name,
+        payload=payload,
+        interval=Interval(
+            every=offline_store_feature_table.feature_job_setting.period_seconds,
+            period="seconds",
+        ),
+        time_modulo_frequency_second=offline_store_feature_table.feature_job_setting.offset_seconds,
+    )
+    yield task_id
+
+
 @pytest.mark.parametrize(
     "feature_job_setting",
     [
@@ -71,6 +107,7 @@ async def test_start_and_stop_job(service, feature_job_setting, offline_store_fe
         every=offline_store_feature_table.feature_job_setting.period_seconds, period="seconds"
     )
     assert periodic_task.time_modulo_frequency_second == feature_job_setting.offset_seconds
+    assert periodic_task.kwargs["command"] == WorkerCommand.FEATURE_MATERIALIZE_SYNC
     assert periodic_task.kwargs["offline_store_feature_table_id"] == str(
         offline_store_feature_table.id
     )
@@ -81,4 +118,45 @@ async def test_start_and_stop_job(service, feature_job_setting, offline_store_fe
     # Test stopping job
     await service.stop_job(offline_store_feature_table.id)
     periodic_task = await service.get_periodic_task(offline_store_feature_table.id)
+    assert periodic_task is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_deprecated_scheduled_job_on_start(
+    service, offline_store_feature_table, deprecated_scheduled_task
+):
+    """
+    Test deprecated scheduled tasks are cleaned up on starting job
+    """
+    # Check there is a deprecated task
+    periodic_task = await service.task_manager.get_periodic_task(deprecated_scheduled_task)
+    assert periodic_task is not None
+    assert periodic_task.kwargs["command"] == WorkerCommand.SCHEDULED_FEATURE_MATERIALIZE
+
+    # Check new task is scheduled
+    await service.start_job_if_not_exist(offline_store_feature_table)
+    periodic_task = await service.get_periodic_task(offline_store_feature_table.id)
+    assert periodic_task is not None
+    assert periodic_task.kwargs["command"] == WorkerCommand.FEATURE_MATERIALIZE_SYNC
+
+    # Check deprecated task is cleaned up
+    periodic_task = await service.get_periodic_task(deprecated_scheduled_task)
+    assert periodic_task is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_deprecated_scheduled_job_on_stop(
+    service, offline_store_feature_table, deprecated_scheduled_task
+):
+    """
+    Test deprecated scheduled tasks are cleaned up on stopping job
+    """
+    # Check there is a deprecated task
+    periodic_task = await service.task_manager.get_periodic_task(deprecated_scheduled_task)
+    assert periodic_task is not None
+    assert periodic_task.kwargs["command"] == WorkerCommand.SCHEDULED_FEATURE_MATERIALIZE
+
+    # Check deprecated task is cleaned up on stop_job
+    await service.stop_job(offline_store_feature_table)
+    periodic_task = await service.get_periodic_task(deprecated_scheduled_task)
     assert periodic_task is None

--- a/tests/unit/service/test_feature_materialize_sync.py
+++ b/tests/unit/service/test_feature_materialize_sync.py
@@ -249,6 +249,9 @@ async def test_run_feature_materialize__no_prerequisites(
         "offline_store_feature_table_id": offline_store_feature_table_no_aggregation_ids.id,
     }.items() <= submitted_payload.items()
 
+    submit_kwargs = mock_task_manager_submit.call_args[1]
+    assert submit_kwargs["mark_as_scheduled_task"] is True
+
 
 @freeze_time(datetime(2024, 1, 15, 9, 12, 0), tick=True)
 @pytest.mark.asyncio
@@ -293,6 +296,9 @@ async def test_run_feature_materialize__prerequisite_met(
         "offline_store_feature_table_id": offline_store_feature_table_1.id,
     }.items() <= submitted_payload.items()
 
+    submit_kwargs = mock_task_manager_submit.call_args[1]
+    assert submit_kwargs["mark_as_scheduled_task"] is True
+
 
 @freeze_time(datetime(2024, 1, 15, 9, 12, 0), tick=True)
 @pytest.mark.asyncio
@@ -328,3 +334,6 @@ async def test_run_feature_materialize__timeout(
         "offline_store_feature_table_name": offline_store_feature_table_1.name,
         "offline_store_feature_table_id": offline_store_feature_table_1.id,
     }.items() <= submitted_payload.items()
+
+    submit_kwargs = mock_task_manager_submit.call_args[1]
+    assert submit_kwargs["mark_as_scheduled_task"] is True

--- a/tests/unit/service/test_offline_store_feature_table_manager.py
+++ b/tests/unit/service/test_offline_store_feature_table_manager.py
@@ -560,7 +560,7 @@ async def get_all_scheduled_tasks(periodic_task_service):
     """
     tasks = {}
     async for periodic_task in periodic_task_service.list_documents_iterator(
-        query_filter={"kwargs.command": "SCHEDULED_FEATURE_MATERIALIZE"}
+        query_filter={"kwargs.command": "FEATURE_MATERIALIZE_SYNC"}
     ):
         tasks[periodic_task.id] = periodic_task
     return tasks


### PR DESCRIPTION
## Description

This updates the feature materialize scheduler to schedule the new FeatureMaterializeSyncTask on deployment. The task handles coordination between dependent tasks and ensures feature materialize runs after required tiles are computed.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
