### PR TITLE
[DEV-3723] Validate table existence when create_table_as fails with exists flag

### DIFF
--- a/featurebyte/sql/base.py
+++ b/featurebyte/sql/base.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from pydantic import BaseModel, PrivateAttr
 
+from featurebyte.query_graph.node.schema import TableDetails
 from featurebyte.query_graph.sql.adapter import BaseAdapter
 from featurebyte.query_graph.sql.common import quoted_identifier, sql_to_string
 from featurebyte.session.base import BaseSession
@@ -98,4 +99,4 @@ class BaseSqlModel(BaseModel):
         -------
             True if table exists, False otherwise
         """
-        return await self._session.table_exists(table_name)
+        return await self._session.table_exists(TableDetails(table_name=table_name.upper()))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -92,7 +92,6 @@ SKIPPED_TESTS = {
         "tests/integration/query_graph/test_online_serving.py",
         "tests/integration/tile/test_generate_tile.py",
         "tests/integration/tile/test_tile_scheduler.py",
-        "tests/integration/api/test_historical_features.py",
         "tests/integration/api/test_event_view_operations.py::test_datetime_comparison__fixed_timestamp_tz[bigquery]",
         "tests/integration/api/test_event_view_operations.py::test_datetime_comparison__fixed_timestamp_non_tz[bigquery]",
         "tests/integration/api/test_features.py::test_features_without_entity[bigquery]",  # mainly checks for deployment

--- a/tests/unit/feature_manager/test_unit_snowflake_feature.py
+++ b/tests/unit/feature_manager/test_unit_snowflake_feature.py
@@ -12,6 +12,7 @@ from featurebyte.common.model_util import get_version
 from featurebyte.feature_manager.model import ExtendedFeatureModel
 from featurebyte.feature_manager.sql_template import tm_feature_tile_monitor
 from featurebyte.models.online_store_spec import OnlineFeatureSpec
+from featurebyte.query_graph.node.schema import TableDetails
 
 
 @pytest.fixture(name="mock_snowflake_feature")
@@ -102,7 +103,7 @@ async def test_online_enable(
 
     # 1. Check if online store table exists (execute_query)
     mock_snowflake_session.table_exists.assert_called_once_with(
-        "ONLINE_STORE_377553E5920DD2DB8B17F21DDD52F8B1194A780C"
+        TableDetails(table_name="ONLINE_STORE_377553E5920DD2DB8B17F21DDD52F8B1194A780C")
     )
 
     # 2. Compute online store values and store in a temporary table


### PR DESCRIPTION
## Description

Previously, legitimate errors that cause table creation to fail were not surfaced properly when the `exists` flag is set. This adds validation in `create_table_as` to prevent that.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
