### PR TITLE
[DEV-3627] Reuse sampled data when executing describe queries

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -65,7 +65,8 @@ services:
         --conf spark.sql.catalogImplementation=hive  \
         --conf spark.sql.warehouse.dir=file:///opt/spark/data/derby/warehouse/ \
         --conf spark.sql.hive.thriftServer.singleSession=false \
-        --conf spark.hadoop.metastore.catalog.default=spark
+        --conf spark.hadoop.metastore.catalog.default=spark \
+        --conf spark.sql.parquet.int96RebaseModeInWrite=CORRECTED
     healthcheck:
       test: netstat -ltn | grep -c 10000
       interval: 10s

--- a/featurebyte/query_graph/sql/interpreter/preview.py
+++ b/featurebyte/query_graph/sql/interpreter/preview.py
@@ -731,6 +731,8 @@ class PreviewMixin(BaseGraphInterpreter):
 
         Parameters
         ----------
+        input_table_name: str
+            Table name to use for input data
         sql_tree: expressions.Select
             SQL Expression to describe
         columns: List[ViewDataColumn]

--- a/featurebyte/query_graph/sql/interpreter/preview.py
+++ b/featurebyte/query_graph/sql/interpreter/preview.py
@@ -571,7 +571,7 @@ class PreviewMixin(BaseGraphInterpreter):
                     quoted=True,
                 ),
             )
-            .from_(CASTED_DATA_TABLE_NAME if use_casted_data else "data")
+            .from_(quoted_identifier(CASTED_DATA_TABLE_NAME if use_casted_data else "data"))
             .group_by(col_expr)
             .order_by(
                 expressions.Ordered(this=quoted_identifier(CATEGORY_COUNT_COLUMN_NAME), desc=True)
@@ -690,7 +690,7 @@ class PreviewMixin(BaseGraphInterpreter):
                 )
             )
         sql_tree = expressions.select(*casted_columns).from_(quoted_identifier(input_table_name))
-        return CASTED_DATA_TABLE_NAME, sql_tree
+        return quoted_identifier(CASTED_DATA_TABLE_NAME), sql_tree
 
     @staticmethod
     def _clip_column_before_stats_func(

--- a/featurebyte/service/preview.py
+++ b/featurebyte/service/preview.py
@@ -256,21 +256,32 @@ class PreviewService:
             columns_batch_size=columns_batch_size,
             total_num_rows=total_num_rows,
         )
