### PR TITLE
[DEV-3811] Support providing definition hashes directly in FeatureTableCacheService

### DIFF
--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -554,7 +554,9 @@ class FeatureTableCacheService:
             feature_store=feature_store
         )
 
-        hashes = await self.get_feature_definition_hashes(graph, nodes, feature_list_id)
+        with timer("get_feature_definition_hashes", logger):
+            hashes = await self.get_feature_definition_hashes(graph, nodes, feature_list_id)
+
         non_cached_nodes = await self.get_non_cached_nodes(cached_definitions, nodes, hashes)
 
         if progress_callback:

--- a/tests/unit/service/test_feature_table_cache.py
+++ b/tests/unit/service/test_feature_table_cache.py
@@ -234,10 +234,18 @@ async def test_get_feature_definition_hashes(
     intercepted_definition_hashes_for_nodes,
 ):
     """Test get_feature_definition_hashes"""
+    if feature_list_id_provided:
+        definition_hashes_mapping = (
+            await feature_table_cache_service._get_definition_hashes_mapping_from_feature_list_id(
+                feature_list_id=regular_feature_list.id
+            )
+        )
+    else:
+        definition_hashes_mapping = None
     hashes = await feature_table_cache_service.get_feature_definition_hashes(
         graph=regular_feature_list.feature_clusters[0].graph,
         nodes=regular_feature_list.feature_clusters[0].nodes,
-        **{"feature_list_id": regular_feature_list.id if feature_list_id_provided else None},
+        definition_hashes_mapping=definition_hashes_mapping,
     )
     if feature_list_id_provided:
         assert intercepted_definition_hashes_for_nodes.call_count == 0


### PR DESCRIPTION
## Description

This adds support for providing feature definition hashes directly in FeatureTableCacheService. In some cases (e.g. EDA), it is much faster to use the already derived definition hashes instead of deriving the hashes again from the graph.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
