### PR TITLE
[chore] Use long running query timeout when listing tables in tile cache

### DIFF
--- a/featurebyte/tile/tile_cache.py
+++ b/featurebyte/tile/tile_cache.py
@@ -35,12 +35,11 @@ from featurebyte.query_graph.sql.tile_util import (
     get_previous_job_epoch_expr,
 )
 from featurebyte.service.tile_manager import TileManagerService
-from featurebyte.session.base import BaseSession
+from featurebyte.session.base import LONG_RUNNING_EXECUTE_QUERY_TIMEOUT_SECONDS, BaseSession
 from featurebyte.session.session_helper import run_coroutines
 
 logger = get_logger(__name__)
 
-TILE_CACHE_LIST_TABLES_TIMEOUT_SECONDS = 60 * 10
 NUM_TRACKER_TABLES_PER_QUERY = 20
 
 
@@ -510,7 +509,7 @@ class TileCache:
         for table in await self.session.list_tables(
             database_name=self.session.database_name,
             schema_name=self.session.schema_name,
-            timeout=TILE_CACHE_LIST_TABLES_TIMEOUT_SECONDS,
+            timeout=LONG_RUNNING_EXECUTE_QUERY_TIMEOUT_SECONDS,
         ):
             # always convert to upper case in case some backends change the casing
             table_name = table.name.upper()


### PR DESCRIPTION
## Description

Use long running query timeout when listing tables in tile cache to avoid timeout errors on many concurrent queries.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
