### PR TITLE
[DEV-3734] BigQuery: Fix errors in F_GET_VALUE and PARSE_JSON

### DIFF
--- a/featurebyte/query_graph/sql/adapter/bigquery.py
+++ b/featurebyte/query_graph/sql/adapter/bigquery.py
@@ -278,13 +278,14 @@ class BigQueryAdapter(BaseAdapter):
         return Anonymous(
             this="LAX_FLOAT64",
             expressions=[
-                Anonymous(
-                    this="PARSE_JSON",
-                    expressions=[
-                        self.call_udf(  # result here is the value in JSON formatted string
-                            "F_GET_VALUE", [dictionary_expression, key_expression]
-                        ),
-                    ],
+                expressions.ParseJSON(
+                    this=self.call_udf(  # result here is the value in JSON formatted string
+                        "F_GET_VALUE", [dictionary_expression, key_expression]
+                    ),
+                    expression=expressions.Kwarg(
+                        this=expressions.Var(this="wide_number_mode"),
+                        expression=make_literal_value("round"),
+                    ),
                 )
             ],
         )

--- a/featurebyte/session/bigquery.py
+++ b/featurebyte/session/bigquery.py
@@ -654,7 +654,7 @@ class BigQuerySchemaInitializer(BaseSchemaInitializer):
 
     @property
     def current_working_schema_version(self) -> int:
-        return 1
+        return 2
 
     async def create_schema(self) -> None:
         create_schema_query = (

--- a/featurebyte/sql/bigquery/F_GET_VALUE.sql
+++ b/featurebyte/sql/bigquery/F_GET_VALUE.sql
@@ -2,7 +2,7 @@ CREATE OR REPLACE FUNCTION `{project}.{dataset}.F_GET_VALUE`(input_map JSON, key
   RETURNS STRING
   LANGUAGE js
 AS r"""
-  if (!(key_to_get in input_map)) {{
+  if (!input_map || !(key_to_get in input_map)) {{
     return JSON.stringify(null);
   }}
   return JSON.stringify(input_map[key_to_get]);

--- a/tests/integration/udf/test_get_value.py
+++ b/tests/integration/udf/test_get_value.py
@@ -1,0 +1,44 @@
+"""
+Tests for F_GET_VALUE UDF
+"""
+
+import json
+
+import numpy as np
+import pytest
+from sqlglot import parse_one
+
+from featurebyte.enum import SourceType
+from tests.integration.udf.util import execute_query_with_udf
+
+
+@pytest.mark.parametrize("source_type", ["bigquery"], indirect=True)
+@pytest.mark.parametrize(
+    "dictionary, key, expected",
+    [
+        (None, "null", np.nan),
+        ({"a": 1}, "null", np.nan),
+        ({"a": 1}, "'a'", 1),
+        ({"a": 1}, "'b'", np.nan),
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_value_udf(session, to_object, dictionary, key, expected):
+    """
+    Test get_value UDF
+    """
+    dictionary_expr = to_object(dictionary)
+    actual = await execute_query_with_udf(
+        session,
+        "F_GET_VALUE",
+        [
+            dictionary_expr,
+            parse_one(key),
+        ],
+    )
+    if session.source_type == SourceType.BIGQUERY:
+        # Result is JSON encoded in case of BigQuery
+        actual = json.loads(actual)
+    if actual is None:
+        actual = np.nan
+    np.testing.assert_allclose(actual, expected, 1e-5)


### PR DESCRIPTION
## Description

Changes:

1. Handle null dictionaries in `F_GET_VALUE` UDF
2. Specify wide number mode to avoid error in `PARSE_JSON`

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
