### PR TITLE
[DEV-3847] Add ObservationTableTileCacheService

### DIFF
--- a/featurebyte/models/observation_table_tile_cache.py
+++ b/featurebyte/models/observation_table_tile_cache.py
@@ -1,0 +1,36 @@
+"""
+ObservationTableTileCacheModel
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from pydantic import Field
+from pymongo import IndexModel
+
+from featurebyte.models.base import FeatureByteCatalogBaseDocumentModel, PydanticObjectId
+
+
+class ObservationTableTileCacheModel(FeatureByteCatalogBaseDocumentModel):
+    """
+    ObservationTableTileCacheModel class
+
+    This model keeps track of the tile tables that have been generated for a given observation
+    table.
+    """
+
+    observation_table_id: PydanticObjectId
+    aggregation_ids: List[str] = Field(default_factory=list)
+
+    class Settings(FeatureByteCatalogBaseDocumentModel.Settings):
+        """
+        MongoDB settings
+        """
+
+        collection_name = "observation_table_tile_cache"
+        unique_constraints = []
+        indexes = FeatureByteCatalogBaseDocumentModel.Settings.indexes + [
+            IndexModel("observation_table_id"),
+        ]
+        auditable = False

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -128,6 +128,7 @@ from featurebyte.service.item_table import ExtendedItemTableService, ItemTableSe
 from featurebyte.service.item_table_validation import ItemTableValidationService
 from featurebyte.service.namespace_handler import NamespaceHandler
 from featurebyte.service.observation_table import ObservationTableService
+from featurebyte.service.observation_table_tile_cache import ObservationTableTileCacheService
 from featurebyte.service.offline_store_feature_table import OfflineStoreFeatureTableService
 from featurebyte.service.offline_store_feature_table_comment import (
     OfflineStoreFeatureTableCommentService,
@@ -323,6 +324,7 @@ app_container_config.register_class(ObservationSetHelper)
 app_container_config.register_class(ObservationTableController)
 app_container_config.register_class(ObservationTableDeleteValidator)
 app_container_config.register_class(ObservationTableService)
+app_container_config.register_class(ObservationTableTileCacheService)
 app_container_config.register_class(OfflineStoreFeatureTableConstructionService)
 app_container_config.register_class(OfflineStoreFeatureTableService)
 app_container_config.register_class(OfflineStoreFeatureTableCommentService)

--- a/featurebyte/service/observation_table_tile_cache.py
+++ b/featurebyte/service/observation_table_tile_cache.py
@@ -1,0 +1,75 @@
+"""
+ObservationTableTileCacheService
+"""
+
+from typing import List
+
+from bson import ObjectId
+
+from featurebyte.models.observation_table_tile_cache import ObservationTableTileCacheModel
+from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema
+from featurebyte.service.base_document import BaseDocumentService
+
+
+class ObservationTableTileCacheService(
+    BaseDocumentService[
+        ObservationTableTileCacheModel,
+        ObservationTableTileCacheModel,
+        BaseDocumentServiceUpdateSchema,
+    ]
+):
+    """
+    ObservationTableTileCacheDocumentService class
+    """
+
+    document_class = ObservationTableTileCacheModel
+
+    async def add_aggregation_ids_for_observation_table(
+        self, observation_table_id: ObjectId, aggregation_ids: List[str]
+    ) -> None:
+        """
+        Update the cache for an observation table
+
+        Parameters
+        ----------
+        observation_table_id: ObjectId
+            Observation table ID
+        aggregation_ids: List[str]
+            List of aggregation IDs
+        """
+        query_filter = {"observation_table_id": observation_table_id}
+        async for doc in self.list_documents_as_dict_iterator(query_filter=query_filter):
+            document_id = doc["_id"]
+            break
+        else:
+            created_doc = await self.create_document(
+                ObservationTableTileCacheModel(observation_table_id=observation_table_id)
+            )
+            document_id = created_doc.id
+        await self.update_documents(
+            query_filter={"_id": document_id},
+            update={"$addToSet": {"aggregation_ids": {"$each": aggregation_ids}}},
+        )
+
+    async def get_non_cached_aggregation_ids(
+        self, observation_table_id: ObjectId, aggregation_ids: List[str]
+    ) -> List[str]:
+        """
+        Get the aggregation IDs that are not cached
+
+        Parameters
+        ----------
+        observation_table_id: ObjectId
+            Observation table ID
+        aggregation_ids: List[str]
+            List of aggregation IDs
+
+        Returns
+        -------
+        List[str]
+        """
+        query_filter = {"observation_table_id": observation_table_id}
+        cached_aggregation_ids = set()
+        async for doc in self.list_documents_as_dict_iterator(query_filter=query_filter):
+            cached_aggregation_ids.update(doc["aggregation_ids"])
+        return [agg_id for agg_id in aggregation_ids if agg_id not in cached_aggregation_ids]

--- a/tests/unit/service/test_observation_table_tile_cache.py
+++ b/tests/unit/service/test_observation_table_tile_cache.py
@@ -1,0 +1,56 @@
+"""
+Unit tests for ObservationTableTileCacheService
+"""
+
+import pytest
+from bson import ObjectId
+
+
+@pytest.fixture(name="service")
+def service_fixture(app_container):
+    """
+    Fixture for ObservationTableTileCacheService
+    """
+    return app_container.observation_table_tile_cache_service
+
+
+@pytest.fixture(name="observation_table_id")
+def observation_table_id_fixture():
+    """
+    Fixture for observation_table_id
+    """
+    return ObjectId()
+
+
+@pytest.fixture(name="another_observation_table_id")
+def another_observation_table_id_fixture():
+    """
+    Fixture for another_observation_table_id
+    """
+    return ObjectId()
+
+
+@pytest.mark.asyncio
+async def test_add_aggregation_ids(service, observation_table_id, another_observation_table_id):
+    """
+    Test add_aggregation_ids_for_observation_table
+    """
+    await service.add_aggregation_ids_for_observation_table(
+        observation_table_id, ["agg_id_1", "agg_id_2"]
+    )
+
+    # Check cached aggregation ids
+    query_agg_ids = ["agg_id_1", "agg_id_2", "agg_id_3"]
+    assert await service.get_non_cached_aggregation_ids(observation_table_id, query_agg_ids) == [
+        "agg_id_3"
+    ]
+
+    # Check another observation table id which should not be affected
+    assert (
+        await service.get_non_cached_aggregation_ids(another_observation_table_id, query_agg_ids)
+        == query_agg_ids
+    )
+
+    # Cache more aggregation ids
+    await service.add_aggregation_ids_for_observation_table(observation_table_id, ["agg_id_3"])
+    assert await service.get_non_cached_aggregation_ids(observation_table_id, query_agg_ids) == []


### PR DESCRIPTION
## Description

Add `ObservationTableTileCacheService` to keep track of tiles that have been generated for a given observation table.

There is no functional changes yet. This will be used in a next PR to change the way tile cache behaves when materialising historical features based on an observation table.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
