### PR TITLE
[DEV-3801] Always create a table for historical feature table

### DIFF
--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -670,21 +670,9 @@ class FeatureTableCacheService:
                 })
             )
         )
-        try:
-            await db_session.create_table_as(
-                table_details=output_view_details,
-                select_expr=select_expr,
-                kind="VIEW",
-            )
-            return True, historical_features_metrics
-        except BaseException as _:
-            logger.info(
-                "Failed to create view. Trying to create a table instead",
-                extra={"observation_table_id": observation_table.id},
-                exc_info=True,
-            )
-            await db_session.create_table_as(
-                table_details=output_view_details,
-                select_expr=select_expr,
-            )
-            return False, historical_features_metrics
+        await db_session.create_table_as(
+            table_details=output_view_details,
+            select_expr=select_expr,
+            kind="TABLE",
+        )
+        return False, historical_features_metrics

--- a/tests/unit/routes/test_target_table.py
+++ b/tests/unit/routes/test_target_table.py
@@ -119,7 +119,7 @@ class TestTargetTableApi(BaseMaterializedTableTestSuite):
             "description": None,
             "entity_column_name_to_count": {},
             "has_row_index": True,
-            "is_view": True,
+            "is_view": False,
             "least_recent_point_in_time": None,
             "location": json_dict["location"],
             "min_interval_secs_between_entities": None,


### PR DESCRIPTION
## Description

Always create a table for historical feature table because there are plans to:

1. Support invalidation of columns in feature table cache
2. Support distributing feature table cache into multiple tables and the view will become more complex

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
