### PR TITLE
[chore] Implement entity dtype validation to enforce dtype consistency

### DIFF
--- a/.changelog/DEV-3744.yaml
+++ b/.changelog/DEV-3744.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Implemented a consistency check to ensure entity data types are consistent between associated tables."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/base_table.py
+++ b/featurebyte/api/base_table.py
@@ -1067,6 +1067,10 @@ class TableApiObject(
             skip_update_schema_check=True,
         )
 
+        if entity_id:
+            # call get to update the object cache of the entity
+            Entity.get_by_id(ObjectId(entity_id))
+
     @typechecked
     def update_column_critical_data_info(
         self, column_name: str, critical_data_info: CriticalDataInfo

--- a/featurebyte/api/base_table.py
+++ b/featurebyte/api/base_table.py
@@ -1067,10 +1067,6 @@ class TableApiObject(
             skip_update_schema_check=True,
         )
 
-        if entity_id:
-            # call get to update the object cache of the entity
-            Entity.get_by_id(ObjectId(entity_id))
-
     @typechecked
     def update_column_critical_data_info(
         self, column_name: str, critical_data_info: CriticalDataInfo

--- a/featurebyte/api/entity.py
+++ b/featurebyte/api/entity.py
@@ -4,7 +4,7 @@ Entity class
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 
 from bson import ObjectId
 from pydantic import Field
@@ -13,6 +13,7 @@ from typeguard import typechecked
 from featurebyte.api.api_object_util import NameAttributeUpdatableMixin
 from featurebyte.api.savable_api_object import DeletableApiObject, SavableApiObject
 from featurebyte.common.doc_util import FBAutoDoc
+from featurebyte.enum import DBVarType
 from featurebyte.exception import RecordRetrievalException
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.entity import EntityModel, ParentEntity
@@ -145,6 +146,18 @@ class Entity(NameAttributeUpdatableMixin, SavableApiObject, DeletableApiObject):
             List of ancestor entity ids.
         """
         return self.cached_model.ancestor_ids
+
+    @property
+    def dtype(self) -> Optional[DBVarType]:
+        """
+        Get the data type of the entity.
+
+        Returns
+        -------
+        Optional[str]
+            Data type of the entity.
+        """
+        return self.cached_model.dtype
 
     @typechecked
     def update_name(self, name: str) -> None:

--- a/featurebyte/models/entity.py
+++ b/featurebyte/models/entity.py
@@ -5,12 +5,12 @@ This module contains Entity related models
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 import pymongo
 from pydantic import Field, StrictStr
 
-from featurebyte.enum import TableDataType
+from featurebyte.enum import DBVarType, TableDataType
 from featurebyte.models.base import (
     FeatureByteBaseModel,
     FeatureByteCatalogBaseDocumentModel,
@@ -83,6 +83,7 @@ class EntityModel(EntityRelationship):
         ID of table with primary key columns associated to the entity
     """
 
+    dtype: Optional[DBVarType] = None
     serving_names: List[NameStr] = Field(frozen=True)
     table_ids: List[PydanticObjectId] = Field(frozen=True, default_factory=list)
     primary_table_ids: List[PydanticObjectId] = Field(frozen=True, default_factory=list)

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -157,7 +157,10 @@ from featurebyte.service.session_validator import SessionValidatorService
 from featurebyte.service.specialized_dtype import SpecializedDtypeDetectionService
 from featurebyte.service.static_source_table import StaticSourceTableService
 from featurebyte.service.table import AllTableService, TableService
-from featurebyte.service.table_columns_info import TableColumnsInfoService
+from featurebyte.service.table_columns_info import (
+    EntityDtypeInitializationAndValidationService,
+    TableColumnsInfoService,
+)
 from featurebyte.service.table_facade import TableFacadeService
 from featurebyte.service.table_info import TableInfoService
 from featurebyte.service.table_status import TableStatusService
@@ -354,6 +357,7 @@ app_container_config.register_class(SessionManagerService)
 app_container_config.register_class(SessionValidatorService)
 app_container_config.register_class(StaticSourceTableController)
 app_container_config.register_class(StaticSourceTableService)
+app_container_config.register_class(EntityDtypeInitializationAndValidationService)
 app_container_config.register_class(TableColumnsInfoService)
 app_container_config.register_class(
     TableController, dependency_override={"service": "table_service"}

--- a/featurebyte/schema/entity.py
+++ b/featurebyte/schema/entity.py
@@ -52,6 +52,7 @@ class EntityServiceUpdate(BaseDocumentServiceUpdateSchema):
     """
 
     name: Optional[NameStr] = Field(default=None)
+    dtype: Optional[str] = Field(default=None)
     ancestor_ids: Optional[List[PydanticObjectId]] = Field(default=None)
     parents: Optional[List[ParentEntity]] = Field(default=None)
     table_ids: Optional[List[PydanticObjectId]] = Field(default=None)

--- a/featurebyte/service/table_columns_info.py
+++ b/featurebyte/service/table_columns_info.py
@@ -5,16 +5,16 @@ TableColumnsInfoService
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import List, Tuple, Union
+from typing import Iterable, List, Optional, Tuple, Union
 
 from bson import ObjectId
 from pymongo.errors import OperationFailure
 from tenacity import retry, retry_if_exception_type, wait_chain, wait_random
 
-from featurebyte.enum import TableDataType
+from featurebyte.enum import DBVarType, TableDataType
 from featurebyte.exception import DocumentUpdateError
 from featurebyte.models.base import PydanticObjectId, User
-from featurebyte.models.entity import ParentEntity
+from featurebyte.models.entity import EntityModel, ParentEntity
 from featurebyte.models.feature_store import TableModel
 from featurebyte.models.relationship import RelationshipType
 from featurebyte.persistent import Persistent
@@ -37,6 +37,146 @@ TableDocumentService = Union[
 ]
 
 
+class EntityDtypeInitializationAndValidationService:
+    """
+    EntityDtypeInitializationAndValidationService is responsible for initializing and validating the entity dtype.
+    """
+
+    def __init__(self, entity_service: EntityService, table_service: TableDocumentService):
+        self.entity_service = entity_service
+        self.table_service = table_service
+
+    async def maybe_initialize_entity_dtype(self, entity_id: ObjectId) -> EntityModel:
+        """
+        Initialize entity dtype for old documents that do not have dtype.
+
+        Parameters
+        ----------
+        entity_id: ObjectId
+            Entity ID
+
+        Returns
+        -------
+        EntityModel
+
+        Raises
+        ------
+        DocumentUpdateError
+            When entity has columns with different dtypes in different tables
+        """
+        entity = await self.entity_service.get_document(entity_id)
+
+        if entity.table_ids and entity.dtype is None:
+            entity_dtype: Optional[DBVarType] = None
+            ref_table_name: Optional[str] = None
+            async for table in self.table_service.list_documents_iterator(
+                query_filter={"_id": {"$in": entity.table_ids}}
+            ):
+                for column_info in table.columns_info:
+                    if column_info.entity_id == entity_id:
+                        if entity_dtype is None:
+                            entity_dtype = column_info.dtype
+                            ref_table_name = table.name
+                        elif entity_dtype != column_info.dtype:
+                            raise DocumentUpdateError(
+                                f"Entity {entity.name} (ID: {entity_id}) has columns with different dtypes "
+                                f"({entity_dtype} and {column_info.dtype}) in tables {ref_table_name} and "
+                                f"{table.name}. Please double-check the entity of the affected columns."
+                            )
+
+            if entity_dtype:
+                # update entity dtype
+                await self.entity_service.update_document(
+                    document_id=entity_id,
+                    data=EntityServiceUpdate(dtype=entity_dtype),
+                    return_document=False,
+                )
+                return await self.entity_service.get_document(entity_id)
+
+        return entity
+
+    @staticmethod
+    def iterate_affected_target_entity_columns_info(
+        original_columns_info: List[ColumnInfo], target_columns_info: List[ColumnInfo]
+    ) -> Iterable[Tuple[ColumnInfo, Optional[ObjectId]]]:
+        """
+        Iterate over the target columns info and yield the affected columns info with the original entity ID.
+
+        Parameters
+        ----------
+        original_columns_info: List[ColumnInfo]
+            Original columns info
+        target_columns_info: List[ColumnInfo]
+            Target columns info
+
+        Yields
+        ------
+        Tuple[ColumnInfo, Optional[ObjectId]]
+            Affected columns info with the original entity ID
+        """
+        original_col_to_entity_id = {
+            col_info.name: col_info.entity_id for col_info in original_columns_info
+        }
+        for col_info in target_columns_info:
+            if col_info.entity_id != original_col_to_entity_id.get(col_info.name):
+                yield col_info, original_col_to_entity_id.get(col_info.name)
+
+    async def validate_entity_dtype(
+        self, table: TableModel, target_columns_info: List[ColumnInfo]
+    ) -> None:
+        """
+        Validate entity dtype for the target columns info.
+
+        Parameters
+        ----------
+        table: TableModel
+            TableModel object
+        target_columns_info: List[ColumnInfo]
+            Target columns info
+
+        Raises
+        ------
+        DocumentUpdateError
+            When the entity dtype does not match the column dtype
+        """
+        for col_info, _ in self.iterate_affected_target_entity_columns_info(
+            original_columns_info=table.columns_info, target_columns_info=target_columns_info
+        ):
+            if col_info.entity_id:
+                # when the entity is associated with a column, validate the entity dtype
+                entity = await self.maybe_initialize_entity_dtype(col_info.entity_id)
+                if entity.dtype and col_info.dtype != entity.dtype:
+                    raise DocumentUpdateError(
+                        f"Column {col_info.name} (Table ID: {table.id}, Name: {table.name}) "
+                        f"has dtype {col_info.dtype} which does not match the entity dtype {entity.dtype}."
+                    )
+
+    async def update_entity_dtype(
+        self, table: TableModel, target_columns_info: List[ColumnInfo]
+    ) -> None:
+        for col_info, prev_entity_id in self.iterate_affected_target_entity_columns_info(
+            original_columns_info=table.columns_info, target_columns_info=target_columns_info
+        ):
+            if col_info.entity_id:
+                # when the entity does not have dtype, update the entity dtype
+                entity = await self.entity_service.get_document(col_info.entity_id)
+                if entity.dtype is None:
+                    await self.entity_service.update_document(
+                        document_id=col_info.entity_id,
+                        data=EntityServiceUpdate(dtype=col_info.dtype),
+                        return_document=False,
+                    )
+
+            if prev_entity_id and col_info.entity_id is None:
+                # when the entity is disassociated from a column, update the entity dtype if needed
+                entity = await self.entity_service.get_document(prev_entity_id)
+                if not entity.table_ids:
+                    await self.entity_service.update_documents(
+                        query_filter={"_id": prev_entity_id},
+                        update={"$unset": {"dtype": ""}},
+                    )
+
+
 class TableColumnsInfoService(OpsServiceMixin):
     """
     TableColumnsInfoService is responsible to orchestrate the update of the table columns info.
@@ -50,6 +190,7 @@ class TableColumnsInfoService(OpsServiceMixin):
         entity_service: EntityService,
         relationship_info_service: RelationshipInfoService,
         entity_relationship_service: EntityRelationshipService,
+        entity_dtype_initialization_and_validation_service: EntityDtypeInitializationAndValidationService,
     ):
         self.user = user
         self.persistent = persistent
@@ -57,6 +198,9 @@ class TableColumnsInfoService(OpsServiceMixin):
         self.entity_service = entity_service
         self.relationship_info_service = relationship_info_service
         self.entity_relationship_service = entity_relationship_service
+        self.entity_dtype_initialization_and_validation_service = (
+            entity_dtype_initialization_and_validation_service
+        )
 
     @staticmethod
     async def _validate_column_info_id_field_values(
@@ -89,7 +233,9 @@ class TableColumnsInfoService(OpsServiceMixin):
                 f"{field_class_name} IDs {list(id_vals)} not found for columns {list(col_names)}."
             )
 
-    async def _validate_column_info(self, columns_info: List[ColumnInfo]) -> None:
+    async def _validate_column_info(
+        self, table: TableModel, columns_info: List[ColumnInfo]
+    ) -> None:
         entity_id_to_column_names = defaultdict(list)
         for col_info in columns_info:
             if col_info.entity_id:
@@ -101,6 +247,11 @@ class TableColumnsInfoService(OpsServiceMixin):
                 raise DocumentUpdateError(
                     f"Entity {entity.name} (ID: {entity_id}) tagged to multiple columns {column_names} in the table."
                 )
+
+        # validate entity dtype
+        await self.entity_dtype_initialization_and_validation_service.validate_entity_dtype(
+            table=table, target_columns_info=columns_info
+        )
 
     @retry(
         retry=retry_if_exception_type(OperationFailure),
@@ -149,7 +300,7 @@ class TableColumnsInfoService(OpsServiceMixin):
                 )
 
             # validate other columns info
-            await self._validate_column_info(columns_info)
+            await self._validate_column_info(document, columns_info)
 
             async with self.persistent.start_transaction():
                 # update columns info
@@ -162,6 +313,11 @@ class TableColumnsInfoService(OpsServiceMixin):
 
                 # update entity table reference
                 await self.update_entity_table_references(document, columns_info)
+
+                # update entity dtype
+                await self.entity_dtype_initialization_and_validation_service.update_entity_dtype(
+                    table=document, target_columns_info=columns_info
+                )
 
     async def _update_entity_table_reference(
         self,

--- a/featurebyte/service/table_columns_info.py
+++ b/featurebyte/service/table_columns_info.py
@@ -79,9 +79,9 @@ class EntityDtypeInitializationAndValidationService:
                             ref_table_name = table.name
                         elif entity_dtype != column_info.dtype:
                             raise DocumentUpdateError(
-                                f"Entity {entity.name} (ID: {entity_id}) has columns with different dtypes "
-                                f"({entity_dtype} and {column_info.dtype}) in tables {ref_table_name} and "
-                                f"{table.name}. Please double-check the entity of the affected columns."
+                                f"Entity {entity.name} (ID: {entity_id}) has columns with different dtypes in "
+                                f"tables {ref_table_name} ({entity_dtype}) and {table.name} ({column_info.dtype}). "
+                                f"Please double-check the entity of the affected columns."
                             )
 
             if entity_dtype:
@@ -154,6 +154,17 @@ class EntityDtypeInitializationAndValidationService:
     async def update_entity_dtype(
         self, table: TableModel, target_columns_info: List[ColumnInfo]
     ) -> None:
+        """
+        Update entity dtype for the target columns info. This method should be called after the table reference
+         update is done as we need to check if the entity is disassociated from any column.
+
+        Parameters
+        ----------
+        table: TableModel
+            Table triggers the entity tag update
+        target_columns_info: List[ColumnInfo]
+            Target columns info
+        """
         for col_info, prev_entity_id in self.iterate_affected_target_entity_columns_info(
             original_columns_info=table.columns_info, target_columns_info=target_columns_info
         ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,7 +117,7 @@ def index_to_timestamp_fixture(request):
 
 
 @pytest.fixture(name="patch_initialize_entity_dtype")
-def always_patch_initialize_entity_dtype_service():
+def patch_initialize_entity_dtype_service():
     """
     Patch the initialize entity dtype method
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,3 +114,27 @@ def index_to_timestamp_fixture(request):
     Parameterized fixture for index to timestamp conversion
     """
     return request.param
+
+
+@pytest.fixture(name="patch_initialize_entity_dtype")
+def always_patch_initialize_entity_dtype_service():
+    """
+    Patch the initialize entity dtype method
+    """
+    module_base_path = (
+        "featurebyte.service.table_columns_info.EntityDtypeInitializationAndValidationService"
+    )
+    patched = {}
+    patch_targets = [
+        "maybe_initialize_entity_dtype",
+        "validate_entity_dtype",
+        "update_entity_dtype",
+    ]
+    started_patchers = []
+    for patch_target in patch_targets:
+        patcher = patch(f"{module_base_path}.{patch_target}")
+        patched[patch_target] = patcher.start()
+        started_patchers.append(patcher)
+    yield started_patchers
+    for patcher in started_patchers:
+        patcher.stop()

--- a/tests/integration/api/test_vector_aggregation_operations.py
+++ b/tests/integration/api/test_vector_aggregation_operations.py
@@ -408,10 +408,14 @@ def test_vector_cosine_similarity(item_table_with_array_column):
 
 
 @pytest.mark.parametrize("source_type", ["spark", "snowflake"], indirect=True)
-def test_vector_value_column_latest_aggregation(event_table_with_array_column):
+def test_vector_value_column_latest_aggregation(
+    event_table_with_array_column, patch_initialize_entity_dtype
+):
     """
     Test latest aggregation on vector column
     """
+    _ = patch_initialize_entity_dtype
+
     event_view = event_table_with_array_column.get_view()
     feature_name = "vector_agg"
     feature = event_view.groupby("USER_ID").aggregate_over(

--- a/tests/integration/api/test_vector_aggregation_operations.py
+++ b/tests/integration/api/test_vector_aggregation_operations.py
@@ -437,8 +437,6 @@ def test_vector_value_column_latest_aggregation(event_table_with_array_column):
     """
     Test latest aggregation on vector column
     """
-    _ = patch_initialize_entity_dtype
-
     event_view = event_table_with_array_column.get_view()
     feature_name = "vector_agg"
     feature = event_view.groupby("USER_ID").aggregate_over(

--- a/tests/integration/api/test_vector_aggregation_operations.py
+++ b/tests/integration/api/test_vector_aggregation_operations.py
@@ -5,6 +5,7 @@ Test vector aggregation operations module
 import json
 import os
 from typing import List
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -26,6 +27,30 @@ VECTOR_VALUE_FLOAT_COL = "VECTOR_VALUE_FLOAT"
 VECTOR_VALUE_INT_COL = "VECTOR_VALUE_INT"
 VECTOR_VALUE_MIXED_COL = "VECTOR_VALUE_MIXED"
 VECTOR_VALUE_DIFF_LENGTH_COL = "VECTOR_VALUE_DIFFERENT_LENGTH"
+
+
+@pytest.fixture(autouse=True, scope="module")
+def always_patch_initialize_entity_dtype():
+    """
+    Patch initialize_entity_dtype
+    """
+    module_base_path = (
+        "featurebyte.service.table_columns_info.EntityDtypeInitializationAndValidationService"
+    )
+    patched = {}
+    patch_targets = [
+        "maybe_initialize_entity_dtype",
+        "validate_entity_dtype",
+        "update_entity_dtype",
+    ]
+    started_patchers = []
+    for patch_target in patch_targets:
+        patcher = patch(f"{module_base_path}.{patch_target}")
+        patched[patch_target] = patcher.start()
+        started_patchers.append(patcher)
+    yield started_patchers
+    for patcher in started_patchers:
+        patcher.stop()
 
 
 def _update_df(df: pd.DataFrame, event_timestamp_col: str) -> pd.DataFrame:
@@ -408,9 +433,7 @@ def test_vector_cosine_similarity(item_table_with_array_column):
 
 
 @pytest.mark.parametrize("source_type", ["spark", "snowflake"], indirect=True)
-def test_vector_value_column_latest_aggregation(
-    event_table_with_array_column, patch_initialize_entity_dtype
-):
+def test_vector_value_column_latest_aggregation(event_table_with_array_column):
     """
     Test latest aggregation on vector column
     """

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -263,6 +263,14 @@ def always_patch_app_get_storage_fixture(storage):
         yield
 
 
+@pytest.fixture(autouse=True)
+def always_patch_initialize_entity_dtype_service(patch_initialize_entity_dtype):
+    """
+    Patch the initialize entity dtype service for all tests in this module
+    """
+    yield patch_initialize_entity_dtype
+
+
 @pytest.fixture(name="config", scope="session")
 def config_fixture(storage):
     """

--- a/tests/unit/api/test_dimension_view.py
+++ b/tests/unit/api/test_dimension_view.py
@@ -283,7 +283,10 @@ def test_as_feature__special_column(snowflake_dimension_view_with_entity):
 
 
 def test_as_feature_same_column_name(
-    snowflake_dimension_view_with_entity, snowflake_scd_table, cust_id_entity
+    snowflake_dimension_view_with_entity,
+    snowflake_scd_table,
+    cust_id_entity,
+    patch_initialize_entity_dtype,
 ):
     """
     Test lookup features with same column name

--- a/tests/unit/api/test_entity.py
+++ b/tests/unit/api/test_entity.py
@@ -153,6 +153,7 @@ def test_entity_update_name(entity, catalog):
             ("INSERT", 'insert: "customer"', "catalog_id", np.nan, str(catalog.id)),
             ("INSERT", 'insert: "customer"', "created_at", np.nan, entity.created_at.isoformat()),
             ("INSERT", 'insert: "customer"', "description", np.nan, None),
+            ("INSERT", 'insert: "customer"', "dtype", np.nan, None),
             ("INSERT", 'insert: "customer"', "is_deleted", np.nan, False),
             ("INSERT", 'insert: "customer"', "name", np.nan, "customer"),
             ("INSERT", 'insert: "customer"', "parents", np.nan, []),

--- a/tests/unit/api/test_event_table.py
+++ b/tests/unit/api/test_event_table.py
@@ -1211,12 +1211,16 @@ def test_create_event_table_without_event_id_column(snowflake_database_table, ca
 
 
 def test_associate_conflicting_dtype_to_different_tables(
-    saved_event_table, saved_scd_table, cust_id_entity
+    saved_event_table, saved_scd_table, cust_id_entity, mock_api_object_cache
 ):
     """Test associating conflicting dtype to different tables"""
+    # check entity dtype is None
+    assert cust_id_entity.dtype is None
+
     # associate cust_id column to entity
     assert saved_event_table.cust_id.info.dtype == DBVarType.INT
     saved_event_table.cust_id.as_entity(cust_id_entity.name)
+    assert cust_id_entity.dtype == DBVarType.INT
 
     # check exception raised when associating conflicting dtype to different tables
     assert saved_scd_table.col_text.info.dtype == DBVarType.VARCHAR

--- a/tests/unit/api/test_feature.py
+++ b/tests/unit/api/test_feature.py
@@ -1506,6 +1506,7 @@ def test_feature_create_new_version__multiple_event_table(
     snowflake_database_table_scd_table,
     cust_id_entity,
     main_data_from_event_table,
+    patch_initialize_entity_dtype,
 ):
     """Test create new version with multiple feature job settings"""
     another_event_table = snowflake_database_table_scd_table.create_event_table(

--- a/tests/unit/api/test_feature_list.py
+++ b/tests/unit/api/test_feature_list.py
@@ -1125,6 +1125,7 @@ def test_get_feature_jobs_status_feature_without_tile(
     snowflake_event_table,
     float_feature,
     feature_job_logs,
+    patch_initialize_entity_dtype,
 ):
     """
     Test get_feature_jobs_status for feature without tile

--- a/tests/unit/api/test_item_view.py
+++ b/tests/unit/api/test_item_view.py
@@ -817,7 +817,7 @@ def test_validate_join(snowflake_scd_view, snowflake_dimension_view, snowflake_i
 
 
 def test_validate_simple_aggregate_parameters(
-    snowflake_item_table, transaction_entity, cust_id_entity
+    snowflake_item_table, transaction_entity, cust_id_entity, patch_initialize_entity_dtype
 ):
     """
     Test validate_simple_aggregate_parameters
@@ -846,7 +846,7 @@ def test_validate_simple_aggregate_parameters(
 
 
 def test_validate_aggregate_over_parameters(
-    snowflake_item_table, transaction_entity, cust_id_entity
+    snowflake_item_table, transaction_entity, cust_id_entity, patch_initialize_entity_dtype
 ):
     """
     Test validate_aggregate_over_parameters

--- a/tests/unit/api/test_offline_ingest_query_graph.py
+++ b/tests/unit/api/test_offline_ingest_query_graph.py
@@ -235,7 +235,7 @@ def test_feature__request_column_ttl_and_non_ttl_components(
 
 
 def test_feature__multiple_non_ttl_components(
-    snowflake_scd_table, snowflake_dimension_table, cust_id_entity
+    snowflake_scd_table, snowflake_dimension_table, cust_id_entity, patch_initialize_entity_dtype
 ):
     """Test that a feature contains multiple non-ttl components."""
     snowflake_scd_table["col_text"].as_entity(cust_id_entity.name)

--- a/tests/unit/api/test_table.py
+++ b/tests/unit/api/test_table.py
@@ -93,7 +93,11 @@ def test_get_dimension_table(saved_dimension_table, snowflake_dimension_table):
 
 
 def test_delete_table_and_entity_referenced_in_feature_entity_relationship(
-    saved_event_table, saved_scd_table, saved_dimension_table, feature_group_feature_job_setting
+    saved_event_table,
+    saved_scd_table,
+    saved_dimension_table,
+    feature_group_feature_job_setting,
+    patch_initialize_entity_dtype,
 ):
     """
     Test delete table (and entity) referenced in feature's relationships_info but not in feature's table_ids
@@ -170,7 +174,12 @@ def test_delete_table_and_entity_referenced_in_feature_entity_relationship(
 
 
 def test_delete_table_and_entity_referenced_in_feature_list_entity_relationship(
-    saved_event_table, saved_dimension_table, float_feature, transaction_entity, cust_id_entity
+    saved_event_table,
+    saved_dimension_table,
+    float_feature,
+    transaction_entity,
+    cust_id_entity,
+    patch_initialize_entity_dtype,
 ):
     """Test delete table (and entity) referenced in feature list's relationships_info"""
     # construct following entity relationship

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1178,6 +1178,30 @@ def item_type_entity_fixture(catalog):
     yield entity
 
 
+@pytest.fixture(name="patch_initialize_entity_dtype")
+def patch_initialize_fixture():
+    """
+    Patch the initialize entity dtype method
+    """
+    module_base_path = (
+        "featurebyte.service.table_columns_info.EntityDtypeInitializationAndValidationService"
+    )
+    patched = {}
+    patch_targets = [
+        "maybe_initialize_entity_dtype",
+        "validate_entity_dtype",
+        "update_entity_dtype",
+    ]
+    started_patchers = []
+    for patch_target in patch_targets:
+        patcher = patch(f"{module_base_path}.{patch_target}")
+        patched[patch_target] = patcher.start()
+        started_patchers.append(patcher)
+    yield patched
+    for patcher in started_patchers:
+        patcher.stop()
+
+
 @pytest.fixture(name="snowflake_event_table_with_entity")
 def snowflake_event_table_with_entity_fixture(
     snowflake_event_table,
@@ -1185,11 +1209,12 @@ def snowflake_event_table_with_entity_fixture(
     transaction_entity,
     mock_api_object_cache,
     mock_detect_and_update_column_dtypes,
+    patch_initialize_entity_dtype,
 ):
     """
     Entity fixture that sets cust_id in snowflake_event_table as an Entity
     """
-    _ = mock_api_object_cache, mock_detect_and_update_column_dtypes
+    _ = mock_api_object_cache, mock_detect_and_update_column_dtypes, patch_initialize_entity_dtype
     snowflake_event_table.cust_id.as_entity(cust_id_entity.name)
     snowflake_event_table.col_int.as_entity(transaction_entity.name)
     yield snowflake_event_table

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1178,30 +1178,6 @@ def item_type_entity_fixture(catalog):
     yield entity
 
 
-@pytest.fixture(name="patch_initialize_entity_dtype")
-def patch_initialize_fixture():
-    """
-    Patch the initialize entity dtype method
-    """
-    module_base_path = (
-        "featurebyte.service.table_columns_info.EntityDtypeInitializationAndValidationService"
-    )
-    patched = {}
-    patch_targets = [
-        "maybe_initialize_entity_dtype",
-        "validate_entity_dtype",
-        "update_entity_dtype",
-    ]
-    started_patchers = []
-    for patch_target in patch_targets:
-        patcher = patch(f"{module_base_path}.{patch_target}")
-        patched[patch_target] = patcher.start()
-        started_patchers.append(patcher)
-    yield started_patchers
-    for patcher in started_patchers:
-        patcher.stop()
-
-
 @pytest.fixture(name="snowflake_event_table_with_entity")
 def snowflake_event_table_with_entity_fixture(
     snowflake_event_table,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1197,7 +1197,7 @@ def patch_initialize_fixture():
         patcher = patch(f"{module_base_path}.{patch_target}")
         patched[patch_target] = patcher.start()
         started_patchers.append(patcher)
-    yield patched
+    yield started_patchers
     for patcher in started_patchers:
         patcher.stop()
 

--- a/tests/unit/models/test_entity.py
+++ b/tests/unit/models/test_entity.py
@@ -35,6 +35,7 @@ def test_entity_model():
         "block_modification_by",
         "description",
         "is_deleted",
+        "dtype",
     }
     assert isinstance(entity_dict["_id"], ObjectId)
     assert isinstance(entity_dict["user_id"], ObjectId)

--- a/tests/unit/service/test_online_serving_feast.py
+++ b/tests/unit/service/test_online_serving_feast.py
@@ -187,6 +187,7 @@ async def test_feature_requiring_parent_serving(
     online_serving_service,
     deployed_feature_list_requiring_parent_serving,
     fl_requiring_parent_serving_deployment_id,
+    patch_initialize_entity_dtype,
 ):
     """
     Test online serving feast with feature requiring parent serving

--- a/tests/unit/service/test_table_columns_info.py
+++ b/tests/unit/service/test_table_columns_info.py
@@ -845,8 +845,8 @@ async def test_entity_dtype_initialization_and_validation__old_records_case_2(
         )
 
     expected_msg = (
-        f"Entity foo (ID: {entity_foo.id}) has columns with different dtypes (VARCHAR and INT) in "
-        f"tables sf_scd_table and sf_event_table. Please double-check the entity of the affected columns."
+        f"Entity foo (ID: {entity_foo.id}) has columns with different dtypes in tables sf_scd_table (VARCHAR) "
+        f"and sf_event_table (INT). Please double-check the entity of the affected columns."
     )
     assert expected_msg in str(exc.value)
 

--- a/tests/unit/service/test_table_columns_info.py
+++ b/tests/unit/service/test_table_columns_info.py
@@ -645,3 +645,231 @@ async def test_scd_table_update_columns_info__entity_relationship(
         child_entity=entity_foo,
         parent_entity=entity_bar,
     )
+
+
+def construct_columns_info(table, target_column, target_entity_id):
+    """
+    Helper function to construct columns info with target entity id for the target column
+    """
+    columns_info = []
+    has_matched_column = False
+    for column_info in table.columns_info:
+        column_info = copy.deepcopy(column_info)
+        if column_info.name == target_column:
+            column_info.entity_id = target_entity_id
+            has_matched_column = True
+        columns_info.append(column_info)
+
+    assert has_matched_column, f"Column {target_column} not found in table {table.name}"
+    return columns_info
+
+
+@pytest.mark.asyncio
+async def test_entity_dtype_initialization_and_validation(
+    app_container,
+    event_table,
+    scd_table,
+    entity_foo,
+    entity_bar,
+):
+    """Test entity dtype initialization and validation"""
+    assert entity_foo.dtype is None
+    assert entity_foo.table_ids == []
+
+    # associate entity foo with event table's col_int
+    await app_container.table_columns_info_service.update_columns_info(
+        service=app_container.event_table_service,
+        document_id=event_table.id,
+        columns_info=construct_columns_info(event_table, "col_int", entity_foo.id),
+    )
+
+    # check entity foo's dtype
+    entity_foo = await app_container.entity_service.get_document(document_id=entity_foo.id)
+    assert entity_foo.dtype == DBVarType.INT
+
+    # associate entity foo with scd table's non-int column
+    with pytest.raises(DocumentUpdateError) as exc:
+        await app_container.table_columns_info_service.update_columns_info(
+            service=app_container.scd_table_service,
+            document_id=scd_table.id,
+            columns_info=construct_columns_info(scd_table, "col_text", entity_foo.id),
+        )
+
+    expected_msg = (
+        f"Column col_text (Table ID: {scd_table.id}, Name: sf_scd_table) has dtype VARCHAR "
+        "which does not match the entity dtype INT."
+    )
+    assert expected_msg in str(exc.value)
+
+    # associate entity foo with scd table's int column
+    await app_container.table_columns_info_service.update_columns_info(
+        service=app_container.scd_table_service,
+        document_id=scd_table.id,
+        columns_info=construct_columns_info(scd_table, "col_int", entity_foo.id),
+    )
+
+    # check entity foo's dtype
+    entity_foo = await app_container.entity_service.get_document(document_id=entity_foo.id)
+    assert entity_foo.dtype == DBVarType.INT
+    assert entity_foo.table_ids == sorted([event_table.id, scd_table.id])
+
+    # disassociate entity foo with event table's col_int
+    await app_container.table_columns_info_service.update_columns_info(
+        service=app_container.event_table_service,
+        document_id=event_table.id,
+        columns_info=construct_columns_info(event_table, "col_int", entity_bar.id),
+    )
+
+    # check entity
+    entity_foo = await app_container.entity_service.get_document(document_id=entity_foo.id)
+    assert entity_foo.dtype == DBVarType.INT
+    assert entity_foo.table_ids == [scd_table.id]
+
+    assert entity_bar.dtype is None
+    assert entity_bar.table_ids == []
+    entity_bar = await app_container.entity_service.get_document(document_id=entity_bar.id)
+    assert entity_bar.dtype == DBVarType.INT
+    assert entity_bar.table_ids == [event_table.id]
+
+    #  disassociate entity foo with scd table's col_int
+    await app_container.table_columns_info_service.update_columns_info(
+        service=app_container.scd_table_service,
+        document_id=scd_table.id,
+        columns_info=construct_columns_info(scd_table, "col_int", None),
+    )
+
+    # check entity
+    entity_foo = await app_container.entity_service.get_document(document_id=entity_foo.id)
+    assert entity_foo.dtype is None
+    assert entity_foo.table_ids == []
+
+
+@pytest.mark.asyncio
+async def test_entity_dtype_initialization_and_validation__old_records_case_1(
+    app_container,
+    event_table,
+    scd_table,
+    entity_foo,
+    patch_initialize_entity_dtype,
+):
+    """Test entity dtype initialization and validation on old records"""
+    assert entity_foo.dtype is None
+    assert entity_foo.table_ids == []
+
+    # simulate old record with no tracking of entity dtype
+    # associate entity foo with event table's col_int
+    await app_container.table_columns_info_service.update_columns_info(
+        service=app_container.event_table_service,
+        document_id=event_table.id,
+        columns_info=construct_columns_info(event_table, "col_int", entity_foo.id),
+    )
+
+    # check entity foo's dtype
+    entity_foo = await app_container.entity_service.get_document(document_id=entity_foo.id)
+    assert entity_foo.dtype is None
+    assert entity_foo.table_ids == [event_table.id]
+
+    # stop patching to enable entity dtype tracking
+    for patcher in patch_initialize_entity_dtype:
+        patcher.stop()
+
+    # associate entity foo with scd table's non-int column
+    with pytest.raises(DocumentUpdateError) as exc:
+        await app_container.table_columns_info_service.update_columns_info(
+            service=app_container.scd_table_service,
+            document_id=scd_table.id,
+            columns_info=construct_columns_info(scd_table, "col_text", entity_foo.id),
+        )
+
+    expected_msg = (
+        f"Column col_text (Table ID: {scd_table.id}, Name: sf_scd_table) has dtype VARCHAR "
+        "which does not match the entity dtype INT."
+    )
+    assert expected_msg in str(exc.value)
+
+    # check entity foo's dtype (should get updated to INT)
+    entity_foo = await app_container.entity_service.get_document(document_id=entity_foo.id)
+    assert entity_foo.dtype == DBVarType.INT
+    assert entity_foo.table_ids == [event_table.id]
+
+    # associate entity foo with scd table's int column should pass
+    await app_container.table_columns_info_service.update_columns_info(
+        service=app_container.scd_table_service,
+        document_id=scd_table.id,
+        columns_info=construct_columns_info(scd_table, "col_int", entity_foo.id),
+    )
+
+
+@pytest.mark.asyncio
+async def test_entity_dtype_initialization_and_validation__old_records_case_2(
+    app_container,
+    event_table,
+    scd_table,
+    dimension_table,
+    entity_foo,
+    patch_initialize_entity_dtype,
+):
+    """Test entity dtype initialization and validation on old records"""
+    assert entity_foo.dtype is None
+    assert entity_foo.table_ids == []
+
+    # simulate old record with no tracking of entity dtype (with conflicting dtype)
+    # associate entity foo with event table's col_int
+    await app_container.table_columns_info_service.update_columns_info(
+        service=app_container.event_table_service,
+        document_id=event_table.id,
+        columns_info=construct_columns_info(event_table, "col_int", entity_foo.id),
+    )
+
+    await app_container.table_columns_info_service.update_columns_info(
+        service=app_container.scd_table_service,
+        document_id=scd_table.id,
+        columns_info=construct_columns_info(scd_table, "col_text", entity_foo.id),
+    )
+
+    # check entity foo's dtype
+    entity_foo = await app_container.entity_service.get_document(document_id=entity_foo.id)
+    assert entity_foo.dtype is None
+    assert entity_foo.table_ids == sorted([event_table.id, scd_table.id])
+
+    # stop patching to enable entity dtype tracking
+    for patcher in patch_initialize_entity_dtype:
+        patcher.stop()
+
+    # associate entity foo with dimension table's col_int should fail
+    with pytest.raises(DocumentUpdateError) as exc:
+        await app_container.table_columns_info_service.update_columns_info(
+            service=app_container.dimension_table_service,
+            document_id=dimension_table.id,
+            columns_info=construct_columns_info(dimension_table, "col_int", entity_foo.id),
+        )
+
+    expected_msg = (
+        f"Entity foo (ID: {entity_foo.id}) has columns with different dtypes (VARCHAR and INT) in "
+        f"tables sf_scd_table and sf_event_table. Please double-check the entity of the affected columns."
+    )
+    assert expected_msg in str(exc.value)
+
+    # remove entity foo from scd table
+    await app_container.table_columns_info_service.update_columns_info(
+        service=app_container.scd_table_service,
+        document_id=scd_table.id,
+        columns_info=construct_columns_info(scd_table, "col_text", None),
+    )
+
+    # check entity foo's dtype
+    entity_foo = await app_container.entity_service.get_document(document_id=entity_foo.id)
+    assert entity_foo.dtype is None
+    assert entity_foo.table_ids == [event_table.id]
+
+    # associate entity foo with dimension table's col_int should pass
+    await app_container.table_columns_info_service.update_columns_info(
+        service=app_container.dimension_table_service,
+        document_id=dimension_table.id,
+        columns_info=construct_columns_info(dimension_table, "col_int", entity_foo.id),
+    )
+
+    # check entity foo's dtype
+    entity_foo = await app_container.entity_service.get_document(document_id=entity_foo.id)
+    assert entity_foo.dtype == DBVarType.INT
+    assert entity_foo.table_ids == sorted([event_table.id, dimension_table.id])

--- a/tests/unit/service/test_table_columns_info.py
+++ b/tests/unit/service/test_table_columns_info.py
@@ -34,6 +34,7 @@ async def test_update_columns_info(
     event_table,
     entity,
     transaction_entity,
+    patch_initialize_entity_dtype,
 ):
     """Test update_columns_info"""
     _ = entity, transaction_entity


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR implements entity dtype validation. When entity is associated with a table column,
* it will initiate entity dtype if the entity has been used by another table column;
* it will throw error if entity dtype inconsistency is detected (user has to resolve the inconsistency first before using it in any other table column);
* checks whether the dtype of the column to be associated is consistent with existing column(s) of the same entity.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
