### PR TITLE
[chore] Make historical feature table compute rerunnable

### DIFF
--- a/featurebyte/schema/worker/task/historical_feature_table.py
+++ b/featurebyte/schema/worker/task/historical_feature_table.py
@@ -23,6 +23,7 @@ class HistoricalFeatureTableTaskPayload(BaseTaskPayload, HistoricalFeatureTableC
     command: ClassVar[WorkerCommand] = WorkerCommand.HISTORICAL_FEATURE_TABLE_CREATE
     output_collection_name: ClassVar[str] = HistoricalFeatureTableModel.collection_name()
     is_revocable: ClassVar[bool] = True
+    is_rerunnable: ClassVar[bool] = True
 
     # instance variables
     task_type: TaskType = Field(default=TaskType.CPU_TASK)


### PR DESCRIPTION
## Description

Make historical feature table compute rerunnable

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
