### PR TITLE
[DEV-3727] Add support for sampling by time range during observation table registration

### DIFF
--- a/.changelog/DEV-3727.yaml
+++ b/.changelog/DEV-3727.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: api
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add support for sampling by time range during registration of observation tables from source table or view."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/obs_table/utils.py
+++ b/featurebyte/api/obs_table/utils.py
@@ -24,6 +24,8 @@ def get_definition_for_obs_table_creation_from_view(
     context_name: Optional[str] = None,
     skip_entity_validation_checks: Optional[bool] = False,
     primary_entities: Optional[List[str]] = None,
+    sample_from_timestamp: Optional[str] = None,
+    sample_to_timestamp: Optional[str] = None,
 ) -> str:
     """
     Helper method to get the definition for creating an observation table from a view.
@@ -48,6 +50,10 @@ def get_definition_for_obs_table_creation_from_view(
         Whether to skip entity validation checks
     primary_entities: Optional[List[str]]
         The primary entities to associate the observation table with
+    sample_from_timestamp: Optional[str]
+        Start of date range to sample from.
+    sample_to_timestamp: Optional[str]
+        End of date range to sample from.
 
     Returns
     -------
@@ -64,6 +70,8 @@ def get_definition_for_obs_table_creation_from_view(
             context_name=context_name,
             skip_entity_validation_checks=skip_entity_validation_checks,
             primary_entities=primary_entities,
+            sample_from_timestamp=sample_from_timestamp,
+            sample_to_timestamp=sample_to_timestamp,
         )
 
         return [(output_var, expression)]

--- a/featurebyte/models/observation_table.py
+++ b/featurebyte/models/observation_table.py
@@ -54,6 +54,8 @@ class TargetInput(FeatureByteBaseModel):
         session: BaseSession,
         destination: TableDetails,
         sample_rows: Optional[int],
+        sample_from_timestamp: Optional[datetime] = None,
+        sample_to_timestamp: Optional[datetime] = None,
     ) -> None:
         """
         No-op materialize. This method isn't needed for TargetInput since we materialize the target separately.
@@ -69,6 +71,10 @@ class TargetInput(FeatureByteBaseModel):
             The destination table to materialize the target input to
         sample_rows: Optional[int]
             The number of rows to sample from the target input
+        sample_from_timestamp: Optional[datetime]
+            The timestamp to sample from
+        sample_to_timestamp: Optional[datetime]
+            The timestamp to sample to
         """
 
 
@@ -85,6 +91,8 @@ class UploadedFileInput(FeatureByteBaseModel):
         session: BaseSession,
         destination: TableDetails,
         sample_rows: Optional[int],
+        sample_from_timestamp: Optional[datetime] = None,
+        sample_to_timestamp: Optional[datetime] = None,
     ) -> None:
         """
         No-op materialize. This method isn't needed for UploadedFileInput since there is nothing to materialize/compute.
@@ -97,6 +105,10 @@ class UploadedFileInput(FeatureByteBaseModel):
             The destination table to materialize the target input to
         sample_rows: Optional[int]
             The number of rows to sample from the target input
