### PR TITLE
[DEV-3641] Update PreviewService to allow long running queries by default

### DIFF
--- a/featurebyte/routes/feature_store/controller.py
+++ b/featurebyte/routes/feature_store/controller.py
@@ -296,7 +296,7 @@ class FeatureStoreController(
         FeatureStoreShape
             FeatureStoreShape object
         """
-        return await self.preview_service.shape(preview=preview)
+        return await self.preview_service.shape(preview=preview, allow_long_running=False)
 
     async def table_shape(self, location: TabularSource) -> FeatureStoreShape:
         """
@@ -330,7 +330,9 @@ class FeatureStoreController(
         dict[str, Any]
             Dataframe converted to json string
         """
-        return await self.preview_service.preview(preview=preview, limit=limit)
+        return await self.preview_service.preview(
+            preview=preview, limit=limit, allow_long_running=False
+        )
 
     async def table_preview(self, location: TabularSource, limit: int) -> dict[str, Any]:
         """
@@ -370,7 +372,9 @@ class FeatureStoreController(
         dict[str, Any]
             Dataframe converted to json string
         """
-        return await self.preview_service.sample(sample=sample, size=size, seed=seed)
+        return await self.preview_service.sample(
+            sample=sample, size=size, seed=seed, allow_long_running=False
+        )
 
     async def describe(self, sample: FeatureStoreSample, size: int, seed: int) -> dict[str, Any]:
         """
@@ -390,7 +394,9 @@ class FeatureStoreController(
         dict[str, Any]
             Dataframe converted to json string
         """
-        return await self.preview_service.describe(sample=sample, size=size, seed=seed)
+        return await self.preview_service.describe(
+            sample=sample, size=size, seed=seed, allow_long_running=False
+        )
 
     async def create_data_description(
         self, sample: FeatureStoreSample, size: int, seed: int, catalog_id: ObjectId

--- a/featurebyte/service/preview.py
+++ b/featurebyte/service/preview.py
@@ -90,7 +90,19 @@ class PreviewService:
         )
         return feature_store, session
 
-    async def shape(self, preview: FeatureStorePreview) -> FeatureStoreShape:
+    @classmethod
+    async def _execute_query(
+        cls, session: BaseSession, query: str, allow_long_running: bool
+    ) -> Optional[pd.DataFrame]:
+        if allow_long_running:
+            result = await session.execute_query_long_running(query)
+        else:
+            result = await session.execute_query(query)
+        return result
+
+    async def shape(
+        self, preview: FeatureStorePreview, allow_long_running: bool = True
+    ) -> FeatureStoreShape:
         """
         Get the shape of a QueryObject that is not a Feature (e.g. SourceTable, EventTable, EventView, etc)
 
@@ -98,6 +110,8 @@ class PreviewService:
         ----------
         preview: FeatureStorePreview
             FeatureStorePreview object
+        allow_long_running: bool
+            Whether to allow a longer timeout for non-interactive queries
 
         Returns
         -------
@@ -124,7 +138,7 @@ class PreviewService:
         with timer(
             "PreviewService.shape: Execute shape SQL", logger, extra={"shape_sql": shape_sql}
         ):
-            result = await session.execute_query(shape_sql)
+            result = await self._execute_query(session, shape_sql, allow_long_running)
 
         assert result is not None
         return FeatureStoreShape(
@@ -132,7 +146,9 @@ class PreviewService:
             num_cols=num_cols,
         )
 
-    async def preview(self, preview: FeatureStorePreview, limit: int) -> dict[str, Any]:
+    async def preview(
+        self, preview: FeatureStorePreview, limit: int, allow_long_running: bool = True
+    ) -> dict[str, Any]:
         """
         Preview a QueryObject that is not a Feature (e.g. SourceTable, EventTable, EventView, etc)
 
@@ -142,6 +158,8 @@ class PreviewService:
             FeatureStorePreview object
         limit: int
             Row limit on preview results
+        allow_long_running: bool
+            Whether to allow a longer timeout for non-interactive queries
 
         Returns
         -------
@@ -164,10 +182,16 @@ class PreviewService:
         ).construct_preview_sql(
             node_name=preview.node_name, num_rows=limit, clip_timestamp_columns=True
         )
-        result = await session.execute_query(preview_sql)
+        result = await self._execute_query(session, preview_sql, allow_long_running)
         return dataframe_to_json(result, type_conversions)
 
-    async def sample(self, sample: FeatureStoreSample, size: int, seed: int) -> dict[str, Any]:
+    async def sample(
+        self,
+        sample: FeatureStoreSample,
+        size: int,
+        seed: int,
+        allow_long_running: bool = True,
+    ) -> dict[str, Any]:
         """
         Sample a QueryObject that is not a Feature (e.g. SourceTable, EventTable, EventView, etc)
 
@@ -179,6 +203,8 @@ class PreviewService:
             Maximum rows to sample
         seed: int
             Random seed to use for sampling
+        allow_long_running: bool
+            Whether to allow a longer timeout for non-interactive queries
 
         Returns
         -------
@@ -191,7 +217,9 @@ class PreviewService:
             feature_store_id=sample.feature_store_id,
         )
         if size > 0:
-            total_num_rows = await self._get_row_count(session, sample)
+            total_num_rows = await self._get_row_count(
+                session, sample, allow_long_running=allow_long_running
+            )
         else:
             warnings.warn(
                 "No limit on sampling size is not recommended and may be slow and trigger OOM errors.",
@@ -210,7 +238,7 @@ class PreviewService:
             timestamp_column=sample.timestamp_column,
             total_num_rows=total_num_rows,
         )
-        result = await session.execute_query(sample_sql)
+        result = await self._execute_query(session, sample_sql, allow_long_running)
         return dataframe_to_json(result, type_conversions)
 
     async def describe(
@@ -220,6 +248,7 @@ class PreviewService:
         seed: int,
         columns_batch_size: Optional[int] = None,
         drop_all_null_stats: bool = True,
+        allow_long_running: bool = True,
     ) -> dict[str, Any]:
         """
         Sample a QueryObject that is not a Feature (e.g. SourceTable, EventTable, EventView, etc)
@@ -238,6 +267,8 @@ class PreviewService:
             will be disabled.
         drop_all_null_stats: bool
             Whether to drop the result of a statistics if all values across all columns are null
+        allow_long_running: bool
+            Whether to allow a longer timeout for non-interactive queries
 
         Returns
         -------
@@ -254,7 +285,7 @@ class PreviewService:
         )
 
         if size > 0:
-            total_num_rows = await self._get_row_count(session, sample)
+            total_num_rows = await self._get_row_count(session, sample, allow_long_running)
         else:
             warnings.warn(
                 "No limit on sampling size is not recommended and may be slow and trigger OOM errors.",
@@ -283,7 +314,7 @@ class PreviewService:
             df_queries = []
             for describe_query in describe_queries.queries:
                 logger.debug("Execute describe SQL", extra={"describe_sql": describe_query.sql})
-                result = await session.execute_query_long_running(describe_query.sql)
+                result = await self._execute_query(session, describe_query.sql, allow_long_running)
                 columns = describe_query.columns
                 assert result is not None
                 df_query = pd.DataFrame(
@@ -393,7 +424,7 @@ class PreviewService:
         done_callback: Callable[[], Coroutine[Any, Any, None]],
     ) -> Tuple[str, dict[Any, int]]:
         session = await session.clone_if_not_threadsafe()
-        df_result = await session.execute_query(value_counts_query.sql)
+        df_result = await session.execute_query_long_running(value_counts_query.sql)
         assert df_result.columns.tolist() == ["key", "count"]  # type: ignore
         df_result.loc[df_result["key"].isnull(), "key"] = None  # type: ignore
         output = df_result.set_index("key")["count"].to_dict()  # type: ignore
@@ -418,8 +449,10 @@ class PreviewService:
         await done_callback()
         return value_counts_query.column_name, output
 
-    @staticmethod
-    async def _get_row_count(session: BaseSession, sample: FeatureStoreSample) -> int:
+    @classmethod
+    async def _get_row_count(
+        cls, session: BaseSession, sample: FeatureStoreSample, allow_long_running: bool
+    ) -> int:
         query = GraphInterpreter(
             sample.graph, source_type=session.source_type
         ).construct_row_count_sql(
@@ -428,5 +461,5 @@ class PreviewService:
             to_timestamp=sample.to_timestamp,
             timestamp_column=sample.timestamp_column,
         )
-        df_result = await session.execute_query(query)
+        df_result = await cls._execute_query(session, query, allow_long_running)
         return df_result.iloc[0]["count"]  # type: ignore

--- a/tests/unit/routes/test_feature_store.py
+++ b/tests/unit/routes/test_feature_store.py
@@ -637,7 +637,7 @@ class TestFeatureStoreApi(BaseApiTestSuite):
             ],
         )
         mock_session = mock_get_session.return_value
-        mock_session.execute_query_long_running.return_value = pd.DataFrame({
+        mock_session.execute_query.return_value = pd.DataFrame({
             "a_dtype": ["FLOAT"],
             "a_unique": [5],
             "a_%missing": [1.0],
@@ -684,7 +684,7 @@ class TestFeatureStoreApi(BaseApiTestSuite):
 
         # check SQL statement
         assert_equal_with_expected_fixture(
-            mock_session.execute_query_long_running.call_args[0][0],
+            mock_session.execute_query.call_args[0][0],
             "tests/fixtures/expected_describe_request.sql",
             update_fixture=update_fixtures,
         )
@@ -713,7 +713,7 @@ class TestFeatureStoreApi(BaseApiTestSuite):
             ],
         )
         mock_session = mock_get_session.return_value
-        mock_session.execute_query_long_running.return_value = pd.DataFrame({
+        mock_session.execute_query.return_value = pd.DataFrame({
             "a_dtype": ["FLOAT"],
             "a_unique": [20],
             "a_%missing": [1.0],

--- a/tests/unit/service/test_preview.py
+++ b/tests/unit/service/test_preview.py
@@ -302,7 +302,7 @@ async def test_value_counts(
     """
     Test value counts
     """
-    mock_snowflake_session.execute_query.return_value = pd.DataFrame({
+    mock_snowflake_session.execute_query_long_running.return_value = pd.DataFrame({
         "key": ["1", "2", None],
         "count": [100, 50, 3],
     })
@@ -359,7 +359,7 @@ async def test_value_counts_not_convert_keys_to_string(
     """
     Test value counts
     """
-    mock_snowflake_session.execute_query.return_value = pd.DataFrame({
+    mock_snowflake_session.execute_query_long_running.return_value = pd.DataFrame({
         "key": keys,
         "count": [100, 50, 3],
     })

--- a/tests/unit/service/test_specialized_dtype.py
+++ b/tests/unit/service/test_specialized_dtype.py
@@ -160,7 +160,7 @@ async def test_add_columns_attributes(
     """Test adding columns attributes"""
     _ = feature_store
 
-    mock_snowflake_session.execute_query.return_value = pd.DataFrame({
+    mock_snowflake_session.execute_query_long_running.return_value = pd.DataFrame({
         "event_id_col": ["a", "b", "c"],
         "event_timestamp_col": [
             pd.to_datetime("2023-01-01"),
@@ -248,7 +248,7 @@ async def test_not_embeddding_column(
     """Test array is not embedding"""
     _ = feature_store
 
-    mock_snowflake_session.execute_query.return_value = sample
+    mock_snowflake_session.execute_query_long_running.return_value = sample
 
     svc = SpecializedDtypeDetectionService(preview_service, feature_store_service)
     await svc.detect_and_update_column_dtypes(table)
@@ -271,7 +271,7 @@ async def test_nested_dict_column(
     """Test dict is not flat"""
     _ = feature_store
 
-    mock_snowflake_session.execute_query.return_value = pd.DataFrame({
+    mock_snowflake_session.execute_query_long_running.return_value = pd.DataFrame({
         "event_id_col": ["a", "b", "c"],
         "event_timestamp_col": [
             pd.to_datetime("2023-01-01"),


### PR DESCRIPTION

## Description

This updates PreviewService to allow long running queries by default. It is disabled for interactive queries triggered by feature store routes.

Cherry pick https://github.com/featurebyte/featurebyte/pull/2496.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
