### PR TITLE
[DEV-3913] Fix observation table creation failure when datetime values or sampling contain timezone info

### DIFF
--- a/.changelog/DEV-3913.yaml
+++ b/.changelog/DEV-3913.yaml
@@ -16,14 +16,12 @@ component: service
 issues: []
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Fix observation table creation failure when using a datetime object with timezone as sample_from_timestamp or sample_to_timestamp."
+note: "Fixed overflow error for specific UDFs in Databricks SQL Warehouse."
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext:
-  The created observation table is also filtered to exclude rows where POINT_IN_TIME is too recent for
-  | feature materialization, or where mapped columns have NULL values.
 
 # SAMPLE
 #subtext: |

--- a/featurebyte/models/observation_table.py
+++ b/featurebyte/models/observation_table.py
@@ -40,14 +40,10 @@ class SourceTableObservationInput(SourceTableRequestInput):
     """
 
 
-class TargetInput(FeatureByteBaseModel):
+class NoOpMaterializeMixin:
     """
-    TargetInput is an input from a target that can be used to create an ObservationTableModel
+    No-op materialize mixin adds a no-op materialize method to the class
     """
-
-    target_id: Optional[PydanticObjectId] = Field(default=None)
-    observation_table_id: Optional[PydanticObjectId] = Field(default=None)
-    type: Literal[RequestInputType.OBSERVATION_TABLE, RequestInputType.DATAFRAME]
 
     async def materialize(
         self,
@@ -56,6 +52,7 @@ class TargetInput(FeatureByteBaseModel):
         sample_rows: Optional[int],
         sample_from_timestamp: Optional[datetime] = None,
         sample_to_timestamp: Optional[datetime] = None,
+        columns_to_exclude_missing_values: Optional[List[str]] = None,
     ) -> None:
         """
         No-op materialize. This method isn't needed for TargetInput since we materialize the target separately.
@@ -75,41 +72,28 @@ class TargetInput(FeatureByteBaseModel):
             The timestamp to sample from
         sample_to_timestamp: Optional[datetime]
             The timestamp to sample to
