### PR TITLE
[DEV-3904] Limit number of output columns when combining tile compute queries

### DIFF
--- a/tests/fixtures/query_graph/expected_combined_tile_query_complex_0.sql
+++ b/tests/fixtures/query_graph/expected_combined_tile_query_complex_0.sql
@@ -1,0 +1,68 @@
+WITH __FB_ENTITY_TABLE_NAME AS (
+  __FB_ENTITY_TABLE_SQL_PLACEHOLDER
+), __FB_TILE_COMPUTE_INPUT_TABLE_NAME AS (
+  SELECT
+    R.*
+  FROM __FB_ENTITY_TABLE_NAME
+  INNER JOIN (
+    SELECT
+      "event_timestamp" AS "event_timestamp",
+      "cust_id" AS "cust_id",
+      (
+        "col_int" + 0.0
+      ) AS "input_col_max_8ebea967ee814d7990b591359b045c522c642448",
+      (
+        "col_int" + 123.0
+      ) AS "input_col_max_66fc16e366c1b5c9aabc812f2af4d08732087415",
+      (
+        "col_int" + 246.0
+      ) AS "input_col_max_04b1aa48269a5bb5baf5c28888aa65a5e9f9315a",
+      (
+        "col_int" + 369.0
+      ) AS "input_col_max_7a0389ed6a775ef2372511b34eee2f96274dc372",
+      (
+        "col_int" + 492.0
+      ) AS "input_col_max_cf117d83e48aafafe17949305d6c886fcf246994",
+      (
+        "col_int" + 615.0
+      ) AS "input_col_max_f81ae93bcda992e9fe17828c530998d961537513",
+      (
+        "col_int" + 738.0
+      ) AS "input_col_max_294e76fd8322a9b9d0146b0a32167786dab74ce4",
+      (
+        "col_int" + 861.0
+      ) AS "input_col_max_a53041702830fee7cc0f450244a06c71c041de49",
+      (
+        "col_int" + 984.0
+      ) AS "input_col_max_217f2549e9dc7f90b4ef458d1ac6b5505fe732da",
+      (
+        "col_int" + 1107.0
+      ) AS "input_col_max_5f9c186c56c2240cf93139cf9efea25b5138e848"
+    FROM "sf_database"."sf_schema"."sf_table"
+  ) AS R
+    ON R."cust_id" = __FB_ENTITY_TABLE_NAME."cust_id"
+    AND R."event_timestamp" >= __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_START_DATE
+    AND R."event_timestamp" < __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_END_DATE
+)
+SELECT
+  index,
+  "cust_id",
+  MAX("input_col_max_8ebea967ee814d7990b591359b045c522c642448") AS value_max_8ebea967ee814d7990b591359b045c522c642448,
+  MAX("input_col_max_66fc16e366c1b5c9aabc812f2af4d08732087415") AS value_max_66fc16e366c1b5c9aabc812f2af4d08732087415,
+  MAX("input_col_max_04b1aa48269a5bb5baf5c28888aa65a5e9f9315a") AS value_max_04b1aa48269a5bb5baf5c28888aa65a5e9f9315a,
+  MAX("input_col_max_7a0389ed6a775ef2372511b34eee2f96274dc372") AS value_max_7a0389ed6a775ef2372511b34eee2f96274dc372,
+  MAX("input_col_max_cf117d83e48aafafe17949305d6c886fcf246994") AS value_max_cf117d83e48aafafe17949305d6c886fcf246994,
+  MAX("input_col_max_f81ae93bcda992e9fe17828c530998d961537513") AS value_max_f81ae93bcda992e9fe17828c530998d961537513,
+  MAX("input_col_max_294e76fd8322a9b9d0146b0a32167786dab74ce4") AS value_max_294e76fd8322a9b9d0146b0a32167786dab74ce4,
+  MAX("input_col_max_a53041702830fee7cc0f450244a06c71c041de49") AS value_max_a53041702830fee7cc0f450244a06c71c041de49,
+  MAX("input_col_max_217f2549e9dc7f90b4ef458d1ac6b5505fe732da") AS value_max_217f2549e9dc7f90b4ef458d1ac6b5505fe732da,
+  MAX("input_col_max_5f9c186c56c2240cf93139cf9efea25b5138e848") AS value_max_5f9c186c56c2240cf93139cf9efea25b5138e848
+FROM (
+  SELECT
+    *,
+    F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "event_timestamp"), 300, 600, 30) AS index
+  FROM __FB_TILE_COMPUTE_INPUT_TABLE_NAME
+)
+GROUP BY
+  index,
+  "cust_id"

