### PR TITLE
[chore] Support fully qualified request table name for join parent entities helper

### DIFF
--- a/featurebyte/query_graph/sql/parent_serving.py
+++ b/featurebyte/query_graph/sql/parent_serving.py
@@ -4,7 +4,7 @@ SQL generation for looking up parent entities
 
 from __future__ import annotations
 
-from typing import List
+from typing import List, Optional
 
 from dataclasses import dataclass
 
@@ -15,10 +15,14 @@ from featurebyte.enum import SpecialColumnName, TableDataType
 from featurebyte.models.parent_serving import EntityLookupStep
 from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.query_graph.node.generic import EventLookupParameters, SCDLookupParameters
-from featurebyte.query_graph.node.schema import FeatureStoreDetails
+from featurebyte.query_graph.node.schema import FeatureStoreDetails, TableDetails
 from featurebyte.query_graph.sql.aggregator.lookup import LookupAggregator
 from featurebyte.query_graph.sql.builder import SQLOperationGraph
-from featurebyte.query_graph.sql.common import SQLType, get_qualified_column_identifier
+from featurebyte.query_graph.sql.common import (
+    SQLType,
+    get_fully_qualified_table_name,
+    get_qualified_column_identifier,
+)
 from featurebyte.query_graph.sql.specifications.lookup import LookupSpec
 from featurebyte.query_graph.sql.specs import AggregationSource
 
@@ -45,10 +49,11 @@ class ParentEntityLookupResult:
 
 
 def construct_request_table_with_parent_entities(
-    request_table_name: str,
+    request_table_name: Optional[str],
     request_table_columns: list[str],
     join_steps: list[EntityLookupStep],
     feature_store_details: FeatureStoreDetails,
+    request_table_details: Optional[TableDetails] = None,
 ) -> ParentEntityLookupResult:
     """
     Construct a query to join parent entities into the request table
@@ -64,6 +69,8 @@ def construct_request_table_with_parent_entities(
         table. Subsequent joins can use the newly joined columns as the join key.
     feature_store_details: FeatureStoreDetails
         Information about the feature store
+    request_table_details: Optional[TableDetails]
+        Location of the request table if it is a table in the warehouse
 
     Returns
     -------
@@ -71,7 +78,14 @@ def construct_request_table_with_parent_entities(
     """
     table_expr = select(
         *[get_qualified_column_identifier(col, "REQ") for col in request_table_columns]
-    ).from_(expressions.alias_(request_table_name, "REQ"))
+    )
+    if request_table_name is not None:
+        table_expr = table_expr.from_(expressions.alias_(request_table_name, "REQ"))
+    else:
+        assert request_table_details is not None
+        table_expr = table_expr.from_(
+            get_fully_qualified_table_name(request_table_details.dict(), alias="REQ"),
+        )
 
     current_columns = request_table_columns[:]
     new_columns = []
@@ -88,7 +102,9 @@ def construct_request_table_with_parent_entities(
     return ParentEntityLookupResult(
         table_expr=table_expr,
         parent_entity_columns=new_columns,
-        new_request_table_name="JOINED_PARENTS_" + request_table_name,
+        new_request_table_name=(
+            "JOINED_PARENTS_" + request_table_name if request_table_name else "JOINED_PARENTS"
+        ),
         new_request_table_columns=current_columns,
     )
 

--- a/tests/unit/query_graph/test_parent_serving.py
+++ b/tests/unit/query_graph/test_parent_serving.py
@@ -4,6 +4,7 @@ Tests sql generation for parent features serving
 
 import textwrap
 
+from featurebyte.query_graph.node.schema import TableDetails
 from featurebyte.query_graph.sql.parent_serving import construct_request_table_with_parent_entities
 
 
@@ -58,4 +59,65 @@ def test_construct_request_table_with_parent_entities(parent_serving_preparation
     assert result.table_expr.sql(pretty=True) == expected
     assert result.parent_entity_columns == ["COL_INT"]
     assert result.new_request_table_name == "JOINED_PARENTS_REQUEST_TABLE"
+    assert result.new_request_table_columns == ["a", "b", "COL_INT"]
+
+
+def test_construct_request_table_with_parent_entities_table_details(parent_serving_preparation):
+    """
+    Test construct_request_table_with_parent_entities when the request table is a table in the
+    warehouse
+    """
+    result = construct_request_table_with_parent_entities(
+        None,
+        request_table_columns=["a", "b"],
+        join_steps=parent_serving_preparation.join_steps,
+        feature_store_details=parent_serving_preparation.feature_store_details,
+        request_table_details=TableDetails(
+            database_name="my_db", schema_name="my_schema", table_name="my_table"
+        ),
+    )
+    expected = textwrap.dedent(
+        """
+        SELECT
+          REQ."a" AS "a",
+          REQ."b" AS "b",
+          REQ."COL_INT" AS "COL_INT"
+        FROM (
+          SELECT
+            REQ."a",
+            REQ."b",
+            "T0"."COL_INT" AS "COL_INT"
+          FROM "my_db"."my_schema"."my_table" AS REQ
+          LEFT JOIN (
+            SELECT
+              "COL_TEXT",
+              ANY_VALUE("COL_INT") AS "COL_INT"
+            FROM (
+              SELECT
+                "col_text" AS "COL_TEXT",
+                "col_int" AS "COL_INT"
+              FROM (
+                SELECT
+                  "col_int" AS "col_int",
+                  "col_float" AS "col_float",
+                  "col_char" AS "col_char",
+                  "col_text" AS "col_text",
+                  "col_binary" AS "col_binary",
+                  "col_boolean" AS "col_boolean",
+                  "event_timestamp" AS "event_timestamp",
+                  "created_at" AS "created_at",
+                  "cust_id" AS "cust_id"
+                FROM "sf_database"."sf_schema"."dimension_table"
+              )
+            )
+            GROUP BY
+              "COL_TEXT"
+          ) AS T0
+            ON REQ."COL_TEXT" = T0."COL_TEXT"
+        ) AS REQ
+        """
+    ).strip()
+    assert result.table_expr.sql(pretty=True) == expected
+    assert result.parent_entity_columns == ["COL_INT"]
+    assert result.new_request_table_name == "JOINED_PARENTS"
     assert result.new_request_table_columns == ["a", "b", "COL_INT"]


### PR DESCRIPTION
## Description

Allows specifying a `table_details` for the request table when calling `construct_request_table_with_parent_entities`.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
