### PR TITLE
[chore] Group job runs by feature table in /deployment/job_history

### DIFF
--- a/featurebyte/schema/deployment.py
+++ b/featurebyte/schema/deployment.py
@@ -92,11 +92,9 @@ class OnlineFeaturesResponseModel(FeatureByteBaseModel):
 
 class FeatureTableJobRun(FeatureByteBaseModel):
     """
-    Schema for feature table job run
+    Schema for a specific job run
     """
 
-    feature_table_id: PydanticObjectId
-    feature_table_name: Optional[str]
     scheduled_ts: datetime
     completion_ts: Optional[datetime]
     completion_status: Optional[CompletionStatus]
@@ -104,9 +102,19 @@ class FeatureTableJobRun(FeatureByteBaseModel):
     incomplete_tile_tasks_count: Optional[int]
 
 
+class FeatureTableJobRuns(FeatureByteBaseModel):
+    """
+    Schema for feature table job runs
+    """
+
+    feature_table_id: PydanticObjectId
+    feature_table_name: Optional[str]
+    runs: List[FeatureTableJobRun]
+
+
 class DeploymentJobHistory(FeatureByteBaseModel):
     """
     Schema for deployment job history
     """
 
-    runs: List[FeatureTableJobRun]
+    feature_table_history: List[FeatureTableJobRuns]

--- a/featurebyte/service/feature_job_history_service.py
+++ b/featurebyte/service/feature_job_history_service.py
@@ -4,12 +4,16 @@ FeatureJobHistoryService class
 
 from __future__ import annotations
 
-from typing import List
+from typing import Dict, List
 
 from bson import ObjectId
 
 from featurebyte.models.feature_materialize_run import FeatureMaterializeRun
-from featurebyte.schema.deployment import DeploymentJobHistory, FeatureTableJobRun
+from featurebyte.schema.deployment import (
+    DeploymentJobHistory,
+    FeatureTableJobRun,
+    FeatureTableJobRuns,
+)
 from featurebyte.service.deployment import DeploymentService
 from featurebyte.service.feature_list import FeatureListService
 from featurebyte.service.feature_materialize_run import FeatureMaterializeRunService
@@ -65,32 +69,40 @@ class FeatureJobHistoryService:
         )
 
         # Construct DeploymentJobHistory
-        job_runs = []
-        for feature_materialize_run in feature_materialize_runs:
-            job_runs.append(
-                self._convert_feature_materialize_run(
-                    feature_materialize_run, aggregation_ids=aggregation_ids
-                )
-            )
-        return DeploymentJobHistory(runs=job_runs)
+        feature_table_job_runs = self._convert_feature_materialize_runs(
+            feature_materialize_runs, aggregation_ids=aggregation_ids
+        )
+        return DeploymentJobHistory(feature_table_history=feature_table_job_runs)
 
     @classmethod
-    def _convert_feature_materialize_run(
-        cls, feature_materialize_run: FeatureMaterializeRun, aggregation_ids: List[str]
-    ) -> FeatureTableJobRun:
-        # Only count an incomplete tile task if the aggregation_id is relevant to the deployment
-        aggregation_ids_set = set(aggregation_ids)
-        relevant_incomplete_tile_tasks = [
-            task
-            for task in feature_materialize_run.incomplete_tile_tasks or []
-            if task.aggregation_id in aggregation_ids_set
-        ]
-        return FeatureTableJobRun(
-            feature_table_id=feature_materialize_run.offline_store_feature_table_id,
-            feature_table_name=feature_materialize_run.offline_store_feature_table_name,
-            scheduled_ts=feature_materialize_run.scheduled_job_ts,
-            completion_ts=feature_materialize_run.completion_ts,
-            completion_status=feature_materialize_run.completion_status,
-            duration_seconds=feature_materialize_run.duration_from_scheduled_seconds,
-            incomplete_tile_tasks_count=len(relevant_incomplete_tile_tasks),
-        )
+    def _convert_feature_materialize_runs(
+        cls, feature_materialize_runs: List[FeatureMaterializeRun], aggregation_ids: List[str]
+    ) -> List[FeatureTableJobRuns]:
+        job_runs: Dict[ObjectId, FeatureTableJobRuns] = {}
+        for feature_materialize_run in feature_materialize_runs:
+            # Only count an incomplete tile task if the aggregation_id is relevant to the deployment
+            aggregation_ids_set = set(aggregation_ids)
+            relevant_incomplete_tile_tasks = [
+                task
+                for task in feature_materialize_run.incomplete_tile_tasks or []
+                if task.aggregation_id in aggregation_ids_set
+            ]
+            key = feature_materialize_run.offline_store_feature_table_id
+            if key not in job_runs:
+                job_runs[key] = FeatureTableJobRuns(
+                    feature_table_id=feature_materialize_run.offline_store_feature_table_id,
+                    feature_table_name=feature_materialize_run.offline_store_feature_table_name,
+                    runs=[],
+                )
+            job_runs[key].runs.append(
+                FeatureTableJobRun(
+                    feature_table_id=feature_materialize_run.offline_store_feature_table_id,
+                    feature_table_name=feature_materialize_run.offline_store_feature_table_name,
+                    scheduled_ts=feature_materialize_run.scheduled_job_ts,
+                    completion_ts=feature_materialize_run.completion_ts,
+                    completion_status=feature_materialize_run.completion_status,
+                    duration_seconds=feature_materialize_run.duration_from_scheduled_seconds,
+                    incomplete_tile_tasks_count=len(relevant_incomplete_tile_tasks),
+                )
+            )
+        return sorted(job_runs.values(), key=lambda x: x.feature_table_id)

