### PR TITLE
[DEV-3732] BigQuery: Cast key to string in get_value

### DIFF
--- a/featurebyte/query_graph/sql/ast/count_dict.py
+++ b/featurebyte/query_graph/sql/ast/count_dict.py
@@ -105,7 +105,8 @@ class GetValueFromDictionaryNode(ExpressionNode):
     @property
     def sql(self) -> Expression:
         return self.context.adapter.get_value_from_dictionary(
-            self.dictionary_feature_node.sql, self.lookup_feature_node.sql
+            self.dictionary_feature_node.sql,
+            self.context.adapter.cast_to_string(self.lookup_feature_node.sql, None),
         )
 
     @classmethod

--- a/tests/unit/query_graph/test_sql.py
+++ b/tests/unit/query_graph/test_sql.py
@@ -329,7 +329,7 @@ def test_get_value_node(input_node):
             input_sql_nodes=[dictionary_node, lookup_node],
         )
     )
-    assert node.sql.sql() == "GET(dictionary, lookup)"
+    assert node.sql.sql() == "GET(dictionary, CAST(lookup AS VARCHAR))"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

The key needs to be of string type and BigQuery doesn't perform implicit type conversion.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
