### PR TITLE
[chore] Add service and API to track internal system metrics

### DIFF
--- a/featurebyte/app.py
+++ b/featurebyte/app.py
@@ -43,6 +43,7 @@ from featurebyte.routes.relationship_info.api import RelationshipInfoRouter
 from featurebyte.routes.scd_table.api import SCDTableRouter
 from featurebyte.routes.semantic.api import SemanticRouter
 from featurebyte.routes.static_source_table.api import StaticSourceTableRouter
+from featurebyte.routes.system_metrics.api import SystemMetricsRouter
 from featurebyte.routes.table.api import TableRouter
 from featurebyte.routes.target.api import TargetRouter
 from featurebyte.routes.target_namespace.api import TargetNamespaceRouter
@@ -247,6 +248,7 @@ def get_app() -> FastAPI:
         RelationshipInfoRouter(),
         SCDTableRouter(),
         StaticSourceTableRouter(prefix="/static_source_table"),
+        SystemMetricsRouter(),
         TableRouter(),
         TargetRouter(),
         TargetNamespaceRouter(),

--- a/featurebyte/models/system_metrics.py
+++ b/featurebyte/models/system_metrics.py
@@ -36,7 +36,9 @@ class HistoricalFeaturesMetrics(FeatureByteBaseModel):
     tile_compute_seconds: Optional[float] = None
     feature_compute_seconds: Optional[float] = None
     feature_cache_update_seconds: Optional[float] = None
-    type: Literal[SystemMetricsType.HISTORICAL_FEATURES] = SystemMetricsType.HISTORICAL_FEATURES
+    metrics_type: Literal[SystemMetricsType.HISTORICAL_FEATURES] = (
+        SystemMetricsType.HISTORICAL_FEATURES
+    )
 
 
 class TileTaskMetrics(FeatureByteBaseModel):
@@ -48,7 +50,7 @@ class TileTaskMetrics(FeatureByteBaseModel):
     tile_monitor_seconds: Optional[float] = None
     tile_compute_seconds: Optional[float] = None
     internal_online_compute_seconds: Optional[float] = None
-    type: Literal[SystemMetricsType.TILE_TASK] = SystemMetricsType.TILE_TASK
+    metrics_type: Literal[SystemMetricsType.TILE_TASK] = SystemMetricsType.TILE_TASK
 
 
 class ScheduledFeatureMaterializeMetrics(FeatureByteBaseModel):
@@ -63,14 +65,14 @@ class ScheduledFeatureMaterializeMetrics(FeatureByteBaseModel):
     generate_precomputed_lookup_feature_tables_seconds: Optional[float] = None
     update_feature_tables_seconds: Optional[float] = None
     online_materialize_seconds: Optional[float] = None
