### PR TITLE
[DEV-3761] BigQuery: Enable sorting by probability by default when sampling

### DIFF
--- a/featurebyte/query_graph/node/input.py
+++ b/featurebyte/query_graph/node/input.py
@@ -48,6 +48,7 @@ class SampleParameters(FeatureByteBaseModel):
     seed: int
     total_num_rows: int
     num_rows: int
+    sort_by_prob: bool
 
 
 class BaseInputNodeParameters(FeatureByteBaseModel):

--- a/featurebyte/query_graph/sql/adapter/base.py
+++ b/featurebyte/query_graph/sql/adapter/base.py
@@ -45,7 +45,6 @@ class BaseAdapter(ABC):
     """
 
     TABLESAMPLE_SUPPORTS_VIEW = True
-    UNIFORM_DISTRIBUTION_SUPPORTS_SEED = True
 
     def __init__(self, source_info: SourceInfo):
         self.source_info = source_info
@@ -573,10 +572,9 @@ class BaseAdapter(ABC):
                     this=quoted_identifier("prob"), expression=make_literal_value(probability)
                 )
             )
+            .order_by(quoted_identifier("prob"))
             .limit(desired_row_count)
         )
-        if cls.UNIFORM_DISTRIBUTION_SUPPORTS_SEED:
-            output = output.order_by(quoted_identifier("prob"))
         return output
 
     @classmethod

--- a/featurebyte/query_graph/sql/adapter/base.py
+++ b/featurebyte/query_graph/sql/adapter/base.py
@@ -531,7 +531,12 @@ class BaseAdapter(ABC):
 
     @classmethod
     def random_sample(
-        cls, select_expr: Select, desired_row_count: int, total_row_count: int, seed: int
+        cls,
+        select_expr: Select,
+        desired_row_count: int,
+        total_row_count: int,
+        seed: int,
+        sort_by_prob: bool = True,
     ) -> Select:
         """
         Construct query to randomly sample some number of rows from a table
@@ -546,6 +551,9 @@ class BaseAdapter(ABC):
             Total number of rows in the table
         seed: int
             Random seed
+        sort_by_prob: bool
+            Whether to sort sampled result by the random probability to correct for oversampling
+            bias. Can be expensive on large samples.
 
         Returns
         -------
@@ -572,9 +580,10 @@ class BaseAdapter(ABC):
                     this=quoted_identifier("prob"), expression=make_literal_value(probability)
                 )
             )
-            .order_by(quoted_identifier("prob"))
             .limit(desired_row_count)
         )
+        if sort_by_prob:
+            output = output.order_by(quoted_identifier("prob"))
         return output
 
     @classmethod

--- a/featurebyte/query_graph/sql/adapter/bigquery.py
+++ b/featurebyte/query_graph/sql/adapter/bigquery.py
@@ -27,7 +27,6 @@ class BigQueryAdapter(BaseAdapter):
     source_type = SourceType.BIGQUERY
 
     TABLESAMPLE_SUPPORTS_VIEW = False
-    UNIFORM_DISTRIBUTION_SUPPORTS_SEED = False
 
     class DataType(StrEnum):
         """

--- a/featurebyte/query_graph/sql/ast/input.py
+++ b/featurebyte/query_graph/sql/ast/input.py
@@ -39,6 +39,7 @@ class InputNode(TableNode):
                 desired_row_count=self.sample_parameters.num_rows,
                 total_row_count=self.sample_parameters.total_num_rows,
                 seed=self.sample_parameters.seed,
+                sort_by_prob=self.sample_parameters.sort_by_prob,
             )
             select_expr = select_expr.from_(sample_expr.subquery())
         else:

--- a/tests/fixtures/adapter/bigquery_random_sample.sql
+++ b/tests/fixtures/adapter/bigquery_random_sample.sql
@@ -15,4 +15,6 @@ FROM (
 )
 WHERE
   `prob` <= 0.15000000000000002
+ORDER BY
+  `prob`
 LIMIT 100

--- a/tests/fixtures/query_graph/expected_sample_sql_disable_sort_by_prob.sql
+++ b/tests/fixtures/query_graph/expected_sample_sql_disable_sort_by_prob.sql
@@ -1,0 +1,27 @@
+SELECT
+  "ts",
+  "cust_id",
+  "a",
+  "b",
+  "a_copy"
+FROM (
+  SELECT
+    CAST(BITAND(RANDOM(1234), 2147483647) AS DOUBLE) / 2147483647.0 AS "prob",
+    "ts",
+    "cust_id",
+    "a",
+    "b",
+    "a_copy"
+  FROM (
+    SELECT
+      "ts" AS "ts",
+      CAST("cust_id" AS VARCHAR) AS "cust_id",
+      "a" AS "a",
+      "b" AS "b",
+      "a" AS "a_copy"
+    FROM "db"."public"."event_table"
+  )
+)
+WHERE
+  "prob" <= 0.15000000000000002
+LIMIT 1000

--- a/tests/fixtures/request_input/materialize_bigquery.sql
+++ b/tests/fixtures/request_input/materialize_bigquery.sql
@@ -47,4 +47,6 @@ FROM (
 )
 WHERE
   `prob` <= 0.15000000000000002
+ORDER BY
+  `prob`
 LIMIT 100;

--- a/tests/unit/query_graph/interpreter/test_preview.py
+++ b/tests/unit/query_graph/interpreter/test_preview.py
@@ -503,3 +503,24 @@ def test_describe__with_primary_table_sampling_on_graph_containing_filter(
     assert_equal_with_expected_fixture(
         describe_query.data.expr.sql(pretty=True), expected_filename, update_fixtures
     )
+
+
+def test_construct_sample_sql(simple_graph, update_fixtures, source_info):
+    """
+    Test setting sort_by_prob=False in construct_sample_sql
+    """
+    graph, node = simple_graph
+    interpreter = GraphInterpreter(graph, source_info)
+    sql_code = sql_to_string(
+        interpreter._construct_sample_sql(
+            node.name,
+            num_rows=1000,
+            total_num_rows=10000,
+            seed=1234,
+            sample_on_primary_table=True,
+            sort_by_prob=False,
+        )[0],
+        source_info.source_type,
+    )
+    expected_filename = "tests/fixtures/query_graph/expected_sample_sql_disable_sort_by_prob.sql"
+    assert_equal_with_expected_fixture(sql_code, expected_filename, update_fixtures)


### PR DESCRIPTION
## Description

This updates the random sampling for BigQuery to perform sorting by prob by default unless explicitly disabled.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
