### PR TITLE
[chore] Do not use --diff option in ruff style checks

### DIFF
--- a/Taskfile.lint.yaml
+++ b/Taskfile.lint.yaml
@@ -84,8 +84,8 @@ tasks:
       - featurebyte/**/*
       - tests/**/*
     cmds:
-      - poetry run ruff check --diff
-      - poetry run ruff format --diff
+      - poetry run ruff check
+      - poetry run ruff format
 
   style-darglint:
     desc: "Run the linter[style] with only darglint"


### PR DESCRIPTION
## Description

Do use use `--diff` option in ruff style check commands since that can cause the exit code be 0 in some cases even when there are violations. (e.g. the violation that this commit https://github.com/featurebyte/featurebyte/pull/2612/commits/e26989aa141dcd0494306041b03b3da30c7dd781 would fix but `task lint:style-ruff` didn't detect that violation).

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