-    type: Literal[SystemMetricsType.SCHEDULED_FEATURE_MATERIALIZE] = (
+    metrics_type: Literal[SystemMetricsType.SCHEDULED_FEATURE_MATERIALIZE] = (
         SystemMetricsType.SCHEDULED_FEATURE_MATERIALIZE
     )
 
 
 SystemMetricsData = Annotated[
     Union[HistoricalFeaturesMetrics, TileTaskMetrics, ScheduledFeatureMaterializeMetrics],
-    Field(discriminator="type"),
+    Field(discriminator="metrics_type"),
 ]
 
 
@@ -85,7 +87,7 @@ class SystemMetricsModel(FeatureByteCatalogBaseDocumentModel):
         collection_name: str = "system_metrics"
         unique_constraints = []
         indexes = FeatureByteCatalogBaseDocumentModel.Settings.indexes + [
-            IndexModel("metrics_data.type"),
+            IndexModel("metrics_data.metrics_type"),
             IndexModel("metrics_data.historical_feature_table_id"),
             IndexModel("metrics_data.tile_table_id"),
             IndexModel("metrics_data.offline_store_feature_table_id"),

--- a/featurebyte/models/system_metrics.py
+++ b/featurebyte/models/system_metrics.py
@@ -43,6 +43,8 @@ class TileTaskMetrics(FeatureByteBaseModel):
     TileTaskMetrics class
     """
 
+    tile_table_id: str
+    tile_monitor_seconds: Optional[float] = None
     tile_compute_seconds: Optional[float] = None
     internal_online_compute_seconds: Optional[float] = None
     type: Literal[SystemMetricsType.TILE_TASK] = SystemMetricsType.TILE_TASK
@@ -66,5 +68,6 @@ class SystemMetricsModel(FeatureByteCatalogBaseDocumentModel):
         indexes = FeatureByteCatalogBaseDocumentModel.Settings.indexes + [
             IndexModel("metrics_data.type"),
             IndexModel("metrics_data.historical_feature_table_id"),
+            IndexModel("metrics_data.tile_table_id"),
         ]
         auditable = False

--- a/featurebyte/models/system_metrics.py
+++ b/featurebyte/models/system_metrics.py
@@ -24,6 +24,7 @@ class SystemMetricsType(StrEnum):
 
     HISTORICAL_FEATURES = "historical_features"
     TILE_TASK = "tile_task"
+    SCHEDULED_FEATURE_MATERIALIZE = "scheduled_feature_materialize"
 
 
 class HistoricalFeaturesMetrics(FeatureByteBaseModel):
@@ -50,8 +51,26 @@ class TileTaskMetrics(FeatureByteBaseModel):
     type: Literal[SystemMetricsType.TILE_TASK] = SystemMetricsType.TILE_TASK
 
 
+class ScheduledFeatureMaterializeMetrics(FeatureByteBaseModel):
+    """
+    ScheduledFeatureMaterializeMetrics class
+    """
+
+    offline_store_feature_table_id: PydanticObjectId
+    num_columns: int
+    generate_entity_universe_seconds: Optional[float] = None
+    generate_feature_table_seconds: Optional[float] = None
+    generate_precomputed_lookup_feature_tables_seconds: Optional[float] = None
+    update_feature_tables_seconds: Optional[float] = None
+    online_materialize_seconds: Optional[float] = None
+    type: Literal[SystemMetricsType.SCHEDULED_FEATURE_MATERIALIZE] = (
+        SystemMetricsType.SCHEDULED_FEATURE_MATERIALIZE
+    )
+
+
 SystemMetricsData = Annotated[
-    Union[HistoricalFeaturesMetrics, TileTaskMetrics], Field(discriminator="type")
+    Union[HistoricalFeaturesMetrics, TileTaskMetrics, ScheduledFeatureMaterializeMetrics],
+    Field(discriminator="type"),
 ]
 
 
@@ -69,5 +88,6 @@ class SystemMetricsModel(FeatureByteCatalogBaseDocumentModel):
             IndexModel("metrics_data.type"),
             IndexModel("metrics_data.historical_feature_table_id"),
             IndexModel("metrics_data.tile_table_id"),
+            IndexModel("metrics_data.offline_store_feature_table_id"),
         ]
         auditable = False

--- a/featurebyte/models/system_metrics.py
+++ b/featurebyte/models/system_metrics.py
@@ -4,13 +4,17 @@ SystemMetricsModel class
 
 from __future__ import annotations
 
-from typing import Annotated, Any, Dict, Literal, Optional, Union
+from typing import Annotated, Literal, Optional, Union
 
 from pydantic import Field
 from pymongo import IndexModel
 
 from featurebyte.enum import StrEnum
-from featurebyte.models.base import FeatureByteBaseModel, FeatureByteCatalogBaseDocumentModel
+from featurebyte.models.base import (
+    FeatureByteBaseModel,
+    FeatureByteCatalogBaseDocumentModel,
+    PydanticObjectId,
+)
 
 
 class SystemMetricsType(StrEnum):
@@ -27,6 +31,7 @@ class HistoricalFeaturesMetrics(FeatureByteBaseModel):
     HistoricalFeaturesMetrics class
     """
 
+    historical_feature_table_id: Optional[PydanticObjectId] = None
     tile_compute_seconds: Optional[float] = None
     feature_compute_seconds: Optional[float] = None
     feature_cache_update_seconds: Optional[float] = None
@@ -43,15 +48,6 @@ class TileTaskMetrics(FeatureByteBaseModel):
     type: Literal[SystemMetricsType.TILE_TASK] = SystemMetricsType.TILE_TASK
 
 
-class SystemMetricsMetadataKey(StrEnum):
-    """
-    SystemMetricsMetadataKey class
-    """
-
-    historical_feature_table_id = "historical_feature_table_id"
-    observation_table_id = "observation_table_id"
-
-
 SystemMetricsData = Annotated[
     Union[HistoricalFeaturesMetrics, TileTaskMetrics], Field(discriminator="type")
 ]
@@ -62,13 +58,13 @@ class SystemMetricsModel(FeatureByteCatalogBaseDocumentModel):
     SystemMetricsModel class
     """
 
-    metrics: SystemMetricsData
-    metadata: Optional[Dict[str, Any]]
+    metrics_data: SystemMetricsData
 
     class Settings(FeatureByteCatalogBaseDocumentModel.Settings):
         collection_name: str = "system_metrics"
         unique_constraints = []
         indexes = FeatureByteCatalogBaseDocumentModel.Settings.indexes + [
-            IndexModel("metadata.historical_feature_table_id"),
+            IndexModel("metrics_data.type"),
+            IndexModel("metrics_data.historical_feature_table_id"),
         ]
         auditable = False

--- a/featurebyte/models/system_metrics.py
+++ b/featurebyte/models/system_metrics.py
@@ -1,0 +1,74 @@
+"""
+SystemMetricsModel class
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Dict, Literal, Optional, Union
+
+from pydantic import Field
+from pymongo import IndexModel
+
+from featurebyte.enum import StrEnum
+from featurebyte.models.base import FeatureByteBaseModel, FeatureByteCatalogBaseDocumentModel
+
+
+class SystemMetricsType(StrEnum):
+    """
+    SystemMetricsType class
+    """
+
+    HISTORICAL_FEATURES = "historical_features"
+    TILE_TASK = "tile_task"
+
+
+class HistoricalFeaturesMetrics(FeatureByteBaseModel):
+    """
+    HistoricalFeaturesMetrics class
+    """
+
+    tile_compute_seconds: Optional[float] = None
+    feature_compute_seconds: Optional[float] = None
+    feature_cache_update_seconds: Optional[float] = None
+    type: Literal[SystemMetricsType.HISTORICAL_FEATURES] = SystemMetricsType.HISTORICAL_FEATURES
+
+
+class TileTaskMetrics(FeatureByteBaseModel):
+    """
+    TileTaskMetrics class
+    """
+
+    tile_compute_seconds: Optional[float] = None
+    internal_online_compute_seconds: Optional[float] = None
+    type: Literal[SystemMetricsType.TILE_TASK] = SystemMetricsType.TILE_TASK
+
+
+class SystemMetricsMetadataKey(StrEnum):
+    """
+    SystemMetricsMetadataKey class
+    """
+
+    historical_feature_table_id = "historical_feature_table_id"
+    observation_table_id = "observation_table_id"
+
+
+SystemMetricsData = Annotated[
+    Union[HistoricalFeaturesMetrics, TileTaskMetrics], Field(discriminator="type")
+]
+
+
+class SystemMetricsModel(FeatureByteCatalogBaseDocumentModel):
+    """
+    SystemMetricsModel class
+    """
+
+    metrics: SystemMetricsData
+    metadata: Optional[Dict[str, Any]]
+
+    class Settings(FeatureByteCatalogBaseDocumentModel.Settings):
+        collection_name: str = "system_metrics"
+        unique_constraints = []
+        indexes = FeatureByteCatalogBaseDocumentModel.Settings.indexes + [
+            IndexModel("metadata.historical_feature_table_id"),
+        ]
+        auditable = False

--- a/featurebyte/routes/common/base.py
+++ b/featurebyte/routes/common/base.py
@@ -38,6 +38,7 @@ from featurebyte.service.relationship_info import RelationshipInfoService
 from featurebyte.service.scd_table import SCDTableService
 from featurebyte.service.semantic import SemanticService
 from featurebyte.service.static_source_table import StaticSourceTableService
+from featurebyte.service.system_metrics import SystemMetricsService
 from featurebyte.service.table import TableService
 from featurebyte.service.target import TargetService
 from featurebyte.service.target_namespace import TargetNamespaceService
@@ -79,6 +80,7 @@ DocumentServiceT = TypeVar(
     UserDefinedFunctionService,
     AllDeploymentService,
     UseCaseService,
+    SystemMetricsService,
 )
 
 

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -157,6 +157,7 @@ from featurebyte.service.session_manager import SessionManagerService
 from featurebyte.service.session_validator import SessionValidatorService
 from featurebyte.service.specialized_dtype import SpecializedDtypeDetectionService
 from featurebyte.service.static_source_table import StaticSourceTableService
+from featurebyte.service.system_metrics import SystemMetricsService
 from featurebyte.service.table import AllTableService, TableService
 from featurebyte.service.table_columns_info import (
     EntityDtypeInitializationAndValidationService,
@@ -359,6 +360,7 @@ app_container_config.register_class(SessionManagerService)
 app_container_config.register_class(SessionValidatorService)
 app_container_config.register_class(StaticSourceTableController)
 app_container_config.register_class(StaticSourceTableService)
+app_container_config.register_class(SystemMetricsService)
 app_container_config.register_class(EntityDtypeInitializationAndValidationService)
 app_container_config.register_class(TableColumnsInfoService)
 app_container_config.register_class(

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -63,6 +63,7 @@ from featurebyte.routes.relationship_info.controller import RelationshipInfoCont
 from featurebyte.routes.scd_table.controller import SCDTableController
 from featurebyte.routes.semantic.controller import SemanticController
 from featurebyte.routes.static_source_table.controller import StaticSourceTableController
+from featurebyte.routes.system_metrics.controller import SystemMetricsController
 from featurebyte.routes.table.controller import TableController
 from featurebyte.routes.target.controller import TargetController
 from featurebyte.routes.target_namespace.controller import TargetNamespaceController
@@ -361,6 +362,9 @@ app_container_config.register_class(SessionValidatorService)
 app_container_config.register_class(StaticSourceTableController)
 app_container_config.register_class(StaticSourceTableService)
 app_container_config.register_class(SystemMetricsService)
+app_container_config.register_class(
+    SystemMetricsController, dependency_override={"service": "system_metrics_service"}
+)
 app_container_config.register_class(EntityDtypeInitializationAndValidationService)
 app_container_config.register_class(TableColumnsInfoService)
 app_container_config.register_class(

--- a/featurebyte/routes/system_metrics/api.py
+++ b/featurebyte/routes/system_metrics/api.py
@@ -4,7 +4,7 @@ System metrics API routes
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import APIRouter, Query, Request
 
@@ -42,6 +42,7 @@ async def list_metrics(
     sort_dir: Optional[SortDir] = SortDirQuery,
     type: Optional[str] = NameQuery,
     historical_feature_table_id: Optional[PyObjectId] = Query(default=None),
+    offline_store_feature_table_id: Optional[PyObjectId] = Query(default=None),
 ) -> SystemMetricsList:
     """
     List Table
@@ -49,10 +50,18 @@ async def list_metrics(
     controller: SystemMetricsController = request.state.app_container.system_metrics_controller
 
     query_filter = {}
+
+    def _add_metrics_data_filter(field: str, value: Any) -> None:
+        query_filter[f"metrics_data.{field}"] = value
+
     if type is not None:
-        query_filter["metrics_data.type"] = type
+        _add_metrics_data_filter("type", type)
+
     if historical_feature_table_id is not None:
-        query_filter["metrics_data.historical_feature_table_id"] = historical_feature_table_id
+        _add_metrics_data_filter("historical_feature_table_id", historical_feature_table_id)
+
+    if offline_store_feature_table_id is not None:
+        _add_metrics_data_filter("offline_store_feature_table_id", offline_store_feature_table_id)
 
     system_metrics_list = await controller.list(
         page=page,

--- a/featurebyte/routes/system_metrics/api.py
+++ b/featurebyte/routes/system_metrics/api.py
@@ -1,0 +1,63 @@
+"""
+System metrics API routes
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Query, Request
+
+from featurebyte.persistent.base import SortDir
+from featurebyte.routes.base_router import BaseRouter
+from featurebyte.routes.common.schema import (
+    NameQuery,
+    PageQuery,
+    PageSizeQuery,
+    PyObjectId,
+    SortByQuery,
+    SortDirQuery,
+)
+from featurebyte.routes.system_metrics.controller import SystemMetricsController
+from featurebyte.schema.system_metrics import SystemMetricsList
+
+router = APIRouter(prefix="/system_metrics")
+
+
+class SystemMetricsRouter(BaseRouter):
+    """
+    System metrics router
+    """
+
+    def __init__(self) -> None:
+        super().__init__(router=router)
+
+
+@router.get("", response_model=SystemMetricsList)
+async def list_metrics(
+    request: Request,
+    page: int = PageQuery,
+    page_size: int = PageSizeQuery,
+    sort_by: Optional[str] = SortByQuery,
+    sort_dir: Optional[SortDir] = SortDirQuery,
+    type: Optional[str] = NameQuery,
+    historical_feature_table_id: Optional[PyObjectId] = Query(default=None),
+) -> SystemMetricsList:
+    """
+    List Table
+    """
+    controller: SystemMetricsController = request.state.app_container.system_metrics_controller
+
+    query_filter = {}
+    if type is not None:
+        query_filter["metrics_data.type"] = type
+    if historical_feature_table_id is not None:
+        query_filter["metrics_data.historical_feature_table_id"] = historical_feature_table_id
+
+    system_metrics_list = await controller.list(
+        page=page,
+        page_size=page_size,
+        sort_by=[(sort_by, sort_dir)] if sort_by and sort_dir else None,
+        query_filter=query_filter,
+    )
+    return system_metrics_list

--- a/featurebyte/routes/system_metrics/api.py
+++ b/featurebyte/routes/system_metrics/api.py
@@ -11,7 +11,6 @@ from fastapi import APIRouter, Query, Request
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseRouter
 from featurebyte.routes.common.schema import (
-    NameQuery,
     PageQuery,
     PageSizeQuery,
     PyObjectId,
@@ -40,8 +39,9 @@ async def list_metrics(
     page_size: int = PageSizeQuery,
     sort_by: Optional[str] = SortByQuery,
     sort_dir: Optional[SortDir] = SortDirQuery,
-    type: Optional[str] = NameQuery,
+    metrics_type: Optional[str] = Query(default=None),
     historical_feature_table_id: Optional[PyObjectId] = Query(default=None),
+    tile_table_id: Optional[str] = Query(default=None),
     offline_store_feature_table_id: Optional[PyObjectId] = Query(default=None),
 ) -> SystemMetricsList:
     """
@@ -54,11 +54,14 @@ async def list_metrics(
     def _add_metrics_data_filter(field: str, value: Any) -> None:
         query_filter[f"metrics_data.{field}"] = value
 
-    if type is not None:
-        _add_metrics_data_filter("type", type)
+    if metrics_type is not None:
+        _add_metrics_data_filter("metrics_type", metrics_type)
 
     if historical_feature_table_id is not None:
         _add_metrics_data_filter("historical_feature_table_id", historical_feature_table_id)
+
+    if tile_table_id is not None:
+        _add_metrics_data_filter("tile_table_id", tile_table_id)
 
     if offline_store_feature_table_id is not None:
         _add_metrics_data_filter("offline_store_feature_table_id", offline_store_feature_table_id)

--- a/featurebyte/routes/system_metrics/controller.py
+++ b/featurebyte/routes/system_metrics/controller.py
@@ -1,0 +1,20 @@
+"""
+System metrics API route controller
+"""
+
+from __future__ import annotations
+
+from featurebyte.models.system_metrics import SystemMetricsModel
+from featurebyte.routes.common.base import BaseDocumentController
+from featurebyte.schema.system_metrics import SystemMetricsList
+from featurebyte.service.system_metrics import SystemMetricsService
+
+
+class SystemMetricsController(
+    BaseDocumentController[SystemMetricsModel, SystemMetricsService, SystemMetricsList]
+):
+    """
+    SystemMetricsList controller
+    """
+
+    paginated_document_class = SystemMetricsList

--- a/featurebyte/schema/system_metrics.py
+++ b/featurebyte/schema/system_metrics.py
@@ -1,0 +1,16 @@
+"""
+System metrics related schemas
+"""
+
+from typing import List
+
+from featurebyte.models.system_metrics import SystemMetricsModel
+from featurebyte.schema.common.base import PaginationMixin
+
+
+class SystemMetricsList(PaginationMixin):
+    """
+    SystemMetricsList used to deserialize list document output
+    """
+
+    data: List[SystemMetricsModel]

--- a/featurebyte/service/feature_materialize.py
+++ b/featurebyte/service/feature_materialize.py
@@ -257,6 +257,8 @@ class FeatureMaterializeService:
             Whether to specify the last materialized timestamp of feature_table_model when creating
             the entity universe. This is set to True on scheduled task, and False on initialization
             of new columns.
+        metrics: Optional[ScheduledFeatureMaterializeMetrics]
+            Metrics object to be updated in place if specified
 
         Yields
         ------

--- a/featurebyte/service/historical_features.py
+++ b/featurebyte/service/historical_features.py
@@ -65,7 +65,10 @@ class HistoricalFeatureExecutor(QueryExecutor[HistoricalFeatureExecutorParams]):
             isinstance(executor_params.observation_set, ObservationTableModel)
             and executor_params.observation_set.has_row_index
         ):
-            is_output_view = await self.feature_table_cache_service.create_view_or_table_from_cache(
+            (
+                is_output_view,
+                historical_features_metrics,
+            ) = await self.feature_table_cache_service.create_view_or_table_from_cache(
                 feature_store=executor_params.feature_store,
                 observation_table=executor_params.observation_set,
                 graph=executor_params.graph,
@@ -77,7 +80,7 @@ class HistoricalFeatureExecutor(QueryExecutor[HistoricalFeatureExecutorParams]):
                 progress_callback=executor_params.progress_callback,
             )
         else:
-            await get_historical_features(
+            historical_features_metrics = await get_historical_features(
                 session=executor_params.session,
                 tile_cache_service=self.tile_cache_service,
                 graph=executor_params.graph,
@@ -90,7 +93,10 @@ class HistoricalFeatureExecutor(QueryExecutor[HistoricalFeatureExecutorParams]):
                 progress_callback=executor_params.progress_callback,
             )
             is_output_view = False
-        return ExecutionResult(is_output_view=is_output_view)
+        return ExecutionResult(
+            is_output_view=is_output_view,
+            historical_features_metrics=historical_features_metrics,
+        )
 
 
 class HistoricalFeaturesValidationParametersService:

--- a/featurebyte/service/historical_features_and_target.py
+++ b/featurebyte/service/historical_features_and_target.py
@@ -154,6 +154,10 @@ async def get_historical_features(
         Output table details to write the results to
     progress_callback: Optional[Callable[[int, str | None], Coroutine[Any, Any, None]]]
         Optional progress callback function
+
+    Returns
+    -------
+    HistoricalFeaturesMetrics
     """
     tic_ = time.time()
 
@@ -290,6 +294,10 @@ async def get_target(
         Preparation required for serving parent features
     progress_callback: Optional[Callable[[int, str | None], Coroutine[Any, Any, None]]]
         Optional progress callback function
+
+    Returns
+    -------
+    HistoricalFeaturesMetrics
     """
     tic_ = time.time()
 

--- a/featurebyte/service/system_metrics.py
+++ b/featurebyte/service/system_metrics.py
@@ -1,0 +1,43 @@
+"""
+SystemMetricsServiceClass
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from featurebyte.models.system_metrics import SystemMetricsData, SystemMetricsModel
+from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema
+from featurebyte.service.base_document import BaseDocumentService
+
+
+class SystemMetricsService(
+    BaseDocumentService[SystemMetricsModel, SystemMetricsModel, BaseDocumentServiceUpdateSchema]
+):
+    """
+    SystemMetricsService class
+    """
+
+    document_class = SystemMetricsModel
+
+    async def get_metrics(self, metadata: Dict[str, Any]) -> Optional[SystemMetricsModel]:
+        """
+        Get metrics document
+        """
+        query_filter = {"metadata": metadata}
+        async for doc in self.list_documents_as_dict_iterator(query_filter=query_filter):
+            return SystemMetricsModel(**doc)
+        return None
+
+    async def create_metrics(
+        self, metrics: SystemMetricsData, metadata: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """
+        Create a new metrics document
+        """
+        await self.create_document(
+            SystemMetricsModel(
+                metrics=metrics,
+                metadata=metadata,
+            ),
+        )

--- a/featurebyte/service/system_metrics.py
+++ b/featurebyte/service/system_metrics.py
@@ -4,8 +4,6 @@ SystemMetricsServiceClass
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
-
 from featurebyte.models.system_metrics import SystemMetricsData, SystemMetricsModel
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema
 from featurebyte.service.base_document import BaseDocumentService
@@ -20,24 +18,13 @@ class SystemMetricsService(
 
     document_class = SystemMetricsModel
 
-    async def get_metrics(self, metadata: Dict[str, Any]) -> Optional[SystemMetricsModel]:
-        """
-        Get metrics document
-        """
-        query_filter = {"metadata": metadata}
-        async for doc in self.list_documents_as_dict_iterator(query_filter=query_filter):
-            return SystemMetricsModel(**doc)
-        return None
-
-    async def create_metrics(
-        self, metrics: SystemMetricsData, metadata: Optional[Dict[str, Any]] = None
-    ) -> None:
+    async def create_metrics(self, metrics_data: SystemMetricsData) -> None:
         """
         Create a new metrics document
+
+        Parameters
+        ----------
+        metrics_data : SystemMetricsData
+            Metrics data to create
         """
-        await self.create_document(
-            SystemMetricsModel(
-                metrics=metrics,
-                metadata=metadata,
-            ),
-        )
+        await self.create_document(SystemMetricsModel(metrics_data=metrics_data))

--- a/featurebyte/service/target_helper/base_feature_or_target_computer.py
+++ b/featurebyte/service/target_helper/base_feature_or_target_computer.py
@@ -13,6 +13,7 @@ import pandas as pd
 from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.models.observation_table import ObservationTableModel
 from featurebyte.models.parent_serving import ParentServingPreparation
+from featurebyte.models.system_metrics import HistoricalFeaturesMetrics
 from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.query_graph.node import Node
 from featurebyte.query_graph.node.schema import TableDetails
@@ -72,6 +73,11 @@ class ExecutionResult:
     """
 
     is_output_view: bool
+    historical_features_metrics: HistoricalFeaturesMetrics
+
+    # forbid extra fields
+    class Config:
+        extra = "forbid"
 
 
 class QueryExecutor(Generic[ExecutorParamsT]):

--- a/featurebyte/service/target_helper/compute_target.py
+++ b/featurebyte/service/target_helper/compute_target.py
@@ -50,7 +50,10 @@ class TargetExecutor(QueryExecutor[ExecutorParams]):
             isinstance(executor_params.observation_set, ObservationTableModel)
             and executor_params.observation_set.has_row_index
         ):
-            is_output_view = await self.feature_table_cache_service.create_view_or_table_from_cache(
+            (
+                is_output_view,
+                historical_features_metrics,
+            ) = await self.feature_table_cache_service.create_view_or_table_from_cache(
                 feature_store=executor_params.feature_store,
                 observation_table=executor_params.observation_set,
                 graph=executor_params.graph,
@@ -60,7 +63,7 @@ class TargetExecutor(QueryExecutor[ExecutorParams]):
                 serving_names_mapping=executor_params.serving_names_mapping,
             )
         else:
-            await get_target(
+            historical_features_metrics = await get_target(
                 session=executor_params.session,
                 graph=executor_params.graph,
                 nodes=executor_params.nodes,
@@ -72,7 +75,9 @@ class TargetExecutor(QueryExecutor[ExecutorParams]):
                 progress_callback=executor_params.progress_callback,
             )
             is_output_view = False
-        return ExecutionResult(is_output_view=is_output_view)
+        return ExecutionResult(
+            is_output_view=is_output_view, historical_features_metrics=historical_features_metrics
+        )
 
 
 class TargetComputer(Computer[ComputeTargetRequest, ExecutorParams]):

--- a/featurebyte/worker/task/historical_feature_table.py
+++ b/featurebyte/worker/task/historical_feature_table.py
@@ -8,7 +8,6 @@ from typing import Any, List, Optional
 
 from featurebyte.logging import get_logger
 from featurebyte.models.historical_feature_table import FeatureInfo, HistoricalFeatureTableModel
-from featurebyte.models.system_metrics import SystemMetricsMetadataKey
 from featurebyte.schema.worker.task.historical_feature_table import (
     HistoricalFeatureTableTaskPayload,
 )
@@ -134,9 +133,6 @@ class HistoricalFeatureTableTask(DataWarehouseMixin, BaseTask[HistoricalFeatureT
                 is_view=result.is_output_view,
             )
             await self.historical_feature_table_service.create_document(historical_feature_table)
-            await self.system_metrics_service.create_metrics(
-                metrics=result.historical_features_metrics,
-                metadata={
-                    SystemMetricsMetadataKey.historical_feature_table_id: payload.output_document_id
-                },
-            )
+            metrics_data = result.historical_features_metrics
+            metrics_data.historical_feature_table_id = payload.output_document_id
+            await self.system_metrics_service.create_metrics(metrics_data=metrics_data)

--- a/tests/fixtures/backward_compatibility/get_routes.txt
+++ b/tests/fixtures/backward_compatibility/get_routes.txt
@@ -25,6 +25,7 @@
 /semantic
 /static_source_table
 /status
+/system_metrics
 /table
 /target
 /target_namespace

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -548,7 +548,7 @@ def check_historical_features_system_metrics(config, historical_feature_table_id
     """
     Check system metrics for historical features
     """
-    params = {"type": "historical_features"}
+    params = {"metrics_type": "historical_features"}
     if historical_feature_table_id is not None:
         params["historical_feature_table_id"] = str(historical_feature_table_id)
 
@@ -565,7 +565,7 @@ def check_historical_features_system_metrics(config, historical_feature_table_id
         "tile_compute_seconds",
         "feature_compute_seconds",
         "feature_cache_update_seconds",
-        "type",
+        "metrics_type",
     }
 
 

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -7,6 +7,7 @@ import os
 import textwrap
 import time
 from datetime import datetime
+from pprint import pprint
 from unittest.mock import patch
 
 import numpy as np
@@ -1335,6 +1336,7 @@ async def test_simulated_materialize__ttl_feature_table(
     session,
     user_entity_ttl_feature_table,
     source_type,
+    config,
 ):
     """
     Test simulating scheduled feature materialization for a feature table with TTL
@@ -1399,6 +1401,19 @@ async def test_simulated_materialize__ttl_feature_table(
     assert df.shape[0] == 36
     assert df["__feature_timestamp"].nunique() == 4
     assert df["üser id"].isnull().sum() == 0
+
+    client = config.get_client()
+    response = client.get(
+        "/system_metrics",
+        params={
+            "offline_store_feature_table_id": str(feature_table_model.id),
+            "type": "scheduled_feature_materialize",
+        },
+    )
+    assert response.status_code == 200
+    response_dict = response.json()
+    pprint(response_dict["data"])
+    assert len(response_dict["data"]) == 3
 
 
 async def reload_feature_table_model(app_container, feature_table_model):

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -1407,7 +1407,7 @@ async def test_simulated_materialize__ttl_feature_table(
         "/system_metrics",
         params={
             "offline_store_feature_table_id": str(feature_table_model.id),
-            "type": "scheduled_feature_materialize",
+            "metrics_type": "scheduled_feature_materialize",
         },
     )
     assert response.status_code == 200

--- a/tests/integration/tile/test_schedule_generate_tile.py
+++ b/tests/integration/tile/test_schedule_generate_tile.py
@@ -265,7 +265,7 @@ async def test_schedule_generate_tile__with_registry(
 @pytest.mark.parametrize("source_type", ["spark", "snowflake"], indirect=True)
 @pytest.mark.asyncio
 async def test_schedule_generate_tile__no_default_job_ts(
-    session, tile_task_prep_spark, base_sql_model, tile_task_executor, tile_registry_service
+    session, tile_task_prep_spark, base_sql_model, tile_task_executor, tile_registry_service, config
 ):
     """
     Test the stored procedure of generating tiles
@@ -341,3 +341,9 @@ async def test_schedule_generate_tile__no_default_job_ts(
         tile_model.last_run_metadata_online.tile_end_date.strftime(date_format)
         == "2023-05-04 14:33:00"
     )
+
+    client = config.get_client()
+    response = client.get("/system_metrics", params={"tile_table_id": tile_id})
+    assert response.status_code == 200
+    response_dict = response.json()
+    assert len(response_dict["data"]) > 0

--- a/tests/integration/tile/test_schedule_generate_tile.py
+++ b/tests/integration/tile/test_schedule_generate_tile.py
@@ -343,7 +343,9 @@ async def test_schedule_generate_tile__no_default_job_ts(
     )
 
     client = config.get_client()
-    response = client.get("/system_metrics", params={"tile_table_id": tile_id})
+    response = client.get(
+        "/system_metrics", params={"tile_table_id": tile_id, "metrics_type": "tile_task"}
+    )
     assert response.status_code == 200
     response_dict = response.json()
     assert len(response_dict["data"]) > 0

--- a/tests/unit/service/test_feature_table_cache.py
+++ b/tests/unit/service/test_feature_table_cache.py
@@ -517,7 +517,7 @@ async def test_create_view_from_cache__create_cache(
         schema_name=mock_snowflake_session.schema_name,
         table_name="result_view",
     )
-    is_output_view = await feature_table_cache_service.create_view_or_table_from_cache(
+    is_output_view, _ = await feature_table_cache_service.create_view_or_table_from_cache(
         feature_store=feature_store,
         observation_table=observation_table,
         graph=feature_list.feature_clusters[0].graph,
@@ -605,7 +605,7 @@ async def test_create_view_from_cache__update_cache(
         schema_name=mock_snowflake_session.schema_name,
         table_name="result_view",
     )
-    is_output_view = await feature_table_cache_service.create_view_or_table_from_cache(
+    is_output_view, _ = await feature_table_cache_service.create_view_or_table_from_cache(
         feature_store=feature_store,
         observation_table=observation_table,
         graph=feature_list.feature_clusters[0].graph,
@@ -696,7 +696,7 @@ async def test_create_view_from_cache__create_view_failed(
         schema_name=mock_snowflake_session.schema_name,
         table_name="result_view",
     )
-    is_output_view = await feature_table_cache_service.create_view_or_table_from_cache(
+    is_output_view, _ = await feature_table_cache_service.create_view_or_table_from_cache(
         feature_store=feature_store,
         observation_table=observation_table,
         graph=feature_list.feature_clusters[0].graph,

--- a/tests/unit/service/test_system_metrics.py
+++ b/tests/unit/service/test_system_metrics.py
@@ -58,6 +58,6 @@ async def test_create_metrics(
             "feature_compute_seconds": 7200,
             "feature_cache_update_seconds": None,
             "historical_feature_table_id": historical_feature_table_id,
-            "type": "historical_features",
+            "metrics_type": "historical_features",
         },
     }.items() < doc.dict().items()

--- a/tests/unit/service/test_system_metrics.py
+++ b/tests/unit/service/test_system_metrics.py
@@ -1,0 +1,56 @@
+"""
+Unit tests for SystemMetricsService
+"""
+
+import pytest
+from bson import ObjectId
+
+from featurebyte.models.system_metrics import HistoricalFeaturesMetrics, SystemMetricsMetadataKey
+from featurebyte.service.system_metrics import SystemMetricsService
+
+
+@pytest.fixture
+def service(app_container) -> SystemMetricsService:
+    """
+    Fixture for SystemMetricsService
+    """
+    return app_container.system_metrics_service
+
+
+@pytest.fixture
+def historical_feature_table_id():
+    """
+    Fixture for historical_feature_table_id
+    """
+    return ObjectId()
+
+
+@pytest.fixture
+def metrics_metadata(historical_feature_table_id):
+    """
+    Fixture for metrics_metadata
+    """
+    return {
+        SystemMetricsMetadataKey.historical_feature_table_id: historical_feature_table_id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_metrics(service, metrics_metadata):
+    """
+    Test create_metrics
+    """
+    await service.create_metrics(
+        metadata=metrics_metadata,
+        metrics=HistoricalFeaturesMetrics(tile_compute_seconds=3600, feature_compute_seconds=7200),
+    )
+    metrics = await service.get_metrics(metadata=metrics_metadata)
+    assert {
+        "metadata": metrics_metadata,
+        "metrics": {
+            "tile_compute_seconds": 3600,
+            "feature_compute_seconds": 7200,
+            "feature_cache_update_seconds": None,
+            "type": "historical_features",
+        },
+    }.items() < metrics.dict().items()

--- a/tests/util/helper.py
+++ b/tests/util/helper.py
@@ -499,7 +499,7 @@ def create_observation_table_by_upload(df):
 
 
 async def compute_historical_feature_table_dataframe_helper(
-    feature_list, df_observation_set, session, data_source, input_format, **kwargs
+    feature_list, df_observation_set, session, data_source, input_format, return_id=False, **kwargs
 ):
     """
     Helper to call compute_historical_feature_table using DataFrame as input, converted to an
@@ -525,7 +525,9 @@ async def compute_historical_feature_table_dataframe_helper(
     df_historical_features = await get_dataframe_from_materialized_table(
         session, historical_feature_table
     )
-    return df_historical_features
+    if not return_id:
+        return df_historical_features
+    return df_historical_features, historical_feature_table.id
 
 
 def check_observation_table_creation_query(query, expected):


### PR DESCRIPTION
## Description

This adds a new service and API to allow tracking and programatically retrieving of internal system metrics.

Currently metrics are tracked in these tasks: historical features computation tasks, scheduled tile tasks, scheduled feature materialize tasks.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