+        sample_from_timestamp: Optional[datetime]
+            The timestamp to sample from
+        sample_to_timestamp: Optional[datetime]
+            The timestamp to sample to
         """
 
 
@@ -147,6 +159,9 @@ class ObservationTableModel(MaterializedTableModel):
     primary_entity_ids: Optional[List[PydanticObjectId]] = Field(default_factory=list)
     has_row_index: Optional[bool] = Field(default=False)
     target_namespace_id: Optional[PydanticObjectId] = Field(default=None)
+    sample_rows: Optional[int] = Field(default=None)
+    sample_from_timestamp: Optional[datetime] = Field(default=None)
+    sample_to_timestamp: Optional[datetime] = Field(default=None)
 
     _sort_primary_entity_ids_validator = field_validator("primary_entity_ids")(
         construct_sort_validator()

--- a/featurebyte/models/request_input.py
+++ b/featurebyte/models/request_input.py
@@ -183,12 +183,11 @@ class BaseRequestInput(FeatureByteBaseModel):
                 )
             )
         if time_range_conditions:
-            if self.columns is None and self.columns_rename_mapping is None:
-                # add a select * in case the expression already has a where clause
-                query_expr = expressions.Select(expressions=[expressions.Star()]).from_(
-                    query_expr.subquery()
-                )
-            query_expr = query_expr.where(expressions.And(expressions=time_range_conditions))
+            query_expr = (
+                expressions.Select(expressions=[expressions.Star()])
+                .from_(query_expr.subquery())
+                .where(expressions.And(expressions=time_range_conditions))
+            )
 
         if sample_rows is not None:
             num_rows = await self.get_row_count(session=session, query_expr=query_expr)

--- a/featurebyte/models/request_input.py
+++ b/featurebyte/models/request_input.py
@@ -188,10 +188,7 @@ class BaseRequestInput(FeatureByteBaseModel):
                 query_expr = expressions.Select(expressions=[expressions.Star()]).from_(
                     query_expr.subquery()
                 )
-            if len(time_range_conditions) == 1:
-                query_expr = query_expr.where(time_range_conditions[0])
-            else:
-                query_expr = query_expr.where(expressions.And(expressions=time_range_conditions))
+            query_expr = query_expr.where(expressions.And(expressions=time_range_conditions))
 
         if sample_rows is not None:
             num_rows = await self.get_row_count(session=session, query_expr=query_expr)

--- a/featurebyte/models/request_input.py
+++ b/featurebyte/models/request_input.py
@@ -185,7 +185,9 @@ class BaseRequestInput(FeatureByteBaseModel):
         if time_range_conditions:
             if self.columns is None and self.columns_rename_mapping is None:
                 # add a select * in case the expression already has a where clause
-                query_expr = expressions.Select(expressions=[expressions.Star()]).from_(query_expr)
+                query_expr = expressions.Select(expressions=[expressions.Star()]).from_(
+                    query_expr.subquery()
+                )
             if len(time_range_conditions) == 1:
                 query_expr = query_expr.where(time_range_conditions[0])
             else:

--- a/featurebyte/models/request_input.py
+++ b/featurebyte/models/request_input.py
@@ -184,7 +184,12 @@ class BaseRequestInput(FeatureByteBaseModel):
             )
         if time_range_conditions:
             query_expr = (
-                expressions.Select(expressions=[expressions.Star()])
+                expressions.Select(
+                    expressions=[
+                        quoted_identifier(col_expr.alias or col_expr.name)
+                        for (column_idx, col_expr) in enumerate(query_expr.expressions)
+                    ]
+                )
                 .from_(query_expr.subquery())
                 .where(expressions.And(expressions=time_range_conditions))
             )

--- a/featurebyte/query_graph/sql/common.py
+++ b/featurebyte/query_graph/sql/common.py
@@ -57,6 +57,8 @@ def quoted_identifier(column_name: str) -> Expression:
     -------
     Expression
     """
+    if column_name == "*":
+        return expressions.Star()
     return expressions.Identifier(this=column_name, quoted=True)
 
 

--- a/featurebyte/query_graph/sql/common.py
+++ b/featurebyte/query_graph/sql/common.py
@@ -57,8 +57,7 @@ def quoted_identifier(column_name: str) -> Expression:
     -------
     Expression
     """
-    if column_name == "*":
-        return expressions.Star()
+    assert column_name != "*", "Column name cannot be *"
     return expressions.Identifier(this=column_name, quoted=True)
 
 

--- a/featurebyte/schema/observation_table.py
+++ b/featurebyte/schema/observation_table.py
@@ -4,6 +4,7 @@ ObservationTableModel API payload schema
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import List, Optional
 
 from bson import ObjectId
@@ -21,6 +22,8 @@ class ObservationTableCreate(BaseRequestTableCreate):
     """
 
     sample_rows: Optional[int] = Field(ge=0, default=None)
