### PR TITLE
Revert "[chore] Remove a parameter that is not required in TileSpec"

### DIFF
--- a/featurebyte/feature_manager/model.py
+++ b/featurebyte/feature_manager/model.py
@@ -41,6 +41,7 @@ class ExtendedFeatureModel(FeatureModel):
                 value_column_types=info.tile_value_types,
                 tile_id=info.tile_table_id,
                 aggregation_id=info.aggregation_id,
+                aggregation_function_name=info.agg_func,
                 parent_column_name=info.parent,
                 category_column_name=info.value_by_column,
                 feature_store_id=self.tabular_source.feature_store_id,

--- a/featurebyte/models/tile.py
+++ b/featurebyte/models/tile.py
@@ -41,6 +41,8 @@ class TileSpec(FeatureByteBaseModel):
         hash value of tile id and name
     aggregation_id: str
         aggregation id for the tile
+    aggregation_function_name: Optional[str]
+        optional aggregation function name
     parent_column_name: Optional[str]
         optional parent column name from groupby node
     category_column_name: Optional[str]
@@ -59,6 +61,7 @@ class TileSpec(FeatureByteBaseModel):
     value_column_types: List[str]
     tile_id: str
     aggregation_id: str
+    aggregation_function_name: Optional[str] = Field(default=None)
     parent_column_name: Optional[str] = Field(default=None)
     category_column_name: Optional[str] = Field(default=None)
     feature_store_id: Optional[ObjectId] = Field(default=None)

--- a/tests/unit/feature_manager/test_model.py
+++ b/tests/unit/feature_manager/test_model.py
@@ -33,6 +33,7 @@ def test_extended_feature_model__float_feature(
             aggregation_id=f"sum_{aggregation_id}",
             feature_store_id=snowflake_feature_store.id,
             parent_column_name="col_float",
+            aggregation_function_name="sum",
             windows=["30m", "2h", "1d"],
         )
     ]
@@ -69,6 +70,7 @@ def test_extended_feature_model__agg_per_category_feature(
             category_column_name="col_int",
             feature_store_id=snowflake_feature_store.id,
             parent_column_name="col_float",
+            aggregation_function_name="sum",
             windows=["30m", "2h", "1d"],
         )
     ]


### PR DESCRIPTION
Reverts featurebyte/featurebyte#2668

The attribute is actually still used, just not within this codebase.