### PR TITLE
[chore] Handle non json-serializable types in bigquery RECORD fields

### DIFF
--- a/tests/unit/session/test_bigquery_session.py
+++ b/tests/unit/session/test_bigquery_session.py
@@ -2,11 +2,13 @@
 Unit test for BigQuerySession
 """
 
+import datetime
 import os
 from unittest.mock import Mock, patch
 
 import pandas as pd
 import pytest
+from dateutil import tz
 from google.cloud.bigquery import SchemaField, StandardSqlTypeNames
 from google.cloud.bigquery.dbapi.cursor import Column
 from google.cloud.bigquery.table import Row
@@ -357,3 +359,21 @@ def test_convert_to_internal_variable_type(bigquery_var_info, scale, expected):
     Test convert_to_internal_variable_type
     """
     assert BigQuerySession._convert_to_internal_variable_type(bigquery_var_info, scale) == expected  # pylint: disable=protected-access
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (
+            {"date": datetime.datetime(2023, 1, 1, 8, 0, 0, tzinfo=tz.gettz("Asia/Singapore"))},
+            '{"date": "2023-01-01T00:00:00"}',
+        ),
+        ({"date": datetime.datetime(2023, 1, 1, 8, 0, 0)}, '{"date": "2023-01-01T08:00:00"}'),
+    ],
+)
+def test_json_serialization_handler(value, expected):
+    """
+    Test json_serialization_handler
+    """
+
+    assert BigQuerySession._format_value(value) == expected  # pylint: disable=protected-access


### PR DESCRIPTION
## Description

Handle non json-serializable types in bigquery RECORD fields

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
