### PR TITLE
[chore] Refactor and speed up app container get key method

### DIFF
--- a/tests/unit/routes/test_lazy_app_container.py
+++ b/tests/unit/routes/test_lazy_app_container.py
@@ -9,7 +9,7 @@ from bson import ObjectId
 
 from featurebyte.models.base import DEFAULT_CATALOG_ID, User
 from featurebyte.routes.app_container_config import AppContainerConfig, ClassDefinition
-from featurebyte.routes.lazy_app_container import LazyAppContainer, get_all_deps_for_key
+from featurebyte.routes.lazy_app_container import LazyAppContainer
 from featurebyte.utils.persistent import MongoDBImpl
 
 
@@ -217,28 +217,6 @@ def get_class_def(key: str, deps: List[str]) -> ClassDefinition:
         getter=TestService,
         dependencies=deps,
     )
-
-
-def test_get_all_deps_for_key():
-    """
-    Test get_all_deps_for_key
-
-    Class dependency graph looks like
-           A
-        //   \\
-       B      C
-       \\  //  \\
-         D      E
-    """
-    class_def_mapping = {
-        "a": get_class_def("a", ["b", "c"]),
-        "b": get_class_def("b", ["d"]),
-        "c": get_class_def("c", ["d", "e"]),
-        "d": get_class_def("d", []),
-        "e": get_class_def("e", []),
-    }
-    deps = get_all_deps_for_key("a", class_def_mapping, {})
-    assert deps == ["e", "d", "c", "b", "a"]
 
 
 def test_disable_block_modification_check(app_container):


### PR DESCRIPTION
## Description

This refactors the `_get_key` method in `LazyAppContainer` to do DFS and instance building in one go. It is simpler and more efficient without expensive operations such as membership check using list, etc.

Profiling result from app unit tests below.

Before:
<img width="699" alt="image" src="https://github.com/user-attachments/assets/0946c0d0-9565-45a4-9e6c-bbb81e199e8e">

After:
<img width="712" alt="image" src="https://github.com/user-attachments/assets/7908277d-66a7-4312-8edf-a9380c7b155d">


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
