### PR TITLE
[DEV-3682] Add retry to sql execution on timeout

### DIFF
--- a/featurebyte/migration/service/data_warehouse.py
+++ b/featurebyte/migration/service/data_warehouse.py
@@ -169,17 +169,17 @@ class DataWarehouseMigrationServiceV1(DataWarehouseMigrationMixin):
         _ = feature_store
 
         df_tile_registry = await session.execute_query("SELECT * FROM TILE_REGISTRY")
-        if "VALUE_COLUMN_TYPES" in df_tile_registry:  # type: ignore[operator]
+        if "VALUE_COLUMN_TYPES" in df_tile_registry:
             return
 
-        df_tile_registry["VALUE_COLUMN_TYPES"] = (  # type: ignore[index]
+        df_tile_registry["VALUE_COLUMN_TYPES"] = (
             self.tile_column_type_extractor.get_tile_column_types_from_names(
-                df_tile_registry["VALUE_COLUMN_NAMES"]  # type: ignore[index]
+                df_tile_registry["VALUE_COLUMN_NAMES"]
             )
         )
         await session.register_table(
             "UPDATED_TILE_REGISTRY",
-            df_tile_registry[["TILE_ID", "VALUE_COLUMN_NAMES", "VALUE_COLUMN_TYPES"]],  # type: ignore[index]
+            df_tile_registry[["TILE_ID", "VALUE_COLUMN_NAMES", "VALUE_COLUMN_TYPES"]],
         )
 
         await session.execute_query(
@@ -198,7 +198,7 @@ class DataWarehouseMigrationServiceV1(DataWarehouseMigrationMixin):
 
         # Update columns in tile tables where the type is not FLOAT. In such cases, tile generation
         # likely encountered error and updating to correct type should fix it.
-        for _, row in df_tile_registry.iterrows():  # type: ignore[union-attr]
+        for _, row in df_tile_registry.iterrows():
             tile_id = row["TILE_ID"]
             tile_column_names = row["VALUE_COLUMN_NAMES"].replace('"', "").split(",")
             tile_column_types = row["VALUE_COLUMN_TYPES"].split(",")

--- a/featurebyte/migration/service/mixin.py
+++ b/featurebyte/migration/service/mixin.py
@@ -294,7 +294,7 @@ class DataWarehouseMigrationMixin(BaseMigrationServiceMixin, ABC):
             Current migration version number
         """
         df_metadata = await session.execute_query("SELECT * FROM METADATA_SCHEMA")
-        if InternalName.MIGRATION_VERSION not in df_metadata:  # type: ignore[operator]
+        if InternalName.MIGRATION_VERSION not in df_metadata:
             await session.execute_query(
                 f"ALTER TABLE METADATA_SCHEMA ADD COLUMN {InternalName.MIGRATION_VERSION} INT"
             )

--- a/featurebyte/session/base.py
+++ b/featurebyte/session/base.py
@@ -108,6 +108,88 @@ async def to_thread(func: Any, timeout: float, /, *args: Any, **kwargs: Any) -> 
         raise
 
 
+def retry(
+    retry_num: int = 3, sleep_interval: int = 1, exception_cls: type[Exception] = Exception
+) -> Any:
+    """
+    Decorator to retry a function on a specific exception
+
+    Parameters
+    ----------
+    retry_num: int
+        Number of retries
+    sleep_interval: int
+        Sleep interval between retries
+    exception_cls: type[Exception]
+        Exception class to retry on
+
+    Returns
+    -------
+    Any
+        Return from function
+    """
+
+    def inner(func: Any) -> Any:
+        """
+        Inner decorator wrapper
+
+        Parameters
+        ----------
+        func: Any
+            Function to wrap
+
+        Returns
+        -------
+        Any
+            Wrapped function
+        """
+
+        @functools.wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            """
+            Wrapped function to retry the operation
+
+            Parameters
+            ----------
+            args: Any
+                Positional arguments for the function
+            kwargs: Any
+                Keyword arguments for the function
+
+            Returns
+            -------
+            Any
+                Return value from execution of the function
+
+            Raises
+            ------
+            exception_cls
+                if the operation fails after retry_num retries
+            """
+            for i in range(retry_num):
+                try:
+                    return await func(*args, **kwargs)
+                except exception_cls as exc:
+                    logger.warning(
+                        "Function call failed",
+                        extra={"attempt": i, "args": args, "kwargs": kwargs, "exception": exc},
+                    )
+                    if i == retry_num - 1:
+                        logger.error(
+                            "Function call failed", extra={"attempts": retry_num, "exception": exc}
+                        )
+                        raise
+
+                random_interval = randint(1, sleep_interval)
+                await asyncio.sleep(random_interval)
+
+            return None
+
+        return wrapper
+
+    return inner
+
+
 class BaseSession(BaseModel):
     """
     Abstract session class to extract data warehouse table metadata & execute query
@@ -542,6 +624,7 @@ class BaseSession(BaseModel):
             "feature_store_id": results["FEATURE_STORE_ID"][0],
         }
 
+    @retry(retry_num=3, sleep_interval=5, exception_cls=QueryExecutionTimeOut)
     async def execute_query(
         self,
         query: str,
@@ -818,31 +901,12 @@ class BaseSession(BaseModel):
         -------
         pd.DataFrame
             Result of the sql operation
-
-        Raises
-        ------
-        Exception
-            if the sql operation fails after retry_num retries
         """
 
-        for i in range(retry_num):
-            try:
-                return await self.execute_query_long_running(sql)
-            except Exception as exc:
-                logger.warning(
-                    "SQL query failed",
-                    extra={"attempt": i, "query": sql.strip()[:50].replace("\n", " ")},
-                )
-                if i == retry_num - 1:
-                    logger.error(
-                        "SQL query failed", extra={"attempts": retry_num, "exception": exc}
-                    )
-                    raise
-
-            random_interval = randint(1, sleep_interval)
-            await asyncio.sleep(random_interval)
-
-        return None
+        execute_query = retry(retry_num=retry_num, sleep_interval=sleep_interval)(
+            self.execute_query_long_running
+        )
+        return await execute_query(sql)
 
     async def table_exists(self, table_name: str) -> bool:
         """


### PR DESCRIPTION
## Description

Add retry to sql execution on timeout for better resilience when compute cluster has heavy load

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
