### PR TITLE
[DEV-3714] BigQuery: Fix to_timestamp usage in FeatureMaterializeService for deployment

### DIFF
--- a/featurebyte/service/feature_materialize.py
+++ b/featurebyte/service/feature_materialize.py
@@ -1229,8 +1229,8 @@ class FeatureMaterializeService:
         feature_timestamp_value: str,
         to_specify_merge_conditions: bool,
     ) -> None:
-        feature_timestamp_value_expr = expressions.Anonymous(
-            this="TO_TIMESTAMP", expressions=[make_literal_value(feature_timestamp_value)]
+        feature_timestamp_value_expr = make_literal_value(
+            feature_timestamp_value, cast_as_timestamp=True
         )
         if to_specify_merge_conditions:
             merge_conditions = [

--- a/tests/fixtures/feature_materialize/initialize_new_columns_existing_table.sql
+++ b/tests/fixtures/feature_materialize/initialize_new_columns_existing_table.sql
@@ -91,10 +91,10 @@ USING (
   FROM "TEMP_FEATURE_TABLE_000000000000000000000000"
 ) AS materialized_features
 ON offline_store_table."cust_id" = materialized_features."cust_id"
-AND "__feature_timestamp" = TO_TIMESTAMP('2022-10-15 10:00:00')
+AND "__feature_timestamp" = CAST('2022-10-15 10:00:00' AS TIMESTAMP)
 WHEN MATCHED THEN UPDATE SET offline_store_table."sum_30m_V220101" = materialized_features."sum_30m_V220101"
 WHEN NOT MATCHED THEN INSERT ("__feature_timestamp", "cust_id", "sum_30m_V220101") VALUES (
-  TO_TIMESTAMP('2022-10-15 10:00:00'),
+  CAST('2022-10-15 10:00:00' AS TIMESTAMP),
   materialized_features."cust_id",
   materialized_features."sum_30m_V220101"
 );

--- a/tests/fixtures/feature_materialize/initialize_new_columns_existing_table_empty.sql
+++ b/tests/fixtures/feature_materialize/initialize_new_columns_existing_table_empty.sql
@@ -89,7 +89,7 @@ USING (
 ON FALSE
 WHEN MATCHED THEN UPDATE SET offline_store_table."sum_30m_V220101" = materialized_features."sum_30m_V220101"
 WHEN NOT MATCHED THEN INSERT ("__feature_timestamp", "cust_id", "sum_30m_V220101") VALUES (
-  TO_TIMESTAMP('2022-01-01T00:00:00'),
+  CAST('2022-01-01T00:00:00' AS TIMESTAMP),
   materialized_features."cust_id",
   materialized_features."sum_30m_V220101"
 );


### PR DESCRIPTION
## Description

This fixes the usage of platform specific `to_timestamp` and make it compatible with BigQuery.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
