### PR TITLE
[DEV-3899] Compute tiles up to required window sizes only

### DIFF
--- a/tests/fixtures/tile_cache_query_by_observation_table/expected_queries.sql
+++ b/tests/fixtures/tile_cache_query_by_observation_table/expected_queries.sql
@@ -7,11 +7,11 @@ SELECT
   DATEADD(
     microsecond,
     (
-      (
-        300 - 600
-      ) * CAST(1000000 AS BIGINT) / CAST(1 AS BIGINT)
-    ),
-    CAST('1970-01-01' AS TIMESTAMP)
+      1 * 1800 * CAST(1000000 AS BIGINT) / CAST(1 AS BIGINT)
+    ) * -1,
+    CAST(FLOOR((
+      DATE_PART(EPOCH_SECOND, MIN(POINT_IN_TIME)) - 300
+    ) / 1800) * 1800 + 300 - 600 AS TIMESTAMP)
   ) AS __FB_ENTITY_TABLE_START_DATE
 FROM "my_request_table"
 GROUP BY
@@ -66,11 +66,11 @@ SELECT
   DATEADD(
     microsecond,
     (
-      (
-        300 - 600
-      ) * CAST(1000000 AS BIGINT) / CAST(1 AS BIGINT)
-    ),
-    CAST('1970-01-01' AS TIMESTAMP)
+      1 * 1800 * CAST(1000000 AS BIGINT) / CAST(1 AS BIGINT)
+    ) * -1,
+    CAST(FLOOR((
+      DATE_PART(EPOCH_SECOND, MIN(POINT_IN_TIME)) - 300
+    ) / 1800) * 1800 + 300 - 600 AS TIMESTAMP)
   ) AS __FB_ENTITY_TABLE_START_DATE
 FROM "my_request_table"
 GROUP BY


### PR DESCRIPTION
## Description

Previously, tiles were computed from the beginning of time to cover all feature derivation windows. Now that tiles are recomputed on-demand we can optimize by limiting computation to the required window sizes and reduce unnecessary overhead.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
