### PR TITLE
[DEV-3863] Make min_featurejob_period configurable when intializing default feature job settings

### DIFF
--- a/featurebyte/api/event_table.py
+++ b/featurebyte/api/event_table.py
@@ -471,7 +471,7 @@ class EventTable(TableApiObject):
         return analysis
 
     @typechecked
-    def initialize_default_feature_job_setting(self) -> None:
+    def initialize_default_feature_job_setting(self, min_featurejob_period: int = 3600) -> None:
         """
         Initializes default feature job setting by performing an analysis on the table to streamline the process of
         setting Feature Job. This analysis relies on the presence of record creation timestamps in the source table,
@@ -498,6 +498,11 @@ class EventTable(TableApiObject):
         helps ensure consistency between offline and online feature values, and accurate historical serving that
         reflects the conditions present in the production environment.
 
+        Parameters
+        ----------
+        min_featurejob_period: int
+            Determines the minimum period (in seconds) between feature jobs. The default value is 3600 seconds (1 hour).
+
         Raises
         ------
         InvalidSettingsError
@@ -515,7 +520,9 @@ class EventTable(TableApiObject):
         if self.default_feature_job_setting:
             raise InvalidSettingsError("Default feature job setting is already initialized")
 
-        analysis = self.create_new_feature_job_setting_analysis()
+        analysis = self.create_new_feature_job_setting_analysis(
+            min_featurejob_period=min_featurejob_period
+        )
         self.update_default_feature_job_setting(analysis.get_recommendation())
 
     def list_feature_job_setting_analysis(self) -> Optional[pd.DataFrame]:

--- a/tests/unit/api/test_event_table.py
+++ b/tests/unit/api/test_event_table.py
@@ -544,7 +544,7 @@ def test_update_default_feature_job_setting__using_feature_job_analysis(
             "event_table_candidate": None,
             "analysis_date": None,
             "analysis_length": 2419200,
-            "min_featurejob_period": 60,
+            "min_featurejob_period": 3600,
             "exclude_late_job": False,
             "blind_spot_buffer_setting": 5,
             "job_time_buffer_setting": "auto",


### PR DESCRIPTION
## Description

Make min_featurejob_period configurable when intializing default feature job settings and defaults to 1h

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
