### PR TITLE
[DEV-3737] BigQuery: Fix UDF calls in tiling.py to use fully qualified names

### DIFF
--- a/featurebyte/query_graph/sql/aggregator/window.py
+++ b/featurebyte/query_graph/sql/aggregator/window.py
@@ -425,7 +425,7 @@ class WindowAggregator(TileBasedAggregator):
         keys: list[str],
         serving_names: list[str],
         value_by: str | None,
-        merge_exprs: list[str],
+        merge_exprs: list[Expression],
         agg_result_names: list[str],
         num_tiles: int,
         is_order_dependent: bool,
@@ -591,7 +591,7 @@ class WindowAggregator(TileBasedAggregator):
     def merge_tiles_order_dependent(
         req_joined_with_tiles: Select,
         inner_group_by_keys: list[Expression],
-        merge_exprs: list[str],
+        merge_exprs: list[Expression],
         inner_agg_result_names: list[str],
     ) -> Select:
         """
@@ -607,7 +607,7 @@ class WindowAggregator(TileBasedAggregator):
             Result of joining expanded request table with tile table
         inner_group_by_keys: list[Expression]
             Keys that the aggregation should use
-        merge_exprs: list[str]
+        merge_exprs: list[Expression]
             Expressions that merge tile values to produce feature values
         inner_agg_result_names: list[str]
             Names of the aggregation results, should have the same length as merge_exprs
@@ -683,7 +683,7 @@ class WindowAggregator(TileBasedAggregator):
                     GroupbyColumn(
                         parent_dtype=agg_spec.dtype,
                         agg_func=agg_spec.agg_func,
-                        parent_expr=expressions.Identifier(this=agg_spec.merge_expr),
+                        parent_expr=agg_spec.merge_expr,
                         result_name=agg_spec.agg_result_name,
                         parent_cols=[
                             expressions.Identifier(this=col) for col in agg_spec.tile_value_columns

--- a/featurebyte/query_graph/sql/specs.py
+++ b/featurebyte/query_graph/sql/specs.py
@@ -142,7 +142,7 @@ class TileBasedAggregationSpec(AggregationSpec):
     aggregation_id: str
     keys: list[str]
     value_by: str | None
-    merge_expr: str
+    merge_expr: Expression
     feature_name: str
     is_order_dependent: bool
     tile_value_columns: list[str]

--- a/tests/unit/query_graph/test_feature_common.py
+++ b/tests/unit/query_graph/test_feature_common.py
@@ -3,6 +3,8 @@ Tests for featurebyte.query_graph.feature_common
 """
 
 from bson import ObjectId
+from sqlglot import expressions
+from sqlglot.expressions import Identifier
 
 from featurebyte.enum import AggFunc, DBVarType
 from featurebyte.query_graph.sql.specs import TileBasedAggregationSpec
