### PR TITLE
[DEV-3810] Fix entity untagging bug when multiple paths exist

### DIFF
--- a/.changelog/DEV-3810.yaml
+++ b/.changelog/DEV-3810.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix entity untagging bug when removing ancestor IDs that can be reached by multiple paths"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/service/relationship.py
+++ b/featurebyte/service/relationship.py
@@ -5,7 +5,7 @@ RelationshipService class
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TypeVar, cast
+from typing import Optional, Set, TypeVar, cast
 
 from bson import ObjectId
 
@@ -138,15 +138,65 @@ class RelationshipService(OpsServiceMixin):
 
             return updated_document
 
-    @staticmethod
-    def _validate_remove_relationship_operation(
-        parent_obj: Relationship, child_obj: Relationship
+    async def _remove_ancestor_ids(
+        self,
+        document: Relationship,
+        remove_parent_id: Optional[ObjectId],
+        remove_ancestor_ids: Set[ObjectId],
+        checked_descendant_ids: Set[ObjectId],
     ) -> None:
-        has_relationship = [par for par in child_obj.parents if par.id == parent_obj.id]
-        if not has_relationship:
-            raise DocumentUpdateError(
-                f'Object "{parent_obj.name}" is not the parent of object "{child_obj.name}".'
+        """
+        Remove ancestor IDs from the document and update all descendant objects
+
+        Parameters
+        ----------
+        document: Relationship
+            Document object
+        remove_parent_id: Optional[ObjectId]
+            Parent ID to be removed
+        remove_ancestor_ids: Set[ObjectId]
+            Ancestor IDs to be removed
+        checked_descendant_ids: Set[ObjectId]
+            Descendant IDs that have been checked
+        """
+        if document.id in checked_descendant_ids:
+            return
+
+        # find the ancestor_ids of the parent objects & keep them
+        keep_parents = [par for par in document.parents if par.id != remove_parent_id]
+        keep_parent_ids = [par.id for par in keep_parents]
+
+        keep_ancestor_ids = set(keep_parent_ids)
+        if keep_parent_ids:
+            async for obj in self.document_service.list_documents_as_dict_iterator(
+                query_filter={"_id": {"$in": keep_parent_ids}},
+                projection={"ancestor_ids": 1},
+            ):
+                keep_ancestor_ids.update(obj["ancestor_ids"])
+
+        ancestor_ids = (
+            set(document.ancestor_ids).difference(remove_ancestor_ids).union(keep_ancestor_ids)
+        )
+        await self.document_service.update_document(
+            document_id=document.id,
+            data=self.prepare_document_update_payload(
+                ancestor_ids=ancestor_ids,
+                parents=keep_parents,
+            ),
+        )
+        checked_descendant_ids.add(document.id)
+
+        async for descendant_obj in self.document_service.list_documents_iterator(
+            query_filter={"parents.id": document.id},
+        ):
+            await self._remove_ancestor_ids(
+                document=cast(Relationship, descendant_obj),
+                # do not remove parent_id for descendant objects
+                remove_parent_id=None,
+                remove_ancestor_ids=remove_ancestor_ids,
+                checked_descendant_ids=checked_descendant_ids,
             )
+            checked_descendant_ids.add(descendant_obj.id)
 
     async def remove_relationship(self, parent_id: ObjectId, child_id: ObjectId) -> Relationship:
         """
@@ -155,52 +205,41 @@ class RelationshipService(OpsServiceMixin):
         Parameters
         ----------
         parent_id: ObjectId
-            Parent object
+            Parent object to be removed from child object
         child_id: ObjectId
             Child object ID
 
         Returns
         -------
         Updated document
+
+        Raises
+        ------
+        DocumentUpdateError
+            If the parent object is not the parent of the child object
         """
-        parent_object = await self.document_service.get_document(document_id=parent_id)
-        child_object = await self.document_service.get_document(document_id=child_id)
-        assert isinstance(parent_object, Relationship)
-        assert isinstance(child_object, Relationship)
-        self._validate_remove_relationship_operation(
-            parent_obj=parent_object, child_obj=child_object
+        parent_obj = await self.document_service.get_document(document_id=parent_id)
+        child_obj = await self.document_service.get_document(document_id=child_id)
+        assert isinstance(parent_obj, Relationship), "Parent object is not a Relationship object"
+        assert isinstance(child_obj, Relationship), "Child object is not a Relationship object"
+
+        # validate relationship first
+        has_relationship = [par for par in child_obj.parents if par.id == parent_obj.id]
+        if not has_relationship:
+            raise DocumentUpdateError(
+                f'Object "{parent_obj.name}" is not the parent of object "{child_obj.name}".'
+            )
+
+        remove_ancestor_ids = {parent_id}.union(parent_obj.ancestor_ids)
+        await self._remove_ancestor_ids(
+            document=child_obj,
+            remove_parent_id=parent_id,
+            remove_ancestor_ids=remove_ancestor_ids,
+            checked_descendant_ids=set(),
         )
 
-        async with self.persistent.start_transaction():
-            updated_document = await self.document_service.update_document(
-                document_id=child_id,
-                data=self.prepare_document_update_payload(
-                    ancestor_ids=set(child_object.ancestor_ids).difference(
-                        self.include_object_id(parent_object.ancestor_ids, parent_id)
-                    ),
-                    parents=[par for par in child_object.parents if par.id != parent_id],
-                ),
-                return_document=True,
-            )
-            updated_document = cast(Relationship, updated_document)
-
-            # update all objects which have child_id in their ancestor_ids
-            query_filter = {"ancestor_ids": {"$in": [child_id]}}
-            async for obj in self.document_service.list_documents_as_dict_iterator(
-                query_filter=query_filter,
-                projection={"_id": 1, "ancestor_ids": 1, "parents": 1},
-            ):
-                await self.document_service.update_document(
-                    document_id=obj["_id"],
-                    data=self.prepare_document_update_payload(
-                        ancestor_ids=set(obj["ancestor_ids"]).difference(
-                            self.include_object_id(parent_object.ancestor_ids, parent_id)
-                        ),
-                        parents=obj["parents"],
-                    ),
-                )
-
-            return updated_document
+        updated_document = await self.document_service.get_document(document_id=child_id)
+        return cast(Relationship, updated_document)
 
 
 class EntityRelationshipService(RelationshipService):


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
Fix the issue where entity untagging removed the path that can be reached by other parents.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
