### PR TITLE
[chore] do not support python 3.12 until numpy can be bumped

### DIFF
--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -109,7 +109,7 @@ jobs:
           - macos-latest
           - windows-latest
         python-version:
-          - 3.12.4
+#          - 3.12.4  # TODO: Uncomment when numpy is bumped
           - 3.11.9
           - 3.10.11
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ pydantic-settings = "^2.3.1"
 pyhive = { version = "^0.7.0", extras = ["hive_pure_sasl"], optional = true }
 pymongo = "^4.6.3"
 pyopenssl = "^24.1.0"
-python = ">=3.9,<4"
+python = ">=3.9,<3.12"  # TODO: numpy needs to be bumped to >1.26.4
 python-multipart = "^0.0.9"  # Dependency on fastapi form data
 python-on-whales = ">=0.60.0"
 redis = {version = "^4.2.0", optional = true}


### PR DESCRIPTION
## Description

![image](https://github.com/user-attachments/assets/bdb22474-86fd-40ca-9207-a33fff9e8918)

```
 name         : numpy
 version      : 1.24.4
 description  : Fundamental package for array computing in Python

required by
 - contourpy >=1.20
 - dask >=1.21
 - databricks-sql-connector >=1.23.4
 - feast >=1.22,<1.25  # Bump this
 - matplotlib >=1.23
 - pandas >=1.23.2,<2
 - pyarrow >=1.16.6
 - scipy >=1.22.4,<2.3

```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