+    sample_from_timestamp: Optional[datetime] = Field(default=None)
+    sample_to_timestamp: Optional[datetime] = Field(default=None)
     request_input: ObservationInput
     skip_entity_validation_checks: bool = Field(default=False)
     purpose: Optional[Purpose] = Field(default=None)

--- a/featurebyte/worker/task/observation_table.py
+++ b/featurebyte/worker/task/observation_table.py
@@ -53,6 +53,8 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask[ObservationTableTaskPayl
             session=db_session,
             destination=location.table_details,
             sample_rows=payload.sample_rows,
+            sample_from_timestamp=payload.sample_from_timestamp,
+            sample_to_timestamp=payload.sample_to_timestamp,
         )
         await self.observation_table_service.add_row_index_column(
             session=db_session, table_details=location.table_details
@@ -87,6 +89,9 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask[ObservationTableTaskPayl
                 primary_entity_ids=primary_entity_ids,
                 has_row_index=True,
                 target_namespace_id=payload.target_namespace_id,
+                sample_rows=payload.sample_rows,
+                sample_from_timestamp=payload.sample_from_timestamp,
+                sample_to_timestamp=payload.sample_to_timestamp,
                 **additional_metadata,
             )
             await self.observation_table_service.create_document(observation_table)

--- a/tests/fixtures/request_payloads/observation_table.json
+++ b/tests/fixtures/request_payloads/observation_table.json
@@ -25,7 +25,9 @@
         },
         "type": "source_table"
     },
+    "sample_from_timestamp": null,
     "sample_rows": null,
+    "sample_to_timestamp": null,
     "skip_entity_validation_checks": false,
     "target_column": null
 }

