### PR TITLE
[DEV-3718] Make event_id, item_id, scd natural_key_column optional for table registration

### DIFF
--- a/.changelog/DEV-3718.yaml
+++ b/.changelog/DEV-3718.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Allow some special columns (event_id_column, item_id_column, natural_key_column) to be optional during table registration."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/change_view.py
+++ b/featurebyte/api/change_view.py
@@ -287,3 +287,6 @@ class ChangeView(View, GroupByMixin):
 
     def get_join_column(self) -> str:
         raise ChangeViewNoJoinColumnError
+
+    def _get_join_column(self) -> Optional[str]:
+        return None

--- a/featurebyte/api/dimension_view.py
+++ b/featurebyte/api/dimension_view.py
@@ -4,7 +4,7 @@ DimensionView class
 
 from __future__ import annotations
 
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Optional
 
 from pydantic import Field
 
@@ -97,5 +97,5 @@ class DimensionView(View, RawMixin):
             logger.error("columns from a SCDView can’t be added to a DimensionView")
             raise JoinViewMismatchError
 
-    def get_join_column(self) -> str:
+    def _get_join_column(self) -> Optional[str]:
         return self.dimension_id_column

--- a/featurebyte/api/event_view.py
+++ b/featurebyte/api/event_view.py
@@ -152,7 +152,7 @@ class EventView(View, GroupByMixin, RawMixin):
     def get_join_column(self) -> str:
         # This is potentially none for backwards compatibility.
         # We can remove this once DEV-556 is done.
-        assert self.event_id_column is not None
+        assert self.event_id_column is not None, "Event ID column is not available."
         return self.event_id_column
 
     def get_additional_lookup_parameters(self, offset: Optional[str] = None) -> dict[str, Any]:

--- a/featurebyte/api/event_view.py
+++ b/featurebyte/api/event_view.py
@@ -152,7 +152,11 @@ class EventView(View, GroupByMixin, RawMixin):
     def get_join_column(self) -> str:
         # This is potentially none for backwards compatibility.
         # We can remove this once DEV-556 is done.
-        assert self.event_id_column is not None, "Event ID column is not available."
+        join_column = self._get_join_column()
+        assert join_column is not None, "Event ID column is not available."
+        return join_column
+
+    def _get_join_column(self) -> Optional[str]:
         return self.event_id_column
 
     def get_additional_lookup_parameters(self, offset: Optional[str] = None) -> dict[str, Any]:

--- a/featurebyte/api/item_table.py
+++ b/featurebyte/api/item_table.py
@@ -101,7 +101,7 @@ class ItemTable(TableApiObject):
 
     # pydantic instance variable (internal use)
     internal_event_id_column: StrictStr = Field(alias="event_id_column")
