### PR TITLE
[DEV-3751] Add validation for event ID column dtypes

### DIFF
--- a/.changelog/DEV-3751.yaml
+++ b/.changelog/DEV-3751.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add validation for event ID column dtypes between item and event table during item table registration."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/routes/item_table/controller.py
+++ b/featurebyte/routes/item_table/controller.py
@@ -7,12 +7,10 @@ from __future__ import annotations
 from bson import ObjectId
 
 from featurebyte.enum import SemanticType
-from featurebyte.exception import ColumnNotFoundError
-from featurebyte.models import EventTableModel
 from featurebyte.models.item_table import ItemTableModel
 from featurebyte.routes.common.base_table import BaseTableDocumentController
 from featurebyte.schema.info import ItemTableInfo
-from featurebyte.schema.item_table import ItemTableCreate, ItemTableList, ItemTableServiceUpdate
+from featurebyte.schema.item_table import ItemTableList, ItemTableServiceUpdate
 from featurebyte.service.entity import EntityService
 from featurebyte.service.event_table import EventTableService
 from featurebyte.service.feature import FeatureService
@@ -72,17 +70,6 @@ class ItemTableController(
         )
         self.table_info_service = table_info_service
         self.event_table_service = event_table_service
-
-    async def create_table(self, data: ItemTableCreate) -> ItemTableModel:  # type: ignore[override]
-        # check existence of event table first before creating item table
-        event_table: EventTableModel = await self.event_table_service.get_document(
-            document_id=data.event_table_id
-        )
-        if not event_table.event_id_column:
-            raise ColumnNotFoundError(
-                f"Event ID column is not available for the event table: {event_table.name}"
-            )
-        return await super().create_table(data=data)
 
     async def get_info(self, document_id: ObjectId, verbose: bool) -> ItemTableInfo:
         """

--- a/featurebyte/service/item_table.py
+++ b/featurebyte/service/item_table.py
@@ -4,12 +4,20 @@ ItemTableService class
 
 from __future__ import annotations
 
-from bson import ObjectId
+from typing import Any, Optional
 
+from bson import ObjectId
+from redis import Redis
+
+from featurebyte.exception import DocumentCreationError
 from featurebyte.models.item_table import ItemTableModel
+from featurebyte.persistent import Persistent
+from featurebyte.routes.block_modification_handler import BlockModificationHandler
 from featurebyte.schema.item_table import ItemTableCreate, ItemTableServiceUpdate
 from featurebyte.service.base_table_document import BaseTableDocumentService
 from featurebyte.service.event_table import EventTableService
+from featurebyte.service.feature_store import FeatureStoreService
+from featurebyte.storage import Storage
 
 
 class ItemTableService(
@@ -22,9 +30,60 @@ class ItemTableService(
     document_class = ItemTableModel
     document_update_class = ItemTableServiceUpdate
 
+    def __init__(
+        self,
+        user: Any,
+        persistent: Persistent,
+        catalog_id: Optional[ObjectId],
+        block_modification_handler: BlockModificationHandler,
+        feature_store_service: FeatureStoreService,
+        storage: Storage,
+        redis: Redis[Any],
+        event_table_service: EventTableService,
+    ):
+        super().__init__(
+            user=user,
+            persistent=persistent,
+            catalog_id=catalog_id,
+            block_modification_handler=block_modification_handler,
+            feature_store_service=feature_store_service,
+            storage=storage,
+            redis=redis,
+        )
+        self.event_table_service = event_table_service
+
     @property
     def class_name(self) -> str:
         return "ItemTable"
+
+    async def create_document(self, data: ItemTableCreate) -> ItemTableModel:
+        # validate event ID column in the event table has matching data type with that in the item table
+        item_table_event_id_dtype = [
+            column_info
+            for column_info in data.columns_info
+            if column_info.name == data.event_id_column
+        ][0].dtype
+        event_table_model = await self.event_table_service.get_document(
+            document_id=data.event_table_id
+        )
+
+        if event_table_model.event_id_column is None:
+            raise DocumentCreationError(
+                f"Event ID column not available in event table {event_table_model.name} (ID: {event_table_model.id})."
+            )
+
+        event_table_event_id_dtype = [
+            column_info
+            for column_info in event_table_model.columns_info
+            if column_info.name == event_table_model.event_id_column
+        ][0].dtype
+        if item_table_event_id_dtype != event_table_event_id_dtype:
+            raise DocumentCreationError(
+                f"Data type mismatch between event ID columns of event table {event_table_model.name} "
+                f"(ID: {event_table_model.id}) ({event_table_event_id_dtype}) and "
+                f"item table ({item_table_event_id_dtype})."
+            )
+        return await super().create_document(data=data)
 
 
 class ExtendedItemTableService:
@@ -32,11 +91,8 @@ class ExtendedItemTableService:
     ExtendedItemTableService class
     """
 
-    def __init__(
-        self, item_table_service: ItemTableService, event_table_service: EventTableService
-    ):
+    def __init__(self, item_table_service: ItemTableService):
         self.item_table_service = item_table_service
-        self.event_table_service = event_table_service
 
     async def get_document_with_event_table_model(self, document_id: ObjectId) -> ItemTableModel:
         """
@@ -52,7 +108,9 @@ class ExtendedItemTableService:
         ItemTableModel
         """
         item_table = await self.item_table_service.get_document(document_id=document_id)
-        item_table.event_table_model = await self.event_table_service.get_document(
-            document_id=item_table.event_table_id
+        item_table.event_table_model = (
+            await self.item_table_service.event_table_service.get_document(
+                document_id=item_table.event_table_id
+            )
         )
         return item_table

--- a/tests/unit/api/test_item_table.py
+++ b/tests/unit/api/test_item_table.py
@@ -552,29 +552,3 @@ def test_create_item_table_without_item_id_column(
 
     # expect subset to work
     _ = item_view[["item_type", "item_amount"]]
-
-
-def test_create_item_table_without_item_id_column_event_table_no_event_id_column(
-    snowflake_database_table, snowflake_database_table_item_table, item_table_dict
-):
-    """
-    Test ItemTable creation using tabular source without item_id_column and using an event table without event_id_column
-    """
-
-    # create event table without event_id_column
-    snowflake_database_table.create_event_table(
-        name="sf_event_table",
-        event_timestamp_column="event_timestamp",
-        record_creation_timestamp_column="created_at",
-        description="Some description",
-    )
-
-    with pytest.raises(RecordCreationException) as exc:
-        snowflake_database_table_item_table.create_item_table(
-            name="sf_item_table",
-            event_id_column="event_id_col",
-            item_id_column=None,
-            event_table_name="sf_event_table",
-            record_creation_timestamp_column="created_at",
-        )
-    assert "Event ID column is not available for the event table: sf_event_table" in str(exc.value)

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -504,9 +504,9 @@ async def event_table_fixture(event_table_factory):
 
 
 @pytest_asyncio.fixture(name="item_table")
-async def item_table_fixture(test_dir, feature_store, item_table_service):
+async def item_table_fixture(test_dir, feature_store, item_table_service, event_table):
     """ItemTable model"""
-    _ = feature_store
+    _, _ = feature_store, event_table
     fixture_path = os.path.join(test_dir, "fixtures/request_payloads/item_table.json")
     with open(fixture_path, encoding="utf") as fhandle:
         payload = json.loads(fhandle.read())


### PR DESCRIPTION
## Description

 Add validation for event ID column data types between item and event table during item table registration.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
