### PR TITLE
[DEV-3641] Update PreviewService to allow long running queries by default

### DIFF
--- a/featurebyte/routes/feature_store/controller.py
+++ b/featurebyte/routes/feature_store/controller.py
@@ -366,8 +366,6 @@ class FeatureStoreController(
             Maximum rows to sample
         seed: int
             Random seed to use for sampling
-        allow_long_running: bool
-            Whether to allow a longer timeout for query
 
         Returns
         -------

--- a/featurebyte/routes/feature_store/controller.py
+++ b/featurebyte/routes/feature_store/controller.py
@@ -296,7 +296,7 @@ class FeatureStoreController(
         FeatureStoreShape
             FeatureStoreShape object
         """
-        return await self.preview_service.shape(preview=preview)
+        return await self.preview_service.shape(preview=preview, allow_long_running=False)
 
     async def table_shape(self, location: TabularSource) -> FeatureStoreShape:
         """
@@ -330,7 +330,9 @@ class FeatureStoreController(
         dict[str, Any]
             Dataframe converted to json string
         """
-        return await self.preview_service.preview(preview=preview, limit=limit)
+        return await self.preview_service.preview(
+            preview=preview, limit=limit, allow_long_running=False
+        )
 
     async def table_preview(self, location: TabularSource, limit: int) -> dict[str, Any]:
         """
@@ -364,13 +366,17 @@ class FeatureStoreController(
             Maximum rows to sample
         seed: int
             Random seed to use for sampling
+        allow_long_running: bool
+            Whether to allow a longer timeout for query
 
         Returns
         -------
         dict[str, Any]
             Dataframe converted to json string
         """
-        return await self.preview_service.sample(sample=sample, size=size, seed=seed)
+        return await self.preview_service.sample(
+            sample=sample, size=size, seed=seed, allow_long_running=False
+        )
 
     async def describe(self, sample: FeatureStoreSample, size: int, seed: int) -> dict[str, Any]:
         """
@@ -390,7 +396,9 @@ class FeatureStoreController(
         dict[str, Any]
             Dataframe converted to json string
         """
-        return await self.preview_service.describe(sample=sample, size=size, seed=seed)
+        return await self.preview_service.describe(
+            sample=sample, size=size, seed=seed, allow_long_running=False
+        )
 
     async def create_data_description(
         self, sample: FeatureStoreSample, size: int, seed: int, catalog_id: ObjectId

--- a/tests/unit/routes/test_feature_store.py
+++ b/tests/unit/routes/test_feature_store.py
@@ -631,7 +631,7 @@ class TestFeatureStoreApi(BaseApiTestSuite):  # pylint: disable=too-many-public-
             ],
         )
         mock_session = mock_get_session.return_value
-        mock_session.execute_query_long_running.return_value = pd.DataFrame(
+        mock_session.execute_query.return_value = pd.DataFrame(
             {
                 "a_dtype": ["FLOAT"],
                 "a_unique": [5],
@@ -680,7 +680,7 @@ class TestFeatureStoreApi(BaseApiTestSuite):  # pylint: disable=too-many-public-
 
         # check SQL statement
         assert_equal_with_expected_fixture(
-            mock_session.execute_query_long_running.call_args[0][0],
+            mock_session.execute_query.call_args[0][0],
             "tests/fixtures/expected_describe_request.sql",
             update_fixture=update_fixtures,
         )
@@ -709,7 +709,7 @@ class TestFeatureStoreApi(BaseApiTestSuite):  # pylint: disable=too-many-public-
             ],
         )
         mock_session = mock_get_session.return_value
-        mock_session.execute_query_long_running.return_value = pd.DataFrame(
+        mock_session.execute_query.return_value = pd.DataFrame(
             {
                 "a_dtype": ["FLOAT"],
                 "a_unique": [20],

--- a/tests/unit/service/test_preview.py
+++ b/tests/unit/service/test_preview.py
@@ -302,7 +302,7 @@ async def test_value_counts(
     """
     Test value counts
     """
-    mock_snowflake_session.execute_query.return_value = pd.DataFrame(
+    mock_snowflake_session.execute_query_long_running.return_value = pd.DataFrame(
         {
             "key": ["1", "2", None],
             "count": [100, 50, 3],
@@ -361,7 +361,7 @@ async def test_value_counts_not_convert_keys_to_string(
     """
     Test value counts
     """
-    mock_snowflake_session.execute_query.return_value = pd.DataFrame(
+    mock_snowflake_session.execute_query_long_running.return_value = pd.DataFrame(
         {
             "key": keys,
             "count": [100, 50, 3],

--- a/tests/unit/service/test_specialized_dtype.py
+++ b/tests/unit/service/test_specialized_dtype.py
@@ -160,7 +160,7 @@ async def test_add_columns_attributes(
     """Test adding columns attributes"""
     _ = feature_store
 
-    mock_snowflake_session.execute_query.return_value = pd.DataFrame(
+    mock_snowflake_session.execute_query_long_running.return_value = pd.DataFrame(
         {
             "event_id_col": ["a", "b", "c"],
             "event_timestamp_col": [
@@ -256,7 +256,7 @@ async def test_not_embeddding_column(
     """Test array is not embedding"""
     _ = feature_store
 
-    mock_snowflake_session.execute_query.return_value = sample
+    mock_snowflake_session.execute_query_long_running.return_value = sample
 
     svc = SpecializedDtypeDetectionService(preview_service, feature_store_service)
     await svc.detect_and_update_column_dtypes(table)
@@ -279,7 +279,7 @@ async def test_nested_dict_column(
     """Test dict is not flat"""
     _ = feature_store
 
-    mock_snowflake_session.execute_query.return_value = pd.DataFrame(
+    mock_snowflake_session.execute_query_long_running.return_value = pd.DataFrame(
         {
             "event_id_col": ["a", "b", "c"],
             "event_timestamp_col": [


### PR DESCRIPTION
## Description

This updates PreviewService to allow long running queries by default. It is disabled for interactive queries triggered by feature store routes.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
