### PR TITLE
[DEV-3827] Improve tile cache working table query efficiency in BigQuery

### DIFF
--- a/.changelog/DEV-3827.yaml
+++ b/.changelog/DEV-3827.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Improve tile cache working table query efficiency in BigQuery"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/service/tile_cache_query_by_entity.py
+++ b/featurebyte/service/tile_cache_query_by_entity.py
@@ -441,7 +441,7 @@ class TileCacheQueryByEntityService:
             tile_info = unique_tile_infos[key]
             tracker_table_name = key.get_entity_tracker_table_name()
             table_alias = f"T{table_index}"
-            join_conditions = []
+            join_conditions: list[Expression] = []
             for serving_name, entity_column_name in zip(
                 tile_info.serving_names, tile_info.entity_columns
             ):

--- a/featurebyte/service/tile_cache_query_by_entity.py
+++ b/featurebyte/service/tile_cache_query_by_entity.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Coroutine, Iterator, Optional, cast
 
 from redis import Redis
-from sqlglot import expressions, parse_one
+from sqlglot import expressions
 from sqlglot.expressions import Expression, select
 
 from featurebyte.common.progress import divide_progress_callback
@@ -29,6 +29,7 @@ from featurebyte.query_graph.sql.ast.datetime import TimedeltaExtractNode
 from featurebyte.query_graph.sql.ast.literal import make_literal_value
 from featurebyte.query_graph.sql.common import (
     apply_serving_names_mapping,
+    get_qualified_column_identifier,
     quoted_identifier,
     sql_to_string,
 )
@@ -445,8 +446,9 @@ class TileCacheQueryByEntityService:
                 tile_info.serving_names, tile_info.entity_columns
             ):
                 join_conditions.append(
-                    parse_one(
-                        f"REQ.{quoted_identifier(serving_name).sql()} <=> {table_alias}.{quoted_identifier(entity_column_name).sql()}"
+                    expressions.EQ(
+                        this=get_qualified_column_identifier(serving_name, "REQ"),
+                        expression=get_qualified_column_identifier(entity_column_name, table_alias),
                     )
                 )
             if not join_conditions:

--- a/tests/integration/tile/test_tile_cache.py
+++ b/tests/integration/tile/test_tile_cache.py
@@ -2,7 +2,6 @@
 Integration tests for SnowflakeTileCache
 """
 
-import numpy as np
 import pandas as pd
 import pytest
 
@@ -111,8 +110,8 @@ async def test_tile_cache(
     _ = groupby_category
 
     df_training_events = pd.DataFrame({
-        "POINT_IN_TIME": pd.to_datetime(["2001-01-02 10:00:00"] * 5),
-        "üser id": [1, 2, 3, 4, np.nan],
+        "POINT_IN_TIME": pd.to_datetime(["2001-01-02 10:00:00"] * 4),
+        "üser id": [1, 2, 3, 4],
     })
 
     request_id = session.generate_session_unique_id()
@@ -132,10 +131,10 @@ async def test_tile_cache(
     requests = request_set.compute_requests
     assert len(requests) == 1
     df_entity_expected = pd.DataFrame({
-        "LAST_TILE_START_DATE": pd.to_datetime(["2001-01-02 07:45:00"] * 5),
-        "ÜSER ID": [1.0, 2.0, 3.0, 4.0, np.nan],
-        "__FB_ENTITY_TABLE_END_DATE": pd.to_datetime(["2001-01-02 08:45:00"] * 5),
-        "__FB_ENTITY_TABLE_START_DATE": pd.to_datetime(["1969-12-31 23:45:00"] * 5),
+        "LAST_TILE_START_DATE": pd.to_datetime(["2001-01-02 07:45:00"] * 4),
+        "ÜSER ID": [1.0, 2.0, 3.0, 4.0],
+        "__FB_ENTITY_TABLE_END_DATE": pd.to_datetime(["2001-01-02 08:45:00"] * 4),
+        "__FB_ENTITY_TABLE_START_DATE": pd.to_datetime(["1969-12-31 23:45:00"] * 4),
     })
     await check_entity_table_sql_and_tile_compute_sql(
         session,
@@ -164,8 +163,8 @@ async def test_tile_cache(
 
     # Check using training events with outdated entities (user 3, 4, 5)
     df_training_events = pd.DataFrame({
-        "POINT_IN_TIME": pd.to_datetime(["2001-01-02 10:00:00"] * 2 + ["2001-01-03 10:00:00"] * 3),
-        "üser id": [1, 2, 3, 4, np.nan],
+        "POINT_IN_TIME": pd.to_datetime(["2001-01-02 10:00:00"] * 2 + ["2001-01-03 10:00:00"] * 2),
+        "üser id": [1, 2, 3, 4],
     })
     await session.register_table(request_table_name, df_training_events)
     request_id = session.generate_session_unique_id()
@@ -180,10 +179,10 @@ async def test_tile_cache(
     requests = request_set.compute_requests
     assert len(requests) == 1
     df_entity_expected = pd.DataFrame({
-        "LAST_TILE_START_DATE": pd.to_datetime(["2001-01-03 07:45:00"] * 3),
-        "ÜSER ID": [3, 4, np.nan],
-        "__FB_ENTITY_TABLE_END_DATE": pd.to_datetime(["2001-01-03 08:45:00"] * 3),
-        "__FB_ENTITY_TABLE_START_DATE": pd.to_datetime(["2001-01-02 08:45:00"] * 3),
+        "LAST_TILE_START_DATE": pd.to_datetime(["2001-01-03 07:45:00"] * 2),
+        "ÜSER ID": [3, 4],
+        "__FB_ENTITY_TABLE_END_DATE": pd.to_datetime(["2001-01-03 08:45:00"] * 2),
+        "__FB_ENTITY_TABLE_START_DATE": pd.to_datetime(["2001-01-02 08:45:00"] * 2),
     })
     await check_entity_table_sql_and_tile_compute_sql(
         session,


### PR DESCRIPTION
## Description

This updates the tile cache working table query to use equal operator instead of `IS NOT DISTINCT FROM` as the join condition to improve efficiency. This was causing the query to timeout in BigQuery.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
