### PR TITLE
[chore] Fix duration type in FeatureTableJobRun

### DIFF
--- a/featurebyte/schema/deployment.py
+++ b/featurebyte/schema/deployment.py
@@ -97,7 +97,7 @@ class FeatureTableJobRun(FeatureByteBaseModel):
     scheduled_ts: datetime
     completion_ts: Optional[datetime]
     completion_status: Optional[CompletionStatus]
-    duration_seconds: Optional[int]
+    duration_seconds: Optional[float]
     incomplete_tile_tasks_count: Optional[int]
 
 

--- a/tests/unit/service/fixtures_feature_materialize_runs.py
+++ b/tests/unit/service/fixtures_feature_materialize_runs.py
@@ -122,9 +122,9 @@ async def saved_feature_materialize_run_models(
                 offline_store_feature_table_id=offline_store_feature_table_id,
                 offline_store_feature_table_name="customer",
                 scheduled_job_ts=current_scheduled_job_ts,
-                completion_ts=current_scheduled_job_ts + timedelta(seconds=10),
+                completion_ts=current_scheduled_job_ts + timedelta(seconds=10, milliseconds=100),
                 completion_status="success" if i % 2 == 0 else "failure",
-                duration_from_scheduled_seconds=10,
+                duration_from_scheduled_seconds=10.1,
                 incomplete_tile_tasks=[
                     IncompleteTileTask(
                         aggregation_id="another_agg_id" if i % 2 == 0 else feature_aggregation_id,

--- a/tests/unit/service/test_feature_job_history.py
+++ b/tests/unit/service/test_feature_job_history.py
@@ -35,25 +35,25 @@ async def test_get_deployment_job_history(service, deployment_id, offline_store_
                 runs=[
                     FeatureTableJobRun(
                         scheduled_ts=datetime(2024, 7, 15, 9, 0),
-                        completion_ts=datetime(2024, 7, 15, 9, 0, 10),
+                        completion_ts=datetime(2024, 7, 15, 9, 0, 10, 100000),
                         completion_status="failure",
-                        duration_seconds=10,
+                        duration_seconds=10.1,
                         incomplete_tile_tasks_count=1,
                     ),
                     # incomplete_tile_tasks_count is 0 because the failed tile task have a different
                     # aggregation id that doesn't match with any features used in the deployment
                     FeatureTableJobRun(
                         scheduled_ts=datetime(2024, 7, 15, 8, 0),
-                        completion_ts=datetime(2024, 7, 15, 8, 0, 10),
+                        completion_ts=datetime(2024, 7, 15, 8, 0, 10, 100000),
                         completion_status="success",
-                        duration_seconds=10,
+                        duration_seconds=10.1,
                         incomplete_tile_tasks_count=0,
                     ),
                     FeatureTableJobRun(
                         scheduled_ts=datetime(2024, 7, 15, 7, 0),
-                        completion_ts=datetime(2024, 7, 15, 7, 0, 10),
+                        completion_ts=datetime(2024, 7, 15, 7, 0, 10, 100000),
                         completion_status="failure",
-                        duration_seconds=10,
+                        duration_seconds=10.1,
                         incomplete_tile_tasks_count=1,
                     ),
                 ],


### PR DESCRIPTION
## Description

The duration type in `FeatureTableJobRun` can be non-integers.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