@@ -39,9 +41,17 @@ def test_aggregation_spec__from_groupby_query_node(
             serving_names=["CUSTOMER_ID"],
             serving_names_mapping=None,
             value_by=None,
-            merge_expr=(
-                f"SUM(sum_value_avg_{groupby_node_aggregation_id}) / "
-                f"SUM(count_value_avg_{groupby_node_aggregation_id})"
+            merge_expr=expressions.Div(
+                this=expressions.Sum(
+                    this=Identifier(
+                        this=f"sum_value_avg_{groupby_node_aggregation_id}",
+                    )
+                ),
+                expression=expressions.Sum(
+                    this=Identifier(
+                        this=f"count_value_avg_{groupby_node_aggregation_id}",
+                    )
+                ),
             ),
             feature_name="a_2h_average",
             is_order_dependent=False,
@@ -68,9 +78,17 @@ def test_aggregation_spec__from_groupby_query_node(
             serving_names=["CUSTOMER_ID"],
             serving_names_mapping=None,
             value_by=None,
-            merge_expr=(
-                f"SUM(sum_value_avg_{groupby_node_aggregation_id}) / "
-                f"SUM(count_value_avg_{groupby_node_aggregation_id})"
+            merge_expr=expressions.Div(
+                this=expressions.Sum(
+                    this=Identifier(
+                        this=f"sum_value_avg_{groupby_node_aggregation_id}",
+                    )
+                ),
+                expression=expressions.Sum(
+                    this=Identifier(
+                        this=f"count_value_avg_{groupby_node_aggregation_id}",
+                    )
+                ),
             ),
             feature_name="a_48h_average",
             is_order_dependent=False,
@@ -123,9 +141,17 @@ def test_aggregation_spec__override_serving_names(
             serving_names=["NEW_CUST_ID"],
             serving_names_mapping=serving_names_mapping,
             value_by=None,
-            merge_expr=(
-                f"SUM(sum_value_avg_{groupby_node_aggregation_id}) / "
-                f"SUM(count_value_avg_{groupby_node_aggregation_id})"
+            merge_expr=expressions.Div(
+                this=expressions.Sum(
+                    this=Identifier(
+                        this=f"sum_value_avg_{groupby_node_aggregation_id}",
+                    )
+                ),
+                expression=expressions.Sum(
+                    this=Identifier(
+                        this=f"count_value_avg_{groupby_node_aggregation_id}",
+                    )
+                ),
             ),
             feature_name="a_2h_average",
             is_order_dependent=False,
@@ -152,9 +178,17 @@ def test_aggregation_spec__override_serving_names(
             serving_names=["NEW_CUST_ID"],
             serving_names_mapping=serving_names_mapping,
             value_by=None,
-            merge_expr=(
-                f"SUM(sum_value_avg_{groupby_node_aggregation_id}) / "
-                f"SUM(count_value_avg_{groupby_node_aggregation_id})"
+            merge_expr=expressions.Div(
+                this=expressions.Sum(
+                    this=Identifier(
+                        this=f"sum_value_avg_{groupby_node_aggregation_id}",
+                    )
+                ),
+                expression=expressions.Sum(
+                    this=Identifier(
+                        this=f"count_value_avg_{groupby_node_aggregation_id}",
+                    )
+                ),
             ),
             feature_name="a_48h_average",
             is_order_dependent=False,

--- a/tests/unit/query_graph/test_feature_compute.py
+++ b/tests/unit/query_graph/test_feature_compute.py
@@ -8,7 +8,8 @@ from dataclasses import asdict
 
 import pytest
 from bson import ObjectId
-from sqlglot import select
+from sqlglot import expressions, select
+from sqlglot.expressions import Identifier
 
 from featurebyte.enum import AggFunc, DBVarType
 from featurebyte.models.parent_serving import (
@@ -46,7 +47,7 @@ def agg_spec_template_fixture(expected_pruned_graph_and_node_1):
         serving_names=["CID"],
         serving_names_mapping=None,
         value_by=None,
-        merge_expr="SUM(value)",
+        merge_expr=expressions.Sum(this=Identifier(this="value")),
         feature_name="Amount (1d sum)",
         is_order_dependent=False,
         tile_value_columns=["value"],
@@ -269,9 +270,17 @@ def test_feature_execution_planner(
                 serving_names=["CUSTOMER_ID"],
                 serving_names_mapping=None,
                 value_by=None,
-                merge_expr=(
-                    f"SUM(sum_value_avg_{groupby_node_aggregation_id}) / "
-                    f"SUM(count_value_avg_{groupby_node_aggregation_id})"
+                merge_expr=expressions.Div(
+                    this=expressions.Sum(
+                        this=Identifier(
+                            this=f"sum_value_avg_{groupby_node_aggregation_id}",
+                        )
+                    ),
+                    expression=expressions.Sum(
+                        this=Identifier(
+                            this=f"count_value_avg_{groupby_node_aggregation_id}",
+                        )
+                    ),
                 ),
                 feature_name="a_2h_average",
                 is_order_dependent=False,
@@ -300,9 +309,17 @@ def test_feature_execution_planner(
                 serving_names=["CUSTOMER_ID"],
                 serving_names_mapping=None,
                 value_by=None,
-                merge_expr=(
-                    f"SUM(sum_value_avg_{groupby_node_aggregation_id}) / "
-                    f"SUM(count_value_avg_{groupby_node_aggregation_id})"
+                merge_expr=expressions.Div(
+                    this=expressions.Sum(
+                        this=Identifier(
+                            this=f"sum_value_avg_{groupby_node_aggregation_id}",
+                        )
+                    ),
+                    expression=expressions.Sum(
+                        this=Identifier(
+                            this=f"count_value_avg_{groupby_node_aggregation_id}",
+                        )
+                    ),
                 ),
                 feature_name="a_48h_average",
                 is_order_dependent=False,
@@ -372,9 +389,17 @@ def test_feature_execution_planner__serving_names_mapping(
                 serving_names=["NEW_CUST_ID"],
                 serving_names_mapping=mapping,
                 value_by=None,
-                merge_expr=(
-                    f"SUM(sum_value_avg_{groupby_node_aggregation_id}) / "
-                    f"SUM(count_value_avg_{groupby_node_aggregation_id})"
+                merge_expr=expressions.Div(
+                    this=expressions.Sum(
+                        this=Identifier(
+                            this=f"sum_value_avg_{groupby_node_aggregation_id}",
+                        )
+                    ),
+                    expression=expressions.Sum(
+                        this=Identifier(
+                            this=f"count_value_avg_{groupby_node_aggregation_id}",
+                        )
+                    ),
                 ),
                 feature_name="a_2h_average",
                 is_order_dependent=False,
@@ -403,9 +428,17 @@ def test_feature_execution_planner__serving_names_mapping(
                 serving_names=["NEW_CUST_ID"],
                 serving_names_mapping=mapping,
                 value_by=None,
-                merge_expr=(
-                    f"SUM(sum_value_avg_{groupby_node_aggregation_id}) / "
-                    f"SUM(count_value_avg_{groupby_node_aggregation_id})"
+                merge_expr=expressions.Div(
+                    this=expressions.Sum(
+                        this=Identifier(
+                            this=f"sum_value_avg_{groupby_node_aggregation_id}",
+                        )
+                    ),
+                    expression=expressions.Sum(
+                        this=Identifier(
+                            this=f"count_value_avg_{groupby_node_aggregation_id}",
+                        )
+                    ),
                 ),
                 feature_name="a_48h_average",
                 is_order_dependent=False,

--- a/tests/unit/query_graph/test_tiling.py
+++ b/tests/unit/query_graph/test_tiling.py
@@ -189,7 +189,7 @@ def test_tiling_aggregators(
     agg = get_aggregator(agg_func, adapter=adapter, parent_dtype=parent_dtype)
     input_column = InputColumn(name="a_column", dtype=DBVarType.VARCHAR)
     tile_specs = agg.tile(input_column, agg_id)
-    merge_expr = agg.merge(agg_id)
+    merge_expr = agg.merge(agg_id).sql()
     assert [t.tile_expr.sql() for t in tile_specs] == [t["tile_expr"] for t in expected_tile_specs]
     assert [t.tile_column_name for t in tile_specs] == [
         t["tile_column_name"] for t in expected_tile_specs


### PR DESCRIPTION
## Description

This updates the `merge` methods in `tiling.py` to return `Expression` type instead of str type and use fully qualified names when calling UDFs for vector aggregation.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
