### PR TITLE
[DEV-3807] Use lock in get_or_create_feature_table_cache

### DIFF
--- a/featurebyte/utils/async_helper.py
+++ b/featurebyte/utils/async_helper.py
@@ -11,9 +11,9 @@ from asyncio import Future, Task
 from typing import Any, Coroutine, List
 
 from redis import Redis
+from redis.exceptions import LockNotOwnedError
 
 from featurebyte.session.base import LONG_RUNNING_EXECUTE_QUERY_TIMEOUT_SECONDS
-from featurebyte.utils.redis import acquire_lock
 
 SEMAPHORE_TIMEOUT_SECONDS = 30
 
@@ -151,6 +151,8 @@ class RedisFairCountingSemaphore:
 
         Raises
         ------
+        TimeoutError
+            If semaphore is not acquired within timeout
         RuntimeError
             If semaphore is already acquired
 
@@ -171,16 +173,31 @@ class RedisFairCountingSemaphore:
                 await self._refresh()
 
         # Try to acquire semaphore
-        async with acquire_lock(
-            self._redis, self._lock, timeout=10, blocking_timeout=self._timeout
-        ):
-            identifier = await self._acquire_semaphore()
-            if identifier:
-                self._identifier = identifier
-                # Add task to refresh semaphore while semaphore is acquired
-                self._semaphore_refresh_task = asyncio.create_task(_semaphore_refresh_task())
-
-        return self
+        now = time.time()
+        while time.time() - now < self._timeout:
+            # Acquire lock for semaphore
+            lock = self._redis.lock(self._lock, timeout=10)
+            if lock.acquire(blocking=False):
+                try:
+                    identifier = await self._acquire_semaphore()
+                    if identifier:
+                        self._identifier = identifier
+                        # Add task to refresh semaphore while semaphore is acquired
+                        self._semaphore_refresh_task = asyncio.create_task(
+                            _semaphore_refresh_task()
+                        )
+                        return self
+                finally:
+                    # Release lock
+                    if lock.owned():
+                        try:
+                            lock.release()
+                        except LockNotOwnedError:
+                            # Lock may have expired before release
+                            pass
+            await asyncio.sleep(0.1)
+        # Timeout trying to acquire semaphore
+        raise TimeoutError(f"Failed to acquire semaphore after {time.time() - now}s")
 
     async def __aexit__(self, *exc: dict[str, Any]) -> None:
         """

--- a/featurebyte/utils/redis.py
+++ b/featurebyte/utils/redis.py
@@ -1,0 +1,77 @@
+"""
+Redis utilities
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Optional
+
+from redis import Redis
+from redis.exceptions import LockNotOwnedError
+from redis.lock import Lock
+
+
+@asynccontextmanager
+async def acquire_lock(
+    redis: Redis[Any],
+    name: str,
+    timeout: Optional[int] = None,
+    blocking_timeout: Optional[int] = None,
+) -> AsyncIterator[Lock]:
+    """
+    Asynchronously acquires a Redis lock, handling scenarios where the lock is not owned on release.
+
+    This context manager attempts to acquire a lock with the specified `name` in Redis.
+    If a `timeout` is provided, the lock will automatically release after the specified duration.
+    The `blocking_timeout`, if given, sets the maximum time the method will attempt to acquire the
+    lock before raising a `TimeoutError`.
+
+    Parameters
+    ----------
+    redis: Redis[Any]
+        Redis client instance.
+    name: str
+        Name of the lock.
+    timeout: Optional[int]
+        Maximum duration in seconds for which the lock should be held. If not specified, the lock
+        will be held indefinitely until explicitly released.
+    blocking_timeout: Optional[int]
+        Maximum duration in seconds to wait for acquiring the lock. If not specified, the method
+        will attempt to acquire the lock indefinitely.
+
+    Yields
+    ------
+    Lock
+        The acquired lock instance.
+
+    Raises
+    ------
+    TimeoutError
+        If the lock cannot be acquired within the specified `blocking_timeout`.
+    """
+    now = time.time()
+
+    lock = redis.lock(name, timeout=timeout)
+    lock_acquired = False
+
+    while blocking_timeout is None or time.time() - now < blocking_timeout:
+        if lock.acquire(blocking=False):
+            lock_acquired = True
+            break
+        await asyncio.sleep(0.1)
+
+    if not lock_acquired:
+        raise TimeoutError(f"Failed to acquire lock after {time.time() - now}s")
+
+    try:
+        yield lock
+    finally:
+        if lock.owned():
+            try:
+                lock.release()
+            except LockNotOwnedError:
+                # Lock may have expired before release
+                pass


### PR DESCRIPTION
## Description

This updates feature table cache metadata service to acquire a lock before creating or updating cache metadata documents in order to handle concurrent queries.

Without this, multiple cache metadata documents might be created unnecessarily and causes tests failures such as 

> FAILED tests/integration/api/test_historical_features.py::test_get_historical_feature_tables_parallel[databricks_unity] - AssertionError: assert 4 == 3

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
