### PR TITLE
[DEV-3721] BigQuery: Cast key to string in get_rank and get_relative_frequency

### DIFF
--- a/featurebyte/query_graph/sql/ast/count_dict.py
+++ b/featurebyte/query_graph/sql/ast/count_dict.py
@@ -131,7 +131,13 @@ class GetRelativeFrequencyNode(ExpressionNode):
     def sql(self) -> Expression:
         return self.context.adapter.call_udf(
             "F_GET_RELATIVE_FREQUENCY",
-            [self.dictionary_node.sql, self.lookup_key_node.sql],
+            [
+                self.dictionary_node.sql,
+                self.context.adapter.cast_to_string(
+                    self.lookup_key_node.sql,
+                    None,
+                ),
+            ],
         )
 
     @classmethod
@@ -160,7 +166,7 @@ class GetRankNode(ExpressionNode):
             "F_GET_RANK",
             [
                 self.dictionary_node.sql,
-                self.lookup_key_node.sql,
+                self.context.adapter.cast_to_string(self.lookup_key_node.sql, None),
                 make_literal_value(self.descending),
             ],
         )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -96,7 +96,6 @@ SKIPPED_TESTS = {
         "tests/integration/api/test_event_view_operations.py::test_datetime_comparison__fixed_timestamp_tz[bigquery]",
         "tests/integration/api/test_event_view_operations.py::test_datetime_comparison__fixed_timestamp_non_tz[bigquery]",
         "tests/integration/api/test_features.py::test_features_without_entity[bigquery]",  # mainly checks for deployment
-        "tests/integration/api/test_features.py::test_relative_frequency_with_non_string_keys[bigquery]",
     ],
 }
 

--- a/tests/unit/query_graph/test_sql.py
+++ b/tests/unit/query_graph/test_sql.py
@@ -335,8 +335,8 @@ def test_get_value_node(input_node):
 @pytest.mark.parametrize(
     "parameters, expected",
     [
-        ({"descending": True}, "F_GET_RANK(dictionary, lookup, TRUE)"),
-        ({"descending": False}, "F_GET_RANK(dictionary, lookup, FALSE)"),
+        ({"descending": True}, "F_GET_RANK(dictionary, CAST(lookup AS VARCHAR), TRUE)"),
+        ({"descending": False}, "F_GET_RANK(dictionary, CAST(lookup AS VARCHAR), FALSE)"),
     ],
 )
 def test_get_rank_node(parameters, expected, input_node):
@@ -367,7 +367,7 @@ def test_get_relative_frequency_node(input_node):
             input_sql_nodes=[dictionary_node, lookup_node],
         )
     )
-    assert node.sql.sql() == "F_GET_RELATIVE_FREQUENCY(dictionary, lookup)"
+    assert node.sql.sql() == "F_GET_RELATIVE_FREQUENCY(dictionary, CAST(lookup AS VARCHAR))"
 
 
 def test_is_in_node(input_node):


### PR DESCRIPTION
## Description

This adds explicit casting of key to string in `get_rank` and `get_relative_frequency` operations. Previously this was relying on the implicit casting to string behaviour while the UDFs were expecting the specified key to be of string type.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
