### PR TITLE
[DEV-3676] Fix feature table cache handling for concurrent requests

### DIFF
--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -369,8 +369,7 @@ class FeatureTableCacheService:
                     ),
                 ],
             )
-            # TODO: add retry?
-            await db_session.execute_query_long_running(
+            await db_session.retry_sql(
                 sql_to_string(merge_expr, source_type=db_session.source_type)
             )
         finally:
@@ -473,6 +472,7 @@ class FeatureTableCacheService:
 
         if non_cached_nodes:
             if not feature_table_cache_exists:
+                # If cache table doesn't exist yet, create one by cloning from the observation table
                 request_column_names = [col.name for col in observation_table.columns_info]
                 await db_session.create_table_as(
                     table_details=TableDetails(

--- a/featurebyte/sql/tile_generate_entity_tracking.py
+++ b/featurebyte/sql/tile_generate_entity_tracking.py
@@ -78,7 +78,7 @@ class TileGenerateEntityTracking(BaseSqlModel):
             merge_sql = f"""
                 merge into {tracking_table_name} a using ({self.entity_table}) b
                     on {entity_filter_cols_str}
-                    when matched and a.{tile_last_start_date_column} < b.{tile_last_start_date_column} then
+                    when matched then
                         update set a.{tile_last_start_date_column} = b.{tile_last_start_date_column}
                     when not matched then
                         insert ({escaped_entity_column_names_str}, {tile_last_start_date_column})
@@ -88,7 +88,7 @@ class TileGenerateEntityTracking(BaseSqlModel):
             merge_sql = f"""
                 merge into {tracking_table_name} a using ({self.entity_table}) b
                     on true
-                    when matched a.{tile_last_start_date_column} < b.{tile_last_start_date_column} then
+                    when matched then
                         update set a.{tile_last_start_date_column} = b.{tile_last_start_date_column}
                     when not matched then
                         insert ({tile_last_start_date_column})

--- a/featurebyte/sql/tile_generate_entity_tracking.py
+++ b/featurebyte/sql/tile_generate_entity_tracking.py
@@ -65,33 +65,33 @@ class TileGenerateEntityTracking(BaseSqlModel):
                     for col in self.entity_column_names + [tile_last_start_date_column]
                 ]
             )
-            entity_table = f"select {cols} from ({self.entity_table})"
+            entity_table = f"select {cols} from ({self.entity_table}) limit 0"
             await self._session.create_table_as(
                 table_details=tracking_table_name,
                 select_expr=entity_table,
-                retry=True,
+                exists=True,
             )
+
+        if self.entity_column_names:
+            entity_insert_cols_str = ", ".join(entity_insert_cols)
+            entity_filter_cols_str = " AND ".join(entity_filter_cols)
+            merge_sql = f"""
+                merge into {tracking_table_name} a using ({self.entity_table}) b
+                    on {entity_filter_cols_str}
+                    when matched and a.{tile_last_start_date_column} < b.{tile_last_start_date_column} then
+                        update set a.{tile_last_start_date_column} = b.{tile_last_start_date_column}
+                    when not matched then
+                        insert ({escaped_entity_column_names_str}, {tile_last_start_date_column})
+                            values ({entity_insert_cols_str}, b.{tile_last_start_date_column})
+            """
         else:
-            if self.entity_column_names:
-                entity_insert_cols_str = ", ".join(entity_insert_cols)
-                entity_filter_cols_str = " AND ".join(entity_filter_cols)
-                merge_sql = f"""
-                    merge into {tracking_table_name} a using ({self.entity_table}) b
-                        on {entity_filter_cols_str}
-                        when matched then
-                            update set a.{tile_last_start_date_column} = b.{tile_last_start_date_column}
-                        when not matched then
-                            insert ({escaped_entity_column_names_str}, {tile_last_start_date_column})
-                                values ({entity_insert_cols_str}, b.{tile_last_start_date_column})
-                """
-            else:
-                merge_sql = f"""
-                    merge into {tracking_table_name} a using ({self.entity_table}) b
-                        on true
-                        when matched then
-                            update set a.{tile_last_start_date_column} = b.{tile_last_start_date_column}
-                        when not matched then
-                            insert ({tile_last_start_date_column})
-                                values (b.{tile_last_start_date_column})
-                """
-            await self._session.retry_sql(merge_sql)
+            merge_sql = f"""
+                merge into {tracking_table_name} a using ({self.entity_table}) b
+                    on true
+                    when matched a.{tile_last_start_date_column} < b.{tile_last_start_date_column} then
+                        update set a.{tile_last_start_date_column} = b.{tile_last_start_date_column}
+                    when not matched then
+                        insert ({tile_last_start_date_column})
+                            values (b.{tile_last_start_date_column})
+            """
+        await self._session.retry_sql(merge_sql)

--- a/tests/integration/api/test_historical_features.py
+++ b/tests/integration/api/test_historical_features.py
@@ -21,6 +21,7 @@ async def test_get_historical_feature_tables_parallel(session, event_view, data_
     num_features = 3
     features_mapping = {}
     for i in range(num_features):
+        # TODO: create mix of same features and different features
         feature_name = f"my_feature_{i}"
         feature = event_view.groupby("ÜSER ID").aggregate_over(
             method="count",
@@ -70,4 +71,4 @@ async def test_get_historical_feature_tables_parallel(session, event_view, data_
         feature_table_name = f"my_feature_table_{i}"
         feature_table = fb.HistoricalFeatureTable.get(feature_table_name)
         df_preview = feature_table.preview()
-        assert df_preview.columns.tolist() == [f"my_feature_name_{i}"]
+        assert df_preview.columns.tolist() == ["POINT_IN_TIME", "üser id", f"my_feature_{i}"]

--- a/tests/integration/api/test_historical_features.py
+++ b/tests/integration/api/test_historical_features.py
@@ -1,0 +1,73 @@
+"""
+Tests for historical features
+"""
+
+import threading
+from queue import Queue
+
+import pandas as pd
+import pytest
+
+import featurebyte as fb
+from tests.util.helper import create_observation_table_from_dataframe
+
+
+@pytest.mark.asyncio
+async def test_get_historical_feature_tables_parallel(session, event_view, data_source):
+    """
+    Test get historical feature tables in parallel on the same observation table
+    """
+    # Create feature lists
+    num_features = 3
+    features_mapping = {}
+    for i in range(num_features):
+        feature_name = f"my_feature_{i}"
+        feature = event_view.groupby("ÜSER ID").aggregate_over(
+            method="count",
+            windows=["24h"],
+            feature_names=[feature_name],
+        )[feature_name]
+        features_mapping[i] = fb.FeatureList([feature], name=feature_name)
+
+    # Create observation table
+    df_observation_set = pd.DataFrame(
+        {
+            "POINT_IN_TIME": pd.to_datetime(["2001-01-02 10:00:00", "2001-01-02 12:00:00"] * 5),
+            "üser id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        }
+    )
+    observation_table = await create_observation_table_from_dataframe(
+        session,
+        df_observation_set,
+        data_source,
+    )
+
+    def run_get_historical_features_table(index, out):
+        """
+        Run compute_historical_feature_table
+        """
+        try:
+            feature_list = features_mapping[i]
+            feature_table_name = f"my_feature_table_{index}"
+            feature_list.compute_historical_feature_table(observation_table, feature_table_name)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            out.put(e)
+
+    # Create feature tables in parallel
+    out = Queue()
+    threads = []
+    for i in range(num_features):
+        t = threading.Thread(target=run_get_historical_features_table, args=(i, out))
+        threads.append(t)
+        t.start()
+    for t in threads:
+        t.join()
+    if not out.empty():
+        raise out.get()
+
+    # Check that the feature tables were created correctly
+    for i in range(num_features):
+        feature_table_name = f"my_feature_table_{i}"
+        feature_table = fb.HistoricalFeatureTable.get(feature_table_name)
+        df_preview = feature_table.preview()
+        assert df_preview.columns.tolist() == [f"my_feature_name_{i}"]

--- a/tests/integration/api/test_historical_features.py
+++ b/tests/integration/api/test_historical_features.py
@@ -18,15 +18,20 @@ async def test_get_historical_feature_tables_parallel(session, event_view, data_
     Test get historical feature tables in parallel on the same observation table
     """
     # Create feature lists
-    num_features = 3
+    num_features = 4
     features_mapping = {}
     for i in range(num_features):
-        # TODO: create mix of same features and different features
+        event_view["derived_value_column"] = (10.0 + i) * event_view["ÀMOUNT"]
+        if i < 2:
+            # Duplicate features with different names but the same definition hash
+            kwargs = {"method": "count", "value_column": None}
+        else:
+            kwargs = {"method": "sum", "value_column": "derived_value_column"}
         feature_name = f"my_feature_{i}"
         feature = event_view.groupby("ÜSER ID").aggregate_over(
-            method="count",
             windows=["24h"],
             feature_names=[feature_name],
+            **kwargs,
         )[feature_name]
         features_mapping[i] = fb.FeatureList([feature], name=feature_name)
 

--- a/tests/integration/api/test_historical_features.py
+++ b/tests/integration/api/test_historical_features.py
@@ -7,26 +7,34 @@ from queue import Queue
 
 import pandas as pd
 import pytest
+from sqlglot import parse_one
 
 import featurebyte as fb
+from featurebyte.query_graph.sql.common import sql_to_string
 from tests.util.helper import create_observation_table_from_dataframe
 
 
 @pytest.mark.asyncio
-async def test_get_historical_feature_tables_parallel(session, event_view, data_source):
+async def test_get_historical_feature_tables_parallel(
+    session, event_view, data_source, feature_table_cache_metadata_service
+):
     """
     Test get historical feature tables in parallel on the same observation table
     """
     # Create feature lists
     num_features = 4
+    num_hashes_expected = 0
     features_mapping = {}
     for i in range(num_features):
         event_view["derived_value_column"] = (10.0 + i) * event_view["ÀMOUNT"]
         if i < 2:
             # Duplicate features with different names but the same definition hash
             kwargs = {"method": "count", "value_column": None}
+            if i == 0:
+                num_hashes_expected += 1
         else:
             kwargs = {"method": "sum", "value_column": "derived_value_column"}
+            num_hashes_expected += 1
         feature_name = f"my_feature_{i}"
         feature = event_view.groupby("ÜSER ID").aggregate_over(
             windows=["24h"],
@@ -77,3 +85,24 @@ async def test_get_historical_feature_tables_parallel(session, event_view, data_
         feature_table = fb.HistoricalFeatureTable.get(feature_table_name)
         df_preview = feature_table.preview()
         assert df_preview.columns.tolist() == ["POINT_IN_TIME", "üser id", f"my_feature_{i}"]
+
+    # Check feature cache metadata and table are expected
+    feature_table_cache = (
+        await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
+            observation_table_id=observation_table.id,
+        )
+    )
+    assert len(feature_table_cache.feature_definitions) == num_hashes_expected
+    query = sql_to_string(
+        parse_one(
+            f"""
+            SELECT * FROM "{session.database_name}"."{session.schema_name}"."{feature_table_cache.table_name}"
+            """
+        ),
+        source_type=session.source_type,
+    )
+    df = await session.execute_query(query)
+    expected_columns = {
+        feature_def.feature_name for feature_def in feature_table_cache.feature_definitions
+    }
+    assert expected_columns.issubset(df.columns)


### PR DESCRIPTION
## Description

This fixes the handling of feature table cache to support concurrent historical features requests on the same observation table. Similar to tile tables, empty feature cache tables will be created first and then be merged into.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
