### PR TITLE
[DEV-3607] Add route to retrieve deployment feature job history

### DIFF
--- a/featurebyte/models/feature_materialize_run.py
+++ b/featurebyte/models/feature_materialize_run.py
@@ -38,12 +38,14 @@ class FeatureMaterializeRun(FeatureByteCatalogBaseDocumentModel):
     """
 
     offline_store_feature_table_id: PydanticObjectId
+    offline_store_feature_table_name: Optional[str] = Field(default=None)
     scheduled_job_ts: datetime
     feature_materialize_ts: Optional[datetime] = Field(default=None)
     completion_ts: Optional[datetime] = Field(default=None)
     completion_status: Optional[CompletionStatus] = Field(default=None)
     duration_from_scheduled_seconds: Optional[float] = Field(default=None)
     incomplete_tile_tasks: Optional[List[IncompleteTileTask]] = Field(default_factory=None)
+    deployment_ids: Optional[List[PydanticObjectId]] = Field(default=None)
 
     class Settings(FeatureByteCatalogBaseDocumentModel.Settings):
         """
@@ -55,6 +57,7 @@ class FeatureMaterializeRun(FeatureByteCatalogBaseDocumentModel):
         indexes = FeatureByteCatalogBaseDocumentModel.Settings.indexes + [
             IndexModel("offline_store_feature_table_id"),
             IndexModel("scheduled_job_ts"),
+            IndexModel("deployment_ids"),
         ]
         auditable = False
 

