### PR TITLE
[DEV-3722] BigQuery: Disable unnecessary sort in random_sample

### DIFF
--- a/featurebyte/query_graph/sql/adapter/base.py
+++ b/featurebyte/query_graph/sql/adapter/base.py
@@ -45,6 +45,7 @@ class BaseAdapter(ABC):
     """
 
     TABLESAMPLE_SUPPORTS_VIEW = True
+    UNIFORM_DISTRIBUTION_SUPPORTS_SEED = True
 
     def __init__(self, source_info: SourceInfo):
         self.source_info = source_info
@@ -564,7 +565,7 @@ class BaseAdapter(ABC):
             quoted=True,
         )
         sampled_expr_with_prob = select(prob_expr, *original_cols).from_(select_expr.subquery())
-        return (
+        output = (
             select(*original_cols)
             .from_(sampled_expr_with_prob.subquery())
             .where(
@@ -573,8 +574,10 @@ class BaseAdapter(ABC):
                 )
             )
             .limit(desired_row_count)
-            .order_by(quoted_identifier("prob"))
         )
+        if cls.UNIFORM_DISTRIBUTION_SUPPORTS_SEED:
+            output = output.order_by(quoted_identifier("prob"))
+        return output
 
     @classmethod
     @abstractmethod

--- a/featurebyte/query_graph/sql/adapter/bigquery.py
+++ b/featurebyte/query_graph/sql/adapter/bigquery.py
@@ -27,6 +27,7 @@ class BigQueryAdapter(BaseAdapter):
     source_type = SourceType.BIGQUERY
 
     TABLESAMPLE_SUPPORTS_VIEW = False
+    UNIFORM_DISTRIBUTION_SUPPORTS_SEED = False
 
     class DataType(StrEnum):
         """

--- a/tests/fixtures/adapter/bigquery_random_sample.sql
+++ b/tests/fixtures/adapter/bigquery_random_sample.sql
@@ -1,0 +1,18 @@
+SELECT
+  `a`,
+  `b`
+FROM (
+  SELECT
+    RAND() AS `prob`,
+    `a`,
+    `b`
+  FROM (
+    SELECT
+      a,
+      b
+    FROM table1
+  )
+)
+WHERE
+  `prob` <= 0.15000000000000002
+LIMIT 100

--- a/tests/fixtures/request_input/materialize_bigquery.sql
+++ b/tests/fixtures/request_input/materialize_bigquery.sql
@@ -47,6 +47,4 @@ FROM (
 )
 WHERE
   `prob` <= 0.15000000000000002
-ORDER BY
-  `prob`
 LIMIT 100;

--- a/tests/unit/query_graph/sql/adapter/test_bigquery.py
+++ b/tests/unit/query_graph/sql/adapter/test_bigquery.py
@@ -1,0 +1,30 @@
+"""
+Tests for BigQueryAdapter
+"""
+
+from sqlglot.expressions import select
+
+from featurebyte.enum import SourceType
+from featurebyte.query_graph.sql.adapter import BigQueryAdapter
+from featurebyte.query_graph.sql.common import sql_to_string
+from tests.util.helper import assert_equal_with_expected_fixture
+
+
+def test_random_sample(update_fixtures):
+    """
+    Test random_sample
+    """
+    output = sql_to_string(
+        BigQueryAdapter.random_sample(
+            select("a", "b").from_("table1"),
+            desired_row_count=100,
+            total_row_count=1000,
+            seed=1234,
+        ),
+        SourceType.BIGQUERY,
+    )
+    assert_equal_with_expected_fixture(
+        output,
+        "tests/fixtures/adapter/bigquery_random_sample.sql",
+        update_fixtures,
+    )


### PR DESCRIPTION
## Description

Sorting is unnecessary when random sampling for bigquery since the `RAND` function doesn't support seed.
## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