-    internal_item_id_column: StrictStr = Field(alias="item_id_column")
+    internal_item_id_column: Optional[StrictStr] = Field(alias="item_id_column")
 
     # pydantic validators
     _model_validator = model_validator(mode="after")(
@@ -367,13 +367,13 @@ class ItemTable(TableApiObject):
             return self.internal_event_id_column
 
     @property
-    def item_id_column(self) -> str:
+    def item_id_column(self) -> Optional[str]:
         """
         Returns the name of the column representing the item key of the Item view.
 
         Returns
         -------
-        str
+        Optional[str]
         """
         try:
             return self.cached_model.item_id_column

--- a/featurebyte/api/item_view.py
+++ b/featurebyte/api/item_view.py
@@ -59,7 +59,7 @@ class ItemView(View, GroupByMixin, RawMixin):
 
     # pydantic instance variables
     event_id_column: str = Field(frozen=True)
-    item_id_column: str = Field(frozen=True)
+    item_id_column: Optional[str] = Field(frozen=True)
     event_table_id: PydanticObjectId = Field(
         frozen=True,
         description="Returns the unique identifier (ID) "
@@ -324,6 +324,7 @@ class ItemView(View, GroupByMixin, RawMixin):
         return True
 
     def get_join_column(self) -> str:
+        assert self.item_id_column is not None, "Item ID column is not available."
         return self.item_id_column
 
     def get_additional_lookup_parameters(self, offset: Optional[str] = None) -> dict[str, Any]:

--- a/featurebyte/api/item_view.py
+++ b/featurebyte/api/item_view.py
@@ -324,7 +324,11 @@ class ItemView(View, GroupByMixin, RawMixin):
         return True
 
     def get_join_column(self) -> str:
-        assert self.item_id_column is not None, "Item ID column is not available."
+        join_column = self._get_join_column()
+        assert join_column is not None, "Item ID column is not available."
+        return join_column
+
+    def _get_join_column(self) -> Optional[str]:
         return self.item_id_column
 
     def get_additional_lookup_parameters(self, offset: Optional[str] = None) -> dict[str, Any]:

--- a/featurebyte/api/scd_table.py
+++ b/featurebyte/api/scd_table.py
@@ -76,7 +76,7 @@ class SCDTable(TableApiObject):
     internal_default_feature_job_setting: Optional[FeatureJobSetting] = Field(
         alias="default_feature_job_setting", default=None
     )
-    internal_natural_key_column: StrictStr = Field(alias="natural_key_column")
+    internal_natural_key_column: Optional[StrictStr] = Field(alias="natural_key_column")
     internal_effective_timestamp_column: StrictStr = Field(alias="effective_timestamp_column")
     internal_surrogate_key_column: Optional[StrictStr] = Field(
         alias="surrogate_key_column", default=None
@@ -379,14 +379,14 @@ class SCDTable(TableApiObject):
             return self.internal_default_feature_job_setting
 
     @property
-    def natural_key_column(self) -> str:
+    def natural_key_column(self) -> Optional[str]:
         """
         Returns the name of the column representing the natural key of a Slowly Changing Dimension (SCD) table. This
         column is used to distinguish each active row and facilitate tracking of changes over time.
 
         Returns
         -------
-        str
+        Optional[str]
         """
         try:
             return self.cached_model.natural_key_column

--- a/featurebyte/api/scd_view.py
+++ b/featurebyte/api/scd_view.py
@@ -51,7 +51,7 @@ class SCDView(View, GroupByMixin, RawMixin):
     _view_graph_node_type: ClassVar[GraphNodeType] = GraphNodeType.SCD_VIEW
 
     # pydantic instance variables
-    natural_key_column: str = Field(frozen=True)
+    natural_key_column: Optional[str] = Field(frozen=True)
     effective_timestamp_column: str = Field(frozen=True)
     surrogate_key_column: Optional[str] = Field(frozen=True)
     end_timestamp_column: Optional[str] = Field(frozen=True)
@@ -120,6 +120,7 @@ class SCDView(View, GroupByMixin, RawMixin):
             raise JoinViewMismatchError
 
     def get_join_column(self) -> str:
+        assert self.natural_key_column is not None, "Natural key column is not available."
         return self.natural_key_column
 
     def get_common_scd_parameters(self) -> SCDBaseParameters:

--- a/featurebyte/api/scd_view.py
+++ b/featurebyte/api/scd_view.py
@@ -120,7 +120,11 @@ class SCDView(View, GroupByMixin, RawMixin):
             raise JoinViewMismatchError
 
     def get_join_column(self) -> str:
-        assert self.natural_key_column is not None, "Natural key column is not available."
+        join_column = self._get_join_column()
+        assert join_column is not None, "Natural key column is not available."
+        return join_column
+
+    def _get_join_column(self) -> Optional[str]:
         return self.natural_key_column
 
     def get_common_scd_parameters(self) -> SCDBaseParameters:

--- a/featurebyte/api/source_table.py
+++ b/featurebyte/api/source_table.py
@@ -452,7 +452,7 @@ class SourceTable(AbstractTableData):
         self,
         name: str,
         event_timestamp_column: str,
-        event_id_column: str,
+        event_id_column: Optional[str] = None,
         event_timestamp_timezone_offset: Optional[str] = None,
         event_timestamp_timezone_offset_column: Optional[str] = None,
         record_creation_timestamp_column: Optional[str] = None,
@@ -478,10 +478,10 @@ class SourceTable(AbstractTableData):
         ----------
         name: str
             The desired name for the new table.
-        event_id_column: str
-            The column that represents the unique identfier for each event.
         event_timestamp_column: str
             The column that contains the timestamp of the associated event.
+        event_id_column: Optional[str]
+            The column that represents the unique identfier for each event.
         event_timestamp_timezone_offset: Optional[str]
             Timezone offset for the event timestamp column. Supported format is "(+|-)HH:mm".
             Specify this if the timezone offset is a fixed value. Examples: "+08:00" or "-05:00".
@@ -538,7 +538,7 @@ class SourceTable(AbstractTableData):
         self,
         name: str,
         event_id_column: str,
-        item_id_column: str,
+        item_id_column: Optional[str],
         event_table_name: str,
         record_creation_timestamp_column: Optional[str] = None,
         description: Optional[str] = None,
@@ -563,7 +563,7 @@ class SourceTable(AbstractTableData):
         event_id_column: str
             The column that represents the unique identifier for the associated event. This column will be used to join
             the item table with the event table.
-        item_id_column: str
+        item_id_column: Optional[str]
             The column that represents the unique identifier for each item.
         event_table_name: str
             The name of the event table that the item table will be associated with. This is used to ensure that the
@@ -687,7 +687,7 @@ class SourceTable(AbstractTableData):
     def create_scd_table(
         self,
         name: str,
-        natural_key_column: str,
+        natural_key_column: Optional[str],
         effective_timestamp_column: str,
         end_timestamp_column: Optional[str] = None,
         surrogate_key_column: Optional[str] = None,
@@ -725,7 +725,7 @@ class SourceTable(AbstractTableData):
         ----------
         name: str
             The desired name for the new table.
-        natural_key_column: str
+        natural_key_column: Optional[str]
             The column that uniquely identifies active records at a given point-in-time.
         effective_timestamp_column: str
             The column that represents when the record becomes effective (i.e., active).
@@ -835,7 +835,7 @@ class SourceTable(AbstractTableData):
         self,
         name: str,
         event_id_column: str,
-        item_id_column: str,
+        item_id_column: Optional[str],
         event_table_name: str,
         record_creation_timestamp_column: Optional[str] = None,
         description: Optional[str] = None,
@@ -851,7 +851,7 @@ class SourceTable(AbstractTableData):
             Item table name.
         event_id_column: str
             Event ID column from the given source table.
-        item_id_column: str
+        item_id_column: Optional[str]
             Item ID column from the given source table.
         event_table_name: str
             Name of the EventTable associated with this ItemTable.

--- a/featurebyte/models/entity_universe.py
+++ b/featurebyte/models/entity_universe.py
@@ -685,6 +685,8 @@ def get_item_relation_table_lookup_universe(item_table_model: TableModel) -> exp
     assert isinstance(item_table_model, ItemTableModel)
     event_table_model = item_table_model.event_table_model
     assert event_table_model is not None
+    assert event_table_model.event_id_column is not None
+    assert item_table_model.item_id_column is not None
     filtered_event_table_expr = (
         expressions.select(quoted_identifier(event_table_model.event_id_column))
         .from_(

--- a/featurebyte/models/event_table.py
+++ b/featurebyte/models/event_table.py
@@ -47,7 +47,7 @@ class EventTableModel(EventTableData, TableModel):
         Data warehouse connection information & table name tuple
     columns_info: List[ColumnInfo]
         List of event table columns
-    event_id_column: str
+    event_id_column: Optional[str]
         Event ID column name
     event_timestamp_column: str
         Event timestamp column name

--- a/featurebyte/models/item_table.py
+++ b/featurebyte/models/item_table.py
@@ -35,7 +35,7 @@ class ItemTableModel(ItemTableData, TableModel):
         Status of the ItemTable
     event_id_column: str
         Event ID column name
-    item_id_column: str
+    item_id_column: Optional[str]
         Item ID column name
     event_table_id: PydanticObjectId
         Id of the associated EventTable
@@ -63,7 +63,7 @@ class ItemTableModel(ItemTableData, TableModel):
 
     @property
     def primary_key_columns(self) -> List[str]:
-        return [self.item_id_column]
+        return [self.item_id_column] if self.item_id_column else []
 
     @property
     def special_columns(self) -> List[str]:

--- a/featurebyte/models/scd_table.py
+++ b/featurebyte/models/scd_table.py
@@ -25,7 +25,7 @@ class SCDTableModel(SCDTableData, TableModel):
 
     default_feature_job_setting : Optional[FeatureJobSetting]
         Default feature job setting
-    natural_key_column: str
+    natural_key_column: Optional[str]
         The column for the natural key (key for which there is one unique active record) in the DWH.
     surrogate_key_column: str
         The column for the surrogate key (the primary key of the SCD) in the DWH.
@@ -69,7 +69,7 @@ class SCDTableModel(SCDTableData, TableModel):
 
     @property
     def primary_key_columns(self) -> List[str]:
-        return [self.natural_key_column]
+        return [self.natural_key_column] if self.natural_key_column else []
 
     @property
     def special_columns(self) -> List[str]:

--- a/featurebyte/query_graph/model/table.py
+++ b/featurebyte/query_graph/model/table.py
@@ -64,7 +64,7 @@ class EventTableData(BaseTableData):
     type: Literal[TableDataType.EVENT_TABLE] = TableDataType.EVENT_TABLE
     id: PydanticObjectId = Field(default_factory=ObjectId, alias="_id")
     event_timestamp_column: StrictStr
-    event_id_column: StrictStr
+    event_id_column: Optional[StrictStr]
     event_timestamp_timezone_offset: Optional[StrictStr] = Field(default=None)
     event_timestamp_timezone_offset_column: Optional[StrictStr] = Field(default=None)
 
@@ -127,12 +127,12 @@ class ItemTableData(BaseTableData):
     type: Literal[TableDataType.ITEM_TABLE] = TableDataType.ITEM_TABLE
     id: PydanticObjectId = Field(default_factory=ObjectId, alias="_id")
     event_id_column: StrictStr
-    item_id_column: StrictStr
+    item_id_column: Optional[StrictStr]
     event_table_id: PydanticObjectId
 
     @property
     def primary_key_columns(self) -> List[str]:
-        return [self.item_id_column]
+        return [self.item_id_column] if self.item_id_column else []
 
     def construct_input_node(self, feature_store_details: FeatureStoreDetails) -> InputNode:
         return InputNode(
@@ -413,7 +413,7 @@ class SCDTableData(BaseTableData):
 
     type: Literal[TableDataType.SCD_TABLE] = TableDataType.SCD_TABLE
     id: PydanticObjectId = Field(default_factory=ObjectId, alias="_id")
-    natural_key_column: StrictStr
+    natural_key_column: Optional[StrictStr]
     effective_timestamp_column: StrictStr
     surrogate_key_column: Optional[StrictStr]
     end_timestamp_column: Optional[StrictStr] = Field(default=None)
@@ -421,7 +421,7 @@ class SCDTableData(BaseTableData):
 
     @property
     def primary_key_columns(self) -> List[str]:
-        return [self.natural_key_column]
+        return [self.natural_key_column] if self.natural_key_column else []
 
     def construct_input_node(self, feature_store_details: FeatureStoreDetails) -> InputNode:
         return InputNode(

--- a/featurebyte/routes/item_table/controller.py
+++ b/featurebyte/routes/item_table/controller.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 from bson import ObjectId
 
 from featurebyte.enum import SemanticType
+from featurebyte.exception import ColumnNotFoundError
+from featurebyte.models import EventTableModel
 from featurebyte.models.item_table import ItemTableModel
 from featurebyte.routes.common.base_table import BaseTableDocumentController
 from featurebyte.schema.info import ItemTableInfo
@@ -73,7 +75,13 @@ class ItemTableController(
 
     async def create_table(self, data: ItemTableCreate) -> ItemTableModel:  # type: ignore[override]
         # check existence of event table first before creating item table
-        _ = await self.event_table_service.get_document(document_id=data.event_table_id)
+        event_table: EventTableModel = await self.event_table_service.get_document(
+            document_id=data.event_table_id
+        )
+        if not event_table.event_id_column:
+            raise ColumnNotFoundError(
+                f"Event ID column is not available for the event table: {event_table.name}"
+            )
         return await super().create_table(data=data)
 
     async def get_info(self, document_id: ObjectId, verbose: bool) -> ItemTableInfo:

--- a/featurebyte/schema/event_table.py
+++ b/featurebyte/schema/event_table.py
@@ -23,7 +23,7 @@ class EventTableCreate(TableCreate):
     """
 
     type: Literal[TableDataType.EVENT_TABLE] = TableDataType.EVENT_TABLE
-    event_id_column: StrictStr
+    event_id_column: Optional[StrictStr] = Field(default=None)
     event_timestamp_column: StrictStr
     event_timestamp_timezone_offset: Optional[StrictStr] = Field(default=None)
     event_timestamp_timezone_offset_column: Optional[StrictStr] = Field(default=None)

--- a/featurebyte/schema/info.py
+++ b/featurebyte/schema/info.py
@@ -193,7 +193,7 @@ class EventTableInfo(TableInfo):
     """
 
     event_timestamp_column: str
-    event_id_column: str
+    event_id_column: Optional[str]
     default_feature_job_setting: Optional[FeatureJobSetting] = Field(default=None)
 
 
@@ -203,7 +203,7 @@ class ItemTableInfo(TableInfo):
     """
 
     event_id_column: str
-    item_id_column: str
+    item_id_column: Optional[str]
     event_table_name: str
 
 

--- a/featurebyte/schema/item_table.py
+++ b/featurebyte/schema/item_table.py
@@ -2,7 +2,7 @@
 ItemTable API payload schema
 """
 
-from typing import List, Literal
+from typing import List, Literal, Optional
 
 from pydantic import StrictStr, field_validator
 
@@ -20,7 +20,7 @@ class ItemTableCreate(TableCreate):
 
     type: Literal[TableDataType.ITEM_TABLE] = TableDataType.ITEM_TABLE
     event_id_column: StrictStr
-    item_id_column: StrictStr
+    item_id_column: Optional[StrictStr]
     event_table_id: PydanticObjectId
 
     # pydantic validators

--- a/tests/unit/api/test_event_table.py
+++ b/tests/unit/api/test_event_table.py
@@ -1202,3 +1202,6 @@ def test_create_event_table_without_event_id_column(
     with pytest.raises(AssertionError) as exc:
         event_view.col_text.as_feature("some feature")
     assert "Event ID column is not available." in str(exc.value)
+
+    # expect subset to work
+    _ = event_view[["col_text", "col_int"]]

--- a/tests/unit/api/test_event_table.py
+++ b/tests/unit/api/test_event_table.py
@@ -1172,3 +1172,33 @@ def test_update_critical_data_info_with_none_value(saved_event_table):
     assert (
         saved_event_table.col_int.info.critical_data_info.cleaning_operations == cleaning_operations
     )
+
+
+def test_create_event_table_without_event_id_column(
+    snowflake_database_table, event_table_dict, catalog
+):
+    """
+    Test EventTable creation using tabular source without event_id_column
+    """
+    _ = catalog
+
+    event_table = snowflake_database_table.create_event_table(
+        name="sf_event_table",
+        event_timestamp_column="event_timestamp",
+        record_creation_timestamp_column="created_at",
+        description="Some description",
+    )
+
+    # check that node parameter is set properly
+    node_params = event_table.frame.node.parameters
+    assert node_params.id == event_table.id
+    assert node_params.type == TableDataType.EVENT_TABLE
+
+    output = event_table.model_dump(by_alias=True)
+    assert output["event_id_column"] is None
+
+    # expect lookup feature to be unsuccessful
+    event_view = event_table.get_view()
+    with pytest.raises(AssertionError) as exc:
+        event_view.col_text.as_feature("some feature")
+    assert "Event ID column is not available." in str(exc.value)

--- a/tests/unit/api/test_item_table.py
+++ b/tests/unit/api/test_item_table.py
@@ -546,6 +546,9 @@ def test_create_item_table_without_item_id_column(
         item_view.item_type.as_feature("some feature")
     assert "Item ID column is not available." in str(exc.value)
 
+    # expect subset to work
+    _ = item_view[["item_type", "item_amount"]]
+
 
 def test_create_item_table_without_item_id_column_event_table_no_event_id_column(
     snowflake_database_table, snowflake_database_table_item_table, item_table_dict

--- a/tests/unit/api/test_scd_table.py
+++ b/tests/unit/api/test_scd_table.py
@@ -522,8 +522,12 @@ def test_create_scd_table_without_natural_key_column(
         scd_view.col_text.as_feature("some feature")
     assert "Natural key column is not available." in str(exc.value)
 
+    # expect aggregate_asat to be successful
     scd_view.groupby("cust_id").aggregate_asat(
         value_column=None,
         method="count",
         feature_name="count_col_int",
     )
+
+    # expect subset to work
+    _ = scd_view[["col_float", "col_text"]]

--- a/tests/unit/api/test_scd_table.py
+++ b/tests/unit/api/test_scd_table.py
@@ -10,7 +10,10 @@ from typeguard import TypeCheckError
 from featurebyte.api.entity import Entity
 from featurebyte.api.scd_table import SCDTable
 from featurebyte.enum import TableDataType
-from featurebyte.exception import DuplicatedRecordException, RecordRetrievalException
+from featurebyte.exception import (
+    DuplicatedRecordException,
+    RecordRetrievalException,
+)
 from featurebyte.models.scd_table import SCDTableModel
 from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
 from tests.unit.api.base_table_test import BaseTableTestSuite, DataType
@@ -457,3 +460,70 @@ def test_update_default_feature_job_setting(saved_scd_table, feature_group_featu
         feature_job_setting=feature_group_feature_job_setting
     )
     assert saved_scd_table.default_feature_job_setting == feature_group_feature_job_setting
+
+
+def test_create_scd_table_without_natural_key_column(
+    snowflake_database_table_scd_table, snowflake_database_table, scd_table_dict, catalog
+):
+    """
+    Test SCDTable creation using tabular source without natural_key_column
+    """
+    _ = catalog
+
+    # create SCD table without both natural key column and end_timestamp_column and expect to fail
+    with pytest.raises(ValueError) as exc:
+        snowflake_database_table_scd_table.create_scd_table(
+            name="sf_scd_table",
+            natural_key_column=None,
+            effective_timestamp_column="effective_timestamp",
+            current_flag_column="is_active",
+            record_creation_timestamp_column="created_at",
+        )
+    assert "Either natural_key_column or end_timestamp_column must be specified" in str(exc.value)
+
+    # create SCD table without natural key column and with end_timestamp_column and expect to work
+    scd_table = snowflake_database_table_scd_table.create_scd_table(
+        name="sf_scd_table",
+        natural_key_column=None,
+        effective_timestamp_column="effective_timestamp",
+        end_timestamp_column="end_timestamp",
+        current_flag_column="is_active",
+        record_creation_timestamp_column="created_at",
+    )
+
+    entity_a = Entity(name="a", serving_names=["a_id"])
+    entity_a.save()
+    scd_table.cust_id.as_entity("a")
+
+    # check that node parameter is set properly
+    node_params = scd_table.frame.node.parameters
+    assert node_params.id == scd_table.id
+    assert node_params.type == TableDataType.SCD_TABLE
+
+    output = scd_table.model_dump(by_alias=True)
+    assert output["natural_key_column"] is None
+
+    event_table = snowflake_database_table.create_event_table(
+        name="sf_event_table",
+        event_timestamp_column="event_timestamp",
+        record_creation_timestamp_column="created_at",
+        description="Some description",
+    )
+    event_view = event_table.get_view()
+    scd_view = scd_table.get_view()
+
+    # expect join to be unsuccessful
+    with pytest.raises(AssertionError) as exc:
+        event_view.join(scd_view)
+        assert "Natural key column is not available." in str(exc.value)
+
+    # expect lookup feature to be unsuccessful
+    with pytest.raises(AssertionError) as exc:
+        scd_view.col_text.as_feature("some feature")
+    assert "Natural key column is not available." in str(exc.value)
+
+    scd_view.groupby("cust_id").aggregate_asat(
+        value_column=None,
+        method="count",
+        feature_name="count_col_int",
+    )

--- a/tests/unit/api/test_view.py
+++ b/tests/unit/api/test_view.py
@@ -65,7 +65,7 @@ class SimpleTestView(View):
     def protected_attributes(self) -> List[str]:
         return []
 
-    def get_join_column(self) -> str:
+    def _get_join_column(self) -> Optional[str]:
         return self.join_col
 
     def model_dump(self, **kwargs: Any) -> Dict[str, Any]:


### PR DESCRIPTION
## Description

Allow some special columns (event_id, item_id, scd natural keys) to be optional during  table registration.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
