### PR TITLE
[DEV-3686] BigQuery: Fix detection of array dtype when listing table schema

### DIFF
--- a/featurebyte/query_graph/sql/adapter/bigquery.py
+++ b/featurebyte/query_graph/sql/adapter/bigquery.py
@@ -4,6 +4,7 @@ BigQueryAdapter class
 
 from __future__ import annotations
 
+from sqlglot import expressions
 from sqlglot.expressions import Anonymous, Expression
 
 from featurebyte.enum import SourceType
@@ -25,3 +26,8 @@ class BigQueryAdapter(SnowflakeAdapter):
             this="JSON_STRIP_NULLS",
             expressions=[Anonymous(this="JSON_OBJECT", expressions=[key_arr, value_arr])],
         )
+
+    @classmethod
+    def get_uniform_distribution_expr(cls, seed: int) -> Expression:
+        _ = seed
+        return expressions.Anonymous(this="RAND", expressions=[])

--- a/featurebyte/session/bigquery.py
+++ b/featurebyte/session/bigquery.py
@@ -520,7 +520,9 @@ class BigQuerySession(BaseSession):
         if table.schema is not None:
             for field in table.schema:
                 dtype = self._convert_to_internal_variable_type(
-                    bigquery_typecode=field.field_type, scale=field.scale
+                    bigquery_typecode=field.field_type,
+                    scale=field.scale,
+                    mode=field.mode,
                 )
                 column_name_type_map[field.name] = ColumnSpecWithDescription(
                     name=field.name,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -87,7 +87,6 @@ logger = get_logger(__name__)
 SKIPPED_TESTS = {
     "bigquery": [
         "tests/integration/api/test_change_view_operations.py",
-        "tests/integration/api/test_column_attributes.py",
         "tests/integration/api/test_dict_operations.py",
         "tests/integration/api/test_dimension_view_operations.py",
         "tests/integration/api/test_distance_operations.py",


### PR DESCRIPTION
## Description

Fix detection of array dtype when listing table schema / constructing a source table object.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