-        df_queries = []
-        for describe_query in describe_queries.queries:
-            logger.debug("Execute describe SQL", extra={"describe_sql": describe_query.sql})
-            result = await session.execute_query_long_running(describe_query.sql)
-            columns = describe_query.columns
-            assert result is not None
-            df_query = pd.DataFrame(
-                result.values.reshape(len(columns), -1).T,
-                index=describe_query.row_names,
-                columns=[str(column.name) for column in columns],
+        await session.create_table_as(
+            table_details=describe_queries.data.output_table_name,
+            select_expr=describe_queries.data.expr,
+        )
+        try:
+            df_queries = []
+            for describe_query in describe_queries.queries:
+                logger.debug("Execute describe SQL", extra={"describe_sql": describe_query.sql})
+                result = await session.execute_query_long_running(describe_query.sql)
+                columns = describe_query.columns
+                assert result is not None
+                df_query = pd.DataFrame(
+                    result.values.reshape(len(columns), -1).T,
+                    index=describe_query.row_names,
+                    columns=[str(column.name) for column in columns],
+                )
+                df_queries.append(df_query)
+            results = pd.concat(df_queries, axis=1)
+            if drop_all_null_stats:
+                results = results.dropna(axis=0, how="all")
+        finally:
+            await session.drop_table(
+                table_name=describe_queries.data.output_table_name,
+                schema_name=session.schema_name,
+                database_name=session.database_name,
             )
-            df_queries.append(df_query)
-        results = pd.concat(df_queries, axis=1)
-        if drop_all_null_stats:
-            results = results.dropna(axis=0, how="all")
         return dataframe_to_json(results, describe_queries.type_conversions, skip_prepare=True)
 
     async def value_counts(

--- a/tests/fixtures/expected_describe_request.sql
+++ b/tests/fixtures/expected_describe_request.sql
@@ -1,16 +1,8 @@
-WITH data AS (
-  SELECT
-    "col_float" AS "col_float",
-    "col_text" AS "col_text"
-  FROM "sf_database"."sf_schema"."sf_table"
-  WHERE
-    "event_timestamp" >= CAST('2012-11-24T11:00:00' AS TIMESTAMPNTZ)
-    AND "event_timestamp" < CAST('2019-11-24T11:00:00' AS TIMESTAMPNTZ)
-), casted_data AS (
+WITH "casted_data" AS (
   SELECT
     CAST("col_float" AS STRING) AS "col_float",
     CAST("col_text" AS STRING) AS "col_text"
-  FROM data
+  FROM "__TEMP_SAMPLED_DATA_66A12A43B78F348D8BEB438B"
 ), counts__1 AS (
   SELECT
     F_COUNT_DICT_ENTROPY(count_dict."COUNT_DICT") AS "entropy__1",
@@ -26,7 +18,7 @@ WITH data AS (
       SELECT
         "col_text",
         COUNT(*) AS "__FB_COUNTS"
-      FROM casted_data
+      FROM "casted_data"
       GROUP BY
         "col_text"
       ORDER BY
@@ -67,7 +59,7 @@ WITH data AS (
     NULL AS "max__1",
     NULL AS "min TZ offset__1",
     NULL AS "max TZ offset__1"
-  FROM data
+  FROM "__TEMP_SAMPLED_DATA_66A12A43B78F348D8BEB438B"
 ), joined_tables_0 AS (
   SELECT
     *

--- a/tests/fixtures/expected_describe_request.sql
+++ b/tests/fixtures/expected_describe_request.sql
@@ -2,7 +2,7 @@ WITH "casted_data" AS (
   SELECT
     CAST("col_float" AS STRING) AS "col_float",
     CAST("col_text" AS STRING) AS "col_text"
-  FROM "__TEMP_SAMPLED_DATA_66A12A43B78F348D8BEB438B"
+  FROM "__TEMP_SAMPLED_DATA_000000000000000000000000"
 ), counts__1 AS (
   SELECT
     F_COUNT_DICT_ENTROPY(count_dict."COUNT_DICT") AS "entropy__1",
@@ -59,7 +59,7 @@ WITH "casted_data" AS (
     NULL AS "max__1",
     NULL AS "min TZ offset__1",
     NULL AS "max TZ offset__1"
-  FROM "__TEMP_SAMPLED_DATA_66A12A43B78F348D8BEB438B"
+  FROM "__TEMP_SAMPLED_DATA_000000000000000000000000"
 ), joined_tables_0 AS (
   SELECT
     *

--- a/tests/fixtures/query_graph/expected_describe_batches_0.sql
+++ b/tests/fixtures/query_graph/expected_describe_batches_0.sql
@@ -1,15 +1,4 @@
-WITH data AS (
-  SELECT
-    "ts" AS "ts",
-    "cust_id" AS "cust_id",
-    "a" AS "a",
-    "b" AS "b",
-    "a" AS "a_copy"
-  FROM "db"."public"."event_table"
-  ORDER BY
-    RANDOM(1234)
-  LIMIT 10
-), stats AS (
+WITH stats AS (
   SELECT
     MIN(
       IFF(
@@ -31,7 +20,7 @@ WITH data AS (
     NULL AS "max__1",
     MIN("a") AS "min__2",
     MAX("a") AS "max__2"
-  FROM data
+  FROM "__TEMP_SAMPLED_DATA_000000000000000000000000"
 ), joined_tables_0 AS (
   SELECT
     *

--- a/tests/fixtures/query_graph/expected_describe_batches_1.sql
+++ b/tests/fixtures/query_graph/expected_describe_batches_1.sql
@@ -1,21 +1,10 @@
-WITH data AS (
-  SELECT
-    "ts" AS "ts",
-    "cust_id" AS "cust_id",
-    "a" AS "a",
-    "b" AS "b",
-    "a" AS "a_copy"
-  FROM "db"."public"."event_table"
-  ORDER BY
-    RANDOM(1234)
-  LIMIT 10
-), stats AS (
+WITH stats AS (
   SELECT
     MIN("b") AS "min__3",
     MAX("b") AS "max__3",
     MIN("a_copy") AS "min__4",
     MAX("a_copy") AS "max__4"
-  FROM data
+  FROM "__TEMP_SAMPLED_DATA_000000000000000000000000"
 ), joined_tables_0 AS (
   SELECT
     *

--- a/tests/fixtures/query_graph/expected_describe_count_based_stats_only.sql
+++ b/tests/fixtures/query_graph/expected_describe_count_based_stats_only.sql
@@ -1,22 +1,11 @@
-WITH data AS (
-  SELECT
-    "ts" AS "ts",
-    "cust_id" AS "cust_id",
-    "a" AS "a",
-    "b" AS "b",
-    "a" AS "a_copy"
-  FROM "db"."public"."event_table"
-  ORDER BY
-    RANDOM(1234)
-  LIMIT 10
-), casted_data AS (
+WITH "casted_data" AS (
   SELECT
     CAST("ts" AS STRING) AS "ts",
     CAST("cust_id" AS STRING) AS "cust_id",
     CAST("a" AS STRING) AS "a",
     CAST("b" AS STRING) AS "b",
     CAST("a_copy" AS STRING) AS "a_copy"
-  FROM data
+  FROM "__TEMP_SAMPLED_DATA_000000000000000000000000"
 ), counts__1 AS (
   SELECT
     F_COUNT_DICT_ENTROPY(count_dict."COUNT_DICT") AS "entropy__1",
@@ -32,7 +21,7 @@ WITH data AS (
       SELECT
         "cust_id",
         COUNT(*) AS "__FB_COUNTS"
-      FROM casted_data
+      FROM "casted_data"
       GROUP BY
         "cust_id"
       ORDER BY

--- a/tests/fixtures/query_graph/expected_describe_databricks.sql
+++ b/tests/fixtures/query_graph/expected_describe_databricks.sql
@@ -1,22 +1,11 @@
-WITH data AS (
-  SELECT
-    `ts` AS `ts`,
-    `cust_id` AS `cust_id`,
-    `a` AS `a`,
-    `b` AS `b`,
-    `a` AS `a_copy`
-  FROM `db`.`public`.`event_table`
-  ORDER BY
-    RANDOM(1234)
-  LIMIT 10
-), casted_data AS (
+WITH `casted_data` AS (
   SELECT
     CAST(`ts` AS STRING) AS `ts`,
     CAST(`cust_id` AS STRING) AS `cust_id`,
     CAST(`a` AS STRING) AS `a`,
     CAST(`b` AS STRING) AS `b`,
     CAST(`a_copy` AS STRING) AS `a_copy`
-  FROM data
+  FROM `__TEMP_SAMPLED_DATA_000000000000000000000000`
 ), counts__1 AS (
   SELECT
     F_COUNT_DICT_ENTROPY(count_dict.`COUNT_DICT`) AS `entropy__1`,
@@ -36,7 +25,7 @@ WITH data AS (
       SELECT
         `cust_id`,
         COUNT(*) AS `__FB_COUNTS`
-      FROM casted_data
+      FROM `casted_data`
       GROUP BY
         `cust_id`
       ORDER BY
@@ -60,7 +49,7 @@ WITH data AS (
       SELECT
         `b`,
         COUNT(*) AS `__FB_COUNTS`
-      FROM casted_data
+      FROM `casted_data`
       GROUP BY
         `b`
       ORDER BY
@@ -152,7 +141,7 @@ WITH data AS (
     MAX(`a_copy`) AS `max__4`,
     NULL AS `min TZ offset__4`,
     NULL AS `max TZ offset__4`
-  FROM data
+  FROM `__TEMP_SAMPLED_DATA_000000000000000000000000`
 ), joined_tables_0 AS (
   SELECT
     *

--- a/tests/fixtures/query_graph/expected_describe_date_range_and_size.sql
+++ b/tests/fixtures/query_graph/expected_describe_date_range_and_size.sql
@@ -1,34 +1,4 @@
-WITH data AS (
-  SELECT
-    "ts",
-    "cust_id",
-    "a",
-    "b",
-    "a_copy"
-  FROM (
-    SELECT
-      CAST(BITAND(RANDOM(1234), 2147483647) AS DOUBLE) / 2147483647.0 AS "prob",
-      "ts",
-      "cust_id",
-      "a",
-      "b",
-      "a_copy"
-    FROM (
-      SELECT
-        "ts" AS "ts",
-        "cust_id" AS "cust_id",
-        "a" AS "a",
-        "b" AS "b",
-        "a" AS "a_copy"
-      FROM "db"."public"."event_table"
-    )
-  )
-  WHERE
-    "prob" <= 0.15000000000000002
-  ORDER BY
-    "prob"
-  LIMIT 10
-), stats AS (
+WITH stats AS (
   SELECT
     MIN(
       IFF(
@@ -54,7 +24,7 @@ WITH data AS (
     MAX("b") AS "max__3",
     MIN("a_copy") AS "min__4",
     MAX("a_copy") AS "max__4"
-  FROM data
+  FROM "__TEMP_SAMPLED_DATA_000000000000000000000000"
 ), joined_tables_0 AS (
   SELECT
     *

--- a/tests/fixtures/query_graph/expected_describe_snowflake.sql
+++ b/tests/fixtures/query_graph/expected_describe_snowflake.sql
@@ -1,22 +1,11 @@
-WITH data AS (
-  SELECT
-    "ts" AS "ts",
-    "cust_id" AS "cust_id",
-    "a" AS "a",
-    "b" AS "b",
-    "a" AS "a_copy"
-  FROM "db"."public"."event_table"
-  ORDER BY
-    RANDOM(1234)
-  LIMIT 10
-), casted_data AS (
+WITH "casted_data" AS (
   SELECT
     CAST("ts" AS STRING) AS "ts",
     CAST("cust_id" AS STRING) AS "cust_id",
     CAST("a" AS STRING) AS "a",
     CAST("b" AS STRING) AS "b",
     CAST("a_copy" AS STRING) AS "a_copy"
-  FROM data
+  FROM "__TEMP_SAMPLED_DATA_000000000000000000000000"
 ), counts__1 AS (
   SELECT
     F_COUNT_DICT_ENTROPY(count_dict."COUNT_DICT") AS "entropy__1",
@@ -32,7 +21,7 @@ WITH data AS (
       SELECT
         "cust_id",
         COUNT(*) AS "__FB_COUNTS"
-      FROM casted_data
+      FROM "casted_data"
       GROUP BY
         "cust_id"
       ORDER BY
@@ -51,7 +40,7 @@ WITH data AS (
       SELECT
         "b",
         COUNT(*) AS "__FB_COUNTS"
-      FROM casted_data
+      FROM "casted_data"
       GROUP BY
         "b"
       ORDER BY
@@ -154,7 +143,7 @@ WITH data AS (
     MAX("a_copy") AS "max__4",
     NULL AS "min TZ offset__4",
     NULL AS "max TZ offset__4"
-  FROM data
+  FROM "__TEMP_SAMPLED_DATA_000000000000000000000000"
 ), joined_tables_0 AS (
   SELECT
     *

--- a/tests/fixtures/query_graph/expected_describe_spark.sql
+++ b/tests/fixtures/query_graph/expected_describe_spark.sql
@@ -1,22 +1,11 @@
-WITH data AS (
-  SELECT
-    `ts` AS `ts`,
-    `cust_id` AS `cust_id`,
-    `a` AS `a`,
-    `b` AS `b`,
-    `a` AS `a_copy`
-  FROM `db`.`public`.`event_table`
-  ORDER BY
-    RANDOM(1234)
-  LIMIT 10
-), casted_data AS (
+WITH `casted_data` AS (
   SELECT
     CAST(`ts` AS STRING) AS `ts`,
     CAST(`cust_id` AS STRING) AS `cust_id`,
     CAST(`a` AS STRING) AS `a`,
     CAST(`b` AS STRING) AS `b`,
     CAST(`a_copy` AS STRING) AS `a_copy`
-  FROM data
+  FROM `__TEMP_SAMPLED_DATA_000000000000000000000000`
 ), counts__1 AS (
   SELECT
     F_COUNT_DICT_ENTROPY(count_dict.`COUNT_DICT`) AS `entropy__1`,
@@ -36,7 +25,7 @@ WITH data AS (
       SELECT
         `cust_id`,
         COUNT(*) AS `__FB_COUNTS`
-      FROM casted_data
+      FROM `casted_data`
       GROUP BY
         `cust_id`
       ORDER BY
@@ -60,7 +49,7 @@ WITH data AS (
       SELECT
         `b`,
         COUNT(*) AS `__FB_COUNTS`
-      FROM casted_data
+      FROM `casted_data`
       GROUP BY
         `b`
       ORDER BY
@@ -152,7 +141,7 @@ WITH data AS (
     MAX(`a_copy`) AS `max__4`,
     NULL AS `min TZ offset__4`,
     NULL AS `max TZ offset__4`
-  FROM data
+  FROM `__TEMP_SAMPLED_DATA_000000000000000000000000`
 ), joined_tables_0 AS (
   SELECT
     *

--- a/tests/fixtures/query_graph/expected_describe_stats_names.sql
+++ b/tests/fixtures/query_graph/expected_describe_stats_names.sql
@@ -1,15 +1,4 @@
-WITH data AS (
-  SELECT
-    "ts" AS "ts",
-    "cust_id" AS "cust_id",
-    "a" AS "a",
-    "b" AS "b",
-    "a" AS "a_copy"
-  FROM "db"."public"."event_table"
-  ORDER BY
-    RANDOM(1234)
-  LIMIT 10
-), stats AS (
+WITH stats AS (
   SELECT
     MIN(
       IFF(
@@ -35,7 +24,7 @@ WITH data AS (
     MAX("b") AS "max__3",
     MIN("a_copy") AS "min__4",
     MAX("a_copy") AS "max__4"
-  FROM data
+  FROM "__TEMP_SAMPLED_DATA_000000000000000000000000"
 ), joined_tables_0 AS (
   SELECT
     *

--- a/tests/fixtures/query_graph/expected_value_counts.sql
+++ b/tests/fixtures/query_graph/expected_value_counts.sql
@@ -1,14 +1,14 @@
-WITH data AS (
+WITH "data" AS (
   SELECT
     "a" AS "a"
   FROM "db"."public"."event_table"
   ORDER BY
     RANDOM(1234)
   LIMIT 50000
-), casted_data AS (
+), "casted_data" AS (
   SELECT
     CAST("a" AS STRING) AS "a"
-  FROM data
+  FROM "data"
 )
 SELECT
   "a" AS "key",
@@ -17,7 +17,7 @@ FROM (
   SELECT
     "a",
     COUNT(*) AS "__FB_COUNTS"
-  FROM casted_data
+  FROM "casted_data"
   GROUP BY
     "a"
   ORDER BY

--- a/tests/fixtures/query_graph/expected_value_counts_no_casting.sql
+++ b/tests/fixtures/query_graph/expected_value_counts_no_casting.sql
@@ -1,4 +1,4 @@
-WITH data AS (
+WITH "data" AS (
   SELECT
     "a" AS "a"
   FROM "db"."public"."event_table"
@@ -13,7 +13,7 @@ FROM (
   SELECT
     "a",
     COUNT(*) AS "__FB_COUNTS"
-  FROM data
+  FROM "data"
   GROUP BY
     "a"
   ORDER BY

--- a/tests/unit/query_graph/interpreter/test_preview.py
+++ b/tests/unit/query_graph/interpreter/test_preview.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from unittest.mock import patch
 
 import pytest
+from bson import ObjectId
 
 from featurebyte.enum import SourceType
 from featurebyte.query_graph.sql.interpreter import GraphInterpreter
@@ -19,6 +20,17 @@ def patch_num_tables_per_join():
     Patch NUM_TABLES_PER_JOIN to 2 for all tests
     """
     with patch("featurebyte.query_graph.sql.interpreter.preview.NUM_TABLES_PER_JOIN", 2):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def patch_unique_identifier():
+    """
+    Patch unique identifier generator
+    """
+    with patch(
+        "featurebyte.query_graph.sql.interpreter.preview.ObjectId", return_value=ObjectId("0" * 24)
+    ):
         yield
 
 

--- a/tests/unit/routes/test_feature_store.py
+++ b/tests/unit/routes/test_feature_store.py
@@ -8,7 +8,7 @@ import json
 import textwrap
 from datetime import datetime
 from http import HTTPStatus
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import numpy as np
 import pandas as pd
@@ -667,7 +667,11 @@ class TestFeatureStoreApi(BaseApiTestSuite):  # pylint: disable=too-many-public-
         mock_session.generate_session_unique_id = Mock(return_value="1")
         sample_payload = copy.deepcopy(data_sample_payload)
         sample_payload["graph"]["nodes"][1]["parameters"]["columns"] = ["col_float", "col_text"]
-        response = test_api_client.post("/feature_store/description", json=sample_payload)
+        with patch(
+            "featurebyte.query_graph.sql.interpreter.preview.ObjectId",
+            return_value=ObjectId("0" * 24),
+        ):
+            response = test_api_client.post("/feature_store/description", json=sample_payload)
         assert response.status_code == HTTPStatus.OK, response.json()
         assert_frame_equal(dataframe_from_json(response.json()), expected_df, check_dtype=False)
 


### PR DESCRIPTION
## Description

This updates describe queries to sample input data once and then reuse it.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
