### PR TITLE
[DEV-3890] Move `store_info` attribute from feature list to deployment model

### DIFF
--- a/.changelog/DEV-3890.yaml
+++ b/.changelog/DEV-3890.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: model
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Move the `store_info` attribute from feature list model to deployment model."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/deployment.py
+++ b/featurebyte/api/deployment.py
@@ -85,7 +85,7 @@ class Deployment(DeletableApiObject):
         if not self.enabled:
             raise DeploymentDataBricksAccessorError("Deployment is not enabled")
 
-        store_info = self.feature_list.cached_model.store_info  # type: ignore
+        store_info = self.cached_model.store_info  # type: ignore
         if store_info.type != "databricks_unity":
             raise DeploymentDataBricksAccessorError(
                 "Deployment is not using DataBricks Unity as the store"

--- a/featurebyte/migration/service/deployment.py
+++ b/featurebyte/migration/service/deployment.py
@@ -1,0 +1,70 @@
+"""
+Deployment migration service
+"""
+
+from featurebyte.logging import get_logger
+from featurebyte.migration.service import migrate
+from featurebyte.migration.service.mixin import BaseDocumentServiceT, BaseMongoCollectionMigration
+from featurebyte.persistent import Persistent
+from featurebyte.service.deployment import DeploymentService
+from featurebyte.service.feature_list import FeatureListService
+
+logger = get_logger(__name__)
+
+
+class DeploymentMigrationServiceV14(BaseMongoCollectionMigration):
+    """
+    DeploymentMigrationService class
+
+    This class is used to migrate the deployment records.
+    """
+
+    # skip audit migration for this migration
+    skip_audit_migration = True
+
+    def __init__(
+        self,
+        persistent: Persistent,
+        deployment_service: DeploymentService,
+        feature_list_service: FeatureListService,
+    ):
+        super().__init__(persistent)
+        self.deployment_service = deployment_service
+        self.feature_list_service = feature_list_service
+
+    @property
+    def delegate_service(self) -> BaseDocumentServiceT:
+        return self.deployment_service  # type: ignore[return-value]
+
+    @migrate(
+        version=14,
+        description="Move store info from feature list to deployment record.",
+    )
+    async def move_store_info_from_feature_list_to_deployment(self) -> None:
+        """Move store info from feature list to deployment record"""
+        query_filter = await self.delegate_service.construct_list_query_filter()
+        total = await self.get_total_record(query_filter=query_filter)
+        sample_ids = []
+
+        async for deployment_dict in self.delegate_service.list_documents_as_dict_iterator(
+            query_filter=query_filter
+        ):
+            feature_list_dict = await self.feature_list_service.get_document_as_dict(
+                deployment_dict["feature_list_id"]
+            )
+            store_info = feature_list_dict.get("store_info")
+            if store_info:
+                await self.delegate_service.update_documents(
+                    query_filter={"_id": deployment_dict["_id"]},
+                    update={"$set": {"store_info": store_info}},
+                )
+                if len(sample_ids) < 10:
+                    sample_ids.append(deployment_dict["_id"])
+
+        # check that store info is migrated successfully
+        async for deployment in self.delegate_service.list_documents_iterator(
+            query_filter={"_id": {"$in": sample_ids}}
+        ):
+            assert deployment.store_info, deployment
+
+        logger.info("Migrated all records successfully (total: %d)", total)

--- a/featurebyte/migration/service/deployment.py
+++ b/featurebyte/migration/service/deployment.py
@@ -2,6 +2,10 @@
 Deployment migration service
 """
 
+from typing import List
+
+from bson import ObjectId
+
 from featurebyte.logging import get_logger
 from featurebyte.migration.service import migrate
 from featurebyte.migration.service.mixin import BaseDocumentServiceT, BaseMongoCollectionMigration
@@ -44,7 +48,7 @@ class DeploymentMigrationServiceV14(BaseMongoCollectionMigration):
         """Move store info from feature list to deployment record"""
         query_filter = await self.delegate_service.construct_list_query_filter()
         total = await self.get_total_record(query_filter=query_filter)
-        sample_ids = []
+        sample_ids: List[ObjectId] = []
 
         async for deployment_dict in self.delegate_service.list_documents_as_dict_iterator(
             query_filter=query_filter
@@ -65,6 +69,6 @@ class DeploymentMigrationServiceV14(BaseMongoCollectionMigration):
         async for deployment in self.delegate_service.list_documents_iterator(
             query_filter={"_id": {"$in": sample_ids}}
         ):
-            assert deployment.store_info, deployment
+            assert deployment.store_info, deployment  # type: ignore[attr-defined]
 
         logger.info("Migrated all records successfully (total: %d)", total)

--- a/featurebyte/migration/service/feature_list.py
+++ b/featurebyte/migration/service/feature_list.py
@@ -223,3 +223,33 @@ class FeatureListMigrationServiceV7(FeatureListMigrationServiceV6):
     @migrate(version=7, description="Add table_ids to feature list record")
     async def run_migration(self) -> None:
         await super().run_migration()
+
+    @migrate(
+        version=15,
+        description="Remove store info from feature list records.",
+    )
+    async def remove_store_info_from_feature_list(self) -> None:
+        """Remove store info from feature list"""
+        query_filter = await self.delegate_service.construct_list_query_filter()
+        total = await self.get_total_record(query_filter=query_filter)
+        sample_ids = []
+
+        async for feature_list_dict in self.delegate_service.list_documents_as_dict_iterator(
+            query_filter=query_filter
+        ):
+            store_info = feature_list_dict.get("store_info")
+            if store_info and store_info.get("feast_enabled"):
+                await self.delegate_service.update_documents(
+                    query_filter={"_id": feature_list_dict["_id"]},
+                    update={"$set": {"feast_enabled": True}},
+                )
+                if len(sample_ids) < 10:
+                    sample_ids.append(feature_list_dict["_id"])
+
+        # check that store info is migrated successfully
+        async for feature_list_dict in self.delegate_service.list_documents_as_dict_iterator(
+            query_filter={"_id": {"$in": sample_ids}}
+        ):
+            assert feature_list_dict["feast_enabled"], feature_list_dict
+
+        logger.info("Migrated all records successfully (total: %d)", total)

--- a/featurebyte/migration/service/feature_list.py
+++ b/featurebyte/migration/service/feature_list.py
@@ -232,7 +232,7 @@ class FeatureListMigrationServiceV7(FeatureListMigrationServiceV6):
         """Remove store info from feature list"""
         query_filter = await self.delegate_service.construct_list_query_filter()
         total = await self.get_total_record(query_filter=query_filter)
-        sample_ids = []
+        sample_ids: List[ObjectId] = []
 
         async for feature_list_dict in self.delegate_service.list_documents_as_dict_iterator(
             query_filter=query_filter

--- a/featurebyte/models/deployment.py
+++ b/featurebyte/models/deployment.py
@@ -4,12 +4,14 @@ Deployment model
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 import pymongo
 from pydantic import Field, StrictStr
 from pydantic_settings import BaseSettings
 
+from featurebyte.enum import SourceType
+from featurebyte.models import FeatureModel, FeatureStoreModel
 from featurebyte.models.base import (
     FeatureByteBaseModel,
     FeatureByteCatalogBaseDocumentModel,
@@ -17,6 +19,16 @@ from featurebyte.models.base import (
     UniqueConstraintResolutionSignature,
     UniqueValuesConstraint,
 )
+from featurebyte.models.feature_list_store_info import (
+    BigQueryStoreInfo,
+    DataBricksStoreInfo,
+    DataBricksUnityStoreInfo,
+    SnowflakeStoreInfo,
+    SparkStoreInfo,
+    StoreInfo,
+    construct_store_info,
+)
+from featurebyte.query_graph.node.schema import ColumnSpec
 
 
 class FeastRegistryInfo(FeatureByteBaseModel):
@@ -37,6 +49,60 @@ class DeploymentModel(FeatureByteCatalogBaseDocumentModel):
     use_case_id: Optional[PydanticObjectId] = Field(default=None)
     registry_info: Optional[FeastRegistryInfo] = Field(default=None)
     serving_entity_ids: Optional[List[PydanticObjectId]] = Field(default=None)
+
+    # store info contains the warehouse specific info for the deployment
+    internal_store_info: Optional[Dict[str, Any]] = Field(alias="store_info", default=None)
+
+    @property
+    def store_info(self) -> StoreInfo:
+        """
+        Store info for a feature list
+
+        Returns
+        -------
+        StoreInfo
+        """
+        obj_dict = self.internal_store_info or {"type": "uninitialized"}
+        return cast(StoreInfo, construct_store_info(**obj_dict))
+
+    def initialize_store_info(
+        self,
+        features: List[FeatureModel],
+        feature_store: FeatureStoreModel,
+        feature_table_map: Dict[str, Any],
+        serving_entity_specs: Optional[List[ColumnSpec]],
+    ) -> None:
+        """
+        Initialize store info for a feature list
+
+        Parameters
+        ----------
+        features: List[FeatureModel]
+            List of features
+        feature_store: FeatureStoreModel
+            Feature store model
+        feature_table_map: Dict[str, Any]
+            List of offline feature table map from source table name to actual feature table
+            (could be a source table or a precomputed lookup table)
+        serving_entity_specs: Optional[List[ColumnSpec]]
+            List of serving entity specs
+        """
+        store_type_to_store_info_class = {
+            SourceType.SNOWFLAKE: SnowflakeStoreInfo,
+            SourceType.DATABRICKS: DataBricksStoreInfo,
+            SourceType.DATABRICKS_UNITY: DataBricksUnityStoreInfo,
+            SourceType.SPARK: SparkStoreInfo,
+            SourceType.BIGQUERY: BigQueryStoreInfo,
+        }
+        if feature_store.type in store_type_to_store_info_class:
+            store_info_class = store_type_to_store_info_class[feature_store.type]
+            store_info = store_info_class.create(
+                features=features,
+                feature_store=feature_store,
+                feature_table_map=feature_table_map,
+                serving_entity_specs=serving_entity_specs,
+            )
+            self.internal_store_info = store_info.model_dump(by_alias=True)
 
     class Settings(FeatureByteCatalogBaseDocumentModel.Settings):
         """

--- a/featurebyte/models/feature_list.py
+++ b/featurebyte/models/feature_list.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import functools
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, cast
+from typing import Any, Dict, List, Optional, Set
 
 import pymongo
 from bson import ObjectId
@@ -24,7 +24,7 @@ from pydantic import (
 from typeguard import typechecked
 
 from featurebyte.common.validator import construct_sort_validator, version_validator
-from featurebyte.enum import DBVarType, SourceType
+from featurebyte.enum import DBVarType
 from featurebyte.models.base import (
     FeatureByteBaseModel,
     FeatureByteCatalogBaseDocumentModel,
@@ -34,17 +34,7 @@ from featurebyte.models.base import (
     VersionIdentifier,
 )
 from featurebyte.models.feature import FeatureModel
-from featurebyte.models.feature_list_store_info import (
-    BigQueryStoreInfo,
-    DataBricksStoreInfo,
-    DataBricksUnityStoreInfo,
-    SnowflakeStoreInfo,
-    SparkStoreInfo,
-    StoreInfo,
-    construct_store_info,
-)
 from featurebyte.models.feature_namespace import FeatureReadiness
-from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.models.parent_serving import FeatureNodeRelationshipsInfo
 from featurebyte.models.utils import serialize_obj
 from featurebyte.query_graph.graph import QueryGraph
@@ -53,7 +43,6 @@ from featurebyte.query_graph.model.entity_relationship_info import (
     FeatureEntityLookupInfo,
 )
 from featurebyte.query_graph.node import Node
-from featurebyte.query_graph.node.schema import ColumnSpec
 from featurebyte.query_graph.pruning_util import get_combined_graph_and_nodes
 
 
@@ -369,7 +358,7 @@ class FeatureListModel(FeatureByteCatalogBaseDocumentModel):
     aggregation_ids: List[str] = Field(frozen=True, default_factory=list)
 
     # store info contains the warehouse specific info for the feature list
-    internal_store_info: Optional[Dict[str, Any]] = Field(alias="store_info", default=None)
+    feast_enabled: bool = Field(default=False)
 
     # pydantic validators
     _sort_ids_validator = field_validator(
@@ -583,57 +572,6 @@ class FeatureListModel(FeatureByteCatalogBaseDocumentModel):
         if feature_clusters_path:
             paths.append(Path(feature_clusters_path))
         return paths
-
-    @property
-    def store_info(self) -> StoreInfo:
-        """
-        Store info for a feature list
-
-        Returns
-        -------
-        StoreInfo
-        """
-        obj_dict = self.internal_store_info or {"type": "uninitialized"}
-        return cast(StoreInfo, construct_store_info(**obj_dict))
-
-    def initialize_store_info(
-        self,
-        features: List[FeatureModel],
-        feature_store: FeatureStoreModel,
-        feature_table_map: Dict[str, Any],
-        serving_entity_specs: Optional[List[ColumnSpec]],
-    ) -> None:
-        """
-        Initialize store info for a feature list
-
-        Parameters
-        ----------
-        features: List[FeatureModel]
-            List of features
-        feature_store: FeatureStoreModel
-            Feature store model
-        feature_table_map: Dict[str, Any]
-            List of offline feature table map from source table name to actual feature table
-            (could be a source table or a precomputed lookup table)
-        serving_entity_specs: Optional[List[ColumnSpec]]
-            List of serving entity specs
-        """
-        store_type_to_store_info_class = {
-            SourceType.SNOWFLAKE: SnowflakeStoreInfo,
-            SourceType.DATABRICKS: DataBricksStoreInfo,
-            SourceType.DATABRICKS_UNITY: DataBricksUnityStoreInfo,
-            SourceType.SPARK: SparkStoreInfo,
-            SourceType.BIGQUERY: BigQueryStoreInfo,
-        }
-        if feature_store.type in store_type_to_store_info_class:
-            store_info_class = store_type_to_store_info_class[feature_store.type]
-            store_info = store_info_class.create(
-                features=features,
-                feature_store=feature_store,
-                feature_table_map=feature_table_map,
-                serving_entity_specs=serving_entity_specs,
-            )
-            self.internal_store_info = store_info.model_dump(by_alias=True)
 
     class Settings(FeatureByteCatalogBaseDocumentModel.Settings):
         """

--- a/featurebyte/models/feature_list.py
+++ b/featurebyte/models/feature_list.py
@@ -360,6 +360,9 @@ class FeatureListModel(FeatureByteCatalogBaseDocumentModel):
     # store info contains the warehouse specific info for the feature list
     feast_enabled: bool = Field(default=False)
 
+    # this field will be deprecated in the future (moved to deployment record)
+    internal_store_info: Optional[Dict[str, Any]] = Field(alias="store_info", default=None)
+
     # pydantic validators
     _sort_ids_validator = field_validator(
         "online_enabled_feature_ids",

--- a/featurebyte/models/feature_list_store_info.py
+++ b/featurebyte/models/feature_list_store_info.py
@@ -40,7 +40,6 @@ class BaseStoreInfo(FeatureByteBaseModel):
     """
 
     type: StoreInfoType
-    feast_enabled: bool = Field(default=False)
 
     @classmethod
     def create(

--- a/featurebyte/routes/deployment/controller.py
+++ b/featurebyte/routes/deployment/controller.py
@@ -250,7 +250,7 @@ class DeploymentController(
         catalog = await self.catalog_service.get_document(feature_list.catalog_id)
         try:
             result: Optional[OnlineFeaturesResponseModel]
-            if feature_list.store_info.feast_enabled and catalog.online_store_id is not None:
+            if feature_list.feast_enabled and catalog.online_store_id is not None:
                 feast_store = (
                     await self.feast_feature_store_service.get_feast_feature_store_for_deployment(
                         deployment=document

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -12,6 +12,7 @@ from featurebyte.migration.service.data_warehouse import (
     DataWarehouseMigrationServiceV3,
     TileColumnTypeExtractor,
 )
+from featurebyte.migration.service.deployment import DeploymentMigrationServiceV14
 from featurebyte.migration.service.event_table import EventTableMigrationServiceV12
 from featurebyte.migration.service.feature import (
     FeatureMigrationServiceV4,
@@ -474,6 +475,7 @@ app_container_config.register_class(FeatureMigrationServiceV8)
 app_container_config.register_class(OfflineStoreFeatureTableMigrationServiceV9)
 app_container_config.register_class(EventTableMigrationServiceV12)
 app_container_config.register_class(FeatureJobSettingAnalysisMigrationServiceV13)
+app_container_config.register_class(DeploymentMigrationServiceV14)
 
 app_container_config.register_factory_method(get_storage)
 app_container_config.register_factory_method(get_redis, name_override="redis")

--- a/featurebyte/schema/feature_list.py
+++ b/featurebyte/schema/feature_list.py
@@ -211,6 +211,7 @@ class FeatureListServiceUpdate(BaseDocumentServiceUpdateSchema, FeatureListUpdat
     deployed: Optional[bool] = Field(default=None)
     online_enabled_feature_ids: Optional[List[PydanticObjectId]] = Field(default=None)
     readiness_distribution: Optional[FeatureReadinessDistribution] = Field(default=None)
+    feast_enabled: Optional[bool] = Field(default=None)
 
 
 class ProductionReadyFractionComparison(FeatureByteBaseModel):

--- a/featurebyte/service/deploy.py
+++ b/featurebyte/service/deploy.py
@@ -686,8 +686,13 @@ class FeastIntegrationService:
             else:
                 feature_table_map[source_table.name] = source_table
 
-        await self.feature_list_service.update_store_info(
+        await self.feature_list_service.update_document(
             document_id=feature_list.id,
+            data=FeatureListServiceUpdate(feast_enabled=True),
+        )
+        await self.deployment_service.update_store_info(
+            deployment=deployment,
+            feature_list=feature_list,
             features=online_enabled_features,
             feature_table_map=feature_table_map,
             serving_entity_specs=serving_entity_specs,

--- a/featurebyte/service/deployment.py
+++ b/featurebyte/service/deployment.py
@@ -4,9 +4,22 @@ DeploymentService class
 
 from __future__ import annotations
 
+from typing import Any, Dict, List, Optional
+
+from bson import ObjectId
+from redis import Redis
+
 from featurebyte.models.deployment import DeploymentModel
+from featurebyte.models.feature import FeatureModel
+from featurebyte.models.feature_list import FeatureListModel
+from featurebyte.models.offline_store_feature_table import OfflineStoreFeatureTableModel
+from featurebyte.persistent import Persistent
+from featurebyte.query_graph.node.schema import ColumnSpec
+from featurebyte.routes.block_modification_handler import BlockModificationHandler
 from featurebyte.schema.deployment import DeploymentServiceUpdate
 from featurebyte.service.base_document import BaseDocumentService
+from featurebyte.service.feature_store import FeatureStoreService
+from featurebyte.storage import Storage
 
 
 class DeploymentService(
@@ -18,6 +31,70 @@ class DeploymentService(
 
     document_class = DeploymentModel
     document_update_class = DeploymentServiceUpdate
+
+    def __init__(
+        self,
+        user: Any,
+        persistent: Persistent,
+        catalog_id: Optional[ObjectId],
+        feature_store_service: FeatureStoreService,
+        block_modification_handler: BlockModificationHandler,
+        storage: Storage,
+        redis: Redis[Any],
+    ):
+        super().__init__(
+            user=user,
+            persistent=persistent,
+            catalog_id=catalog_id,
+            block_modification_handler=block_modification_handler,
+            storage=storage,
+            redis=redis,
+        )
+        self.feature_store_service = feature_store_service
+
+    async def update_store_info(
+        self,
+        deployment: DeploymentModel,
+        feature_list: FeatureListModel,
+        features: List[FeatureModel],
+        feature_table_map: Dict[str, OfflineStoreFeatureTableModel],
+        serving_entity_specs: Optional[List[ColumnSpec]],
+    ) -> None:
+        """
+        Update store info for a feature list
+
+        Parameters
+        ----------
+        deployment: DeploymentModel
+            Deployment model
+        feature_list: FeatureListModel
+            Feature list model
+        features: List[FeatureModel]
+            List of features
+        feature_table_map: Dict[str, OfflineStoreFeatureTableModel]
+            Feature table map
+        serving_entity_specs: Optional[List[ColumnSpec]]
+            List of serving entity specs
+        """
+        assert set(feature_list.feature_ids) == set(feature.id for feature in features)
+
+        feature_store = await self.feature_store_service.get_document(
+            document_id=features[0].tabular_source.feature_store_id
+        )
+        deployment.initialize_store_info(
+            features=features,
+            feature_store=feature_store,
+            feature_table_map=feature_table_map,
+            serving_entity_specs=serving_entity_specs,
+        )
+        if deployment.internal_store_info:
+            await self.persistent.update_one(
+                collection_name=self.collection_name,
+                query_filter=await self.construct_get_query_filter(document_id=deployment.id),
+                update={"$set": {"store_info": deployment.internal_store_info}},
+                user_id=self.user.id,
+                disable_audit=self.should_disable_audit,
+            )
 
 
 class AllDeploymentService(DeploymentService):

--- a/featurebyte/service/offline_store_feature_table_manager.py
+++ b/featurebyte/service/offline_store_feature_table_manager.py
@@ -510,7 +510,7 @@ class OfflineStoreFeatureTableManagerService:
                 # skip the feature list to be disabled
                 continue
 
-            if feature_list.store_info.feast_enabled:
+            if feature_list.feast_enabled:
                 feature_lists.append(feature_list)
                 if (
                     feature_list_to_online_enable

--- a/tests/fixtures/migration/deployment
+++ b/tests/fixtures/migration/deployment
@@ -1,0 +1,47 @@
+[
+  {
+    "_id": {
+      "$oid": "6736ce9f496a7e859718107b"
+    },
+    "user_id": {
+      "$oid": "662a7b245587863a7f672e7a"
+    },
+    "name": "200 features: Loan_Default_Prediction_Feature_Set_V2",
+    "created_at": {
+      "$date": "2024-11-15T04:31:28.154Z"
+    },
+    "updated_at": {
+      "$date": "2024-11-15T05:14:26.537Z"
+    },
+    "block_modification_by": [],
+    "description": null,
+    "is_deleted": false,
+    "catalog_id": {
+      "$oid": "64708919ea4c4876a77d2b80"
+    },
+    "feature_list_id": {
+      "$oid": "6478ab35b68c91fb84f1e147"
+    },
+    "feature_list_namespace_id": {
+      "$oid": "673581f89385427653344fb5"
+    },
+    "enabled": true,
+    "context_id": {
+      "$oid": "6731ef3c0a3a81d7366a5cb7"
+    },
+    "use_case_id": {
+      "$oid": "6731ef3d0a3a81d7366a5cb8"
+    },
+    "registry_info": {
+      "registry_id": {
+        "$oid": "6736cea01b517fb9b6fb2dfa"
+      },
+      "registry_path": "catalog/6731e7ced6b3811a47ac6e9b/feast_registry/6736cea01b517fb9b6fb2dfa/feast_registry.pb"
+    },
+    "serving_entity_ids": [
+      {
+        "$oid": "6731ef340a3a81d7366a5caf"
+      }
+    ]
+  }
+]

--- a/tests/fixtures/migration/feature_list
+++ b/tests/fixtures/migration/feature_list
@@ -504,6 +504,37 @@
     "feature_list_namespace_id": {
       "$oid": "6478ab36173590eb5f4046ca"
     },
-    "online_enabled_feature_ids": []
+    "online_enabled_feature_ids": [],
+    "store_info": {
+      "type": "databricks_unity",
+      "feast_enabled": true,
+      "databricks_sdk_version": "0.16.3",
+      "feature_specs": [
+        {
+          "table_name": "ml.staging_prod.cat1_clientid_1d_via_sk_id_curr_55518d",
+          "lookup_key": [
+              "SK_ID_CURR"
+          ],
+          "timestamp_lookup_key": "timestamp_lookup_key",
+          "lookback_window": null,
+          "feature_names": [
+              "CLIENT_vs_OVERALL_Count_of_Late_Inst_status_Installments_by_PriorApplication_NAME_CLIENT_TYPE_52w_V241112"
+          ],
+          "rename_outputs": {
+              "CLIENT_vs_OVERALL_Count_of_Late_Inst_status_Installments_by_PriorApplication_NAME_CLIENT_TYPE_52w_V241112": "CLIENT_vs_OVERALL_Count_of_Late_Inst_status_Installments_by_PriorApplication_NAME_CLIENT_TYPE_52w"
+          }
+        }
+      ],
+      "base_dataframe_specs": [
+        {
+          "name": "SK_ID_CURR",
+          "dtype": "INT"
+        }
+      ],
+      "exclude_columns": [
+        "POINT_IN_TIME"
+      ],
+      "require_timestamp_lookup_key": true
+    }
   }
 ]

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -408,7 +408,7 @@ async def _deploy_feature_list(app_container, saved_feature_list, deployment_nam
             feature_list_model = await app_container.feature_list_service.get_document(
                 saved_feature_list.id, populate_remote_attributes=False
             )
-            assert feature_list_model.store_info.feast_enabled
+            assert feature_list_model.feast_enabled
             return deployment
 
 

--- a/tests/unit/api/test_feature_list.py
+++ b/tests/unit/api/test_feature_list.py
@@ -541,6 +541,7 @@ def test_get_feature_list(
             ("primary_entity_ids", [str(cust_id_entity.id)]),
             ("readiness_distribution", [{"readiness": "DRAFT", "count": 1}]),
             ("relationships_info", _get_new_value_from_audit_history("relationships_info")),
+            ("store_info", None),
             (
                 "supported_serving_entity_ids",
                 sorted([[str(cust_id_entity.id)], [str(transaction_entity.id)]]),

--- a/tests/unit/api/test_feature_list.py
+++ b/tests/unit/api/test_feature_list.py
@@ -525,6 +525,7 @@ def test_get_feature_list(
             ("description", None),
             ("dtype_distribution", [{"dtype": "FLOAT", "count": 1}]),
             ("entity_ids", [str(cust_id_entity.id)]),
+            ("feast_enabled", False),
             ("feature_clusters", _get_new_value_from_audit_history("feature_clusters")),
             ("feature_clusters_path", _get_new_value_from_audit_history("feature_clusters_path")),
             ("feature_ids", [str(saved_feature_list.feature_ids[0])]),
@@ -540,7 +541,6 @@ def test_get_feature_list(
             ("primary_entity_ids", [str(cust_id_entity.id)]),
             ("readiness_distribution", [{"readiness": "DRAFT", "count": 1}]),
             ("relationships_info", _get_new_value_from_audit_history("relationships_info")),
-            ("store_info", None),
             (
                 "supported_serving_entity_ids",
                 sorted([[str(cust_id_entity.id)], [str(transaction_entity.id)]]),

--- a/tests/unit/models/test_feature_list.py
+++ b/tests/unit/models/test_feature_list.py
@@ -84,6 +84,7 @@ def test_feature_list_model(feature_list_model_dict):
     feature_list_dict_sorted_ids["features_primary_entity_ids"] = []
     feature_list_dict_sorted_ids["table_ids"] = []
     feature_list_dict_sorted_ids["feature_clusters_path"] = None
+    feature_list_dict_sorted_ids["store_info"] = None
     assert serialized_feature_list == feature_list_dict_sorted_ids
 
     feature_list_json = feature_list.model_dump_json(by_alias=True)

--- a/tests/unit/models/test_feature_list.py
+++ b/tests/unit/models/test_feature_list.py
@@ -37,12 +37,12 @@ def feature_list_model_dict_fixture():
         "catalog_id": DEFAULT_CATALOG_ID,
         "relationships_info": None,
         "features_entity_lookup_info": None,
-        "store_info": None,
         "supported_serving_entity_ids": [],
         "block_modification_by": [],
         "description": None,
         "is_deleted": False,
         "aggregation_ids": [],
+        "feast_enabled": False,
     }
 
 
@@ -105,7 +105,7 @@ def test_feature_list_model(feature_list_model_dict):
     assert loaded_old_feature_list == updated_feature_list
 
     # check that feature list store info for older record
-    assert loaded_old_feature_list.store_info.feast_enabled is False
+    assert loaded_old_feature_list.feast_enabled is False
 
 
 def test_feature_list_namespace_model(feature_list_namespace_model_dict):

--- a/tests/unit/routes/test_deployment.py
+++ b/tests/unit/routes/test_deployment.py
@@ -143,6 +143,7 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
                     "context_id": None,
                     "registry_info": None,
                     "serving_entity_ids": ["63f94ed6ea1f050131379214"],
+                    "store_info": None,
                     "is_deleted": False,
                 },
                 {
@@ -163,6 +164,7 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
                     "context_id": None,
                     "registry_info": None,
                     "serving_entity_ids": ["63f94ed6ea1f050131379214"],
+                    "store_info": None,
                     "is_deleted": False,
                 },
                 {
@@ -183,6 +185,7 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
                     "context_id": None,
                     "registry_info": None,
                     "serving_entity_ids": ["63f94ed6ea1f050131379214"],
+                    "store_info": None,
                     "is_deleted": False,
                 },
             ],
@@ -227,6 +230,7 @@ class TestDeploymentApi(BaseAsyncApiTestSuite, BaseCatalogApiTestSuite):
                     "user_id": response_dict["data"][0]["user_id"],
                     "registry_info": None,
                     "serving_entity_ids": ["63f94ed6ea1f050131379214"],
+                    "store_info": None,
                     "is_deleted": False,
                 }
             ],

--- a/tests/unit/service/test_deploy.py
+++ b/tests/unit/service/test_deploy.py
@@ -481,7 +481,7 @@ async def test_deployment_enable__feast_enable_backward_compatibility(
     feature_list1 = await app_container.feature_list_service.get_document(
         document_id=feature_list1.id
     )
-    assert not feature_list1.store_info.feast_enabled
+    assert not feature_list1.feast_enabled
 
     # create another deployment using the same feature list when feast integration is enabled
     with patch.dict(os.environ, {"FEATUREBYTE_FEAST_INTEGRATION_ENABLED": "False"}):
@@ -498,7 +498,7 @@ async def test_deployment_enable__feast_enable_backward_compatibility(
     feature_list1 = await app_container.feature_list_service.get_document(
         document_id=feature_list1.id
     )
-    assert not feature_list1.store_info.feast_enabled
+    assert not feature_list1.feast_enabled
 
     # create another deployment using a new feature list when feast integration is enabled
     with patch.dict(os.environ, {"FEATUREBYTE_FEAST_INTEGRATION_ENABLED": "True"}):
@@ -515,7 +515,7 @@ async def test_deployment_enable__feast_enable_backward_compatibility(
     feature_list2 = await app_container.feature_list_service.get_document(
         document_id=feature_list2.id
     )
-    assert feature_list2.store_info.feast_enabled
+    assert feature_list2.feast_enabled
 
     # disable deployment1 & deployment2, check feature list store info
     with patch.dict(os.environ, {"FEATUREBYTE_FEAST_INTEGRATION_ENABLED": "True"}):
@@ -532,7 +532,7 @@ async def test_deployment_enable__feast_enable_backward_compatibility(
     feature_list = await app_container.feature_list_service.get_document(
         document_id=deployment.feature_list_id
     )
-    assert not feature_list.store_info.feast_enabled
+    assert not feature_list.feast_enabled
 
     # enable deployment1 again & check feature list store info
     with patch.dict(os.environ, {"FEATUREBYTE_FEAST_INTEGRATION_ENABLED": "True"}):
@@ -547,7 +547,7 @@ async def test_deployment_enable__feast_enable_backward_compatibility(
     feature_list = await app_container.feature_list_service.get_document(
         document_id=deployment.feature_list_id
     )
-    assert feature_list.store_info.feast_enabled
+    assert feature_list.feast_enabled
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

`store_info` attribute is used to construct DataBricks feature specs definition. Currently, the attribute is stored at feature list level and it can cause issue when the feature list is deployed more than 1 with different serving entities. To address the issue, this PR moves the attribute from feature list model to deployment model.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