--- a/featurebyte/routes/deployment/controller.py
+++ b/featurebyte/routes/deployment/controller.py
@@ -27,6 +27,7 @@ from featurebyte.schema.deployment import (
     AllDeploymentList,
     AllDeploymentListRecord,
     DeploymentCreate,
+    DeploymentJobHistory,
     DeploymentList,
     DeploymentSummary,
     DeploymentUpdate,
@@ -45,6 +46,7 @@ from featurebyte.service.catalog import AllCatalogService, CatalogService
 from featurebyte.service.context import ContextService
 from featurebyte.service.deployment import AllDeploymentService, DeploymentService
 from featurebyte.service.entity_serving_names import EntityServingNamesService
+from featurebyte.service.feature_job_history_service import FeatureJobHistoryService
 from featurebyte.service.feature_list import AllFeatureListService, FeatureListService
 from featurebyte.service.mixin import DEFAULT_PAGE_SIZE
 from featurebyte.service.online_serving import OnlineServingService
@@ -72,6 +74,7 @@ class DeploymentController(  # pylint: disable=too-many-instance-attributes, too
         batch_feature_table_service: BatchFeatureTableService,
         feast_feature_store_service: FeastFeatureStoreService,
         entity_serving_names_service: EntityServingNamesService,
+        feature_job_history_service: FeatureJobHistoryService,
     ):
         super().__init__(deployment_service)
         self.catalog_service = catalog_service
@@ -83,6 +86,7 @@ class DeploymentController(  # pylint: disable=too-many-instance-attributes, too
         self.batch_feature_table_service = batch_feature_table_service
         self.feast_feature_store_service = feast_feature_store_service
         self.entity_serving_names_service = entity_serving_names_service
+        self.feature_job_history_service = feature_job_history_service
 
     async def create_deployment(self, data: DeploymentCreate) -> Task:
         """
@@ -345,6 +349,28 @@ class DeploymentController(  # pylint: disable=too-many-instance-attributes, too
                 )
             )
         return SampleEntityServingNames(entity_serving_names=entity_serving_names)
+
+    async def get_deployment_job_history(
+        self, deployment_id: ObjectId, num_runs: int
+    ) -> DeploymentJobHistory:
+        """
+        Get job history for a deployment
+
+        Parameters
+        ----------
+        deployment_id: ObjectId
+            Deployment ID
+        num_runs: int
+            Number of runs to retrieve
+
+        Returns
+        -------
+        DeploymentJobHistory
+        """
+        return await self.feature_job_history_service.get_deployment_job_history(
+            deployment_id=deployment_id,
+            num_runs=num_runs,
+        )
 
 
 class AllDeploymentController(

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -93,6 +93,7 @@ from featurebyte.service.entity_validation import EntityValidationService
 from featurebyte.service.event_table import EventTableService
 from featurebyte.service.feature import FeatureService
 from featurebyte.service.feature_facade import FeatureFacadeService
+from featurebyte.service.feature_job_history_service import FeatureJobHistoryService
 from featurebyte.service.feature_job_setting_analysis import FeatureJobSettingAnalysisService
 from featurebyte.service.feature_list import AllFeatureListService, FeatureListService
 from featurebyte.service.feature_list_facade import FeatureListFacadeService
@@ -267,6 +268,7 @@ app_container_config.register_class(FeatureService)
 app_container_config.register_class(FeatureFacadeService)
 app_container_config.register_class(FeatureJobSettingAnalysisController)
 app_container_config.register_class(FeatureJobSettingAnalysisService)
+app_container_config.register_class(FeatureJobHistoryService)
 app_container_config.register_class(FeatureListController)
 app_container_config.register_class(FeatureListEntityRelationshipValidator)
 app_container_config.register_class(FeatureListFacadeService)

--- a/featurebyte/schema/deployment.py
+++ b/featurebyte/schema/deployment.py
@@ -6,11 +6,14 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
+from datetime import datetime
+
 from bson import ObjectId
 from pydantic import Field
 
 from featurebyte.models.base import FeatureByteBaseModel, NameStr, PydanticObjectId
 from featurebyte.models.deployment import DeploymentModel, FeastRegistryInfo
+from featurebyte.models.feature_materialize_run import CompletionStatus
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema, PaginationMixin
 
 
@@ -85,3 +88,25 @@ class OnlineFeaturesResponseModel(FeatureByteBaseModel):
     """
 
     features: List[Dict[str, Any]]
+
+
+class FeatureTableJobRun(FeatureByteBaseModel):
+    """
+    Schema for feature table job run
+    """
+
+    feature_table_id: PydanticObjectId
+    feature_table_name: Optional[str]
+    scheduled_ts: datetime
+    completion_ts: Optional[datetime]
+    completion_status: Optional[CompletionStatus]
+    duration_seconds: Optional[int]
+    incomplete_tile_tasks_count: Optional[int]
+
+
+class DeploymentJobHistory(FeatureByteBaseModel):
+    """
+    Schema for deployment job history
+    """
+
+    runs: List[FeatureTableJobRun]

--- a/featurebyte/service/base_document.py
+++ b/featurebyte/service/base_document.py
@@ -750,6 +750,8 @@ class BaseDocumentService(
             Use only provided query filter (without any further processing)
         populate_remote_attributes: bool
             Populate attributes that are stored remotely (e.g. file paths)
+        kwargs: Any
+            Additional keyword arguments
 
         Yields
         -------

--- a/featurebyte/service/base_document.py
+++ b/featurebyte/service/base_document.py
@@ -737,6 +737,7 @@ class BaseDocumentService(
         query_filter: QueryFilter,
         use_raw_query_filter: bool = False,
         populate_remote_attributes: bool = True,
+        **kwargs: Any,
     ) -> AsyncIterator[Document]:
         """
         List documents iterator to retrieve all the results based on given document service & query filter
@@ -758,6 +759,7 @@ class BaseDocumentService(
         async for doc in self.list_documents_as_dict_iterator(
             query_filter=query_filter,
             use_raw_query_filter=use_raw_query_filter,
+            **kwargs,
         ):
             document = self.document_class(**doc)
             if populate_remote_attributes:

--- a/featurebyte/service/feature_job_history_service.py
+++ b/featurebyte/service/feature_job_history_service.py
@@ -1,0 +1,64 @@
+"""
+FeatureJobHistoryService class
+"""
+
+from __future__ import annotations
+
+from bson import ObjectId
+
+from featurebyte.models.feature_materialize_run import FeatureMaterializeRun
+from featurebyte.schema.deployment import DeploymentJobHistory, FeatureTableJobRun
+from featurebyte.service.feature_materialize_run import FeatureMaterializeRunService
+
+
+class FeatureJobHistoryService:
+    """
+    FeatureJobHistoryService for retrieving feature job history for deployments
+    """
+
+    def __init__(
+        self,
+        feature_materialize_run_service: FeatureMaterializeRunService,
+    ):
+        self.feature_materialize_run_service = feature_materialize_run_service
+
+    async def get_deployment_job_history(
+        self, deployment_id: ObjectId, num_runs: int
+    ) -> DeploymentJobHistory:
+        """
+        Get a DeploymentJobHistory object for the given deployment_id
+
+        Parameters
+        ----------
+        deployment_id: ObjectId
+            Deployment identifier
+        num_runs: int
+            Number of recent job runs to retrieve
+
+        Returns
+        -------
+        DeploymentJobHistory
+        """
+        feature_materialize_runs = (
+            await self.feature_materialize_run_service.get_recent_runs_by_deployment_id(
+                deployment_id=deployment_id, num_runs=num_runs
+            )
+        )
+        job_runs = []
+        for feature_materialize_run in feature_materialize_runs:
+            job_runs.append(self._convert_feature_materialize_run(feature_materialize_run))
+        return DeploymentJobHistory(runs=job_runs)
+
+    @classmethod
+    def _convert_feature_materialize_run(
+        cls, feature_materialize_run: FeatureMaterializeRun
+    ) -> FeatureTableJobRun:
+        return FeatureTableJobRun(
+            feature_table_id=feature_materialize_run.offline_store_feature_table_id,
+            feature_table_name=feature_materialize_run.offline_store_feature_table_name,
+            scheduled_ts=feature_materialize_run.scheduled_job_ts,
+            completion_ts=feature_materialize_run.completion_ts,
+            completion_status=feature_materialize_run.completion_status,
+            duration_seconds=feature_materialize_run.duration_from_scheduled_seconds,
+            incomplete_tile_tasks_count=len(feature_materialize_run.incomplete_tile_tasks or []),
+        )

--- a/featurebyte/service/feature_list.py
+++ b/featurebyte/service/feature_list.py
@@ -512,6 +512,7 @@ class FeatureListService(  # pylint: disable=too-many-instance-attributes
         query_filter: QueryFilter,
         use_raw_query_filter: bool = False,
         populate_remote_attributes: bool = True,
+        **kwargs: Any,
     ) -> AsyncIterator[FeatureListModel]:
         raise RuntimeError(
             "Do not use this method as it takes long time to deserialize the data, "

--- a/featurebyte/service/feature_materialize_run.py
+++ b/featurebyte/service/feature_materialize_run.py
@@ -101,3 +101,30 @@ class FeatureMaterializeRunService(
                 duration_from_scheduled_seconds=duration,
             ),
         )
+
+    async def get_recent_runs_by_deployment_id(
+        self, deployment_id: ObjectId, num_runs: int
+    ) -> List[FeatureMaterializeRun]:
+        """
+        Get recent feature materialize runs for the deployment_id
+
+        Parameters
+        ----------
+        deployment_id: ObjectId
+            Identifier of the deployment of interest
+        num_runs: int
+            Number of recent runs to retrieve
+
+        Returns
+        -------
+        List[FeatureMaterializeRun]
+        """
+        runs = []
+        async for run in self.list_documents_iterator(
+            query_filter={"deployment_ids": deployment_id},
+            sort_by=[("scheduled_job_ts", "desc"), ("_id", "desc")],
+        ):
+            runs.append(run)
+            if len(runs) >= num_runs:
+                break
+        return runs

--- a/featurebyte/service/feature_materialize_sync.py
+++ b/featurebyte/service/feature_materialize_sync.py
@@ -166,9 +166,11 @@ class FeatureMaterializeSyncService:
         feature_materialize_run = await self.feature_materialize_run_service.create_document(
             FeatureMaterializeRun(
                 offline_store_feature_table_id=offline_store_feature_table_id,
+                offline_store_feature_table_name=feature_table.name,
                 scheduled_job_ts=await self._get_scheduled_job_ts_for_feature_table(
                     offline_store_feature_table_id,
                 ),
+                deployment_ids=feature_table.deployment_ids,
             ),
         )
 

--- a/tests/unit/service/fixtures_feature_materialize_runs.py
+++ b/tests/unit/service/fixtures_feature_materialize_runs.py
@@ -1,0 +1,97 @@
+"""
+Shared fixtures of FeatureMaterializeRun
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from bson import ObjectId
+
+from featurebyte.models.feature_materialize_run import FeatureMaterializeRun
+
+
+@pytest.fixture
+def feature_materialize_run_service(app_container):
+    """
+    Fixture for FeatureMaterializeRunService
+    """
+    return app_container.feature_materialize_run_service
+
+
+@pytest.fixture
+def offline_store_feature_table_id():
+    """
+    Fixture for offline store feature table id
+    """
+    return ObjectId()
+
+
+@pytest.fixture
+def scheduled_job_ts():
+    """
+    Fixture for a scheduled job timestamp
+    """
+    return datetime(2024, 7, 15, 0, 0, 0)
+
+
+@pytest.fixture
+def completion_ts(scheduled_job_ts):
+    """
+    Fixture for a completion timestamp
+    """
+    return scheduled_job_ts + timedelta(seconds=10)
+
+
+@pytest.fixture
+def feature_materialize_run_model(offline_store_feature_table_id, scheduled_job_ts):
+    """
+    Fixture for a FeatureMaterializeRun
+    """
+    return FeatureMaterializeRun(
+        offline_store_feature_table_id=offline_store_feature_table_id,
+        scheduled_job_ts=scheduled_job_ts,
+    )
+
+
+@pytest.fixture
+def deployment_id():
+    """
+    Fixture for a deployment id
+    """
+    return ObjectId()
+
+
+@pytest.fixture
+def another_deployment_id():
+    """
+    Fixture for another deployment id
+    """
+    return ObjectId()
+
+
+@pytest_asyncio.fixture
+async def saved_feature_materialize_run_models(
+    feature_materialize_run_service,
+    offline_store_feature_table_id,
+    scheduled_job_ts,
+    deployment_id,
+    another_deployment_id,
+):
+    """
+    Fixture for a list of saved FeatureMaterializeRun models
+    """
+    models = []
+    for current_deployment_id in [deployment_id, another_deployment_id]:
+        for i in range(10):
+            current_scheduled_job_ts = scheduled_job_ts + i * timedelta(hours=1)
+            model = FeatureMaterializeRun(
+                offline_store_feature_table_id=offline_store_feature_table_id,
+                scheduled_job_ts=current_scheduled_job_ts,
+                completion_ts=current_scheduled_job_ts + timedelta(seconds=10),
+                completion_status="success" if i % 2 == 0 else "failure",
+                duration_from_scheduled_seconds=10,
+                deployment_ids=[current_deployment_id],
+            )
+            models.append(await feature_materialize_run_service.create_document(model))
+    yield models

--- a/tests/unit/service/test_feature_job_history.py
+++ b/tests/unit/service/test_feature_job_history.py
@@ -2,6 +2,8 @@
 Tests for FeatureJobHistoryService
 """
 
+# pylint: disable=wildcard-import,unused-wildcard-import
+
 from featurebyte.schema.deployment import DeploymentJobHistory, FeatureTableJobRun
 from featurebyte.service.feature_job_history_service import FeatureJobHistoryService
 from tests.unit.service.fixtures_feature_materialize_runs import *

--- a/tests/unit/service/test_feature_job_history.py
+++ b/tests/unit/service/test_feature_job_history.py
@@ -1,0 +1,55 @@
+"""
+Tests for FeatureJobHistoryService
+"""
+
+from featurebyte.schema.deployment import DeploymentJobHistory, FeatureTableJobRun
+from featurebyte.service.feature_job_history_service import FeatureJobHistoryService
+from tests.unit.service.fixtures_feature_materialize_runs import *
+
+
+@pytest.fixture
+def service(app_container) -> FeatureJobHistoryService:
+    """
+    Fixture for a FeatureJobHistoryService
+    """
+    return app_container.feature_job_history_service
+
+
+@pytest.mark.usefixtures("saved_feature_materialize_run_models")
+@pytest.mark.asyncio
+async def test_get_deployment_job_history(service, deployment_id, offline_store_feature_table_id):
+    """
+    Tests for get_deployment_job_history
+    """
+    job_history = await service.get_deployment_job_history(deployment_id, 3)
+    assert job_history == DeploymentJobHistory(
+        runs=[
+            FeatureTableJobRun(
+                feature_table_id=offline_store_feature_table_id,
+                feature_table_name=None,
+                scheduled_ts=datetime(2024, 7, 15, 9, 0),
+                completion_ts=datetime(2024, 7, 15, 9, 0, 10),
+                completion_status="failure",
+                duration_seconds=10,
+                incomplete_tile_tasks_count=0,
+            ),
+            FeatureTableJobRun(
+                feature_table_id=offline_store_feature_table_id,
+                feature_table_name=None,
+                scheduled_ts=datetime(2024, 7, 15, 8, 0),
+                completion_ts=datetime(2024, 7, 15, 8, 0, 10),
+                completion_status="success",
+                duration_seconds=10,
+                incomplete_tile_tasks_count=0,
+            ),
+            FeatureTableJobRun(
+                feature_table_id=offline_store_feature_table_id,
+                feature_table_name=None,
+                scheduled_ts=datetime(2024, 7, 15, 7, 0),
+                completion_ts=datetime(2024, 7, 15, 7, 0, 10),
+                completion_status="failure",
+                duration_seconds=10,
+                incomplete_tile_tasks_count=0,
+            ),
+        ]
+    )

--- a/tests/unit/service/test_feature_materialize_run.py
+++ b/tests/unit/service/test_feature_materialize_run.py
@@ -5,7 +5,9 @@ Unit tests for FeatureMaterializeRunService
 from datetime import datetime, timedelta
 
 import pytest
+import pytest_asyncio
 from bson import ObjectId
+from freezegun import freeze_time
 
 from featurebyte.models.feature_materialize_run import FeatureMaterializeRun, IncompleteTileTask
 
@@ -31,7 +33,7 @@ def scheduled_job_ts():
     """
     Fixture for a scheduled job timestamp
     """
-    return datetime.utcnow().replace(microsecond=0)
+    return datetime(2024, 7, 15, 0, 0, 0)
 
 
 @pytest.fixture
@@ -51,6 +53,45 @@ def feature_materialize_run_model(offline_store_feature_table_id, scheduled_job_
         offline_store_feature_table_id=offline_store_feature_table_id,
         scheduled_job_ts=scheduled_job_ts,
     )
+
+
+@pytest.fixture
+def deployment_id():
+    """
+    Fixture for a deployment id
+    """
+    return ObjectId()
+
+
+@pytest.fixture
+def another_deployment_id():
+    """
+    Fixture for another deployment id
+    """
+    return ObjectId()
+
+
+@pytest_asyncio.fixture
+async def saved_feature_materialize_run_models(
+    service, offline_store_feature_table_id, scheduled_job_ts, deployment_id, another_deployment_id
+):
+    """
+    Fixture for a list of saved FeatureMaterializeRun models
+    """
+    models = []
+    for current_deployment_id in [deployment_id, another_deployment_id]:
+        for i in range(10):
+            current_scheduled_job_ts = scheduled_job_ts + i * timedelta(hours=1)
+            model = FeatureMaterializeRun(
+                offline_store_feature_table_id=offline_store_feature_table_id,
+                scheduled_job_ts=current_scheduled_job_ts,
+                completion_ts=current_scheduled_job_ts + timedelta(seconds=10),
+                completion_status="success",
+                duration_from_scheduled_seconds=10,
+                deployment_ids=[current_deployment_id],
+            )
+            models.append(await service.create_document(model))
+    yield models
 
 
 @pytest.mark.asyncio
@@ -112,3 +153,21 @@ async def test_set_completion(service, feature_materialize_run_model, completion
     assert retrieved_model.completion_ts == completion_ts
     assert retrieved_model.completion_status == "success"
     assert retrieved_model.duration_from_scheduled_seconds == 10.0
+
+
+@pytest.mark.usefixtures("saved_feature_materialize_run_models")
+@pytest.mark.asyncio
+async def test_get_recent_runs_by_deployment_id(service, deployment_id):
+    """
+    Test get_recent_runs_by_deployment_id
+    """
+    runs = await service.get_recent_runs_by_deployment_id(deployment_id, num_runs=3)
+    assert len(runs) == 3
+    for run in runs:
+        assert run.deployment_ids == [deployment_id]
+    runs_scheduled_ts = [run.scheduled_job_ts for run in runs]
+    assert runs_scheduled_ts == [
+        datetime(2024, 7, 15, 9, 0, 0),
+        datetime(2024, 7, 15, 8, 0, 0),
+        datetime(2024, 7, 15, 7, 0, 0),
+    ]

--- a/tests/unit/service/test_feature_materialize_run.py
+++ b/tests/unit/service/test_feature_materialize_run.py
@@ -2,14 +2,8 @@
 Unit tests for FeatureMaterializeRunService
 """
 
-from datetime import datetime, timedelta
-
-import pytest
-import pytest_asyncio
-from bson import ObjectId
-from freezegun import freeze_time
-
-from featurebyte.models.feature_materialize_run import FeatureMaterializeRun, IncompleteTileTask
+from featurebyte.models.feature_materialize_run import IncompleteTileTask
+from tests.unit.service.fixtures_feature_materialize_runs import *
 
 
 @pytest.fixture
@@ -18,80 +12,6 @@ def service(app_container):
     Fixture for a FeatureMaterializePrerequisiteService
     """
     return app_container.feature_materialize_run_service
-
-
-@pytest.fixture
-def offline_store_feature_table_id():
-    """
-    Fixture for offline store feature table id
-    """
-    return ObjectId()
-
-
-@pytest.fixture
-def scheduled_job_ts():
-    """
-    Fixture for a scheduled job timestamp
-    """
-    return datetime(2024, 7, 15, 0, 0, 0)
-
-
-@pytest.fixture
-def completion_ts(scheduled_job_ts):
-    """
-    Fixture for a completion timestamp
-    """
-    return scheduled_job_ts + timedelta(seconds=10)
-
-
-@pytest.fixture
-def feature_materialize_run_model(offline_store_feature_table_id, scheduled_job_ts):
-    """
-    Fixture for a FeatureMaterializeRun
-    """
-    return FeatureMaterializeRun(
-        offline_store_feature_table_id=offline_store_feature_table_id,
-        scheduled_job_ts=scheduled_job_ts,
-    )
-
-
-@pytest.fixture
-def deployment_id():
-    """
-    Fixture for a deployment id
-    """
-    return ObjectId()
-
-
-@pytest.fixture
-def another_deployment_id():
-    """
-    Fixture for another deployment id
-    """
-    return ObjectId()
-
-
-@pytest_asyncio.fixture
-async def saved_feature_materialize_run_models(
-    service, offline_store_feature_table_id, scheduled_job_ts, deployment_id, another_deployment_id
-):
-    """
-    Fixture for a list of saved FeatureMaterializeRun models
-    """
-    models = []
-    for current_deployment_id in [deployment_id, another_deployment_id]:
-        for i in range(10):
-            current_scheduled_job_ts = scheduled_job_ts + i * timedelta(hours=1)
-            model = FeatureMaterializeRun(
-                offline_store_feature_table_id=offline_store_feature_table_id,
-                scheduled_job_ts=current_scheduled_job_ts,
-                completion_ts=current_scheduled_job_ts + timedelta(seconds=10),
-                completion_status="success",
-                duration_from_scheduled_seconds=10,
-                deployment_ids=[current_deployment_id],
-            )
-            models.append(await service.create_document(model))
-    yield models
 
 
 @pytest.mark.asyncio

--- a/tests/unit/service/test_feature_materialize_run.py
+++ b/tests/unit/service/test_feature_materialize_run.py
@@ -2,6 +2,8 @@
 Unit tests for FeatureMaterializeRunService
 """
 
+# pylint: disable=wildcard-import,unused-wildcard-import
+
 from featurebyte.models.feature_materialize_run import IncompleteTileTask
 from tests.unit.service.fixtures_feature_materialize_runs import *
 

--- a/tests/unit/service/test_feature_materialize_sync.py
+++ b/tests/unit/service/test_feature_materialize_sync.py
@@ -260,6 +260,7 @@ async def test_run_feature_materialize__no_prerequisites(
     )
     assert {
         "offline_store_feature_table_id": offline_store_feature_table_no_aggregation_ids.id,
+        "offline_store_feature_table_name": "cust_id_1d",
         "scheduled_job_ts": datetime(2024, 1, 15, 0, 0, 0),
         "incomplete_tile_tasks": None,
     }.items() <= run_model.dict().items()
@@ -319,6 +320,7 @@ async def test_run_feature_materialize__prerequisite_met(
     )
     assert {
         "offline_store_feature_table_id": offline_store_feature_table_1.id,
+        "offline_store_feature_table_name": "cust_id_1h",
         "scheduled_job_ts": datetime(2024, 1, 15, 9, 10, 0),
         "incomplete_tile_tasks": None,
     }.items() <= run_model.dict().items()
@@ -370,6 +372,7 @@ async def test_run_feature_materialize__timeout(
     )
     assert {
         "offline_store_feature_table_id": offline_store_feature_table_1.id,
+        "offline_store_feature_table_name": "cust_id_1h",
         "scheduled_job_ts": datetime(2024, 1, 15, 9, 10, 0),
         "incomplete_tile_tasks": [{"aggregation_id": "agg_id_x", "reason": "timeout"}],
     }.items() <= run_model.dict().items()


### PR DESCRIPTION
## Description

This adds an API route to retrieve deployment feature job history.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
