### PR TITLE
[DEV-3766] BigQuery: Fix handling native datetime objects in session register_table

### DIFF
--- a/tests/integration/session/test_bigquery.py
+++ b/tests/integration/session/test_bigquery.py
@@ -223,7 +223,7 @@ async def test_register_table_timestamp_type(
     _ = config
     session = session_without_datasets
     df = pd.DataFrame({"ts_col": timestamp_column})
-    table_name = f"test_table_{ObjectId()}"
+    table_name = f"test_register_table_timestamp_type_{ObjectId()}"
     await session.register_table(table_name=table_name, dataframe=df)
     result = await session.execute_query(f"SELECT * FROM {table_name}")
     assert result["ts_col"].tolist() == expected

--- a/tests/integration/session/test_bigquery.py
+++ b/tests/integration/session/test_bigquery.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 import pandas as pd
 import pytest
+from bson import ObjectId
 
 from featurebyte.enum import DBVarType
 from featurebyte.query_graph.model.column_info import ColumnSpecWithDescription
@@ -182,6 +183,50 @@ async def test_register_table(config, session_without_datasets):
     session = session_without_datasets
     df = pd.DataFrame({"a": [1, 2, 3], "date": pd.date_range("2021-01-01", periods=3)})
     await session.register_table(table_name="test_table", dataframe=df)
+
+
+@pytest.mark.parametrize("source_type", ["bigquery"], indirect=True)
+@pytest.mark.parametrize(
+    "timestamp_column, expected",
+    [
+        (
+            pd.to_datetime(["2021-01-01 10:00:00"]),
+            [pd.Timestamp("2021-01-01 10:00:00")],
+        ),
+        (
+            pd.to_datetime(["2021-01-01 10:00:00+08:00"]),
+            [pd.Timestamp("2021-01-01 02:00:00")],
+        ),
+        # Mixed offsets with python datetime objects in Series
+        (
+            pd.Series([
+                pd.Timestamp("2021-01-01 10:00:00+0800").to_pydatetime(),
+                pd.Timestamp("2021-01-01 10:00:00-0800").to_pydatetime(),
+            ]),
+            [
+                pd.Timestamp("2021-01-01 02:00:00"),
+                pd.Timestamp("2021-01-01 18:00:00"),
+            ],
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_register_table_timestamp_type(
+    config,
+    session_without_datasets,
+    timestamp_column,
+    expected,
+):
+    """
+    Test timestamp handling in register_table
+    """
+    _ = config
+    session = session_without_datasets
+    df = pd.DataFrame({"ts_col": timestamp_column})
+    table_name = f"test_table_{ObjectId()}"
+    await session.register_table(table_name=table_name, dataframe=df)
+    result = await session.execute_query(f"SELECT * FROM {table_name}")
+    assert result["ts_col"].tolist() == expected
 
 
 @pytest.mark.parametrize("source_type", ["bigquery"], indirect=True)


### PR DESCRIPTION
## Description

This fixes an error in BigQuery session's `register_table` when a timestamp column contains native datetime objects.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
