### PR TITLE
[DEV-3912] Disable bigquery storage client when running in io workers

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -80,7 +80,7 @@ _main() {
     elif [ "$1" = 'worker' ]; then
       celery --app featurebyte.worker.start.celery beat --loglevel=INFO --scheduler featurebyte.worker.schedulers.MongoScheduler --max-interval=1 &
       celery --app featurebyte.worker.start.celery worker -Q cpu_task,cpu_task:1,cpu_task:2,cpu_task:3 --loglevel=INFO --pool=prefork &
-      celery --app featurebyte.worker.start.celery worker -Q io_task,io_task:1,io_task:2,io_task:3 --loglevel=INFO --pool=gevent -c 500
+      HOSTNAME="featurebyte-docker-worker-io" celery --app featurebyte.worker.start.celery worker -Q io_task,io_task:1,io_task:2,io_task:3 --loglevel=INFO --pool=gevent -c 500
     elif [ "$1" = 'server' ]; then
       python /scripts/migration.py
       uvicorn featurebyte.app:app --host=$API_HOST --port=$API_PORT --timeout-keep-alive=300 --log-level=info

--- a/featurebyte/common/env_util.py
+++ b/featurebyte/common/env_util.py
@@ -122,3 +122,14 @@ def is_development_mode() -> bool:
     bool
     """
     return os.environ.get("FEATUREBYTE_EXECUTION_MODE") == "development"
+
+
+def is_io_worker() -> bool:
+    """
+    Check whether the code is running in IO worker
+
+    Returns
+    -------
+    bool
+    """
+    return "worker-io" in os.environ.get("HOSTNAME", "")

--- a/featurebyte/service/session_manager.py
+++ b/featurebyte/service/session_manager.py
@@ -223,8 +223,9 @@ class SessionManagerService:
                 f'Credential used to access FeatureStore (name: "{feature_store.name}") is missing or invalid.'
             ) from exc
 
+    @classmethod
     async def get_session(
-        self,
+        cls,
         feature_store: FeatureStoreModel,
         credentials: Optional[CredentialModel] = None,
         timeout: float = NON_INTERACTIVE_SESSION_TIMEOUT_SECONDS,

--- a/featurebyte/session/bigquery.py
+++ b/featurebyte/session/bigquery.py
@@ -268,6 +268,7 @@ class BigQuerySession(BaseSession):
                 credentials=self._credentials,
                 client_info=ClientInfo(user_agent=APPLICATION_NAME),
             )
+            connection_args: dict[str, Any]
             if is_io_worker():
                 # Fetching result from cursor hangs in IO worker due to gevent if using BQ storage
                 # client. Set prefer_bqstorage_client to False to avoid this issue.

--- a/featurebyte/session/bigquery.py
+++ b/featurebyte/session/bigquery.py
@@ -28,9 +28,11 @@ from google.cloud.bigquery import (
 from google.cloud.bigquery.dbapi import Connection, DatabaseError
 from google.cloud.bigquery.enums import SqlTypeNames, StandardSqlTypeNames
 from google.cloud.bigquery.table import TableReference
+from google.cloud.bigquery_storage_v1 import BigQueryReadClient
 from google.oauth2 import service_account
 from pydantic import PrivateAttr
 
+from featurebyte.common.env_util import is_io_worker
 from featurebyte.common.utils import ARROW_METADATA_DB_VAR_TYPE
 from featurebyte.enum import DBVarType, InternalName, SourceType
 from featurebyte.exception import DataWarehouseConnectionError
@@ -266,10 +268,19 @@ class BigQuerySession(BaseSession):
                 credentials=self._credentials,
                 client_info=ClientInfo(user_agent=APPLICATION_NAME),
             )
+            if is_io_worker():
+                # Fetching result from cursor hangs in IO worker due to gevent if using BQ storage
+                # client. Set prefer_bqstorage_client to False to avoid this issue.
+                connection_args = {
+                    "prefer_bqstorage_client": False,
+                }
+            else:
+                connection_args = {
+                    "bqstorage_client": BigQueryReadClient(credentials=self._credentials),
+                }
             self._connection = Connection(
                 client=self._client,
-                prefer_bqstorage_client=False,
-                # bqstorage_client=BigQueryReadClient(credentials=self._credentials),
+                **connection_args,
             )
         except (MalformedError, DefaultCredentialsError) as exc:
             raise DataWarehouseConnectionError(str(exc)) from exc

--- a/featurebyte/session/bigquery.py
+++ b/featurebyte/session/bigquery.py
@@ -28,7 +28,6 @@ from google.cloud.bigquery import (
 from google.cloud.bigquery.dbapi import Connection, DatabaseError
 from google.cloud.bigquery.enums import SqlTypeNames, StandardSqlTypeNames
 from google.cloud.bigquery.table import TableReference
-from google.cloud.bigquery_storage_v1 import BigQueryReadClient
 from google.oauth2 import service_account
 from pydantic import PrivateAttr
 
@@ -269,7 +268,8 @@ class BigQuerySession(BaseSession):
             )
             self._connection = Connection(
                 client=self._client,
-                bqstorage_client=BigQueryReadClient(credentials=self._credentials),
+                prefer_bqstorage_client=False,
+                # bqstorage_client=BigQueryReadClient(credentials=self._credentials),
             )
         except (MalformedError, DefaultCredentialsError) as exc:
             raise DataWarehouseConnectionError(str(exc)) from exc

--- a/featurebyte/session/bigquery.py
+++ b/featurebyte/session/bigquery.py
@@ -271,6 +271,7 @@ class BigQuerySession(BaseSession):
             if is_io_worker():
                 # Fetching result from cursor hangs in IO worker due to gevent if using BQ storage
                 # client. Set prefer_bqstorage_client to False to avoid this issue.
+                logger.info("Not using BigQueryReadClient for BigQuery session")
                 connection_args = {
                     "prefer_bqstorage_client": False,
                 }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -827,9 +827,7 @@ def get_session_callback_fixture(feature_store, feature_store_credential):
     # We are not using a SessionManagerService fixture, because scoped fixtures would not work
     # SessionManagerService instantiated here functions as a utility module rather than a service
     async def callback():
-        return await SessionManagerService(None, None).get_session(
-            feature_store, feature_store_credential
-        )
+        return await SessionManagerService.get_session(feature_store, feature_store_credential)
 
     return callback
 
@@ -941,11 +939,7 @@ async def session_without_datasets_fixture(source_type, feature_store, feature_s
     """
     Fixture for a BaseSession based on source_type
     """
-    # We are using SessionManagerService as a static function
-    # so its constructor dependencies are irrelevant
-    db_session = await SessionManagerService(None, None).get_session(
-        feature_store, feature_store_credential
-    )
+    db_session = await SessionManagerService.get_session(feature_store, feature_store_credential)
 
     yield db_session
 

--- a/tests/integration/session/test_bigquery.py
+++ b/tests/integration/session/test_bigquery.py
@@ -2,8 +2,10 @@
 This module contains session to BigQuery integration tests.
 """
 
+import os
 from collections import OrderedDict
 from decimal import Decimal
+from unittest.mock import patch
 
 import pandas as pd
 import pytest
@@ -11,6 +13,8 @@ from bson import ObjectId
 
 from featurebyte.enum import DBVarType
 from featurebyte.query_graph.model.column_info import ColumnSpecWithDescription
+from featurebyte.service.session_manager import SessionManagerService
+from featurebyte.session.base import session_cache
 from featurebyte.session.bigquery import BigQuerySchemaInitializer, BigQuerySession
 
 
@@ -265,3 +269,27 @@ async def test_list_table_schema_decimal_parameterized(config, session_without_d
     assert table_schema["A"].dtype == DBVarType.FLOAT
     df = await session.execute_query("SELECT * FROM TABLE_DECIMAL_SCALE")
     assert df.iloc[0]["A"] == Decimal("1.234")
+
+
+@pytest.mark.parametrize("source_type", ["bigquery"], indirect=True)
+@pytest.mark.parametrize(
+    "hostname, bqstorage_client_expected",
+    [
+        ("featurebyte-worker-io", False),
+        ("featurebyte-worker-cpu", True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_create_session__bqstorage_client(
+    feature_store, feature_store_credential, hostname, bqstorage_client_expected
+):
+    """
+    Test bqstorage client is disabled when running on an IO worker.
+    """
+    session_cache.clear()
+    with patch.dict(os.environ, {"HOSTNAME": hostname}):
+        session = await SessionManagerService.get_session(feature_store, feature_store_credential)
+    if bqstorage_client_expected:
+        assert session.connection._bqstorage_client is not None
+    else:
+        assert session.connection._bqstorage_client is None


### PR DESCRIPTION
## Description

Fix the issue where bigquery session creation hangs when running in IO workers due to gevent.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
