### PR TITLE
[chore] Add total seconds for historical features and scheduled materialize metriccs

### DIFF
--- a/featurebyte/models/system_metrics.py
+++ b/featurebyte/models/system_metrics.py
@@ -66,6 +66,7 @@ class ScheduledFeatureMaterializeMetrics(FeatureByteBaseModel):
     generate_precomputed_lookup_feature_tables_seconds: Optional[float] = None
     update_feature_tables_seconds: Optional[float] = None
     online_materialize_seconds: Optional[float] = None
+    total_seconds: Optional[float] = None
     metrics_type: Literal[SystemMetricsType.SCHEDULED_FEATURE_MATERIALIZE] = (
         SystemMetricsType.SCHEDULED_FEATURE_MATERIALIZE
     )

--- a/featurebyte/models/system_metrics.py
+++ b/featurebyte/models/system_metrics.py
@@ -36,6 +36,7 @@ class HistoricalFeaturesMetrics(FeatureByteBaseModel):
     tile_compute_seconds: Optional[float] = None
     feature_compute_seconds: Optional[float] = None
     feature_cache_update_seconds: Optional[float] = None
+    total_seconds: Optional[float] = None
     metrics_type: Literal[SystemMetricsType.HISTORICAL_FEATURES] = (
         SystemMetricsType.HISTORICAL_FEATURES
     )

--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -698,6 +698,7 @@ class FeatureTableCacheService:
         bool
             Whether the output is a view
         """
+        first_tic = time.time()
         with timer(
             "Update feature table cache",
             logger,
@@ -733,4 +734,5 @@ class FeatureTableCacheService:
             select_expr=select_expr,
             kind="TABLE",
         )
+        historical_features_metrics.total_seconds = time.time() - first_tic
         return False, historical_features_metrics

--- a/featurebyte/service/historical_features_and_target.py
+++ b/featurebyte/service/historical_features_and_target.py
@@ -160,8 +160,6 @@ async def get_historical_features(
     -------
     HistoricalFeaturesMetrics
     """
-    first_tic = time.time()
-
     output_include_row_index = (
         isinstance(observation_set, ObservationTableModel) and observation_set.has_row_index is True
     )
@@ -263,7 +261,6 @@ async def get_historical_features(
     return HistoricalFeaturesMetrics(
         tile_compute_seconds=tile_compute_seconds,
         feature_compute_seconds=feature_compute_seconds,
-        total_seconds=time.time() - first_tic,
     )
 
 
@@ -309,8 +306,6 @@ async def get_target(
     -------
     HistoricalFeaturesMetrics
     """
-    first_tic = time.time()
-
     output_include_row_index = (
         isinstance(observation_set, ObservationTableModel) and observation_set.has_row_index is True
     )
@@ -376,5 +371,4 @@ async def get_target(
     return HistoricalFeaturesMetrics(
         tile_compute_seconds=0,
         feature_compute_seconds=feature_compute_seconds,
-        total_seconds=time.time() - first_tic,
     )

--- a/featurebyte/service/historical_features_and_target.py
+++ b/featurebyte/service/historical_features_and_target.py
@@ -160,7 +160,7 @@ async def get_historical_features(
     -------
     HistoricalFeaturesMetrics
     """
-    tic_ = time.time()
+    first_tic = time.time()
 
     output_include_row_index = (
         isinstance(observation_set, ObservationTableModel) and observation_set.has_row_index is True
@@ -220,6 +220,7 @@ async def get_historical_features(
             )
 
         # Generate SQL code that computes the features
+        tic = time.time()
         historical_feature_query_set = get_historical_features_query_set(
             graph=graph,
             nodes=nodes,
@@ -250,7 +251,7 @@ async def get_historical_features(
                 else None
             ),
         )
-        feature_compute_seconds = time.time() - tic_
+        feature_compute_seconds = time.time() - tic
         logger.debug(f"compute_historical_features in total took {feature_compute_seconds:.2f}s")
     finally:
         await session.drop_table(
@@ -262,6 +263,7 @@ async def get_historical_features(
     return HistoricalFeaturesMetrics(
         tile_compute_seconds=tile_compute_seconds,
         feature_compute_seconds=feature_compute_seconds,
+        total_seconds=time.time() - first_tic,
     )
 
 
@@ -307,7 +309,7 @@ async def get_target(
     -------
     HistoricalFeaturesMetrics
     """
-    tic_ = time.time()
+    first_tic = time.time()
 
     output_include_row_index = (
         isinstance(observation_set, ObservationTableModel) and observation_set.has_row_index is True
@@ -346,6 +348,7 @@ async def get_target(
             progress_message=PROGRESS_MESSAGE_COMPUTING_TARGET,
         )
 
+        tic = time.time()
         await execute_feature_query_set(
             session_handler=SessionHandler(
                 session=session, redis=redis, feature_store=feature_store
@@ -361,7 +364,7 @@ async def get_target(
                 else None
             ),
         )
-        feature_compute_seconds = time.time() - tic_
+        feature_compute_seconds = time.time() - tic
         logger.debug(f"compute_targets in total took {feature_compute_seconds:.2f}s")
     finally:
         await session.drop_table(
@@ -373,4 +376,5 @@ async def get_target(
     return HistoricalFeaturesMetrics(
         tile_compute_seconds=0,
         feature_compute_seconds=feature_compute_seconds,
+        total_seconds=time.time() - first_tic,
     )

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -591,6 +591,7 @@ def check_historical_features_system_metrics(config, historical_feature_table_id
         "tile_compute_seconds",
         "feature_compute_seconds",
         "feature_cache_update_seconds",
+        "total_seconds",
         "metrics_type",
     }
 

--- a/tests/unit/service/test_system_metrics.py
+++ b/tests/unit/service/test_system_metrics.py
@@ -33,6 +33,7 @@ def historical_feature_metrics_data(historical_feature_table_id):
     return HistoricalFeaturesMetrics(
         tile_compute_seconds=3600,
         feature_compute_seconds=7200,
+        total_seconds=10000,
         historical_feature_table_id=historical_feature_table_id,
     )
 
@@ -58,6 +59,7 @@ async def test_create_metrics(
             "feature_compute_seconds": 7200,
             "feature_cache_update_seconds": None,
             "historical_feature_table_id": historical_feature_table_id,
+            "total_seconds": 10000,
             "metrics_type": "historical_features",
         },
     }.items() < doc.dict().items()


### PR DESCRIPTION
## Description

Add `total_seconds` to track end to end timing. Also update `feature_compute_seconds` to exclude tile compute time.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