+        columns_to_exclude_missing_values: Optional[List[str]
+            The columns to exclude missing values from
         """
 
 
-class UploadedFileInput(FeatureByteBaseModel):
+class TargetInput(FeatureByteBaseModel, NoOpMaterializeMixin):
+    """
+    TargetInput is an input from a target that can be used to create an ObservationTableModel
+    """
+
+    target_id: Optional[PydanticObjectId] = Field(default=None)
+    observation_table_id: Optional[PydanticObjectId] = Field(default=None)
+    type: Literal[RequestInputType.OBSERVATION_TABLE, RequestInputType.DATAFRAME]
+
+
+class UploadedFileInput(FeatureByteBaseModel, NoOpMaterializeMixin):
     """
     UploadedFileInput is an input from an uploaded file that can be used to create an ObservationTableModel.
     """
 
     type: Literal[RequestInputType.UPLOADED_FILE]
     file_name: Optional[str] = Field(default=None)
-
-    async def materialize(
-        self,
-        session: BaseSession,
-        destination: TableDetails,
-        sample_rows: Optional[int],
-        sample_from_timestamp: Optional[datetime] = None,
-        sample_to_timestamp: Optional[datetime] = None,
-    ) -> None:
-        """
-        No-op materialize. This method isn't needed for UploadedFileInput since there is nothing to materialize/compute.
-
-        Parameters
-        ----------
-        session: BaseSession
-            The session to use to materialize the target input
-        destination: TableDetails
-            The destination table to materialize the target input to
-        sample_rows: Optional[int]
-            The number of rows to sample from the target input
-        sample_from_timestamp: Optional[datetime]
-            The timestamp to sample from
-        sample_to_timestamp: Optional[datetime]
-            The timestamp to sample to
-        """
 
 
 ObservationInput = Annotated[

--- a/featurebyte/query_graph/sql/feature_historical.py
+++ b/featurebyte/query_graph/sql/feature_historical.py
@@ -20,6 +20,7 @@ from featurebyte.logging import get_logger
 from featurebyte.models.feature_query_set import FeatureQuery, FeatureQuerySet
 from featurebyte.models.observation_table import ObservationTableModel
 from featurebyte.models.parent_serving import ParentServingPreparation
+from featurebyte.models.request_input import HISTORICAL_REQUESTS_POINT_IN_TIME_RECENCY_HOUR
 from featurebyte.models.tile import OnDemandTileTable
 from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.query_graph.node import Node
@@ -35,8 +36,6 @@ from featurebyte.query_graph.sql.common import get_fully_qualified_table_name, s
 from featurebyte.query_graph.sql.feature_compute import FeatureExecutionPlanner
 from featurebyte.query_graph.sql.source_info import SourceInfo
 from featurebyte.session.base import BaseSession
-
-HISTORICAL_REQUESTS_POINT_IN_TIME_RECENCY_HOUR = 48
 
 PROGRESS_MESSAGE_COMPUTING_FEATURES = "Computing features"
 PROGRESS_MESSAGE_COMPUTING_TARGET = "Computing target"

--- a/featurebyte/query_graph/sql/feature_historical.py
+++ b/featurebyte/query_graph/sql/feature_historical.py
@@ -20,7 +20,6 @@ from featurebyte.logging import get_logger
 from featurebyte.models.feature_query_set import FeatureQuery, FeatureQuerySet
 from featurebyte.models.observation_table import ObservationTableModel
 from featurebyte.models.parent_serving import ParentServingPreparation
-from featurebyte.models.request_input import HISTORICAL_REQUESTS_POINT_IN_TIME_RECENCY_HOUR
 from featurebyte.models.tile import OnDemandTileTable
 from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.query_graph.node import Node
@@ -36,6 +35,8 @@ from featurebyte.query_graph.sql.common import get_fully_qualified_table_name, s
 from featurebyte.query_graph.sql.feature_compute import FeatureExecutionPlanner
 from featurebyte.query_graph.sql.source_info import SourceInfo
 from featurebyte.session.base import BaseSession
+
+HISTORICAL_REQUESTS_POINT_IN_TIME_RECENCY_HOUR = 48
 
 PROGRESS_MESSAGE_COMPUTING_FEATURES = "Computing features"
 PROGRESS_MESSAGE_COMPUTING_TARGET = "Computing target"

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -371,7 +371,10 @@ class ObservationTableService(
             )
             db_session = await self.session_manager_service.get_feature_store_session(feature_store)
             # validate columns
-            available_columns = await data.request_input.get_column_names(db_session)
+            column_names_and_dtypes = await data.request_input.get_column_names_and_dtypes(
+                db_session
+            )
+            available_columns = list(column_names_and_dtypes.keys())
             columns_rename_mapping = data.request_input.columns_rename_mapping
             if columns_rename_mapping:
                 available_columns = [

--- a/featurebyte/worker/task/observation_table.py
+++ b/featurebyte/worker/task/observation_table.py
@@ -4,11 +4,19 @@ ObservationTable creation task
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 from typing import Any
 
+from dateutil import tz
+
+from featurebyte.enum import SpecialColumnName
 from featurebyte.logging import get_logger
 from featurebyte.models.observation_table import ObservationTableModel, TargetInput
+from featurebyte.query_graph.sql.feature_historical import (
+    HISTORICAL_REQUESTS_POINT_IN_TIME_RECENCY_HOUR,
+)
 from featurebyte.schema.worker.task.observation_table import ObservationTableTaskPayload
+from featurebyte.service.entity import EntityService
 from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.service.observation_table import ObservationTableService
 from featurebyte.service.session_manager import SessionManagerService
@@ -32,11 +40,13 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask[ObservationTableTaskPayl
         feature_store_service: FeatureStoreService,
         session_manager_service: SessionManagerService,
         observation_table_service: ObservationTableService,
+        entity_service: EntityService,
     ):
         super().__init__(task_manager=task_manager)
         self.feature_store_service = feature_store_service
         self.session_manager_service = session_manager_service
         self.observation_table_service = observation_table_service
+        self.entity_service = entity_service
 
     async def get_task_description(self, payload: ObservationTableTaskPayload) -> str:
         return f'Save observation table "{payload.name}" from source table.'
@@ -49,12 +59,39 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask[ObservationTableTaskPayl
         location = await self.observation_table_service.generate_materialized_table_location(
             payload.feature_store_id,
         )
+
+        # exclude rows with null values in key columns (POINT_IN_TIME, entity columns, target_column)
+        columns_to_exclude_missing_values = [str(SpecialColumnName.POINT_IN_TIME)]
+        if payload.primary_entity_ids is not None:
+            for entity_id in payload.primary_entity_ids:
+                entity = await self.entity_service.get_document(document_id=entity_id)
+                columns_to_exclude_missing_values.extend(entity.serving_names)
+        if payload.target_column is not None:
+            columns_to_exclude_missing_values.append(payload.target_column)
+
+        # limit POINT_IN_TIME to a certain recency to avoid historical request failures
+        max_timestamp = datetime.utcnow() - timedelta(
+            hours=HISTORICAL_REQUESTS_POINT_IN_TIME_RECENCY_HOUR
+        )
+        if payload.sample_to_timestamp is not None:
+            if payload.sample_to_timestamp.tzinfo is not None:
+                sample_to_timestamp = payload.sample_to_timestamp.astimezone(tz.UTC).replace(
+                    tzinfo=None
+                )
+            else:
+                sample_to_timestamp = payload.sample_to_timestamp
+
+            sample_to_timestamp = min(sample_to_timestamp, max_timestamp)
+        else:
+            sample_to_timestamp = max_timestamp
+
         await payload.request_input.materialize(
             session=db_session,
             destination=location.table_details,
             sample_rows=payload.sample_rows,
             sample_from_timestamp=payload.sample_from_timestamp,
-            sample_to_timestamp=payload.sample_to_timestamp,
+            sample_to_timestamp=sample_to_timestamp,
+            columns_to_exclude_missing_values=columns_to_exclude_missing_values,
         )
         await self.observation_table_service.add_row_index_column(
             session=db_session, table_details=location.table_details

--- a/scripts/enforce_import_rules.py
+++ b/scripts/enforce_import_rules.py
@@ -139,6 +139,7 @@ if __name__ == "__main__":
         "cachetools",
         "cryptography",
         "databricks",
+        "dateutil",
         "fastapi",
         "jinja2",
         "matplotlib",

--- a/tests/fixtures/request_input/materialize_bigquery.sql
+++ b/tests/fixtures/request_input/materialize_bigquery.sql
@@ -2,29 +2,6 @@ SELECT
   COUNT(*) AS `row_count`
 FROM (
   SELECT
-    `event_timestamp` AS `POINT_IN_TIME`,
-    `col_int` AS `col_int`
-  FROM (
-    SELECT
-      `col_int` AS `col_int`,
-      `col_float` AS `col_float`,
-      `col_char` AS `col_char`,
-      `col_text` AS `col_text`,
-      `col_binary` AS `col_binary`,
-      `col_boolean` AS `col_boolean`,
-      `event_timestamp` AS `event_timestamp`,
-      `cust_id` AS `cust_id`
-    FROM `sf_database`.`sf_schema`.`sf_table`
-  )
-);
-
-CREATE TABLE `sf_database`.`sf_schema`.`my_materialized_table` AS
-SELECT
-  `POINT_IN_TIME`,
-  `col_int`
-FROM (
-  SELECT
-    RAND() AS `prob`,
     `POINT_IN_TIME`,
     `col_int`
   FROM (
@@ -43,6 +20,45 @@ FROM (
         `cust_id` AS `cust_id`
       FROM `sf_database`.`sf_schema`.`sf_table`
     )
+  )
+  WHERE
+      CAST(`POINT_IN_TIME` AS DATETIME) < CAST('2011-03-06T15:37:00' AS DATETIME) AND
+      `POINT_IN_TIME` IS NOT NULL
+);
+
+CREATE TABLE `sf_database`.`sf_schema`.`my_materialized_table` AS
+SELECT
+  `POINT_IN_TIME`,
+  `col_int`
+FROM (
+  SELECT
+    RAND() AS `prob`,
+    `POINT_IN_TIME`,
+    `col_int`
+  FROM (
+    SELECT
+      `POINT_IN_TIME`,
+      `col_int`
+    FROM (
+      SELECT
+        `event_timestamp` AS `POINT_IN_TIME`,
+        `col_int` AS `col_int`
+      FROM (
+        SELECT
+          `col_int` AS `col_int`,
+          `col_float` AS `col_float`,
+          `col_char` AS `col_char`,
+          `col_text` AS `col_text`,
+          `col_binary` AS `col_binary`,
+          `col_boolean` AS `col_boolean`,
+          `event_timestamp` AS `event_timestamp`,
+          `cust_id` AS `cust_id`
+        FROM `sf_database`.`sf_schema`.`sf_table`
+      )
+    )
+    WHERE
+        CAST(`POINT_IN_TIME` AS DATETIME) < CAST('2011-03-06T15:37:00' AS DATETIME) AND
+        `POINT_IN_TIME` IS NOT NULL
   )
 )
 WHERE

--- a/tests/fixtures/request_input/materialize_bigquery.sql
+++ b/tests/fixtures/request_input/materialize_bigquery.sql
@@ -2,6 +2,29 @@ SELECT
   COUNT(*) AS `row_count`
 FROM (
   SELECT
+    `event_timestamp` AS `POINT_IN_TIME`,
+    `col_int` AS `col_int`
+  FROM (
+    SELECT
+      `col_int` AS `col_int`,
+      `col_float` AS `col_float`,
+      `col_char` AS `col_char`,
+      `col_text` AS `col_text`,
+      `col_binary` AS `col_binary`,
+      `col_boolean` AS `col_boolean`,
+      `event_timestamp` AS `event_timestamp`,
+      `cust_id` AS `cust_id`
+    FROM `sf_database`.`sf_schema`.`sf_table`
+  )
+);
+
+CREATE TABLE `sf_database`.`sf_schema`.`my_materialized_table` AS
+SELECT
+  `POINT_IN_TIME`,
+  `col_int`
+FROM (
+  SELECT
+    RAND() AS `prob`,
     `POINT_IN_TIME`,
     `col_int`
   FROM (
@@ -20,45 +43,6 @@ FROM (
         `cust_id` AS `cust_id`
       FROM `sf_database`.`sf_schema`.`sf_table`
     )
-  )
-  WHERE
-      CAST(`POINT_IN_TIME` AS DATETIME) < CAST('2011-03-06T15:37:00' AS DATETIME) AND
-      `POINT_IN_TIME` IS NOT NULL
-);
-
-CREATE TABLE `sf_database`.`sf_schema`.`my_materialized_table` AS
-SELECT
-  `POINT_IN_TIME`,
-  `col_int`
-FROM (
-  SELECT
-    RAND() AS `prob`,
-    `POINT_IN_TIME`,
-    `col_int`
-  FROM (
-    SELECT
-      `POINT_IN_TIME`,
-      `col_int`
-    FROM (
-      SELECT
-        `event_timestamp` AS `POINT_IN_TIME`,
-        `col_int` AS `col_int`
-      FROM (
-        SELECT
-          `col_int` AS `col_int`,
-          `col_float` AS `col_float`,
-          `col_char` AS `col_char`,
-          `col_text` AS `col_text`,
-          `col_binary` AS `col_binary`,
-          `col_boolean` AS `col_boolean`,
-          `event_timestamp` AS `event_timestamp`,
-          `cust_id` AS `cust_id`
-        FROM `sf_database`.`sf_schema`.`sf_table`
-      )
-    )
-    WHERE
-        CAST(`POINT_IN_TIME` AS DATETIME) < CAST('2011-03-06T15:37:00' AS DATETIME) AND
-        `POINT_IN_TIME` IS NOT NULL
   )
 )
 WHERE

--- a/tests/integration/api/test_observation_table.py
+++ b/tests/integration/api/test_observation_table.py
@@ -227,8 +227,8 @@ async def test_observation_table_sample_time_range(
     observation_table = view.create_observation_table(
         f"MY_OBSERVATION_TABLE_FROM_VIEW_{source_type}_TIME_RANGE_SAMPLED",
         sample_rows=sample_rows,
-        sample_from_timestamp="2001-02-01",
-        sample_to_timestamp="2001-06-30",
+        sample_from_timestamp="2001-02-01T00:00:00Z",
+        sample_to_timestamp="2001-06-30T00:00:00Z",
         columns=[view.timestamp_column, "ÜSER ID"],
         columns_rename_mapping={view.timestamp_column: "POINT_IN_TIME", "ÜSER ID": "üser id"},
     )

--- a/tests/unit/api/test_event_view.py
+++ b/tests/unit/api/test_event_view.py
@@ -887,7 +887,8 @@ def test_create_observation_table_from_event_view__no_sample(
         )
         WHERE
             "POINT_IN_TIME" < CAST('2011-03-06T15:37:00' AS TIMESTAMP) AND
-            "POINT_IN_TIME" IS NOT NULL
+            "POINT_IN_TIME" IS NOT NULL AND
+            "cust_id" IS NOT NULL
         """,
     )
     _, kwargs = snowflake_execute_query.call_args_list[-1]
