### PR TITLE
[DEV-3765] Add route to preview feature in historical feature table

### DIFF
--- a/.changelog/DEV-3765.yaml
+++ b/.changelog/DEV-3765.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: route
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add route to preview a feature from a historical feature table."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/routes/common/base_materialized_table.py
+++ b/featurebyte/routes/common/base_materialized_table.py
@@ -211,6 +211,7 @@ class BaseMaterializedTableController(
         self,
         document_id: ObjectId,
         limit: int,
+        column_names: Optional[list[str]] = None,
     ) -> dict[str, Any]:
         """
         Preview materialized table as pyarrow table
@@ -221,6 +222,8 @@ class BaseMaterializedTableController(
             ID of materialized table to preview
         limit: int
             Number of rows to preview
+        column_names: Optional[list[str]]
+            Column names to preview
 
         Returns
         -------
@@ -234,6 +237,7 @@ class BaseMaterializedTableController(
                     location=table.location,
                     limit=limit,
                     order_by_column=InternalName.TABLE_ROW_INDEX,
+                    column_names=column_names,
                 )
             except Exception as exc:
                 if is_development_mode():
@@ -241,10 +245,10 @@ class BaseMaterializedTableController(
 
                 # if table does not have row index column, preview without ordering
                 return await self.feature_store_warehouse_service.table_preview(
-                    location=table.location, limit=limit
+                    location=table.location, limit=limit, column_names=column_names
                 )
 
         # the table does not have internal row index column
         return await self.feature_store_warehouse_service.table_preview(
-            location=table.location, limit=limit
+            location=table.location, limit=limit, column_names=column_names
         )

--- a/featurebyte/routes/historical_feature_table/api.py
+++ b/featurebyte/routes/historical_feature_table/api.py
@@ -247,3 +247,24 @@ async def preview_historical_feature_table(
         limit=limit,
     )
     return preview
+
+
+@router.get(
+    "/{historical_feature_table_id}/feature_preview/{feature_id}", response_model=Dict[str, Any]
+)
+async def preview_historical_feature_table_feature(
+    request: Request,
+    historical_feature_table_id: PyObjectId,
+    feature_id: PyObjectId,
+    limit: int = Query(default=PREVIEW_DEFAULT, gt=0, le=PREVIEW_LIMIT),
+) -> Dict[str, Any]:
+    """
+    Preview feature in historical feature table
+    """
+    controller = request.state.app_container.historical_feature_table_controller
+    preview: Dict[str, Any] = await controller.preview_feature(
+        document_id=historical_feature_table_id,
+        feature_id=feature_id,
+        limit=limit,
+    )
+    return preview

--- a/featurebyte/routes/historical_feature_table/controller.py
+++ b/featurebyte/routes/historical_feature_table/controller.py
@@ -9,6 +9,8 @@ from typing import Any, Optional
 import pandas as pd
 from bson import ObjectId
 
+from featurebyte.common.env_util import is_development_mode
+from featurebyte.enum import InternalName
 from featurebyte.models.base_feature_or_target_table import BaseFeatureOrTargetTableModel
 from featurebyte.models.historical_feature_table import HistoricalFeatureTableModel
 from featurebyte.routes.common.feature_or_target_table import (
@@ -26,6 +28,7 @@ from featurebyte.schema.worker.task.historical_feature_table import (
     HistoricalFeatureTableTaskPayload,
 )
 from featurebyte.service.entity_validation import EntityValidationService
+from featurebyte.service.feature import FeatureService
 from featurebyte.service.feature_list import FeatureListService
 from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.service.feature_store_warehouse import FeatureStoreWarehouseService
@@ -61,6 +64,7 @@ class HistoricalFeatureTableController(
         task_controller: TaskController,
         feature_list_service: FeatureListService,
         historical_features_validation_parameters_service: HistoricalFeaturesValidationParametersService,
+        feature_service: FeatureService,
     ):
         super().__init__(
             service=historical_feature_table_service,
@@ -74,6 +78,7 @@ class HistoricalFeatureTableController(
         self.historical_features_validation_parameters_service = (
             historical_features_validation_parameters_service
         )
+        self.feature_service = feature_service
 
     async def get_payload(
         self,
@@ -129,3 +134,64 @@ class HistoricalFeatureTableController(
         )
         assert isinstance(table, HistoricalFeatureTableModel)
         return table
+
+    async def preview_feature(
+        self,
+        document_id: ObjectId,
+        feature_id: ObjectId,
+        limit: int,
+    ) -> dict[str, Any]:
+        """
+        Preview feature from materialized table as pyarrow table
+
+        Parameters
+        ----------
+        document_id: ObjectId
+            ID of materialized table to preview
+        feature_id: ObjectId
+            ID of feature to preview
+        limit: int
+            Number of rows to preview
+
+        Raises
+        ------
+        Exception
+            If table does not have row index column and preview fails
+
+        Returns
+        -------
+        dict[str, Any]
+            Preview of feature from materialized table
+        """
+        table = await self.service.get_document(document_id=document_id)
+
+        # include observation table and feature column names
+        assert table.observation_table_id is not None
+        observation_table = await self.observation_table_service.get_document(
+            table.observation_table_id
+        )
+        feature = await self.feature_service.get_document(feature_id)
+        assert feature.name is not None
+        column_names = [col.name for col in observation_table.columns_info] + [feature.name]
+
+        if self.has_internal_row_index_column_in_table:
+            try:
+                return await self.feature_store_warehouse_service.table_preview(
+                    location=table.location,
+                    limit=limit,
+                    order_by_column=InternalName.TABLE_ROW_INDEX,
+                    column_names=column_names,
+                )
+            except Exception as exc:
+                if is_development_mode():
+                    raise exc
+
+                # if table does not have row index column, preview without ordering
+                return await self.feature_store_warehouse_service.table_preview(
+                    location=table.location, limit=limit, column_names=column_names
+                )
+
+        # the table does not have internal row index column
+        return await self.feature_store_warehouse_service.table_preview(
+            location=table.location, limit=limit
+        )

--- a/featurebyte/routes/historical_feature_table/controller.py
+++ b/featurebyte/routes/historical_feature_table/controller.py
@@ -151,11 +151,6 @@ class HistoricalFeatureTableController(
         limit: int
             Number of rows to preview
 
-        Raises
-        ------
-        Exception
-            If table does not have row index column and preview fails
-
         Returns
         -------
         dict[str, Any]

--- a/featurebyte/service/feature_store_warehouse.py
+++ b/featurebyte/service/feature_store_warehouse.py
@@ -346,7 +346,11 @@ class FeatureStoreWarehouseService:
         return FeatureStoreShape(num_rows=shape[0], num_cols=shape[1])
 
     async def table_preview(
-        self, location: TabularSource, limit: int, order_by_column: Optional[str] = None
+        self,
+        location: TabularSource,
+        limit: int,
+        order_by_column: Optional[str] = None,
+        column_names: Optional[List[str]] = None,
     ) -> dict[str, Any]:
         """
         Preview table from location.
@@ -359,6 +363,8 @@ class FeatureStoreWarehouseService:
             Row limit on preview results
         order_by_column: Optional[str]
             Column to order by
+        column_names: Optional[List[str]]
+            Columns to project
 
         Returns
         -------
@@ -371,7 +377,7 @@ class FeatureStoreWarehouseService:
         db_session = await self.session_manager_service.get_feature_store_session(
             feature_store=feature_store, timeout=INTERACTIVE_SESSION_TIMEOUT_SECONDS
         )
-        sql_expr = get_source_expr(source=location.table_details)
+        sql_expr = get_source_expr(source=location.table_details, column_names=column_names)
 
         # apply order by if specified
         if order_by_column:


### PR DESCRIPTION
## Description

Add route to preview feature in historical feature table.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
