### PR TITLE
[bug] fixing artifact publish action defaulting to not adding hidden file

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -80,7 +80,7 @@ jobs:
       - name: Generate HTML
         run: cat diff.txt | diff2html -i stdin --title="Documentation Differences" -F diff.html --style="side" --renderNothingWhenEmpty
       - name: Upload diff html
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: docs-diff.html
           path: diff.html

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Building hive-udf
         run: task build-jar
       - name: Upload hive-udf
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: hive-udf
           path: hive-udf/lib/build/libs/*
@@ -113,15 +113,16 @@ jobs:
       - name: Renaming test assets
         run: mv .coverage .coverage.0
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: python-${{ matrix.python-version }}-pytest.xml.0
           path: pytest.xml.0
       - name: Upload coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: python-${{ matrix.python-version }}-.coverage.0
           path: .coverage.0
+          include-hidden-files: true
   test-integration-snowflake:
     needs:
       - build-jar
@@ -176,17 +177,18 @@ jobs:
           mv .coverage .coverage.1.${{ matrix.pytest-group }}
           mv pytest.xml.1 pytest.xml.1.${{ matrix.pytest-group }}
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: python-${{ matrix.python-version }}-pytest.xml.1.${{ matrix.pytest-group }}
           path: pytest.xml.1.${{ matrix.pytest-group }}
           overwrite: true
       - name: Upload coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: python-${{ matrix.python-version }}-.coverage.1.${{ matrix.pytest-group }}
           path: .coverage.1.${{ matrix.pytest-group }}
           overwrite: true
+          include-hidden-files: true
   test-integration-spark:
     needs:
       - build-jar
@@ -258,7 +260,7 @@ jobs:
           mv .coverage .coverage.2.${{ matrix.pytest-group }}
           mv pytest.xml.2 pytest.xml.2.${{ matrix.pytest-group }}
       - name: Upload spark-thrift log file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: spark-thrift-logs-${{ matrix.python-version }}-${{ matrix.spark-version }}-${{ matrix.pytest-group }}
           path: spark-thrift-${{ matrix.python-version }}-${{ matrix.spark-version }}-${{ matrix.pytest-group }}.log
@@ -266,17 +268,18 @@ jobs:
 
       # NOTE: Only holding 1 test result to be used in pytest report
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: python-${{ matrix.python-version }}-pytest.xml.2.${{ matrix.pytest-group }}
           path: pytest.xml.2.${{ matrix.pytest-group }}
           overwrite: true
       - name: Upload coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: python-${{ matrix.python-version }}-.coverage.2.${{ matrix.pytest-group }}
           path: .coverage.2.${{ matrix.pytest-group }}
           overwrite: true
+          include-hidden-files: true
 
       # Fail the job if the test run failed
       - name: Check test status
@@ -333,15 +336,16 @@ jobs:
           mv .coverage .coverage.4.${{ matrix.pytest-group }}
           mv pytest.xml.4 pytest.xml.4.${{ matrix.pytest-group }}
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: python-${{ matrix.python-version }}-pytest.xml.4.${{ matrix.pytest-group }}
           path: pytest.xml.4.${{ matrix.pytest-group }}
       - name: Upload coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: python-${{ matrix.python-version }}-.coverage.4.${{ matrix.pytest-group }}
           path: .coverage.4.${{ matrix.pytest-group }}
+          include-hidden-files: true
 
   test-integration-bigquery:
     needs:
@@ -396,17 +400,18 @@ jobs:
           mv .coverage .coverage.5.${{ matrix.pytest-group }}
           mv pytest.xml.5 pytest.xml.5.${{ matrix.pytest-group }}
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: python-${{ matrix.python-version }}-pytest.xml.5.${{ matrix.pytest-group }}
           path: pytest.xml.5.${{ matrix.pytest-group }}
           overwrite: true
       - name: Upload coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: python-${{ matrix.python-version }}-.coverage.5.${{ matrix.pytest-group }}
           path: .coverage.5.${{ matrix.pytest-group }}
           overwrite: true
+          include-hidden-files: true
 
   test-docs:
     needs:
@@ -496,7 +501,7 @@ jobs:
       - name: Merge test results
         run: task test-merge
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: pytest-coverage.txt
           path: pytest-coverage.txt

--- a/Taskfile.lint.yaml
+++ b/Taskfile.lint.yaml
@@ -71,9 +71,6 @@ tasks:
   style-darglint:
     desc: "Run the linter[style] with only darglint"
     vars:
-      CPU_CORES:
-        sh: python -c 'import multiprocessing as mp; print(mp.cpu_count())'
-    env:
       DARG_SOURCES:
         sh: |
           echo "$(find featurebyte -type d \( -path featurebyte/routes \) -prune -false -o -name "*.py" ! -path "featurebyte/__main__.py" ! -path "featurebyte/datasets/*" ! -path "featurebyte/conftest.py" | xargs)" "$(find featurebyte -type f \( -path featurebyte/routes \) -o -name "controller.py" | xargs)"
@@ -81,7 +78,7 @@ tasks:
       - featurebyte/**/*
       - tests/**/*
     cmds:
-      - echo "${DARG_SOURCES}" | xargs -n16 -P {{ .CPU_CORES }} poetry run darglint
+      - poetry run darglint --docstring-style numpy --strictness full -v 2 {{.DARG_SOURCES}}
 
   type:
     desc: "Run the linter[type]"

--- a/Taskfile.lint.yaml
+++ b/Taskfile.lint.yaml
@@ -71,6 +71,9 @@ tasks:
   style-darglint:
     desc: "Run the linter[style] with only darglint"
     vars:
+      CPU_CORES:
+        sh: python -c 'import multiprocessing as mp; print(mp.cpu_count())'
+    env:
       DARG_SOURCES:
         sh: |
           echo "$(find featurebyte -type d \( -path featurebyte/routes \) -prune -false -o -name "*.py" ! -path "featurebyte/__main__.py" ! -path "featurebyte/datasets/*" ! -path "featurebyte/conftest.py" | xargs)" "$(find featurebyte -type f \( -path featurebyte/routes \) -o -name "controller.py" | xargs)"
@@ -78,7 +81,7 @@ tasks:
       - featurebyte/**/*
       - tests/**/*
     cmds:
-      - poetry run darglint --docstring-style numpy --strictness full -v 2 {{.DARG_SOURCES}}
+      - echo "${DARG_SOURCES}" | xargs -n16 -P {{ .CPU_CORES }} poetry run darglint --docstring-style numpy --strictness full -v 2
 
   type:
     desc: "Run the linter[type]"


### PR DESCRIPTION
## Description

A new `actions/upload-artifact@v4.4.0` version ignores hidden file by default

```diff
      - name: Upload coverage results
        uses: actions/upload-artifact@v4.4.0
        with:
          name: python-${{ matrix.python-version }}-.coverage.2
          path: .coverage.2
+         include-hidden-files: true
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
