### PR TITLE
[DEV-3912] Disable bigquery storage client when running in io workers (cherry-pick)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -80,7 +80,7 @@ _main() {
     elif [ "$1" = 'worker' ]; then
       celery --app featurebyte.worker.start.celery beat --loglevel=INFO --scheduler featurebyte.worker.schedulers.MongoScheduler --max-interval=1 &
       celery --app featurebyte.worker.start.celery worker -Q cpu_task,cpu_task:1,cpu_task:2,cpu_task:3 --loglevel=INFO --pool=prefork &
-      celery --app featurebyte.worker.start.celery worker -Q io_task,io_task:1,io_task:2,io_task:3 --loglevel=INFO --pool=gevent -c 500
+      HOSTNAME="featurebyte-docker-worker-io" celery --app featurebyte.worker.start.celery worker -Q io_task,io_task:1,io_task:2,io_task:3 --loglevel=INFO --pool=gevent -c 500
     elif [ "$1" = 'server' ]; then
       python /scripts/migration.py
       uvicorn featurebyte.app:app --host=$API_HOST --port=$API_PORT --timeout-keep-alive=300 --log-level=info

--- a/featurebyte/common/env_util.py
+++ b/featurebyte/common/env_util.py
@@ -122,3 +122,14 @@ def is_development_mode() -> bool:
     bool
     """
     return os.environ.get("FEATUREBYTE_EXECUTION_MODE") == "development"
+
+
+def is_io_worker() -> bool:
+    """
+    Check whether the code is running in IO worker
+
+    Returns
+    -------
+    bool
+    """
+    return "worker-io" in os.environ.get("HOSTNAME", "")

--- a/tests/integration/session/test_bigquery.py
+++ b/tests/integration/session/test_bigquery.py
@@ -2,8 +2,10 @@
 This module contains session to BigQuery integration tests.
 """
 
+import os
 from collections import OrderedDict
 from decimal import Decimal
+from unittest.mock import patch
 
 import pandas as pd
 import pytest
@@ -11,6 +13,8 @@ from bson import ObjectId
 
 from featurebyte.enum import DBVarType
 from featurebyte.query_graph.model.column_info import ColumnSpecWithDescription
+from featurebyte.service.session_manager import SessionManagerService
+from featurebyte.session.base import session_cache
 from featurebyte.session.bigquery import BigQuerySchemaInitializer, BigQuerySession
 from featurebyte.session.manager import SessionManager
 
@@ -263,3 +267,27 @@ async def test_list_table_schema_decimal_parameterized(config, session_without_d
     assert table_schema["A"].dtype == DBVarType.FLOAT
     df = await session.execute_query("SELECT * FROM TABLE_DECIMAL_SCALE")
     assert df.iloc[0]["A"] == Decimal("1.234")
+
+
+@pytest.mark.parametrize("source_type", ["bigquery"], indirect=True)
+@pytest.mark.parametrize(
+    "hostname, bqstorage_client_expected",
+    [
+        ("featurebyte-worker-io", False),
+        ("featurebyte-worker-cpu", True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_create_session__bqstorage_client(
+    feature_store, feature_store_credential, hostname, bqstorage_client_expected
+):
+    """
+    Test bqstorage client is disabled when running on an IO worker.
+    """
+    session_cache.clear()
+    with patch.dict(os.environ, {"HOSTNAME": hostname}):
+        session = await SessionManagerService.get_session(feature_store, feature_store_credential)
+    if bqstorage_client_expected:
+        assert session.connection._bqstorage_client is not None
+    else:
+        assert session.connection._bqstorage_client is None

--- a/tests/integration/session/test_bigquery.py
+++ b/tests/integration/session/test_bigquery.py
@@ -13,7 +13,6 @@ from bson import ObjectId
 
 from featurebyte.enum import DBVarType
 from featurebyte.query_graph.model.column_info import ColumnSpecWithDescription
-from featurebyte.service.session_manager import SessionManagerService
 from featurebyte.session.base import session_cache
 from featurebyte.session.bigquery import BigQuerySchemaInitializer, BigQuerySession
 from featurebyte.session.manager import SessionManager
@@ -279,14 +278,17 @@ async def test_list_table_schema_decimal_parameterized(config, session_without_d
 )
 @pytest.mark.asyncio
 async def test_create_session__bqstorage_client(
-    feature_store, feature_store_credential, hostname, bqstorage_client_expected
+    feature_store,
+    hostname,
+    bqstorage_client_expected,
+    session_manager,
 ):
     """
     Test bqstorage client is disabled when running on an IO worker.
     """
     session_cache.clear()
     with patch.dict(os.environ, {"HOSTNAME": hostname}):
-        session = await SessionManagerService.get_session(feature_store, feature_store_credential)
+        session = await session_manager.get_session(feature_store)
     if bqstorage_client_expected:
         assert session.connection._bqstorage_client is not None
     else:


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

Cherry pick: #2690 


## Related Issue
## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
