### PR TITLE
[DEV-3673] Resolve conflict column name in `ItemTable.get_view()` by default

### DIFF
--- a/.changelog/DEV-3673.yaml
+++ b/.changelog/DEV-3673.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update ItemTable.get_view() method to auto-resolve column name conflicts by removing the conflicting column from the event table"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/item_table.py
+++ b/featurebyte/api/item_table.py
@@ -144,6 +144,10 @@ class ItemTable(TableApiObject):
         The event timestamp and event attributes representing entities in the related Event table are also
         automatically added to the ItemView.
 
+        If there are column name conflicts between the EventTable and the ItemTable, and all the parameters are
+        default, the column names from the EventTable that conflict with the ItemTable columns will be automatically
+        removed from the ItemView.
+
         In manual mode, the default cleaning operations are not applied, and you have the flexibility to define your
         own cleaning operations.
 
@@ -220,6 +224,17 @@ class ItemTable(TableApiObject):
             event_join_column_names=event_join_column_names,
         )
 
+        # auto resolve conflict columns only if all the parameters are default
+        to_auto_resolve_column_conflict = (
+            event_suffix is None
+            and view_mode == ViewMode.AUTO
+            and drop_column_names is None
+            and column_cleaning_operations is None
+            and event_drop_column_names is None
+            and event_column_cleaning_operations is None
+            and event_join_column_names is None
+        )
+
         event_table = EventTable.get_by_id(self.event_table_id)
         event_view = event_table.get_view(
             drop_column_names=event_drop_column_names,
@@ -286,6 +301,7 @@ class ItemTable(TableApiObject):
                 event_join_column_names=event_join_column_names,
                 event_table_id=event_table.id,
             ),
+            to_auto_resolve_column_conflict=to_auto_resolve_column_conflict,
         )
         timestamp_column = apply_column_name_modifiers(
             [event_view.timestamp_column], rsuffix=event_suffix, rprefix=None

--- a/tests/unit/api/test_item_view.py
+++ b/tests/unit/api/test_item_view.py
@@ -460,7 +460,7 @@ def test_join_event_table_attributes__missing_required_event_suffix(snowflake_it
     Test when event_suffix is required but not provided
     """
     with pytest.raises(RepeatedColumnNamesError) as exc:
-        snowflake_item_table.get_view()
+        snowflake_item_table.get_view(drop_column_names=[])
     assert "Duplicate column names ['event_timestamp'] found" in str(exc.value)
 
 
@@ -480,7 +480,7 @@ def test_item_view__item_table_same_event_id_column_as_event_table(
     Test creating ItemView when ItemTable has the same event_id_column as EventTable
     """
     # No need to specify event_suffix
-    item_view = snowflake_item_table_same_event_id.get_view()
+    item_view = snowflake_item_table_same_event_id.get_view(drop_column_names=[])
     assert item_view.timestamp_column == "event_timestamp"
 
     view_dict = item_view.model_dump()
@@ -1136,3 +1136,39 @@ def test_item_view_aggregate_metadata(snowflake_item_table, transaction_entity):
         },
         "post_aggregation": None,
     }
+
+
+def test_get_view__auto_resolve_column_conflict(
+    snowflake_item_table,
+    snowflake_event_table_id,
+    snowflake_item_table_id,
+):
+    """
+    Test ItemView automatically joins timestamp column and entity columns from related EventTable
+    """
+    timestamp_col = "event_timestamp"
+    view = snowflake_item_table.get_view()
+    assert view.timestamp_column_name == timestamp_col
+
+    assert view.event_view.columns == [
+        "col_int",
+        "col_float",
+        "col_char",
+        "col_text",
+        "col_binary",
+        "col_boolean",
+        "event_timestamp",
+        "cust_id",
+    ]
+
+    metadata = view.node.parameters.metadata
+    assert metadata.event_join_column_names == ["cust_id"]
+    assert view.columns == [
+        "event_id_col",
+        "item_id_col",
+        "item_type",
+        "item_amount",
+        "created_at",
+        "event_timestamp",
+        "cust_id",
+    ]


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
This PR revises `ItemTable.get_view()` to avoid throwing column name conflict error when no parameters is provided.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
