### PR TITLE
[cherry-pick][DEV-3627] Reuse sampled data when executing describe queries

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -65,7 +65,8 @@ services:
         --conf spark.sql.catalogImplementation=hive  \
         --conf spark.sql.warehouse.dir=file:///opt/spark/data/derby/warehouse/ \
         --conf spark.sql.hive.thriftServer.singleSession=false \
-        --conf spark.hadoop.metastore.catalog.default=spark
+        --conf spark.hadoop.metastore.catalog.default=spark \
+        --conf spark.sql.parquet.int96RebaseModeInWrite=CORRECTED
     healthcheck:
       test: netstat -ltn | grep -c 10000
       interval: 10s

--- a/featurebyte/query_graph/sql/interpreter/preview.py
+++ b/featurebyte/query_graph/sql/interpreter/preview.py
@@ -13,6 +13,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import datetime
 
+from bson import ObjectId
 from sqlglot import expressions, parse_one
 
 from featurebyte.enum import DBVarType
@@ -37,6 +38,16 @@ NUM_TABLES_PER_JOIN = 10
 
 
 @dataclass
+class DataQuery:
+    """
+    Query to obtain possibly sampled data
+    """
+
+    expr: expressions.Select
+    output_table_name: str
+
+
+@dataclass
 class DescribeQuery:
     """
     Query to describe selected columns for a given node
@@ -53,6 +64,7 @@ class DescribeQueries:
     Collection of queries to describe all columns for a given node
     """
 
+    data: DataQuery
     queries: List[DescribeQuery]
     type_conversions: dict[Optional[str], DBVarType]
 
@@ -559,7 +571,7 @@ class PreviewMixin(BaseGraphInterpreter):
                     quoted=True,
                 ),
             )
-            .from_(CASTED_DATA_TABLE_NAME if use_casted_data else "data")
+            .from_(quoted_identifier(CASTED_DATA_TABLE_NAME if use_casted_data else "data"))
             .group_by(col_expr)
             .order_by(
                 expressions.Ordered(this=quoted_identifier(CATEGORY_COUNT_COLUMN_NAME), desc=True)
@@ -662,7 +674,9 @@ class PreviewMixin(BaseGraphInterpreter):
         )
 
     @staticmethod
-    def _get_cte_with_casted_data(sql_tree: expressions.Expression) -> CteStatement:
+    def _get_cte_with_casted_data(
+        sql_tree: expressions.Expression, input_table_name: str
+    ) -> CteStatement:
         # get subquery with columns casted to string to compute value counts
         casted_columns = []
         for col_expr in sql_tree.expressions:
@@ -675,8 +689,8 @@ class PreviewMixin(BaseGraphInterpreter):
                     quoted=True,
                 )
             )