--- a/tests/integration/api/test_observation_table.py
+++ b/tests/integration/api/test_observation_table.py
@@ -239,6 +239,9 @@ async def test_observation_table_sample_time_range(
     check_location_valid(table_details, session)
     await check_materialized_table_accessible(table_details, session, source_type, sample_rows)
 
+    df_preview = observation_table.preview(limit=10)
+    assert df_preview.columns.tolist() == ["POINT_IN_TIME", "üser id"]
+
     df_describe = observation_table.describe()
     assert pd.to_datetime(df_describe.loc["min", "POINT_IN_TIME"]) >= pd.Timestamp("2001-02-01")
     assert pd.to_datetime(df_describe.loc["max", "POINT_IN_TIME"]) <= pd.Timestamp("2001-06-30")

--- a/tests/unit/api/observation_table/test_utils.py
+++ b/tests/unit/api/observation_table/test_utils.py
@@ -34,6 +34,7 @@ def test_get_definition_for_obs_table_creation_from_view(
         context_name=context.name,
         skip_entity_validation_checks=True,
         primary_entities=[cust_id_entity.name],
+        sample_from_timestamp="2021-01-01T13:15:00",
     )
     version = get_version()
     expected_definition = f"""
@@ -55,6 +56,8 @@ def test_get_definition_for_obs_table_creation_from_view(
         context_name="test_context",
         skip_entity_validation_checks=True,
         primary_entities=["customer"],
+        sample_from_timestamp="2021-01-01T13:15:00",
+        sample_to_timestamp=None,
     )
     """
     assert textwrap.dedent(definition).strip() == textwrap.dedent(expected_definition).strip()

--- a/tests/unit/models/test_request_input.py
+++ b/tests/unit/models/test_request_input.py
@@ -292,7 +292,7 @@ async def test_materialize__with_sample_timestamp(
           FROM "sf_database"."sf_schema"."sf_table"
         )
         WHERE
-          "POINT_IN_TIME" < CAST('2011-03-08T00:00:00' AS TIMESTAMP)
+            "POINT_IN_TIME" < CAST('2011-03-08T00:00:00' AS TIMESTAMP)
         """
     ).strip()
     assert session.execute_query_long_running.call_args_list == [call(expected_query)]

--- a/tests/unit/models/test_request_input.py
+++ b/tests/unit/models/test_request_input.py
@@ -3,6 +3,7 @@ Unit tests related to RequestInput
 """
 
 import textwrap
+from datetime import datetime
 from functools import partial
 from unittest.mock import AsyncMock, Mock, call
 
@@ -250,3 +251,88 @@ async def test_materialize__view_bigquery(
         "tests/fixtures/request_input/materialize_bigquery.sql",
         update_fixtures,
     )
+
+
+@pytest.mark.asyncio
+async def test_materialize__with_sample_timestamp(
+    session, snowflake_event_table, destination_table
+):
+    """
+    Test materializing with sample from timestamp
+    """
+    view = snowflake_event_table.get_view()
+    pruned_graph, mapped_node = view.extract_pruned_graph_and_node()
+    request_input = ViewRequestInput(
+        columns=["event_timestamp", "col_int"],
+        columns_rename_mapping={"event_timestamp": "POINT_IN_TIME"},
+        graph=pruned_graph,
+        node_name=mapped_node.name,
+    )
+    await request_input.materialize(session, destination_table, None, None, datetime(2011, 3, 8))
+
+    # No need to query database to get column names
+    assert session.list_table_schema.call_args_list == []
+
+    expected_query = textwrap.dedent(
+        """
+        CREATE TABLE "sf_database"."sf_schema"."my_materialized_table" AS
+        SELECT
+          "event_timestamp" AS "POINT_IN_TIME",
+          "col_int" AS "col_int"
+        FROM (
+          SELECT
+            "col_int" AS "col_int",
+            "col_float" AS "col_float",
+            "col_char" AS "col_char",
+            "col_text" AS "col_text",
+            "col_binary" AS "col_binary",
+            "col_boolean" AS "col_boolean",
+            "event_timestamp" AS "event_timestamp",
+            "cust_id" AS "cust_id"
+          FROM "sf_database"."sf_schema"."sf_table"
+        )
+        WHERE
+          "POINT_IN_TIME" < CAST('2011-03-08T00:00:00' AS TIMESTAMP)
+        """
+    ).strip()
+    assert session.execute_query_long_running.call_args_list == [call(expected_query)]
+
+
+@pytest.mark.asyncio
+async def test_materialize__with_sample_timestamp_biqquery(
+    session, snowflake_database_table, destination_table, bigquery_source_info
+):
+    """
+    Test materializing with sample from timestamp
+    """
+    session.get_source_info.return_value = bigquery_source_info
+    session.source_type = SourceType.BIGQUERY
+    request_input = SourceTableRequestInput(
+        columns=["a", "b"],
+        source=snowflake_database_table.tabular_source,
+    )
+    await request_input.materialize(
+        session, destination_table, None, datetime(2011, 3, 8), datetime(2012, 5, 9)
+    )
+
+    assert session.list_table_schema.call_args_list == [
+        call(table_name="sf_table", database_name="sf_database", schema_name="sf_schema")
+    ]
+
+    expected_query = textwrap.dedent(
+        """
+        CREATE TABLE `sf_database`.`sf_schema`.`my_materialized_table` AS
+        SELECT
+          `a`,
+          `b`
+        FROM (
+          SELECT
+            *
+          FROM `sf_database`.`sf_schema`.`sf_table`
+        )
+        WHERE
+            CAST(`POINT_IN_TIME` AS DATETIME) >= CAST('2011-03-08T00:00:00' AS DATETIME) AND
+            CAST(`POINT_IN_TIME` AS DATETIME) < CAST('2012-05-09T00:00:00' AS DATETIME)
+        """
+    ).strip()
+    assert session.execute_query_long_running.call_args_list == [call(expected_query)]

--- a/tests/unit/models/test_request_input.py
+++ b/tests/unit/models/test_request_input.py
@@ -277,19 +277,23 @@ async def test_materialize__with_sample_timestamp(
         """
         CREATE TABLE "sf_database"."sf_schema"."my_materialized_table" AS
         SELECT
-          "event_timestamp" AS "POINT_IN_TIME",
-          "col_int" AS "col_int"
+          *
         FROM (
           SELECT
-            "col_int" AS "col_int",
-            "col_float" AS "col_float",
-            "col_char" AS "col_char",
-            "col_text" AS "col_text",
-            "col_binary" AS "col_binary",
-            "col_boolean" AS "col_boolean",
-            "event_timestamp" AS "event_timestamp",
-            "cust_id" AS "cust_id"
-          FROM "sf_database"."sf_schema"."sf_table"
+            "event_timestamp" AS "POINT_IN_TIME",
+            "col_int" AS "col_int"
+          FROM (
+            SELECT
+              "col_int" AS "col_int",
+              "col_float" AS "col_float",
+              "col_char" AS "col_char",
+              "col_text" AS "col_text",
+              "col_binary" AS "col_binary",
+              "col_boolean" AS "col_boolean",
+              "event_timestamp" AS "event_timestamp",
+              "cust_id" AS "cust_id"
+            FROM "sf_database"."sf_schema"."sf_table"
+          )
         )
         WHERE
             "POINT_IN_TIME" < CAST('2011-03-08T00:00:00' AS TIMESTAMP)
@@ -323,12 +327,16 @@ async def test_materialize__with_sample_timestamp_biqquery(
         """
         CREATE TABLE `sf_database`.`sf_schema`.`my_materialized_table` AS
         SELECT
-          `a`,
-          `b`
+          *
         FROM (
           SELECT
-            *
-          FROM `sf_database`.`sf_schema`.`sf_table`
+            `a`,
+            `b`
+          FROM (
+            SELECT
+              *
+            FROM `sf_database`.`sf_schema`.`sf_table`
+          )
         )
         WHERE
             CAST(`POINT_IN_TIME` AS DATETIME) >= CAST('2011-03-08T00:00:00' AS DATETIME) AND

--- a/tests/unit/models/test_request_input.py
+++ b/tests/unit/models/test_request_input.py
@@ -277,7 +277,8 @@ async def test_materialize__with_sample_timestamp(
         """
         CREATE TABLE "sf_database"."sf_schema"."my_materialized_table" AS
         SELECT
-          *
+          "POINT_IN_TIME",
+          "col_int"
         FROM (
           SELECT
             "event_timestamp" AS "POINT_IN_TIME",
@@ -327,7 +328,8 @@ async def test_materialize__with_sample_timestamp_biqquery(
         """
         CREATE TABLE `sf_database`.`sf_schema`.`my_materialized_table` AS
         SELECT
-          *
+          `a`,
+          `b`
         FROM (
           SELECT
             `a`,
@@ -368,7 +370,14 @@ async def test_materialize__with_sample_timestamp_no_columns_rename(
         """
         CREATE TABLE "sf_database"."sf_schema"."my_materialized_table" AS
         SELECT
-          *
+          "col_int",
+          "col_float",
+          "col_char",
+          "col_text",
+          "col_binary",
+          "col_boolean",
+          "event_timestamp",
+          "cust_id"
         FROM (
           SELECT
             "col_int" AS "col_int",

--- a/tests/unit/routes/test_target_table.py
+++ b/tests/unit/routes/test_target_table.py
@@ -138,6 +138,9 @@ class TestTargetTableApi(BaseMaterializedTableTestSuite):
             "use_case_ids": [],
             "user_id": str(user_id),
             "is_deleted": False,
+            "sample_from_timestamp": None,
+            "sample_rows": None,
+            "sample_to_timestamp": None,
         }
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Add support for sampling by time range during registration of observation tables from source table or view.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