@@ -959,7 +960,8 @@ def test_create_observation_table_from_event_view__with_sample(
           )
           WHERE
               "POINT_IN_TIME" < CAST('2011-03-06T15:37:00' AS TIMESTAMP) AND
-              "POINT_IN_TIME" IS NOT NULL
+              "POINT_IN_TIME" IS NOT NULL AND
+              "cust_id" IS NOT NULL
         ) TABLESAMPLE (14)
         ORDER BY
           RANDOM()

--- a/tests/unit/api/test_event_view.py
+++ b/tests/unit/api/test_event_view.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from unittest import mock
 from unittest.mock import AsyncMock, patch
 
+import freezegun
 import pandas as pd
 import pytest
 from bson import ObjectId
@@ -836,6 +837,7 @@ def test_sdk_code_generation(saved_event_table, update_fixtures):
 
 
 @pytest.mark.usefixtures("patched_observation_table_service")
+@freezegun.freeze_time("2011-03-08T15:37:00")
 def test_create_observation_table_from_event_view__no_sample(
     snowflake_event_table, snowflake_execute_query, catalog, cust_id_entity
 ):
@@ -864,20 +866,28 @@ def test_create_observation_table_from_event_view__no_sample(
         """
         CREATE TABLE "sf_database"."sf_schema"."OBSERVATION_TABLE" AS
         SELECT
-          "event_timestamp" AS "POINT_IN_TIME",
-          "cust_id" AS "cust_id"
+          "POINT_IN_TIME",
+          "cust_id"
         FROM (
           SELECT
-            "col_int" AS "col_int",
-            "col_float" AS "col_float",
-            "col_char" AS "col_char",
-            "col_text" AS "col_text",
-            "col_binary" AS "col_binary",
-            "col_boolean" AS "col_boolean",
-            "event_timestamp" AS "event_timestamp",
+            "event_timestamp" AS "POINT_IN_TIME",
             "cust_id" AS "cust_id"
-          FROM "sf_database"."sf_schema"."sf_table"
+          FROM (
+            SELECT
+              "col_int" AS "col_int",
+              "col_float" AS "col_float",
+              "col_char" AS "col_char",
+              "col_text" AS "col_text",
+              "col_binary" AS "col_binary",
+              "col_boolean" AS "col_boolean",
+              "event_timestamp" AS "event_timestamp",
+              "cust_id" AS "cust_id"
+            FROM "sf_database"."sf_schema"."sf_table"
+          )
         )
+        WHERE
+            "POINT_IN_TIME" < CAST('2011-03-06T15:37:00' AS TIMESTAMP) AND
+            "POINT_IN_TIME" IS NOT NULL
         """,
     )
     _, kwargs = snowflake_execute_query.call_args_list[-1]
