### PR TITLE
[DEV-3676] Fix feature table cache handling for concurrent requests (main)

### DIFF
--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -29,6 +29,7 @@ from featurebyte.query_graph.sql.common import (
     quoted_identifier,
     sql_to_string,
 )
+from featurebyte.query_graph.sql.materialisation import get_source_expr
 from featurebyte.query_graph.transform.definition import DefinitionHashExtractor
 from featurebyte.query_graph.transform.offline_store_ingest import extract_dtype_from_graph
 from featurebyte.service.entity_validation import EntityValidationService
@@ -261,68 +262,7 @@ class FeatureTableCacheService:
                 progress_callback=progress_callback,
             )
 
-    async def _create_table(
-        self,
-        feature_store: FeatureStoreModel,
-        observation_table: ObservationTableModel,
-        db_session: BaseSession,
-        final_table_name: str,
-        graph: QueryGraph,
-        nodes: List[Tuple[Node, CachedFeatureDefinition]],
-        is_target: bool = False,
-        serving_names_mapping: Optional[Dict[str, str]] = None,
-        progress_callback: Optional[
-            Callable[[int, Optional[str]], Coroutine[Any, Any, None]]
-        ] = None,
-    ) -> None:
-        intermediate_table_name = (
-            f"__TEMP__{MaterializedTableNamePrefix.FEATURE_TABLE_CACHE}_{ObjectId()}"
-        )
-        try:
-            await self._populate_intermediate_table(
-                feature_store=feature_store,
-                observation_table=observation_table,
-                db_session=db_session,
-                intermediate_table_name=intermediate_table_name,
-                graph=graph,
-                nodes=nodes,
-                is_target=is_target,
-                serving_names_mapping=serving_names_mapping,
-                progress_callback=progress_callback,
-            )
-
-            request_column_names = [col.name for col in observation_table.columns_info]
-            request_columns = [quoted_identifier(col) for col in request_column_names]
-            feature_names = [
-                expressions.alias_(
-                    quoted_identifier(cast(str, graph.get_node_output_column_name(node.name))),
-                    alias=feature_definition.feature_name,
-                    quoted=True,
-                )
-                for node, feature_definition in nodes
-            ]
-            await db_session.create_table_as(
-                table_details=TableDetails(
-                    database_name=db_session.database_name,
-                    schema_name=db_session.schema_name,
-                    table_name=final_table_name,
-                ),
-                select_expr=(
-                    expressions.select(quoted_identifier(InternalName.TABLE_ROW_INDEX))
-                    .select(*request_columns)
-                    .select(*feature_names)
-                    .from_(quoted_identifier(intermediate_table_name))
-                ),
-            )
-        finally:
-            await db_session.drop_table(
-                database_name=db_session.database_name,
-                schema_name=db_session.schema_name,
-                table_name=intermediate_table_name,
-                if_exists=True,
-            )
-
-    async def _update_table(
+    async def _update_table(  # pylint: disable=too-many-arguments
         self,
         feature_store: FeatureStoreModel,
         observation_table: ObservationTableModel,
@@ -373,9 +313,13 @@ class FeatureTableCacheService:
                 )
                 for node, definition in non_cached_nodes
             ]
-            await db_session.execute_query_long_running(
-                adapter.alter_table_add_columns(table_exr, columns_expr)
-            )
+            try:
+                await db_session.execute_query_long_running(
+                    adapter.alter_table_add_columns(table_exr, columns_expr)
+                )
+            except db_session.no_schema_error:
+                # Can occur on concurrent historical feature tasks on overlapping features
+                pass
 
             # merge temp table into cache table
             merge_conditions = [
@@ -423,7 +367,7 @@ class FeatureTableCacheService:
                     ),
                 ],
             )