--- a/tests/fixtures/query_graph/expected_combined_tile_query_complex_1.sql
+++ b/tests/fixtures/query_graph/expected_combined_tile_query_complex_1.sql
@@ -1,0 +1,68 @@
+WITH __FB_ENTITY_TABLE_NAME AS (
+  __FB_ENTITY_TABLE_SQL_PLACEHOLDER
+), __FB_TILE_COMPUTE_INPUT_TABLE_NAME AS (
+  SELECT
+    R.*
+  FROM __FB_ENTITY_TABLE_NAME
+  INNER JOIN (
+    SELECT
+      "event_timestamp" AS "event_timestamp",
+      "cust_id" AS "cust_id",
+      (
+        "col_int" + 1230.0
+      ) AS "input_col_max_cc732f2766b32468e3b026f79aa4f62ba0a43cbb",
+      (
+        "col_int" + 1353.0
+      ) AS "input_col_max_8f0fb4310a3f8030aeac8457a91e47570f9fc823",
+      (
+        "col_int" + 1476.0
+      ) AS "input_col_max_e36c6a2d2cb25bd0a07d24f60fe69b191bd31536",
+      (
+        "col_int" + 1599.0
+      ) AS "input_col_max_5c841e4276de72b8ae4395b314186cfd4490d32f",
+      (
+        "col_int" + 1722.0
+      ) AS "input_col_max_8076f9cea53a4b2bb24b10231b225df51e4f022f",
+      (
+        "col_int" + 1845.0
+      ) AS "input_col_max_cc8379055af579870915276f38a470934d61e6bd",
+      (
+        "col_int" + 1968.0
+      ) AS "input_col_max_0d3e7252a0ebaa61c8db7faaf65d27bf278c2152",
+      (
+        "col_int" + 2091.0
+      ) AS "input_col_max_83cc4131d5b87ae06257ef8a595c719a9de1c525",
+      (
+        "col_int" + 2214.0
+      ) AS "input_col_max_777c038d9440890b081de40c56f975b882cc75ac",
+      (
+        "col_int" + 2337.0
+      ) AS "input_col_max_55f3230d7d572d67e1fe57fff6bbb25415a02753"
+    FROM "sf_database"."sf_schema"."sf_table"
+  ) AS R
+    ON R."cust_id" = __FB_ENTITY_TABLE_NAME."cust_id"
+    AND R."event_timestamp" >= __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_START_DATE
+    AND R."event_timestamp" < __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_END_DATE
+)
+SELECT
+  index,
+  "cust_id",
+  MAX("input_col_max_cc732f2766b32468e3b026f79aa4f62ba0a43cbb") AS value_max_cc732f2766b32468e3b026f79aa4f62ba0a43cbb,
+  MAX("input_col_max_8f0fb4310a3f8030aeac8457a91e47570f9fc823") AS value_max_8f0fb4310a3f8030aeac8457a91e47570f9fc823,
+  MAX("input_col_max_e36c6a2d2cb25bd0a07d24f60fe69b191bd31536") AS value_max_e36c6a2d2cb25bd0a07d24f60fe69b191bd31536,
+  MAX("input_col_max_5c841e4276de72b8ae4395b314186cfd4490d32f") AS value_max_5c841e4276de72b8ae4395b314186cfd4490d32f,
+  MAX("input_col_max_8076f9cea53a4b2bb24b10231b225df51e4f022f") AS value_max_8076f9cea53a4b2bb24b10231b225df51e4f022f,
+  MAX("input_col_max_cc8379055af579870915276f38a470934d61e6bd") AS value_max_cc8379055af579870915276f38a470934d61e6bd,
+  MAX("input_col_max_0d3e7252a0ebaa61c8db7faaf65d27bf278c2152") AS value_max_0d3e7252a0ebaa61c8db7faaf65d27bf278c2152,
+  MAX("input_col_max_83cc4131d5b87ae06257ef8a595c719a9de1c525") AS value_max_83cc4131d5b87ae06257ef8a595c719a9de1c525,
+  MAX("input_col_max_777c038d9440890b081de40c56f975b882cc75ac") AS value_max_777c038d9440890b081de40c56f975b882cc75ac,
+  MAX("input_col_max_55f3230d7d572d67e1fe57fff6bbb25415a02753") AS value_max_55f3230d7d572d67e1fe57fff6bbb25415a02753
+FROM (
+  SELECT
+    *,
+    F_TIMESTAMP_TO_INDEX(CONVERT_TIMEZONE('UTC', "event_timestamp"), 300, 600, 30) AS index
+  FROM __FB_TILE_COMPUTE_INPUT_TABLE_NAME
+)
+GROUP BY
+  index,
+  "cust_id"


### PR DESCRIPTION
## Description

Impose a constraint on the number of output columns per combined tile query.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