-        sql_tree = expressions.select(*casted_columns).from_("data")
-        return CASTED_DATA_TABLE_NAME, sql_tree
+        sql_tree = expressions.select(*casted_columns).from_(quoted_identifier(input_table_name))
+        return quoted_identifier(CASTED_DATA_TABLE_NAME), sql_tree
 
     @staticmethod
     def _clip_column_before_stats_func(
@@ -707,6 +721,7 @@ class PreviewMixin(BaseGraphInterpreter):
 
     def _construct_stats_sql(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         self,
+        input_table_name: str,
         sql_tree: expressions.Select,
         columns: List[ViewDataColumn],
         stats_names: Optional[List[str]] = None,
@@ -716,6 +731,8 @@ class PreviewMixin(BaseGraphInterpreter):
 
         Parameters
         ----------
+        input_table_name: str
+            Table name to use for input data
         sql_tree: expressions.Select
             SQL Expression to describe
         columns: List[ViewDataColumn]
@@ -732,11 +749,8 @@ class PreviewMixin(BaseGraphInterpreter):
             column.name: column for column in columns if column.name or len(columns) == 1
         }
 
-        # original data
-        cte_statements: List[CteStatement] = [("data", sql_tree)]
-
         # data casted to string
-        cte_casted_data = self._get_cte_with_casted_data(sql_tree)
+        cte_casted_data = self._get_cte_with_casted_data(sql_tree, input_table_name)
 
         # only extract requested stats if specified
         required_stats_expressions = {}
@@ -744,6 +758,7 @@ class PreviewMixin(BaseGraphInterpreter):
             if stats_names is None or stats_name in stats_names:
                 required_stats_expressions[stats_name] = stats_values
 
+        cte_statements: List[CteStatement] = []
         stats_selections = []
         count_tables = []
         final_selections = []
@@ -831,21 +846,23 @@ class PreviewMixin(BaseGraphInterpreter):
         # get statistics
         all_tables = []
         if stats_selections:
-            sql_tree = expressions.select(*stats_selections).from_("data")
+            sql_tree = expressions.select(*stats_selections).from_(
+                quoted_identifier(input_table_name)
+            )
             cte_statements.append(("stats", sql_tree))
             all_tables.append("stats")
         all_tables.extend(count_tables)
 
         # check if data casted to string is used and if so add it to cte_statements
         used_casted_data = False
-        for _, cte_expr in cte_statements[1:]:
+        for _, cte_expr in cte_statements:
             for cur_expr, _, _ in cte_expr.walk():
                 if isinstance(cur_expr, expressions.Identifier):
                     if cur_expr.alias_or_name == CASTED_DATA_TABLE_NAME:
                         used_casted_data = True
                         break
         if used_casted_data:
-            cte_statements.insert(1, cte_casted_data)
+            cte_statements.insert(0, cte_casted_data)
 
         sql_tree = self._join_all_tables(cte_statements, all_tables).select(*final_selections)
 
@@ -952,6 +969,7 @@ class PreviewMixin(BaseGraphInterpreter):
             skip_conversion=True,
             total_num_rows=total_num_rows,
         )
+        sample_table_name = f"__TEMP_SAMPLED_DATA_{ObjectId()}".upper()
 
         if not columns_batch_size:
             columns_batch_size = len(operation_structure.columns)
@@ -959,6 +977,7 @@ class PreviewMixin(BaseGraphInterpreter):
         queries = []
         for i in range(0, len(operation_structure.columns), columns_batch_size):
             sql_tree, row_indices, columns = self._construct_stats_sql(
+                input_table_name=sample_table_name,
                 sql_tree=sample_sql_tree,
                 columns=operation_structure.columns[i : i + columns_batch_size],
                 stats_names=stats_names,
@@ -970,7 +989,11 @@ class PreviewMixin(BaseGraphInterpreter):
                     columns=columns,
                 )
             )
-        return DescribeQueries(queries=queries, type_conversions=type_conversions)
+        return DescribeQueries(
+            data=DataQuery(expr=sample_sql_tree, output_table_name=sample_table_name),
+            queries=queries,
+            type_conversions=type_conversions,
+        )
 
     def construct_value_counts_sql(
         self,
@@ -1007,11 +1030,11 @@ class PreviewMixin(BaseGraphInterpreter):
             seed=seed,
         )
         cte_statements: List[CteStatement] = [
-            ("data", sql_tree),
+            (quoted_identifier("data"), sql_tree),
         ]
         if convert_keys_to_string:
             cte_statements.append(
-                self._get_cte_with_casted_data(sql_tree),
+                self._get_cte_with_casted_data(sql_tree, "data"),
             )
         # It's expected that this function is called on a node that is associated with a column and
         # not a frame, so here we simply take the first column.

--- a/featurebyte/service/preview.py
+++ b/featurebyte/service/preview.py
@@ -256,21 +256,32 @@ class PreviewService:
             columns_batch_size=columns_batch_size,
             total_num_rows=total_num_rows,
         )