--- a/tests/unit/service/test_feature_job_history.py
+++ b/tests/unit/service/test_feature_job_history.py
@@ -4,7 +4,11 @@ Tests for FeatureJobHistoryService
 
 # pylint: disable=wildcard-import,unused-wildcard-import
 
-from featurebyte.schema.deployment import DeploymentJobHistory, FeatureTableJobRun
+from featurebyte.schema.deployment import (
+    DeploymentJobHistory,
+    FeatureTableJobRun,
+    FeatureTableJobRuns,
+)
 from featurebyte.service.feature_job_history_service import FeatureJobHistoryService
 from tests.unit.service.fixtures_feature_materialize_runs import *
 
@@ -25,35 +29,35 @@ async def test_get_deployment_job_history(service, deployment_id, offline_store_
     """
     job_history = await service.get_deployment_job_history(deployment_id, 3)
     assert job_history == DeploymentJobHistory(
-        runs=[
-            FeatureTableJobRun(
+        feature_table_history=[
+            FeatureTableJobRuns(
                 feature_table_id=offline_store_feature_table_id,
                 feature_table_name="customer",
-                scheduled_ts=datetime(2024, 7, 15, 9, 0),
-                completion_ts=datetime(2024, 7, 15, 9, 0, 10),
-                completion_status="failure",
-                duration_seconds=10,
-                incomplete_tile_tasks_count=1,
-            ),
-            # incomplete_tile_tasks_count is 0 because the failed tile task have a different
-            # aggregation id that doesn't match with any features used in the deployment
-            FeatureTableJobRun(
-                feature_table_id=offline_store_feature_table_id,
-                feature_table_name="customer",
-                scheduled_ts=datetime(2024, 7, 15, 8, 0),
-                completion_ts=datetime(2024, 7, 15, 8, 0, 10),
-                completion_status="success",
-                duration_seconds=10,
-                incomplete_tile_tasks_count=0,
-            ),
-            FeatureTableJobRun(
-                feature_table_id=offline_store_feature_table_id,
-                feature_table_name="customer",
-                scheduled_ts=datetime(2024, 7, 15, 7, 0),
-                completion_ts=datetime(2024, 7, 15, 7, 0, 10),
-                completion_status="failure",
-                duration_seconds=10,
-                incomplete_tile_tasks_count=1,
+                runs=[
+                    FeatureTableJobRun(
+                        scheduled_ts=datetime(2024, 7, 15, 9, 0),
+                        completion_ts=datetime(2024, 7, 15, 9, 0, 10),
+                        completion_status="failure",
+                        duration_seconds=10,
+                        incomplete_tile_tasks_count=1,
+                    ),
+                    # incomplete_tile_tasks_count is 0 because the failed tile task have a different
+                    # aggregation id that doesn't match with any features used in the deployment
+                    FeatureTableJobRun(
+                        scheduled_ts=datetime(2024, 7, 15, 8, 0),
+                        completion_ts=datetime(2024, 7, 15, 8, 0, 10),
+                        completion_status="success",
+                        duration_seconds=10,
+                        incomplete_tile_tasks_count=0,
+                    ),
+                    FeatureTableJobRun(
+                        scheduled_ts=datetime(2024, 7, 15, 7, 0),
+                        completion_ts=datetime(2024, 7, 15, 7, 0, 10),
+                        completion_status="failure",
+                        duration_seconds=10,
+                        incomplete_tile_tasks_count=1,
+                    ),
+                ],
             ),
         ]
     )


### PR DESCRIPTION
## Description

This rework the structure of `DeploymentJobHistory` to group job runs by feature table so the output is easier to consume.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
