### PR TITLE
[DEV-3748] Prevent users to tag multiple columns with the same entity

### DIFF
--- a/.changelog/DEV-3748.yaml
+++ b/.changelog/DEV-3748.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Prevent users to tag multiple columns with the same entity in the same table."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/tests/unit/routes/test_event_table.py
+++ b/tests/unit/routes/test_event_table.py
@@ -593,3 +593,38 @@ class TestEventTableApi(BaseTableApiTestSuite):
         assert response.json()["status"] == "DEPRECATED"
         for col in response.json()["columns_info"]:
             assert col["entity_id"] is None
+
+    def test_tag_same_entity_on_multiple_columns_422(
+        self, test_api_client_persistent, create_success_response
+    ):
+        """Test tag same entity on multiple columns"""
+        test_api_client, _ = test_api_client_persistent
+        table_dict = create_success_response.json()
+        columns = set(col_info["name"] for col_info in table_dict["columns_info"])
+        table_id = table_dict["_id"]
+
+        # tag 1st column with entity (expect success)
+        entity_payload = self.load_payload("tests/fixtures/request_payloads/entity.json")
+        col1 = "cust_id"
+        assert col1 in columns
+        response = test_api_client.patch(
+            f"/event_table/{table_id}/column_entity",
+            json={"column_name": col1, "entity_id": entity_payload["_id"]},
+        )
+        assert response.status_code == HTTPStatus.OK
+
+        # tag 2nd column with same entity (expect failure)
+        col2 = "col_int"
+        assert col2 in columns
+        response = test_api_client.patch(
+            f"/event_table/{table_id}/column_entity",
+            json={"column_name": col2, "entity_id": entity_payload["_id"]},
+        )
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        expected_error = (
+            "It looks like the columns ['col_int', 'cust_id'] are all linked to "
+            f"the same entity (ID: {entity_payload['_id']}, Name: customer). "
+            "Each column should be associated with a unique entity. Please "
+            "check your data and ensure that each entity corresponds to only one column."
+        )
+        assert response.json()["detail"] == expected_error


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
This PR prevents users to tag multiple columns with the same entity in the same table.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
