### PR TITLE
[DEV-3896] Use deployment serving entities in online serving code template

### DIFF
--- a/.changelog/DEV-3896.yaml
+++ b/.changelog/DEV-3896.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fixed online serving code using serving entities from feature list instead of deployment."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/routes/deployment/controller.py
+++ b/featurebyte/routes/deployment/controller.py
@@ -312,12 +312,8 @@ class DeploymentController(
         if not deployment.enabled:
             raise FeatureListNotOnlineEnabledError("Deployment is not enabled.")
 
-        feature_list = await self.feature_list_service.get_document(
-            document_id=deployment.feature_list_id
-        )
         return await self.online_serving_service.get_request_code_template(
             deployment=deployment,
-            feature_list=feature_list,
             language=language,
         )
 

--- a/tests/unit/api/test_deployment.py
+++ b/tests/unit/api/test_deployment.py
@@ -346,3 +346,27 @@ def test_deployment_with_unbounded_window(
     )
 
     deployment.disable()
+
+
+def test_get_online_serving_code_uses_deployment_entities(deployment, config_file):
+    """Test feature get_online_serving_code"""
+    # Use config
+    Configurations(config_file, force=True)
+
+    deployment.enable()
+    assert deployment.enabled is True
+
+    with (
+        patch("featurebyte.service.deployment.DeploymentService.get_document") as mock_get_document,
+        patch(
+            "featurebyte.service.entity_serving_names.EntityServingNamesService.get_sample_entity_serving_names"
+        ) as mock_get_sample_entity_serving_names,
+    ):
+        mock_get_sample_entity_serving_names.return_value = [{"cust_id": "sample_cust_id"}]
+        deployment.get_online_serving_code()
+        deployment = mock_get_document.return_value
+        mock_get_sample_entity_serving_names.assert_called_once_with(
+            entity_ids=deployment.serving_entity_ids,
+            table_ids=None,
+            count=1,
+        )


### PR DESCRIPTION
## Description

Code template for online serving is using Feature List entities which can be wrong if deployment uses child entities as serving entities. This PR will fix that so the code template is using deployment serving entities instead. 

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
