### PR TITLE
[DEV-3644] Add time buffer when retrieving stale cache records for cleanup

### DIFF
--- a/featurebyte/service/query_cache_manager.py
+++ b/featurebyte/service/query_cache_manager.py
@@ -242,8 +242,10 @@ class QueryCacheManagerService:
         await self.query_cache_cleanup_scheduler_service.start_job_if_not_exist(feature_store_id)
 
     async def _get_document_by_key(self, key: str) -> Optional[QueryCacheModel]:
+        query_filter = {"cache_key": key}
+        query_filter.update(self.query_cache_document_service.get_cache_validity_filter())
         async for doc in self.query_cache_document_service.list_documents_iterator(
-            query_filter={"cache_key": key}
+            query_filter=query_filter
         ):
             return doc
         return None


### PR DESCRIPTION
## Description

Add time buffer when retrieving stale cache records for cleanup. This is to ensure that the cached table name is not being used during cleanup. 

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