-        df_queries = []
-        for describe_query in describe_queries.queries:
-            logger.debug("Execute describe SQL", extra={"describe_sql": describe_query.sql})
-            result = await session.execute_query_long_running(describe_query.sql)
-            columns = describe_query.columns
-            assert result is not None
-            df_query = pd.DataFrame(
-                result.values.reshape(len(columns), -1).T,
-                index=describe_query.row_names,
-                columns=[str(column.name) for column in columns],
+        await session.create_table_as(
+            table_details=describe_queries.data.output_table_name,
+            select_expr=describe_queries.data.expr,
+        )
+        try:
+            df_queries = []
+            for describe_query in describe_queries.queries:
+                logger.debug("Execute describe SQL", extra={"describe_sql": describe_query.sql})
+                result = await session.execute_query_long_running(describe_query.sql)
+                columns = describe_query.columns
+                assert result is not None
+                df_query = pd.DataFrame(
+                    result.values.reshape(len(columns), -1).T,
+                    index=describe_query.row_names,
+                    columns=[str(column.name) for column in columns],
+                )
+                df_queries.append(df_query)
+            results = pd.concat(df_queries, axis=1)
+            if drop_all_null_stats:
+                results = results.dropna(axis=0, how="all")
+        finally:
+            await session.drop_table(
+                table_name=describe_queries.data.output_table_name,
+                schema_name=session.schema_name,
+                database_name=session.database_name,
             )
-            df_queries.append(df_query)
-        results = pd.concat(df_queries, axis=1)
-        if drop_all_null_stats:
-            results = results.dropna(axis=0, how="all")
         return dataframe_to_json(results, describe_queries.type_conversions, skip_prepare=True)
 
     async def value_counts(

--- a/tests/fixtures/expected_describe_request.sql
+++ b/tests/fixtures/expected_describe_request.sql
@@ -1,16 +1,8 @@
-WITH data AS (
-  SELECT
-    "col_float" AS "col_float",
-    "col_text" AS "col_text"
-  FROM "sf_database"."sf_schema"."sf_table"
-  WHERE
-    "event_timestamp" >= CAST('2012-11-24T11:00:00' AS TIMESTAMPNTZ)
-    AND "event_timestamp" < CAST('2019-11-24T11:00:00' AS TIMESTAMPNTZ)
-), casted_data AS (
+WITH "casted_data" AS (
   SELECT
     CAST("col_float" AS STRING) AS "col_float",
     CAST("col_text" AS STRING) AS "col_text"
-  FROM data
+  FROM "__TEMP_SAMPLED_DATA_000000000000000000000000"
 ), counts__1 AS (
   SELECT
     F_COUNT_DICT_ENTROPY(count_dict."COUNT_DICT") AS "entropy__1",
@@ -26,7 +18,7 @@ WITH data AS (
       SELECT
         "col_text",
         COUNT(*) AS "__FB_COUNTS"
-      FROM casted_data
+      FROM "casted_data"
       GROUP BY
         "col_text"
       ORDER BY
@@ -67,7 +59,7 @@ WITH data AS (
     NULL AS "max__1",
     NULL AS "min TZ offset__1",
     NULL AS "max TZ offset__1"
-  FROM data
+  FROM "__TEMP_SAMPLED_DATA_000000000000000000000000"
 ), joined_tables_0 AS (
   SELECT
     *

--- a/tests/fixtures/query_graph/expected_describe_batches_0.sql
+++ b/tests/fixtures/query_graph/expected_describe_batches_0.sql
@@ -1,15 +1,4 @@
-WITH data AS (
-  SELECT
-    "ts" AS "ts",
-    "cust_id" AS "cust_id",
-    "a" AS "a",
-    "b" AS "b",
-    "a" AS "a_copy"
-  FROM "db"."public"."event_table"
-  ORDER BY
-    RANDOM(1234)
-  LIMIT 10
-), stats AS (
+WITH stats AS (
   SELECT
     MIN(
       IFF(
@@ -31,7 +20,7 @@ WITH data AS (
     NULL AS "max__1",
     MIN("a") AS "min__2",
     MAX("a") AS "max__2"
-  FROM data
+  FROM "__TEMP_SAMPLED_DATA_000000000000000000000000"
 ), joined_tables_0 AS (
   SELECT
     *

--- a/tests/fixtures/query_graph/expected_describe_batches_1.sql
+++ b/tests/fixtures/query_graph/expected_describe_batches_1.sql
@@ -1,21 +1,10 @@
-WITH data AS (
-  SELECT
-    "ts" AS "ts",
-    "cust_id" AS "cust_id",
-    "a" AS "a",
-    "b" AS "b",
-    "a" AS "a_copy"
-  FROM "db"."public"."event_table"
-  ORDER BY
-    RANDOM(1234)
-  LIMIT 10
-), stats AS (
+WITH stats AS (
   SELECT
     MIN("b") AS "min__3",
     MAX("b") AS "max__3",
     MIN("a_copy") AS "min__4",
     MAX("a_copy") AS "max__4"
-  FROM data
+  FROM "__TEMP_SAMPLED_DATA_000000000000000000000000"
 ), joined_tables_0 AS (
   SELECT
     *

--- a/tests/fixtures/query_graph/expected_describe_count_based_stats_only.sql
+++ b/tests/fixtures/query_graph/expected_describe_count_based_stats_only.sql
@@ -1,22 +1,11 @@
-WITH data AS (
-  SELECT
-    "ts" AS "ts",
-    "cust_id" AS "cust_id",
-    "a" AS "a",
-    "b" AS "b",
-    "a" AS "a_copy"
-  FROM "db"."public"."event_table"
-  ORDER BY
-    RANDOM(1234)
-  LIMIT 10
-), casted_data AS (
+WITH "casted_data" AS (
   SELECT
     CAST("ts" AS STRING) AS "ts",
     CAST("cust_id" AS STRING) AS "cust_id",
     CAST("a" AS STRING) AS "a",
     CAST("b" AS STRING) AS "b",
     CAST("a_copy" AS STRING) AS "a_copy"
-  FROM data
+  FROM "__TEMP_SAMPLED_DATA_000000000000000000000000"
 ), counts__1 AS (
   SELECT
     F_COUNT_DICT_ENTROPY(count_dict."COUNT_DICT") AS "entropy__1",
@@ -32,7 +21,7 @@ WITH data AS (
       SELECT
         "cust_id",
         COUNT(*) AS "__FB_COUNTS"
-      FROM casted_data
+      FROM "casted_data"
       GROUP BY
         "cust_id"
       ORDER BY

--- a/tests/fixtures/query_graph/expected_describe_databricks.sql
+++ b/tests/fixtures/query_graph/expected_describe_databricks.sql
@@ -1,22 +1,11 @@
-WITH data AS (
-  SELECT
-    `ts` AS `ts`,
-    `cust_id` AS `cust_id`,
-    `a` AS `a`,
-    `b` AS `b`,
-    `a` AS `a_copy`
-  FROM `db`.`public`.`event_table`
-  ORDER BY
-    RANDOM(1234)
-  LIMIT 10
-), casted_data AS (
+WITH `casted_data` AS (
   SELECT
     CAST(`ts` AS STRING) AS `ts`,
     CAST(`cust_id` AS STRING) AS `cust_id`,
     CAST(`a` AS STRING) AS `a`,
     CAST(`b` AS STRING) AS `b`,
     CAST(`a_copy` AS STRING) AS `a_copy`
-  FROM data
+  FROM `__TEMP_SAMPLED_DATA_000000000000000000000000`
 ), counts__1 AS (
   SELECT
     F_COUNT_DICT_ENTROPY(count_dict.`COUNT_DICT`) AS `entropy__1`,
@@ -36,7 +25,7 @@ WITH data AS (
       SELECT
         `cust_id`,
         COUNT(*) AS `__FB_COUNTS`
-      FROM casted_data
+      FROM `casted_data`
       GROUP BY
         `cust_id`
       ORDER BY
@@ -60,7 +49,7 @@ WITH data AS (
       SELECT
         `b`,
         COUNT(*) AS `__FB_COUNTS`
-      FROM casted_data
+      FROM `casted_data`
       GROUP BY
         `b`
       ORDER BY
@@ -152,7 +141,7 @@ WITH data AS (
     MAX(`a_copy`) AS `max__4`,
     NULL AS `min TZ offset__4`,
     NULL AS `max TZ offset__4`
-  FROM data
+  FROM `__TEMP_SAMPLED_DATA_000000000000000000000000`
 ), joined_tables_0 AS (
   SELECT
     *

--- a/tests/fixtures/query_graph/expected_describe_date_range_and_size.sql
+++ b/tests/fixtures/query_graph/expected_describe_date_range_and_size.sql
@@ -1,34 +1,4 @@
-WITH data AS (
-  SELECT
-    "ts",
-    "cust_id",
-    "a",
-    "b",
-    "a_copy"
-  FROM (
-    SELECT
-      CAST(BITAND(RANDOM(1234), 2147483647) AS DOUBLE) / 2147483647.0 AS "prob",
-      "ts",
-      "cust_id",
-      "a",
-      "b",
-      "a_copy"
-    FROM (
-      SELECT
-        "ts" AS "ts",
-        "cust_id" AS "cust_id",
-        "a" AS "a",
-        "b" AS "b",
-        "a" AS "a_copy"
-      FROM "db"."public"."event_table"
-    )
-  )
-  WHERE
-    "prob" <= 0.15000000000000002
-  ORDER BY
-    "prob"
-  LIMIT 10
-), stats AS (
+WITH stats AS (
   SELECT
     MIN(
       IFF(
@@ -54,7 +24,7 @@ WITH data AS (
     MAX("b") AS "max__3",
     MIN("a_copy") AS "min__4",
     MAX("a_copy") AS "max__4"
-  FROM data
+  FROM "__TEMP_SAMPLED_DATA_000000000000000000000000"
 ), joined_tables_0 AS (
   SELECT
     *

--- a/tests/fixtures/query_graph/expected_describe_snowflake.sql
+++ b/tests/fixtures/query_graph/expected_describe_snowflake.sql
@@ -1,22 +1,11 @@
-WITH data AS (
-  SELECT
-    "ts" AS "ts",
-    "cust_id" AS "cust_id",
-    "a" AS "a",
-    "b" AS "b",
-    "a" AS "a_copy"
-  FROM "db"."public"."event_table"
-  ORDER BY
-    RANDOM(1234)
-  LIMIT 10
-), casted_data AS (
+WITH "casted_data" AS (
   SELECT
     CAST("ts" AS STRING) AS "ts",
     CAST("cust_id" AS STRING) AS "cust_id",
     CAST("a" AS STRING) AS "a",
     CAST("b" AS STRING) AS "b",
     CAST("a_copy" AS STRING) AS "a_copy"
-  FROM data
+  FROM "__TEMP_SAMPLED_DATA_000000000000000000000000"
 ), counts__1 AS (
   SELECT
     F_COUNT_DICT_ENTROPY(count_dict."COUNT_DICT") AS "entropy__1",
@@ -32,7 +21,7 @@ WITH data AS (
       SELECT
         "cust_id",
         COUNT(*) AS "__FB_COUNTS"
-      FROM casted_data
+      FROM "casted_data"
       GROUP BY
         "cust_id"
       ORDER BY
@@ -51,7 +40,7 @@ WITH data AS (
       SELECT
         "b",
         COUNT(*) AS "__FB_COUNTS"
-      FROM casted_data
+      FROM "casted_data"
       GROUP BY
         "b"
       ORDER BY
@@ -154,7 +143,7 @@ WITH data AS (
     MAX("a_copy") AS "max__4",
     NULL AS "min TZ offset__4",
     NULL AS "max TZ offset__4"
-  FROM data
+  FROM "__TEMP_SAMPLED_DATA_000000000000000000000000"
 ), joined_tables_0 AS (
   SELECT
     *

--- a/tests/fixtures/query_graph/expected_describe_spark.sql
+++ b/tests/fixtures/query_graph/expected_describe_spark.sql
@@ -1,22 +1,11 @@
-WITH data AS (
-  SELECT
-    `ts` AS `ts`,
-    `cust_id` AS `cust_id`,
-    `a` AS `a`,
-    `b` AS `b`,
-    `a` AS `a_copy`
-  FROM `db`.`public`.`event_table`
-  ORDER BY
-    RANDOM(1234)
-  LIMIT 10
-), casted_data AS (
+WITH `casted_data` AS (
   SELECT
     CAST(`ts` AS STRING) AS `ts`,
     CAST(`cust_id` AS STRING) AS `cust_id`,
     CAST(`a` AS STRING) AS `a`,
     CAST(`b` AS STRING) AS `b`,
     CAST(`a_copy` AS STRING) AS `a_copy`
-  FROM data
+  FROM `__TEMP_SAMPLED_DATA_000000000000000000000000`
 ), counts__1 AS (
   SELECT
     F_COUNT_DICT_ENTROPY(count_dict.`COUNT_DICT`) AS `entropy__1`,
@@ -36,7 +25,7 @@ WITH data AS (
       SELECT
         `cust_id`,
         COUNT(*) AS `__FB_COUNTS`
-      FROM casted_data
+      FROM `casted_data`
       GROUP BY
         `cust_id`
       ORDER BY
@@ -60,7 +49,7 @@ WITH data AS (
       SELECT
         `b`,
         COUNT(*) AS `__FB_COUNTS`
-      FROM casted_data
+      FROM `casted_data`
       GROUP BY
         `b`
       ORDER BY
@@ -152,7 +141,7 @@ WITH data AS (
     MAX(`a_copy`) AS `max__4`,
     NULL AS `min TZ offset__4`,
     NULL AS `max TZ offset__4`
-  FROM data
+  FROM `__TEMP_SAMPLED_DATA_000000000000000000000000`
 ), joined_tables_0 AS (
   SELECT
     *

--- a/tests/fixtures/query_graph/expected_describe_stats_names.sql
+++ b/tests/fixtures/query_graph/expected_describe_stats_names.sql
@@ -1,15 +1,4 @@
-WITH data AS (
-  SELECT
-    "ts" AS "ts",
-    "cust_id" AS "cust_id",
-    "a" AS "a",
-    "b" AS "b",
-    "a" AS "a_copy"
-  FROM "db"."public"."event_table"
-  ORDER BY
-    RANDOM(1234)
-  LIMIT 10
-), stats AS (
+WITH stats AS (
   SELECT
     MIN(
       IFF(
@@ -35,7 +24,7 @@ WITH data AS (
     MAX("b") AS "max__3",
     MIN("a_copy") AS "min__4",
     MAX("a_copy") AS "max__4"
-  FROM data
+  FROM "__TEMP_SAMPLED_DATA_000000000000000000000000"
 ), joined_tables_0 AS (
   SELECT
     *

--- a/tests/fixtures/query_graph/expected_value_counts.sql
+++ b/tests/fixtures/query_graph/expected_value_counts.sql
@@ -1,14 +1,14 @@
-WITH data AS (
+WITH "data" AS (
   SELECT
     "a" AS "a"
   FROM "db"."public"."event_table"
   ORDER BY
     RANDOM(1234)
   LIMIT 50000
-), casted_data AS (
+), "casted_data" AS (
   SELECT
     CAST("a" AS STRING) AS "a"
-  FROM data
+  FROM "data"
 )
 SELECT
   "a" AS "key",
@@ -17,7 +17,7 @@ FROM (
   SELECT
     "a",
     COUNT(*) AS "__FB_COUNTS"
-  FROM casted_data
+  FROM "casted_data"
   GROUP BY
     "a"
   ORDER BY

--- a/tests/fixtures/query_graph/expected_value_counts_no_casting.sql
+++ b/tests/fixtures/query_graph/expected_value_counts_no_casting.sql
@@ -1,4 +1,4 @@
-WITH data AS (
+WITH "data" AS (
   SELECT
     "a" AS "a"
   FROM "db"."public"."event_table"
@@ -13,7 +13,7 @@ FROM (
   SELECT
     "a",
     COUNT(*) AS "__FB_COUNTS"
-  FROM data
+  FROM "data"
   GROUP BY
     "a"
   ORDER BY

--- a/tests/unit/query_graph/interpreter/test_preview.py
+++ b/tests/unit/query_graph/interpreter/test_preview.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from unittest.mock import patch
 
 import pytest
+from bson import ObjectId
 
 from featurebyte.enum import SourceType
 from featurebyte.query_graph.sql.interpreter import GraphInterpreter
@@ -19,6 +20,17 @@ def patch_num_tables_per_join():
     Patch NUM_TABLES_PER_JOIN to 2 for all tests
     """
     with patch("featurebyte.query_graph.sql.interpreter.preview.NUM_TABLES_PER_JOIN", 2):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def patch_unique_identifier():
+    """
+    Patch unique identifier generator
+    """
+    with patch(
+        "featurebyte.query_graph.sql.interpreter.preview.ObjectId", return_value=ObjectId("0" * 24)
+    ):
         yield
 
 

--- a/tests/unit/routes/test_feature_store.py
+++ b/tests/unit/routes/test_feature_store.py
@@ -8,7 +8,7 @@ import json
 import textwrap
 from datetime import datetime
 from http import HTTPStatus
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import numpy as np
 import pandas as pd
@@ -660,7 +660,11 @@ class TestFeatureStoreApi(BaseApiTestSuite):  # pylint: disable=too-many-public-
         mock_session.generate_session_unique_id = Mock(return_value="1")
         sample_payload = copy.deepcopy(data_sample_payload)
         sample_payload["graph"]["nodes"][1]["parameters"]["columns"] = ["col_float", "col_text"]
-        response = test_api_client.post("/feature_store/description", json=sample_payload)
+        with patch(
+            "featurebyte.query_graph.sql.interpreter.preview.ObjectId",
+            return_value=ObjectId("0" * 24),
+        ):
+            response = test_api_client.post("/feature_store/description", json=sample_payload)
         assert response.status_code == HTTPStatus.OK, response.json()
         assert_frame_equal(dataframe_from_json(response.json()), expected_df, check_dtype=False)
 

--- a/tests/unit/service/test_observation_table.py
+++ b/tests/unit/service/test_observation_table.py
@@ -4,7 +4,7 @@ Test for ObservationTableService
 
 import textwrap
 from unittest import mock
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pandas as pd
 import pytest
@@ -23,6 +23,17 @@ from featurebyte.query_graph.model.common_table import TabularSource
 from featurebyte.query_graph.node.schema import TableDetails
 from featurebyte.service.observation_table import validate_columns_info
 from featurebyte.session.base import BaseSession
+
+
+@pytest.fixture(autouse=True)
+def patch_unique_identifier():
+    """
+    Patch unique identifier generator
+    """
+    with patch(
+        "featurebyte.query_graph.sql.interpreter.preview.ObjectId", return_value=ObjectId("0" * 24)
+    ):
+        yield
 
 
 @pytest.fixture(name="observation_table_from_source_table")
@@ -115,6 +126,8 @@ def db_session_fixture(point_in_time_has_missing_values):
         list_table_schema=Mock(side_effect=mock_list_table_schema),
         execute_query_long_running=Mock(side_effect=execute_query_long_running),
         source_type=SourceType.SNOWFLAKE,
+        schema_name="my_schema",
+        database_name="my_db",
     )
     return mock_db_session
 
@@ -190,12 +203,7 @@ async def test_validate__most_recent_point_in_time(
 
         expected_query = textwrap.dedent(
             """
-            WITH data AS (
-              SELECT
-                "POINT_IN_TIME" AS "POINT_IN_TIME",
-                "cust_id" AS "cust_id"
-              FROM "fb_database"."fb_schema"."fb_table"
-            ), stats AS (
+            WITH stats AS (
               SELECT
                 COUNT(DISTINCT "POINT_IN_TIME") AS "unique__0",
                 (
@@ -223,7 +231,7 @@ async def test_validate__most_recent_point_in_time(
                 ) * 100 AS "%missing__1",
                 NULL AS "min__1",
                 NULL AS "max__1"
-              FROM data
+              FROM "__TEMP_SAMPLED_DATA_000000000000000000000000"
             ), joined_tables_0 AS (
               SELECT
                 *


### PR DESCRIPTION
## Description

Cherry pick https://github.com/featurebyte/featurebyte/pull/2475.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
