### PR TITLE
[DEV-3832] Fix error in min/max aggregations on timestamp columns for historical features

### DIFF
--- a/.changelog/DEV-3832.yaml
+++ b/.changelog/DEV-3832.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fixed an error in historical feature materialization when performing min/max aggregations on timestamp columns."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -542,6 +542,30 @@ def get_training_events_and_expected_result():
             0.4629100498862757,
             np.nan,
         ],
+        "TS_MIN_24h": [
+            pd.Timestamp("2001-01-02 08:42:19.000673"),
+            pd.Timestamp("2001-01-02 10:56:57.000561"),
+            pd.Timestamp("2001-01-02 08:06:01.000282"),
+            pd.Timestamp("2001-01-02 08:41:46.000438"),
+            pd.Timestamp("2001-01-02 06:54:51.000699"),
+            pd.Timestamp("2001-01-02 10:29:32.000059"),
+            pd.Timestamp("2001-01-02 06:12:39.000024"),
+            pd.Timestamp("2001-01-02 07:59:55.000736"),
+            pd.Timestamp("2001-01-02 07:19:27.000175"),
+            pd.NaT,
+        ],
+        "TS_MAX_24h": [
+            pd.Timestamp("2001-01-02 08:42:19.000673"),
+            pd.Timestamp("2001-01-02 10:56:57.000561"),
+            pd.Timestamp("2001-01-02 08:06:01.000282"),
+            pd.Timestamp("2001-01-02 08:41:46.000438"),
+            pd.Timestamp("2001-01-02 06:54:51.000699"),
+            pd.Timestamp("2001-01-02 10:29:32.000059"),
+            pd.Timestamp("2001-01-02 06:12:39.000024"),
+            pd.Timestamp("2001-01-02 07:59:55.000736"),
+            pd.Timestamp("2001-01-02 07:19:27.000175"),
+            pd.NaT,
+        ],
     })
     return df_training_events, df_historical_expected
 
@@ -587,6 +611,7 @@ async def test_get_historical_features(
     data_source,
     feature_group,
     feature_group_per_category,
+    feature_group_timestamp_agg,
     in_out_formats,
     user_entity,
     new_user_id_entity,
@@ -611,6 +636,8 @@ async def test_get_historical_features(
             feature_group_per_category["NUM_UNIQUE_ACTION_24h"],
             feature_group["COUNT_2h DIV COUNT_24h"],
             feature_group_per_category["ACTION_SIMILARITY_2h_to_24h"],
+            feature_group_timestamp_agg["TS_MIN_24h"],
+            feature_group_timestamp_agg["TS_MAX_24h"],
         ],
         name="My FeatureList",
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1795,6 +1795,26 @@ def feature_group_per_category_fixture(event_view):
     return feature_group_per_category
 
 
+@pytest.fixture(name="feature_group_timestamp_agg")
+def feature_group_timestamp_agg_fixture(event_view):
+    """
+    Fixture for a simple FeatureGroup with count features
+    """
+    feature_ts_max = event_view.groupby("ÜSER ID").aggregate_over(
+        value_column="ëvent_timestamp".upper(),
+        method="max",
+        windows=["24h"],
+        feature_names=["TS_MAX_24h"],
+    )["TS_MAX_24h"]
+    feature_ts_min = event_view.groupby("ÜSER ID").aggregate_over(
+        value_column="ëvent_timestamp".upper(),
+        method="max",
+        windows=["24h"],
+        feature_names=["TS_MIN_24h"],
+    )["TS_MIN_24h"]
+    return FeatureGroup([feature_ts_max, feature_ts_min])
+
+
 @pytest.fixture(name="count_distinct_feature_group")
 def count_distinct_feature_group_fixture(item_table, dimension_table):
     """

--- a/tests/unit/query_graph/test_tiling.py
+++ b/tests/unit/query_graph/test_tiling.py
@@ -68,20 +68,24 @@ def make_expected_tile_spec(tile_expr, tile_column_name, tile_column_type=None):
         ),
         (
             AggFunc.MIN,
-            None,
+            DBVarType.INT,
             [
                 make_expected_tile_spec(
-                    tile_expr='MIN("a_column")', tile_column_name="value_1234beef"
+                    tile_expr='MIN("a_column")',
+                    tile_column_name="value_1234beef",
+                    tile_column_type="FLOAT",
                 )
             ],
             "MIN(value_1234beef)",
         ),
         (
             AggFunc.MAX,
-            None,
+            DBVarType.TIMESTAMP,
             [
                 make_expected_tile_spec(
-                    tile_expr='MAX("a_column")', tile_column_name="value_1234beef"
+                    tile_expr='MAX("a_column")',
+                    tile_column_name="value_1234beef",
+                    tile_column_type="TIMESTAMP_NTZ",
                 )
             ],
             "MAX(value_1234beef)",
@@ -140,7 +144,7 @@ def make_expected_tile_spec(tile_expr, tile_column_name, tile_column_type=None):
         ),
         (
             AggFunc.LATEST,
-            None,
+            DBVarType.VARCHAR,
             [
                 make_expected_tile_spec(
                     tile_expr='FIRST_VALUE("a_column")',
@@ -157,7 +161,7 @@ def make_expected_tile_spec(tile_expr, tile_column_name, tile_column_type=None):
                 make_expected_tile_spec(
                     tile_expr='VECTOR_AGGREGATE_MAX("a_column")',
                     tile_column_name="value_1234beef",
-                    tile_column_type="VARCHAR",
+                    tile_column_type="ARRAY",
                 )
             ],
             "VECTOR_AGGREGATE_MAX(value_1234beef)",
@@ -187,12 +191,15 @@ def test_tiling_aggregators(
     """Test tiling aggregators produces expected expressions"""
     agg_id = "1234beef"
     agg = get_aggregator(agg_func, adapter=adapter, parent_dtype=parent_dtype)
-    input_column = InputColumn(name="a_column", dtype=DBVarType.VARCHAR)
+    input_column = InputColumn(name="a_column", dtype=parent_dtype)
     tile_specs = agg.tile(input_column, agg_id)
     merge_expr = agg.merge(agg_id).sql()
     assert [t.tile_expr.sql() for t in tile_specs] == [t["tile_expr"] for t in expected_tile_specs]
     assert [t.tile_column_name for t in tile_specs] == [
         t["tile_column_name"] for t in expected_tile_specs
+    ]
+    assert [t.tile_column_type for t in tile_specs] == [
+        t["tile_column_type"] for t in expected_tile_specs
     ]
     assert merge_expr == expected_merge_expr
 


### PR DESCRIPTION
## Description

Min/max aggregations on timestamp columns were failing because the tile column types were not set correctly.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