@@ -894,6 +904,7 @@ def test_create_observation_table_from_event_view__no_sample(
 
 
 @pytest.mark.usefixtures("patched_observation_table_service")
+@freezegun.freeze_time("2011-03-08T15:37:00")
 def test_create_observation_table_from_event_view__with_sample(
     snowflake_event_table_with_entity, snowflake_execute_query, cust_id_entity
 ):
@@ -927,20 +938,28 @@ def test_create_observation_table_from_event_view__with_sample(
           *
         FROM (
           SELECT
-            "event_timestamp" AS "POINT_IN_TIME",
-            "cust_id" AS "cust_id"
+            "POINT_IN_TIME",
+            "cust_id"
           FROM (
             SELECT
-              "col_int" AS "col_int",
-              "col_float" AS "col_float",
-              "col_char" AS "col_char",
-              "col_text" AS "col_text",
-              "col_binary" AS "col_binary",
-              "col_boolean" AS "col_boolean",
-              "event_timestamp" AS "event_timestamp",
+              "event_timestamp" AS "POINT_IN_TIME",
               "cust_id" AS "cust_id"
-            FROM "sf_database"."sf_schema"."sf_table"
+            FROM (
+              SELECT
+                "col_int" AS "col_int",
+                "col_float" AS "col_float",
+                "col_char" AS "col_char",
+                "col_text" AS "col_text",
+                "col_binary" AS "col_binary",
+                "col_boolean" AS "col_boolean",
+                "event_timestamp" AS "event_timestamp",
+                "cust_id" AS "cust_id"
+              FROM "sf_database"."sf_schema"."sf_table"
+            )
           )
+          WHERE
+              "POINT_IN_TIME" < CAST('2011-03-06T15:37:00' AS TIMESTAMP) AND
+              "POINT_IN_TIME" IS NOT NULL
         ) TABLESAMPLE (14)
         ORDER BY
           RANDOM()

--- a/tests/unit/api/test_source_table.py
+++ b/tests/unit/api/test_source_table.py
@@ -4,6 +4,7 @@ Unit test for SourceTable
 
 from unittest.mock import AsyncMock, Mock, patch
 
+import freezegun
 import pandas as pd
 import pytest
 
@@ -191,6 +192,7 @@ def test_get_or_create_scd_table__create(snowflake_database_table_scd_table, cat
 
 
 @pytest.mark.usefixtures("patched_observation_table_service")
+@freezegun.freeze_time("2011-03-08T15:37:00")
 def test_create_observation_table(
     snowflake_database_table, snowflake_execute_query, catalog, cust_id_entity, mock_log_handler
 ):
@@ -218,13 +220,21 @@ def test_create_observation_table(
         """
         CREATE TABLE "sf_database"."sf_schema"."OBSERVATION_TABLE" AS
         SELECT
-          "event_timestamp" AS "POINT_IN_TIME",
-          "cust_id" AS "cust_id"
+          "POINT_IN_TIME",
+          "cust_id"
         FROM (
           SELECT
-            *
-          FROM "sf_database"."sf_schema"."sf_table"
+            "event_timestamp" AS "POINT_IN_TIME",
+            "cust_id" AS "cust_id"
+          FROM (
+            SELECT
+              *
+            FROM "sf_database"."sf_schema"."sf_table"
+          )
         )
+        WHERE
+            "POINT_IN_TIME" < CAST('2011-03-06T15:37:00' AS TIMESTAMP) AND
+            "POINT_IN_TIME" IS NOT NULL
         """,
     )
     _, kwargs = snowflake_execute_query.call_args_list[-1]
@@ -241,6 +251,7 @@ def test_create_observation_table(
 
 
 @pytest.mark.usefixtures("patched_observation_table_service")
+@freezegun.freeze_time("2011-03-08T15:37:00")
 def test_create_observation_table_with_sample_rows(
     snowflake_database_table, snowflake_execute_query, catalog
 ):
@@ -271,20 +282,35 @@ def test_create_observation_table_with_sample_rows(
           *
         FROM (
           SELECT
-            "col_int" AS "col_int",
-            "col_float" AS "col_float",
-            "col_char" AS "col_char",
-            "col_text" AS "col_text",
-            "col_binary" AS "col_binary",
-            "col_boolean" AS "col_boolean",
-            "event_timestamp" AS "POINT_IN_TIME",
-            "created_at" AS "created_at",
-            "cust_id" AS "cust_id"
+            "col_int",
+            "col_float",
+            "col_char",
+            "col_text",
+            "col_binary",
+            "col_boolean",
+            "POINT_IN_TIME",
+            "created_at",
+            "cust_id"
           FROM (
             SELECT
-              *
-            FROM "sf_database"."sf_schema"."sf_table"
+              "col_int" AS "col_int",
+              "col_float" AS "col_float",
+              "col_char" AS "col_char",
+              "col_text" AS "col_text",
+              "col_binary" AS "col_binary",
+              "col_boolean" AS "col_boolean",
+              "event_timestamp" AS "POINT_IN_TIME",
+              "created_at" AS "created_at",
+              "cust_id" AS "cust_id"
+            FROM (
+              SELECT
+                *
+              FROM "sf_database"."sf_schema"."sf_table"
+            )
           )
+          WHERE
+              "POINT_IN_TIME" < CAST('2011-03-06T15:37:00' AS TIMESTAMP) AND
+              "POINT_IN_TIME" IS NOT NULL
         ) TABLESAMPLE (14)
         ORDER BY
           RANDOM()

--- a/tests/unit/api/test_source_table.py
+++ b/tests/unit/api/test_source_table.py
@@ -234,7 +234,8 @@ def test_create_observation_table(
         )
         WHERE
             "POINT_IN_TIME" < CAST('2011-03-06T15:37:00' AS TIMESTAMP) AND
-            "POINT_IN_TIME" IS NOT NULL
+            "POINT_IN_TIME" IS NOT NULL AND
+            "cust_id" IS NOT NULL
         """,
     )
     _, kwargs = snowflake_execute_query.call_args_list[-1]

--- a/tests/unit/models/test_request_input.py
+++ b/tests/unit/models/test_request_input.py
@@ -7,8 +7,10 @@ from datetime import datetime
 from functools import partial
 from unittest.mock import AsyncMock, Mock, call
 
+import freezegun
 import pandas as pd
 import pytest
+from dateutil import tz
 
 from featurebyte import SourceType
 from featurebyte.enum import DBVarType
@@ -33,6 +35,9 @@ def session_fixture(adapter):
             return_value={
                 "a": ColumnSpecWithDescription(name="a", dtype=DBVarType.INT),
                 "b": ColumnSpecWithDescription(name="a", dtype=DBVarType.INT),
+                "POINT_IN_TIME": ColumnSpecWithDescription(
+                    name="POINT_IN_TIME", dtype=DBVarType.TIMESTAMP
+                ),
             }
         ),
         adapter=adapter,
@@ -107,13 +112,20 @@ async def test_materialize__with_columns_and_renames(
         """
         CREATE TABLE "sf_database"."sf_schema"."my_materialized_table" AS
         SELECT
-          "a" AS "a",
-          "b" AS "NEW_B"
+          "a",
+          "NEW_B"
         FROM (
           SELECT
-            *
-          FROM "sf_database"."sf_schema"."sf_table"
+            "a" AS "a",
+            "b" AS "NEW_B"
+          FROM (
+            SELECT
+              *
+            FROM "sf_database"."sf_schema"."sf_table"
+          )
         )
+        WHERE
+            "NEW_B" IS NOT NULL
         """
     ).strip()
     assert session.execute_query_long_running.call_args_list == [call(expected_query)]
@@ -125,6 +137,7 @@ async def test_materialize__with_renames_only(session, snowflake_database_table,
     Test materializing when only the columns rename mapping is specified
     """
     request_input = SourceTableRequestInput(
+        columns=["a", "b"],
         columns_rename_mapping={"b": "NEW_B"},
         source=snowflake_database_table.tabular_source,
     )
@@ -138,13 +151,20 @@ async def test_materialize__with_renames_only(session, snowflake_database_table,
         """
         CREATE TABLE "sf_database"."sf_schema"."my_materialized_table" AS
         SELECT
-          "a" AS "a",
-          "b" AS "NEW_B"
+          "a",
+          "NEW_B"
         FROM (
           SELECT
-            *
-          FROM "sf_database"."sf_schema"."sf_table"
+            "a" AS "a",
+            "b" AS "NEW_B"
+          FROM (
+            SELECT
+              *
+            FROM "sf_database"."sf_schema"."sf_table"
+          )
         )
+        WHERE
+            "NEW_B" IS NOT NULL
         """
     ).strip()
     assert session.execute_query_long_running.call_args_list == [call(expected_query)]
@@ -181,6 +201,7 @@ async def test_materialize__invalid_rename_mapping(
 
 
 @pytest.mark.asyncio
+@freezegun.freeze_time("2011-03-08T15:37:00")
 async def test_materialize__from_view_with_columns_and_renames(
     session, destination_table, snowflake_event_table
 ):
@@ -204,26 +225,35 @@ async def test_materialize__from_view_with_columns_and_renames(
         """
         CREATE TABLE "sf_database"."sf_schema"."my_materialized_table" AS
         SELECT
-          "event_timestamp" AS "POINT_IN_TIME",
-          "col_int" AS "col_int"
+          "POINT_IN_TIME",
+          "col_int"
         FROM (
           SELECT
-            "col_int" AS "col_int",
-            "col_float" AS "col_float",
-            "col_char" AS "col_char",
-            "col_text" AS "col_text",
-            "col_binary" AS "col_binary",
-            "col_boolean" AS "col_boolean",
-            "event_timestamp" AS "event_timestamp",
-            "cust_id" AS "cust_id"
-          FROM "sf_database"."sf_schema"."sf_table"
+            "event_timestamp" AS "POINT_IN_TIME",
+            "col_int" AS "col_int"
+          FROM (
+            SELECT
+              "col_int" AS "col_int",
+              "col_float" AS "col_float",
+              "col_char" AS "col_char",
+              "col_text" AS "col_text",
+              "col_binary" AS "col_binary",
+              "col_boolean" AS "col_boolean",
+              "event_timestamp" AS "event_timestamp",
+              "cust_id" AS "cust_id"
+            FROM "sf_database"."sf_schema"."sf_table"
+          )
         )
+        WHERE
+            "POINT_IN_TIME" < CAST('2011-03-06T15:37:00' AS TIMESTAMP) AND
+            "POINT_IN_TIME" IS NOT NULL
         """
     ).strip()
     assert session.execute_query_long_running.call_args_list == [call(expected_query)]
 
 
 @pytest.mark.asyncio
+@freezegun.freeze_time("2011-03-08T15:37:00")
 async def test_materialize__view_bigquery(
     session, destination_table, snowflake_event_table, bigquery_source_info, update_fixtures
 ):
@@ -297,7 +327,8 @@ async def test_materialize__with_sample_timestamp(
           )
         )
         WHERE
-            "POINT_IN_TIME" < CAST('2011-03-08T00:00:00' AS TIMESTAMP)
+            "POINT_IN_TIME" < CAST('2011-03-08T00:00:00' AS TIMESTAMP) AND
+            "POINT_IN_TIME" IS NOT NULL
         """
     ).strip()
     assert session.execute_query_long_running.call_args_list == [call(expected_query)]
@@ -397,6 +428,122 @@ async def test_materialize__with_sample_timestamp_no_columns_rename(
         WHERE
             "POINT_IN_TIME" >= CAST('2011-03-08T00:00:00' AS TIMESTAMP) AND
             "POINT_IN_TIME" < CAST('2012-05-09T00:00:00' AS TIMESTAMP)
+        """
+    ).strip()
+    assert session.execute_query_long_running.call_args_list == [call(expected_query)]
+
+
+@pytest.mark.asyncio
+async def test_materialize__with_sample_timestamp_with_tz(
+    session, snowflake_event_table, destination_table
+):
+    """
+    Test materializing with sample from timestamp with timezone
+    """
+    view = snowflake_event_table.get_view()
+    view = view[view.col_int == 1]
+    pruned_graph, mapped_node = view.extract_pruned_graph_and_node()
+    request_input = ViewRequestInput(
+        graph=pruned_graph,
+        node_name=mapped_node.name,
+        columns_rename_mapping={"event_timestamp": "POINT_IN_TIME", "cust_id": "CUST_ID"},
+    )
+
+    await request_input.materialize(
+        session,
+        destination_table,
+        None,
+        datetime(2011, 3, 8, tzinfo=tz.gettz("Asia/Singapore")),
+        datetime(2012, 5, 9, tzinfo=tz.gettz("Asia/Singapore")),
+    )
+
+    expected_query = textwrap.dedent(
+        """
+        CREATE TABLE "sf_database"."sf_schema"."my_materialized_table" AS
+        SELECT
+          "col_int",
+          "col_float",
+          "col_char",
+          "col_text",
+          "col_binary",
+          "col_boolean",
+          "POINT_IN_TIME",
+          "CUST_ID"
+        FROM (
+          SELECT
+            "col_int" AS "col_int",
+            "col_float" AS "col_float",
+            "col_char" AS "col_char",
+            "col_text" AS "col_text",
+            "col_binary" AS "col_binary",
+            "col_boolean" AS "col_boolean",
+            "event_timestamp" AS "POINT_IN_TIME",
+            "cust_id" AS "CUST_ID"
+          FROM (
+            SELECT
+              "col_int" AS "col_int",
+              "col_float" AS "col_float",
+              "col_char" AS "col_char",
+              "col_text" AS "col_text",
+              "col_binary" AS "col_binary",
+              "col_boolean" AS "col_boolean",
+              "event_timestamp" AS "event_timestamp",
+              "cust_id" AS "cust_id"
+            FROM "sf_database"."sf_schema"."sf_table"
+            WHERE
+              (
+                "col_int" = 1
+              )
+          )
+        )
+        WHERE
+            "POINT_IN_TIME" >= CAST('2011-03-07T16:00:00' AS TIMESTAMP) AND
+            "POINT_IN_TIME" < CAST('2012-05-08T16:00:00' AS TIMESTAMP) AND
+            "POINT_IN_TIME" IS NOT NULL AND
+            "CUST_ID" IS NOT NULL
+        """
+    ).strip()
+    assert session.execute_query_long_running.call_args_list == [call(expected_query)]
+
+
+@pytest.mark.asyncio
+@freezegun.freeze_time("2011-03-08T15:37:00")
+async def test_materialize__with_point_in_time_limit(
+    session, snowflake_database_table, destination_table
+):
+    """
+    Test materializing when with point-in-time limited by filter
+    """
+    request_input = SourceTableRequestInput(
+        columns=["a", "b", "POINT_IN_TIME"],
+        source=snowflake_database_table.tabular_source,
+    )
+    await request_input.materialize(session, destination_table, None)
+
+    assert session.list_table_schema.call_args_list == [
+        call(table_name="sf_table", database_name="sf_database", schema_name="sf_schema")
+    ]
+
+    expected_query = textwrap.dedent(
+        """
+        CREATE TABLE "sf_database"."sf_schema"."my_materialized_table" AS
+        SELECT
+          "a",
+          "b",
+          "POINT_IN_TIME"
+        FROM (
+          SELECT
+            "a",
+            "b",
+            "POINT_IN_TIME"
+          FROM (
+            SELECT
+              *
+            FROM "sf_database"."sf_schema"."sf_table"
+          )
+        )
+        WHERE
+            "POINT_IN_TIME" < CAST('2011-03-06T15:37:00' AS TIMESTAMP)
         """
     ).strip()
     assert session.execute_query_long_running.call_args_list == [call(expected_query)]


### PR DESCRIPTION

## Description

This PR makes the following changes during observation table materialization:
- Cast `sample_from_timestamp` and `sample_to_timestamp` to UTC timestamps without timezone info
- Exclude rows where mapped columns contain NULL values
- Exclude rows where `POINT_IN_TIME` is too recent for feature materialization

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
