### PR TITLE
[DEV-3711] BigQuery: Fix observation table creation by sampling from view

### DIFF
--- a/featurebyte/query_graph/sql/adapter/base.py
+++ b/featurebyte/query_graph/sql/adapter/base.py
@@ -43,6 +43,8 @@ class BaseAdapter(ABC):
     Helper class to generate engine specific SQL expressions
     """
 
+    TABLESAMPLE_SUPPORTS_VIEW = True
+
     def __init__(self, source_info: SourceInfo):
         self.source_info = source_info
         self.source_type = source_info.source_type

--- a/featurebyte/query_graph/sql/adapter/bigquery.py
+++ b/featurebyte/query_graph/sql/adapter/bigquery.py
@@ -23,6 +23,8 @@ class BigQueryAdapter(SnowflakeAdapter):
 
     source_type = SourceType.BIGQUERY
 
+    TABLESAMPLE_SUPPORTS_VIEW = False
+
     class DataType(StrEnum):
         """
         Possible column types in BigQuery online store tables

--- a/tests/fixtures/request_input/materialize_bigquery.sql
+++ b/tests/fixtures/request_input/materialize_bigquery.sql
@@ -1,0 +1,52 @@
+SELECT
+  COUNT(*) AS `row_count`
+FROM (
+  SELECT
+    `event_timestamp` AS `POINT_IN_TIME`,
+    `col_int` AS `col_int`
+  FROM (
+    SELECT
+      `col_int` AS `col_int`,
+      `col_float` AS `col_float`,
+      `col_char` AS `col_char`,
+      `col_text` AS `col_text`,
+      `col_binary` AS `col_binary`,
+      `col_boolean` AS `col_boolean`,
+      `event_timestamp` AS `event_timestamp`,
+      `cust_id` AS `cust_id`
+    FROM `sf_database`.`sf_schema`.`sf_table`
+  )
+);
+
+CREATE TABLE `sf_database`.`sf_schema`.`my_materialized_table` AS
+SELECT
+  `POINT_IN_TIME`,
+  `col_int`
+FROM (
+  SELECT
+    RAND() AS `prob`,
+    `POINT_IN_TIME`,
+    `col_int`
+  FROM (
+    SELECT
+      `event_timestamp` AS `POINT_IN_TIME`,
+      `col_int` AS `col_int`
+    FROM (
+      SELECT
+        `col_int` AS `col_int`,
+        `col_float` AS `col_float`,
+        `col_char` AS `col_char`,
+        `col_text` AS `col_text`,
+        `col_binary` AS `col_binary`,
+        `col_boolean` AS `col_boolean`,
+        `event_timestamp` AS `event_timestamp`,
+        `cust_id` AS `cust_id`
+      FROM `sf_database`.`sf_schema`.`sf_table`
+    )
+  )
+)
+WHERE
+  `prob` <= 0.15000000000000002
+ORDER BY
+  `prob`
+LIMIT 100;

--- a/tests/integration/api/test_view_sample.py
+++ b/tests/integration/api/test_view_sample.py
@@ -21,15 +21,19 @@ def maybe_tz_convert(ts: Any):
     return ts
 
 
-def test_event_table_sample(event_table):
+def test_event_table_sample(event_table, source_type):
     """
     Test event table sample & event table column sample
     """
     sample_kwargs = {"from_timestamp": "2001-01-01", "to_timestamp": "2001-02-01"}
     event_table_df = event_table.sample(**sample_kwargs)
+
     ts_col = "ËVENT_TIMESTAMP"
     ev_ts = event_table[ts_col].sample(**sample_kwargs)
-    pd.testing.assert_frame_equal(event_table_df[[ts_col]], ev_ts)
+
+    # bigquery view sample and series sample are not expected to produce the same result
+    if source_type != "bigquery":
+        pd.testing.assert_frame_equal(event_table_df[[ts_col]], ev_ts)
 
     # check the sample result
     assert ev_ts.shape[0] == 10

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -92,7 +92,6 @@ SKIPPED_TESTS = {
         "tests/integration/api/test_item_view_operations.py",
         "tests/integration/api/test_lookup_feature_operations.py",
         "tests/integration/api/test_lookup_target_operations.py",
-        "tests/integration/api/test_observation_table.py",
         "tests/integration/api/test_on_demand_features.py",
         "tests/integration/api/test_serving_parent_features.py",
         "tests/integration/api/test_target_correctness.py",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -96,7 +96,6 @@ SKIPPED_TESTS = {
         "tests/integration/api/test_on_demand_features.py",
         "tests/integration/api/test_serving_parent_features.py",
         "tests/integration/api/test_target_correctness.py",
-        "tests/integration/api/test_view_sample.py",
         "tests/integration/feature_store_integration/test_feature_materialize.py",
         "tests/integration/migration/test_data_warehouse_migration.py",
         "tests/integration/query_graph/test_online_serving.py",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2601,6 +2601,16 @@ def spark_source_info_fixture():
     )
 
 
+@pytest.fixture(name="bigquery_source_info")
+def bigquery_source_info_fixture():
+    """Fixture for a BigQuery SourceInfo object to use in tests"""
+    return SourceInfo(
+        database_name="my_db",
+        schema_name="my_schema",
+        source_type=SourceType.BIGQUERY,
+    )
+
+
 @pytest.fixture(name="adapter")
 def adapter_fixture(source_info):
     """Fixture for a default BaseAdapter object to use in tests"""


### PR DESCRIPTION
## Description

Fix an observation table creation error for BigQuery because the table sample clause is not supported for views. We will use a different random sampling method for BigQuery.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
