### PR TITLE
[chore] Add option to disable query cache in PreviewService

### DIFF
--- a/featurebyte/schema/feature_store.py
+++ b/featurebyte/schema/feature_store.py
@@ -47,6 +47,7 @@ class FeatureStorePreview(FeatureByteBaseModel):
     graph: QueryGraph
     node_name: str
     feature_store_id: Optional[PydanticObjectId] = Field(default=None)
+    enable_query_cache: bool = Field(default=True)
 
 
 class FeatureStoreSample(FeatureStorePreview):

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -604,6 +604,7 @@ class ObservationTableService(
             node_name=node.name,
             stats_names=["unique", "max", "min", "%missing"],
             feature_store_id=feature_store.id,
+            enable_query_cache=False,  # query is one off and not expected to be reused
         )
         describe_stats_json = await self.preview_service.describe(sample, 0, 1234)
         describe_stats_dataframe = dataframe_from_json(describe_stats_json)

--- a/featurebyte/service/preview.py
+++ b/featurebyte/service/preview.py
@@ -109,10 +109,10 @@ class PreviewService:
     async def _get_or_cache_table(
         self,
         session: BaseSession,
-        feature_store_id: Optional[ObjectId],
+        params: FeatureStorePreview,
         table_expr: Select,
     ) -> str:
-        if feature_store_id is None:
+        if params.feature_store_id is None or params.enable_query_cache is False:
             # No caching possible without feature_store_id
             table_name = f"__FB_TEMPORARY_TABLE_{ObjectId()}".upper()
             await session.create_table_as(table_details=table_name, select_expr=table_expr)
@@ -120,7 +120,7 @@ class PreviewService:
 
         return await self.query_cache_manager_service.get_or_cache_table(
             session=session,
-            feature_store_id=feature_store_id,
+            feature_store_id=params.feature_store_id,
             table_expr=table_expr,
         )
 
@@ -371,7 +371,7 @@ class PreviewService:
         feature_store_id = sample.feature_store_id
         input_table_name = await self._get_or_cache_table(
             session=session,
-            feature_store_id=feature_store_id,
+            params=sample,
             table_expr=describe_queries.data.expr,
         )
 
@@ -480,7 +480,7 @@ class PreviewService:
         )
         input_table_name = await self._get_or_cache_table(
             session=session,
-            feature_store_id=preview.feature_store_id,
+            params=preview,
             table_expr=value_counts_queries.data.expr,
         )
         try:

--- a/tests/fixtures/request_payloads/feature_store_sample.json
+++ b/tests/fixtures/request_payloads/feature_store_sample.json
@@ -4,6 +4,7 @@
         "Instead, update the test tests/unit/test_generate_payload_fixtures.py#test_save_payload_fixtures.",
         "Run `pytest --update-fixtures` to update it."
     ],
+    "enable_query_cache": true,
     "feature_store_id": "646f6c190ed28a5271fb02a1",
     "from_timestamp": "2012-11-24T11:00:00",
     "graph": {

--- a/tests/unit/service/test_observation_table.py
+++ b/tests/unit/service/test_observation_table.py
@@ -30,7 +30,7 @@ def patch_unique_identifier():
     """
     Patch unique identifier generator
     """
-    with patch("featurebyte.service.query_cache_manager.ObjectId", return_value=ObjectId("0" * 24)):
+    with patch("featurebyte.service.preview.ObjectId", return_value=ObjectId("0" * 24)):
         yield
 
 
@@ -236,7 +236,7 @@ async def test_validate__most_recent_point_in_time(
                 ) * 100 AS "%missing__1",
                 NULL AS "min__1",
                 NULL AS "max__1"
-              FROM "__FB_CACHED_TABLE_000000000000000000000000"
+              FROM "__FB_TEMPORARY_TABLE_000000000000000000000000"
             ), joined_tables_0 AS (
               SELECT
                 *


### PR DESCRIPTION
## Description

Previously, calling the methods in PreviewService such as describe uses query cache by default. However, there are some operations such as getting statistics for a newly materialized observation table that are one-off and not expected to benefit from the cache. This adds an option to disable query cache that can be specified for those cases.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
