### PR TITLE
[chore] Update Celery options to better handle long running tasks

### DIFF
--- a/featurebyte/worker/__init__.py
+++ b/featurebyte/worker/__init__.py
@@ -231,6 +231,7 @@ def get_celery(
         "priority_steps": list(range(3)),
         "sep": ":",
         "queue_order_strategy": "priority",
+        "visibility_timeout": 36000,
     }
 
     # task tombstones options

--- a/featurebyte/worker/__init__.py
+++ b/featurebyte/worker/__init__.py
@@ -220,6 +220,7 @@ def get_celery(
     celery_app.conf.task_track_started = True
     celery_app.conf.result_backend = f"featurebyte.worker:ExtendedMongoBackend+{mongo_uri}"
     celery_app.conf.broker_connection_retry_on_startup = True
+    celery_app.conf.worker_prefetch_multiplier = 1
 
     # task queues and routing
     celery_app.conf.task_routes = {
@@ -231,7 +232,7 @@ def get_celery(
         "priority_steps": list(range(3)),
         "sep": ":",
         "queue_order_strategy": "priority",
-        "visibility_timeout": 36000,
+        "visibility_timeout": 3600 * 24,
     }
 
     # task tombstones options


### PR DESCRIPTION
## Description

Update Celery options to reduce chance of duplicate tasks since our tasks are typically long running. 

1. Increase `visibility_timeout` to avoid premature redelivery of tasks (https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/redis.html#id2)

2. Disable tasks prefetching by setting `worker_prefetch_multiplier` to 1 (https://docs.celeryq.dev/en/stable/userguide/optimizing.html#prefetch-limits)

    From celery docs:

    > If you have many tasks with a long duration you want the multiplier value to be one: meaning it’ll only reserve one task per worker process at a time.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
