### PR TITLE
[DEV-3800] Track updated timestamp in table validation field

### DIFF
--- a/featurebyte/models/feature_store.py
+++ b/featurebyte/models/feature_store.py
@@ -5,6 +5,7 @@ This module contains DatabaseSource related models
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import Any, ClassVar, Dict, List, Optional, Set, Tuple, Type
 
 import pymongo
@@ -131,6 +132,7 @@ class TableValidation(FeatureByteBaseModel):
 
     status: TableValidationStatus
     validation_message: Optional[StrictStr] = Field(default=None)
+    updated_at: Optional[datetime] = Field(default=None)
     task_id: Optional[str] = Field(default=None)
 
 

--- a/featurebyte/routes/common/base_table.py
+++ b/featurebyte/routes/common/base_table.py
@@ -8,6 +8,7 @@ from typing import Any, List, Optional, Tuple, Type, TypeVar, cast
 
 from bson import ObjectId
 
+from featurebyte.common.model_util import get_utc_now
 from featurebyte.enum import SemanticType
 from featurebyte.exception import ColumnNotFoundError, EntityTaggingIsNotAllowedError
 from featurebyte.models.dimension_table import DimensionTableModel
@@ -198,7 +199,9 @@ class BaseTableDocumentController(
                     document_id=table_document.id,
                     data=self.document_update_schema_class(  # type: ignore
                         validation=TableValidation(
-                            status=TableValidationStatus.PENDING, task_id=task_id
+                            status=TableValidationStatus.PENDING,
+                            task_id=task_id,
+                            updated_at=get_utc_now(),
                         )
                     ),
                 )
@@ -206,7 +209,10 @@ class BaseTableDocumentController(
             await self.service.update_document(
                 document_id=table_document.id,
                 data=self.document_update_schema_class(  # type: ignore
-                    validation=TableValidation(status=TableValidationStatus.PASSED)
+                    validation=TableValidation(
+                        status=TableValidationStatus.PASSED,
+                        updated_at=get_utc_now(),
+                    )
                 ),
             )
 

--- a/featurebyte/service/base_table_validation.py
+++ b/featurebyte/service/base_table_validation.py
@@ -8,6 +8,7 @@ from typing import Generic
 
 from bson import ObjectId
 
+from featurebyte.common.model_util import get_utc_now
 from featurebyte.exception import TableValidationError
 from featurebyte.models.feature_store import TableValidation, TableValidationStatus
 from featurebyte.service.base_table_document import (
@@ -66,6 +67,7 @@ class BaseTableValidationService(Generic[Document, DocumentCreate, DocumentUpdat
                 status=TableValidationStatus.FAILED,
                 validation_message=str(e),
             )
+        new_validation_state.updated_at = get_utc_now()
         await self.table_document_service.update_document(
             table_id,
             self.table_document_service.document_update_class(validation=new_validation_state),

--- a/tests/integration/api/test_scd_view_operations.py
+++ b/tests/integration/api/test_scd_view_operations.py
@@ -156,6 +156,7 @@ async def test_scd_join_small(session, data_source, source_type, config):
     response = client.get(f"/scd_table/{scd_table.id}")
     assert response.status_code == 200
     response_dict = response.json()
+    assert response_dict["validation"].pop("updated_at") is not None
     assert response_dict["validation"] == {
         "status": "FAILED",
         "validation_message": "Multiple records found for the same effective timestamp and natural key combination. Examples of invalid natural keys: [1000, 1000, 1000]",

--- a/tests/unit/routes/test_event_table.py
+++ b/tests/unit/routes/test_event_table.py
@@ -120,7 +120,7 @@ class TestEventTableApi(BaseTableApiTestSuite):
             "record_creation_timestamp_column": "created_at",
             "default_feature_job_setting": {"blind_spot": "10m", "period": "30m", "offset": "5m"},
             "status": "PUBLISHED",
-            "validation": {"status": "PASSED", "validation_message": None},
+            "validation": {"status": "PASSED", "validation_message": None, "updated_at": None},
             "user_id": str(user_id),
             "_id": ObjectId(),
         }
@@ -135,6 +135,7 @@ class TestEventTableApi(BaseTableApiTestSuite):
         output = EventTableModel(**event_table_dict).json_dict()
         assert output.pop("created_at") is None
         assert output.pop("updated_at") is None
+        output["validation"].pop("updated_at")
         output["catalog_id"] = str(default_catalog_id)
         return output
 
@@ -173,6 +174,8 @@ class TestEventTableApi(BaseTableApiTestSuite):
         assert update_response_dict["_id"] == insert_id
         update_response_dict.pop("created_at")
         update_response_dict.pop("updated_at")
+        if "validation" in update_response_dict:
+            update_response_dict["validation"].pop("updated_at")
 
         # default_feature_job_setting should be updated
         assert (
@@ -254,6 +257,8 @@ class TestEventTableApi(BaseTableApiTestSuite):
         assert data["_id"] == insert_id
         data.pop("created_at")
         data.pop("updated_at")
+        if "validation" in data:
+            data["validation"].pop("updated_at")
 
         # default_feature_job_setting should be updated
         assert (

--- a/tests/unit/service/test_base_table_validation.py
+++ b/tests/unit/service/test_base_table_validation.py
@@ -73,7 +73,9 @@ async def test_validate_and_update__success(
     with patch.object(table_validation_service, "validate_table", side_effect=None):
         await table_validation_service.validate_and_update(table_model.id)
     updated_table_model = await document_service.get_document(table_model.id)
-    assert updated_table_model.validation.dict() == {
+    updated_table_model_dict = updated_table_model.dict()
+    assert updated_table_model_dict["validation"].pop("updated_at") is not None
+    assert updated_table_model_dict["validation"] == {
         "status": "PASSED",
         "validation_message": None,
         "task_id": None,
@@ -96,7 +98,9 @@ async def test_validate_and_update__failure(
     ):
         await table_validation_service.validate_and_update(table_model.id)
     updated_table_model = await document_service.get_document(table_model.id)
-    assert updated_table_model.validation.dict() == {
+    updated_table_model_dict = updated_table_model.dict()
+    assert updated_table_model_dict["validation"].pop("updated_at") is not None
+    assert updated_table_model_dict["validation"] == {
         "status": "FAILED",
         "validation_message": "custom message",
         "task_id": None,


### PR DESCRIPTION
## Description

Add a `updated_at` field in `TableValidation` model.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
