### PR TITLE
[DEV-3680] Support OBJECT_AGG aggregation function for BigQuery

### DIFF
--- a/featurebyte/query_graph/sql/adapter/__init__.py
+++ b/featurebyte/query_graph/sql/adapter/__init__.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from featurebyte.enum import SourceType
 from featurebyte.query_graph.sql.adapter.base import BaseAdapter
+from featurebyte.query_graph.sql.adapter.bigquery import BigQueryAdapter
 from featurebyte.query_graph.sql.adapter.databricks import DatabricksAdapter
 from featurebyte.query_graph.sql.adapter.snowflake import SnowflakeAdapter
 from featurebyte.query_graph.sql.adapter.spark import SparkAdapter
@@ -37,4 +38,6 @@ def get_sql_adapter(source_type: SourceType) -> BaseAdapter:
         return DatabricksAdapter()
     if source_type == SourceType.SPARK:
         return SparkAdapter()
+    if source_type == SourceType.BIGQUERY:
+        return BigQueryAdapter()
     return SnowflakeAdapter()

--- a/featurebyte/query_graph/sql/adapter/bigquery.py
+++ b/featurebyte/query_graph/sql/adapter/bigquery.py
@@ -1,0 +1,27 @@
+"""
+BigQueryAdapter class
+"""
+
+from __future__ import annotations
+
+from sqlglot.expressions import Anonymous, Expression
+
+from featurebyte.enum import SourceType
+from featurebyte.query_graph.sql.adapter.snowflake import SnowflakeAdapter
+
+
+class BigQueryAdapter(SnowflakeAdapter):
+    """
+    Helper class to generate BigQuery specific SQL expressions
+    """
+
+    source_type = SourceType.BIGQUERY
+
+    @classmethod
+    def object_agg(cls, key_column: str | Expression, value_column: str | Expression) -> Expression:
+        key_arr = Anonymous(this="ARRAY_AGG", expressions=[key_column])
+        value_arr = Anonymous(this="ARRAY_AGG", expressions=[value_column])
+        return Anonymous(
+            this="JSON_STRIP_NULLS",
+            expressions=[Anonymous(this="JSON_OBJECT", expressions=[key_arr, value_arr])],
+        )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -118,7 +118,6 @@ SKIPPED_TESTS = {
         "tests/integration/udf/test_get_relative_frequency.py",
         "tests/integration/udf/test_least_frequent.py",
         "tests/integration/udf/test_most_frequent.py",
-        "tests/integration/udf/test_object_agg.py",
         "tests/integration/udf/test_timestamp_to_index.py",
         "tests/integration/udf/test_timezone_offset_to_second.py",
     ],

--- a/tests/integration/udf/test_object_agg.py
+++ b/tests/integration/udf/test_object_agg.py
@@ -8,7 +8,11 @@ import pytest_asyncio
 from sqlglot import expressions
 
 from featurebyte.query_graph.sql.adapter import get_sql_adapter
-from featurebyte.query_graph.sql.common import quoted_identifier, sql_to_string
+from featurebyte.query_graph.sql.common import (
+    get_fully_qualified_table_name,
+    quoted_identifier,
+    sql_to_string,
+)
 
 TEST_TABLE_NAME = "OBJECT_AGG_TEST_TABLE"
 
@@ -44,7 +48,13 @@ async def test_object_agg_udf(source_type, session, setup_test_data):
             alias="OUT",
             quoted=True,
         )
-    ).from_(quoted_identifier(TEST_TABLE_NAME))
+    ).from_(
+        get_fully_qualified_table_name({
+            "table_name": TEST_TABLE_NAME,
+            "schema_name": session.schema_name,
+            "database_name": session.database_name,
+        })
+    )
     df = await session.execute_query(sql_to_string(select_expr, source_type))
     actual = df.iloc[0]["OUT"]
     assert actual == {"2": -1.5}


### PR DESCRIPTION
## Description

This adds support for the OBJECT_AGG aggregation function for BigQuery.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