-            await db_session.execute_query_long_running(
+            await db_session.retry_sql(
                 sql_to_string(merge_expr, source_type=db_session.source_type)
             )
         finally:
@@ -525,32 +469,32 @@ class FeatureTableCacheService:
             remaining_progress_callback = None
 
         if non_cached_nodes:
-            if feature_table_cache_exists:
-                # if feature table cache exists - update existing table with new features
-                await self._update_table(
-                    feature_store=feature_store,
-                    observation_table=observation_table,
-                    cache_metadata=cache_metadata,
-                    db_session=db_session,
-                    graph=graph,
-                    non_cached_nodes=non_cached_nodes,
-                    is_target=is_target,
-                    serving_names_mapping=serving_names_mapping,
-                    progress_callback=remaining_progress_callback,
+            if not feature_table_cache_exists:
+                # If cache table doesn't exist yet, create one by cloning from the observation table
+                request_column_names = [col.name for col in observation_table.columns_info]
+                await db_session.create_table_as(
+                    table_details=TableDetails(
+                        database_name=db_session.database_name,
+                        schema_name=db_session.schema_name,
+                        table_name=cache_metadata.table_name,
+                    ),
+                    select_expr=get_source_expr(
+                        observation_table.location.table_details,
+                        column_names=[InternalName.TABLE_ROW_INDEX.value] + request_column_names,
+                    ),
+                    exists=True,
                 )
-            else:
-                # if feature table doesn't exist yet - create from scratch
-                await self._create_table(
-                    feature_store=feature_store,
-                    observation_table=observation_table,
-                    db_session=db_session,
-                    final_table_name=cache_metadata.table_name,
-                    graph=graph,
-                    nodes=non_cached_nodes,
-                    is_target=is_target,
-                    serving_names_mapping=serving_names_mapping,
-                    progress_callback=remaining_progress_callback,
-                )
+            await self._update_table(
+                feature_store=feature_store,
+                observation_table=observation_table,
+                cache_metadata=cache_metadata,
+                db_session=db_session,
+                graph=graph,
+                non_cached_nodes=non_cached_nodes,
+                is_target=is_target,
+                serving_names_mapping=serving_names_mapping,
+                progress_callback=remaining_progress_callback,
+            )
 
             await self.feature_table_cache_metadata_service.update_feature_table_cache(
                 observation_table_id=observation_table.id,

--- a/tests/integration/api/test_historical_features.py
+++ b/tests/integration/api/test_historical_features.py
@@ -1,0 +1,106 @@
+"""
+Tests for historical features
+"""
+
+import threading
+from queue import Queue
+
+import pandas as pd
+import pytest
+from sqlglot import parse_one
+
+import featurebyte as fb
+from featurebyte.query_graph.sql.common import sql_to_string
+from tests.util.helper import create_observation_table_from_dataframe
+
+
+@pytest.mark.asyncio
+async def test_get_historical_feature_tables_parallel(
+    session, event_view, data_source, feature_table_cache_metadata_service
+):
+    """
+    Test get historical feature tables in parallel on the same observation table
+    """
+    # Create feature lists
+    num_features = 4
+    num_hashes_expected = 0
+    features_mapping = {}
+    for i in range(num_features):
+        event_view["derived_value_column"] = (10.0 + i) * event_view["ÀMOUNT"]
+        if i < 2:
+            # Duplicate features with different names but the same definition hash
+            kwargs = {"method": "count", "value_column": None}
+            if i == 0:
+                num_hashes_expected += 1
+        else:
+            kwargs = {"method": "sum", "value_column": "derived_value_column"}
+            num_hashes_expected += 1
+        feature_name = f"my_feature_{i}"
+        feature = event_view.groupby("ÜSER ID").aggregate_over(
+            windows=["24h"],
+            feature_names=[feature_name],
+            **kwargs,
+        )[feature_name]
+        features_mapping[i] = fb.FeatureList([feature], name=feature_name)
+
+    # Create observation table
+    df_observation_set = pd.DataFrame({
+        "POINT_IN_TIME": pd.to_datetime(["2001-01-02 10:00:00", "2001-01-02 12:00:00"] * 5),
+        "üser id": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    })
+    observation_table = await create_observation_table_from_dataframe(
+        session,
+        df_observation_set,
+        data_source,
+    )
+
+    def run_get_historical_features_table(index, out):
+        """
+        Run compute_historical_feature_table
+        """
+        try:
+            feature_list = features_mapping[i]
+            feature_table_name = f"my_feature_table_{index}"
+            feature_list.compute_historical_feature_table(observation_table, feature_table_name)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            out.put(e)
+
+    # Create feature tables in parallel
+    out = Queue()
+    threads = []
+    for i in range(num_features):
+        t = threading.Thread(target=run_get_historical_features_table, args=(i, out))
+        threads.append(t)
+        t.start()
+    for t in threads:
+        t.join()
+    if not out.empty():
+        raise out.get()
+
+    # Check that the feature tables were created correctly
+    for i in range(num_features):
+        feature_table_name = f"my_feature_table_{i}"
+        feature_table = fb.HistoricalFeatureTable.get(feature_table_name)
+        df_preview = feature_table.preview()
+        assert df_preview.columns.tolist() == ["POINT_IN_TIME", "üser id", f"my_feature_{i}"]
+
+    # Check feature cache metadata and table are expected
+    feature_table_cache = (
+        await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
+            observation_table_id=observation_table.id,
+        )
+    )
+    assert len(feature_table_cache.feature_definitions) == num_hashes_expected
+    query = sql_to_string(
+        parse_one(
+            f"""
+            SELECT * FROM "{session.database_name}"."{session.schema_name}"."{feature_table_cache.table_name}"
+            """
+        ),
+        source_type=session.source_type,
+    )
+    df = await session.execute_query(query)
+    expected_columns = {
+        feature_def.feature_name for feature_def in feature_table_cache.feature_definitions
+    }
+    assert expected_columns.issubset(df.columns)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -116,6 +116,7 @@ SKIPPED_TESTS = {
         "tests/integration/udf/test_count_dict_num_unique.py",
         "tests/integration/udf/test_get_rank.py",
         "tests/integration/udf/test_get_relative_frequency.py",
+        "tests/integration/api/test_historical_features.py",
         "tests/integration/udf/test_least_frequent.py",
         "tests/integration/udf/test_most_frequent.py",
         "tests/integration/udf/test_timestamp_to_index.py",

--- a/tests/unit/service/test_feature_table_cache.py
+++ b/tests/unit/service/test_feature_table_cache.py
@@ -2,6 +2,8 @@
 Test FeatureTableCacheService
 """
 
+# pylint: disable=line-too-long
+
 import json
 import os
 from unittest.mock import patch
@@ -269,7 +271,7 @@ async def test_create_feature_table_cache(
     assert params["output_table_details"].schema_name == "sf_schema"
     assert params["output_table_details"].table_name == "__TEMP__FEATURE_TABLE_CACHE_ObjectId"
 
-    assert mock_snowflake_session.execute_query_long_running.await_count == 2
+    assert mock_snowflake_session.execute_query_long_running.await_count == 4
 
     feature_table_cache = (
         await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
@@ -282,16 +284,16 @@ async def test_create_feature_table_cache(
     assert "COUNT(*)" in sql
 
     sql = mock_snowflake_session.execute_query_long_running.await_args_list[1].args[0]
-    assert sql == (
-        "CREATE TABLE "
-        f'"sf_db"."sf_schema"."{feature_table_cache.table_name}" AS\n'
-        "SELECT\n"
-        '  "__FB_TABLE_ROW_INDEX",\n'
-        '  "cust_id",\n'
-        '  "POINT_IN_TIME",\n'
-        '  "sum_30m" AS "FEATURE_1032f6901100176e575f87c44398a81f0d5db5c5",\n'
-        '  "sum_2h" AS "FEATURE_ada88371db4be31a4e9c0538fb675d8e573aed24"\n'
-        'FROM "__TEMP__FEATURE_TABLE_CACHE_ObjectId"'
+    assert_sql_equal(
+        sql,
+        f"""
+        CREATE TABLE IF NOT EXISTS "sf_db"."sf_schema"."{feature_table_cache.table_name}" AS
+        SELECT
+          "__FB_TABLE_ROW_INDEX",
+          "cust_id",
+          "POINT_IN_TIME"
+        FROM "fb_database"."fb_schema"."fb_materialized_table"
+        """,
     )
 
 
@@ -319,7 +321,7 @@ async def test_update_feature_table_cache(
     params = mock_get_historical_features.await_args.kwargs
     assert params["graph"] == feature_list.feature_clusters[0].graph
     assert params["nodes"] == feature_list.feature_clusters[0].nodes[:1]
-    assert mock_snowflake_session.execute_query_long_running.await_count == 2
+    assert mock_snowflake_session.execute_query_long_running.await_count == 4
 
     feature_table_cache = (
         await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
@@ -328,20 +330,34 @@ async def test_update_feature_table_cache(
     )
     assert len(feature_table_cache.feature_definitions) == 1
 
-    sql = mock_snowflake_session.execute_query_long_running.await_args_list[0].args[0]
-    assert "COUNT(*)" in sql
+    sqls = [arg[0][0] for arg in mock_snowflake_session.execute_query_long_running.await_args_list]
+    assert "COUNT(*)" in sqls[0]
 
     # check first create sql
-    sql = mock_snowflake_session.execute_query_long_running.await_args.args[0]
-    assert sql == (
-        "CREATE TABLE "
-        f'"sf_db"."sf_schema"."{feature_table_cache.table_name}" AS\n'
-        "SELECT\n"
-        '  "__FB_TABLE_ROW_INDEX",\n'
-        '  "cust_id",\n'
-        '  "POINT_IN_TIME",\n'
-        '  "sum_30m" AS "FEATURE_1032f6901100176e575f87c44398a81f0d5db5c5"\n'
-        'FROM "__TEMP__FEATURE_TABLE_CACHE_ObjectId"'
+    assert_sql_equal(
+        sqls[1],
+        f"""
+        CREATE TABLE IF NOT EXISTS "sf_db"."sf_schema"."{feature_table_cache.table_name}" AS
+        SELECT
+          "__FB_TABLE_ROW_INDEX",
+          "cust_id",
+          "POINT_IN_TIME"
+        FROM "fb_database"."fb_schema"."fb_materialized_table"
+        """,
+    )
+    assert_sql_equal(
+        sqls[2],
+        f'ALTER TABLE "sf_db"."sf_schema"."{feature_table_cache.table_name}" ADD COLUMN "FEATURE_1032f6901100176e575f87c44398a81f0d5db5c5" FLOAT',
+    )
+    assert sqls[3] == (
+        "MERGE INTO "
+        f'"sf_db"."sf_schema"."{feature_table_cache.table_name}" AS '
+        "feature_table_cache USING "
+        '"sf_db"."sf_schema"."__TEMP__FEATURE_TABLE_CACHE_ObjectId" AS '
+        'partial_features ON feature_table_cache."__FB_TABLE_ROW_INDEX" = '
+        'partial_features."__FB_TABLE_ROW_INDEX"   WHEN MATCHED THEN UPDATE SET '
+        'feature_table_cache."FEATURE_1032f6901100176e575f87c44398a81f0d5db5c5" = '
+        'partial_features."sum_30m"'
     )
 
     mock_get_historical_features.reset_mock()
@@ -515,7 +531,7 @@ async def test_create_view_from_cache__create_cache(
     )
 
     assert mock_get_historical_features.await_count == 1
-    assert mock_snowflake_session.execute_query_long_running.await_count == 3
+    assert mock_snowflake_session.execute_query_long_running.await_count == 5
     assert is_output_view is True
 
     feature_table_cache = (
@@ -536,18 +552,31 @@ async def test_create_view_from_cache__create_cache(
         LIMIT 1
         """,
     )
-    assert sqls[1] == (
-        "CREATE TABLE "
-        f'"sf_db"."sf_schema"."{feature_table_cache.table_name}" AS\n'
-        "SELECT\n"
-        '  "__FB_TABLE_ROW_INDEX",\n'
-        '  "cust_id",\n'
-        '  "POINT_IN_TIME",\n'
-        '  "sum_30m" AS "FEATURE_1032f6901100176e575f87c44398a81f0d5db5c5",\n'
-        '  "sum_2h" AS "FEATURE_ada88371db4be31a4e9c0538fb675d8e573aed24"\n'
-        'FROM "__TEMP__FEATURE_TABLE_CACHE_ObjectId"'
+    assert_sql_equal(
+        sqls[1],
+        f"""
+        CREATE TABLE IF NOT EXISTS "sf_db"."sf_schema"."{feature_table_cache.table_name}" AS
+        SELECT
+          "__FB_TABLE_ROW_INDEX",
+          "cust_id",
+          "POINT_IN_TIME"
+        FROM "fb_database"."fb_schema"."fb_materialized_table"
+        """,
     )
-    assert sqls[2] == (
+    assert_sql_equal(
+        sqls[2],
+        f"""
+        ALTER TABLE "sf_db"."sf_schema"."{feature_table_cache.table_name}" ADD COLUMN "FEATURE_1032f6901100176e575f87c44398a81f0d5db5c5" FLOAT,
+"FEATURE_ada88371db4be31a4e9c0538fb675d8e573aed24" FLOAT
+        """,
+    )
+    assert_sql_equal(
+        sqls[3],
+        f"""
+        MERGE INTO "sf_db"."sf_schema"."{feature_table_cache.table_name}" AS feature_table_cache USING "sf_db"."sf_schema"."__TEMP__FEATURE_TABLE_CACHE_ObjectId" AS partial_features ON feature_table_cache."__FB_TABLE_ROW_INDEX" = partial_features."__FB_TABLE_ROW_INDEX"   WHEN MATCHED THEN UPDATE SET feature_table_cache."FEATURE_1032f6901100176e575f87c44398a81f0d5db5c5" = partial_features."sum_30m", feature_table_cache."FEATURE_ada88371db4be31a4e9c0538fb675d8e573aed24" = partial_features."sum_2h"
+        """,
+    )
+    assert sqls[4] == (
         'CREATE VIEW "sf_db"."sf_schema"."result_view" AS\n'
         "SELECT\n"
         '  "__FB_TABLE_ROW_INDEX",\n'
@@ -586,7 +615,7 @@ async def test_create_view_from_cache__update_cache(
         feature_list_id=feature_list.id,
     )
     assert mock_get_historical_features.await_count == 1
-    assert mock_snowflake_session.execute_query_long_running.await_count == 3
+    assert mock_snowflake_session.execute_query_long_running.await_count == 5
     assert is_output_view is True
 
     mock_get_historical_features.reset_mock()
@@ -679,7 +708,7 @@ async def test_create_view_from_cache__create_view_failed(
     )
 
     assert mock_get_historical_features.await_count == 1
-    assert mock_snowflake_session.execute_query_long_running.await_count == 4
+    assert mock_snowflake_session.execute_query_long_running.await_count == 6
     assert is_output_view is False
 
     feature_table_cache = (
@@ -700,18 +729,31 @@ async def test_create_view_from_cache__create_view_failed(
         LIMIT 1
         """,
     )
-    assert sqls[1] == (
-        "CREATE TABLE "
-        f'"sf_db"."sf_schema"."{feature_table_cache.table_name}" AS\n'
-        "SELECT\n"
-        '  "__FB_TABLE_ROW_INDEX",\n'
-        '  "cust_id",\n'
-        '  "POINT_IN_TIME",\n'
-        '  "sum_30m" AS "FEATURE_1032f6901100176e575f87c44398a81f0d5db5c5",\n'
-        '  "sum_2h" AS "FEATURE_ada88371db4be31a4e9c0538fb675d8e573aed24"\n'
-        'FROM "__TEMP__FEATURE_TABLE_CACHE_ObjectId"'
+    assert_sql_equal(
+        sqls[1],
+        f"""
+        CREATE TABLE IF NOT EXISTS "sf_db"."sf_schema"."{feature_table_cache.table_name}" AS
+        SELECT
+          "__FB_TABLE_ROW_INDEX",
+          "cust_id",
+          "POINT_IN_TIME"
+        FROM "fb_database"."fb_schema"."fb_materialized_table"
+        """,
     )
-    assert sqls[2] == (
+    assert_sql_equal(
+        sqls[2],
+        f"""
+        ALTER TABLE "sf_db"."sf_schema"."{feature_table_cache.table_name}" ADD COLUMN "FEATURE_1032f6901100176e575f87c44398a81f0d5db5c5" FLOAT,
+"FEATURE_ada88371db4be31a4e9c0538fb675d8e573aed24" FLOAT
+        """,
+    )
+    assert_sql_equal(
+        sqls[3],
+        f"""
+        MERGE INTO "sf_db"."sf_schema"."{feature_table_cache.table_name}" AS feature_table_cache USING "sf_db"."sf_schema"."__TEMP__FEATURE_TABLE_CACHE_ObjectId" AS partial_features ON feature_table_cache."__FB_TABLE_ROW_INDEX" = partial_features."__FB_TABLE_ROW_INDEX"   WHEN MATCHED THEN UPDATE SET feature_table_cache."FEATURE_1032f6901100176e575f87c44398a81f0d5db5c5" = partial_features."sum_30m", feature_table_cache."FEATURE_ada88371db4be31a4e9c0538fb675d8e573aed24" = partial_features."sum_2h"
+        """,
+    )
+    assert sqls[4] == (
         'CREATE VIEW "sf_db"."sf_schema"."result_view" AS\n'
         "SELECT\n"
         '  "__FB_TABLE_ROW_INDEX",\n'
@@ -721,7 +763,7 @@ async def test_create_view_from_cache__create_view_failed(
         '  "FEATURE_ada88371db4be31a4e9c0538fb675d8e573aed24" AS "sum_2h"\n'
         f'FROM "sf_db"."sf_schema"."{feature_table_cache.table_name}"'
     )
-    assert sqls[3] == (
+    assert sqls[5] == (
         'CREATE TABLE "sf_db"."sf_schema"."result_view" AS\n'
         "SELECT\n"
         '  "__FB_TABLE_ROW_INDEX",\n'
@@ -760,7 +802,7 @@ async def test_create_feature_table_cache__with_target(
     assert params["output_table_details"].schema_name == "sf_schema"
     assert params["output_table_details"].table_name == "__TEMP__FEATURE_TABLE_CACHE_ObjectId"
 
-    assert mock_snowflake_session.execute_query_long_running.await_count == 2
+    assert mock_snowflake_session.execute_query_long_running.await_count == 4
 
     feature_table_cache = (
         await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
@@ -770,15 +812,11 @@ async def test_create_feature_table_cache__with_target(
     assert len(feature_table_cache.feature_definitions) == 1
 
     sql = mock_snowflake_session.execute_query_long_running.await_args.args[0]
-    assert sql == (
-        "CREATE TABLE "
-        f'"sf_db"."sf_schema"."{feature_table_cache.table_name}" AS\n'
-        "SELECT\n"
-        '  "__FB_TABLE_ROW_INDEX",\n'
-        '  "cust_id",\n'
-        '  "POINT_IN_TIME",\n'
-        '  "float_target" AS "FEATURE_8bf3807cdb51975c6e7460e4cd56ce3a38213996"\n'
-        'FROM "__TEMP__FEATURE_TABLE_CACHE_ObjectId"'
+    assert_sql_equal(
+        sql,
+        f"""
+        MERGE INTO "sf_db"."sf_schema"."{feature_table_cache.table_name}" AS feature_table_cache USING "sf_db"."sf_schema"."__TEMP__FEATURE_TABLE_CACHE_ObjectId" AS partial_features ON feature_table_cache."__FB_TABLE_ROW_INDEX" = partial_features."__FB_TABLE_ROW_INDEX"   WHEN MATCHED THEN UPDATE SET feature_table_cache."FEATURE_8bf3807cdb51975c6e7460e4cd56ce3a38213996" = partial_features."float_target"
+        """,
     )
 
 
@@ -801,7 +839,7 @@ async def test_read_from_cache(
         feature_list_id=feature_list.id,
     )
     assert mock_get_historical_features.await_count == 1
-    assert mock_snowflake_session.execute_query_long_running.await_count == 2
+    assert mock_snowflake_session.execute_query_long_running.await_count == 4
 
     mock_snowflake_session.reset_mock()
 


### PR DESCRIPTION
## Description

This fixes the handling of feature table cache to support concurrent historical features requests on the same observation table. Similar to tile tables, empty feature cache tables will be created first and then be merged into.

Cherry pick: #2530

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
