### PR TITLE
[chore] Update default spark version for local test env to 3.5.0

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -250,7 +250,7 @@ tasks:
         sh: id -u
       LOCAL_GID:
         sh: id -g
-      SPARK_VERSION: '{{default "3.3.1"}}'
+      SPARK_VERSION: '{{default "3.5.0"}}'
     cmds:
       - echo "SPARK_VERSION=$SPARK_VERSION"
       - mkdir -p ~/.spark/data
@@ -275,7 +275,7 @@ tasks:
   test-teardown:
     desc: "Teardown the test environment"
     env:
-      SPARK_VERSION: '{{default "3.3.1"}}'
+      SPARK_VERSION: '{{default "3.5.0"}}'
     preconditions:
       - sh: docker compose ls | grep 'featurebyte_docker'
         msg: "Test environment is not running."


### PR DESCRIPTION
## Description

Update default spark version for local test env to 3.5.0 to match with CI.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
