### PR TITLE
[DEV-3743] Add transform_arrow patch to fix performance issue

### DIFF
--- a/featurebyte/feast/patch.py
+++ b/featurebyte/feast/patch.py
@@ -242,6 +242,32 @@ def transform_arrow(
     pa_table: pyarrow.Table,
     full_feature_names: bool = False,
 ) -> pyarrow.Table:
+    """
+    Tha main difference between this and the original Feast implementation is that this function converts the
+    arrow table to a pandas dataframe first and then call `transform` method of the feature view to transform
+    the features. DataFrame with alias column names support is used to improve the runtime & memory performance
+    of the function without copying the columns & dropping after transformation. This significantly reduces the
+    runtime & memory usage of the function.
+
+    Parameters
+    ----------
+    feature_view: OnDemandFeatureView
+        OnDemandFeatureView object
+    pa_table: pyarrow.Table
+        Arrow table to transform
+    full_feature_names: bool
+        A boolean that provides the option to add the feature view prefixes to the feature names,
+
+    Returns
+    -------
+    pyarrow.Table
+        PyArrow table with transformed features
+
+    Raises
+    ------
+    TypeError
+        transform_arrow only accepts pyarrow.Table
+    """
     if not isinstance(pa_table, pyarrow.Table):
         raise TypeError("transform_arrow only accepts pyarrow.Table")
 

--- a/tests/unit/feast/test_patch.py
+++ b/tests/unit/feast/test_patch.py
@@ -1,0 +1,21 @@
+"""Unit tests for the feast.patch module."""
+
+import pandas as pd
+
+from featurebyte.feast.patch import DataFrameWrapper
+
+
+def test_getitem():
+    """Test the __getitem__ method."""
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+    df_wrapper = DataFrameWrapper(df)
+    df_wrapper.add_column_alias("a", "a_alias")
+    df_wrapper.add_column_alias("b", "b_alias")
+
+    assert df_wrapper["a_alias"].equals(pd.Series([1, 2, 3]))
+    assert df_wrapper["b_alias"].equals(pd.Series([4, 5, 6]))
+
+    output = df_wrapper[["a", "a_alias"]]
+    expected = pd.DataFrame({"a": df["a"], "a_alias": df["a"]})
+    assert output.equals(expected)


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

Previous Feast upgrade PR (https://github.com/featurebyte/featurebyte/pull/2588) drops `get_transformed_features_df` patch as the method has been removed from Feast. After testing the online features request performance, the online features request for a feature list with 380+ features increase from 3s to 2 minutes. This PR adds a `transform_arrow` patch that functions similar to `get_transformed_features_df` in previous version. With this patch, the online request performance is comparable with the performance before recent Feast upgrade.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
