### PR TITLE
[chore] Add timestamp_schema field in ColumnSpec and node hash handling

### DIFF
--- a/featurebyte/query_graph/model/graph.py
+++ b/featurebyte/query_graph/model/graph.py
@@ -12,6 +12,7 @@ from featurebyte.exception import GraphInconsistencyError
 from featurebyte.models.base import FeatureByteBaseModel
 from featurebyte.query_graph.algorithm import dfs_traversal, topological_sort
 from featurebyte.query_graph.enum import GraphNodeType, NodeOutputType, NodeType
+from featurebyte.query_graph.model.node_hash_util import exclude_default_timestamp_schema
 from featurebyte.query_graph.node import Node, construct_node
 from featurebyte.query_graph.node.generic import AliasNode, ProjectNode
 from featurebyte.query_graph.node.input import InputNode, ItemTableInputNodeParameters
@@ -239,6 +240,7 @@ class QueryGraphModel(FeatureByteBaseModel):
         if node.type == NodeType.INPUT:
             # exclude feature_store_details.details from input node hash if it exists
             node_parameters["feature_store_details"].pop("details", None)
+            exclude_default_timestamp_schema(node_parameters)
         if node.type == NodeType.GROUPBY:
             node_parameters.pop("tile_id_version", None)
             fjs = node_parameters.pop("feature_job_setting")

--- a/featurebyte/query_graph/model/node_hash_util.py
+++ b/featurebyte/query_graph/model/node_hash_util.py
@@ -1,0 +1,27 @@
+"""
+Utility functions for hashing nodes
+"""
+
+from typing import Any, Dict
+
+
+def exclude_default_timestamp_schema(node_parameters: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Exclude default timestamp_schema from node parameters. node_parameters is assumed to be the
+    parameters from an InputNode.
+
+    Parameters
+    ----------
+    node_parameters: Dict[str, Any]
+        Node parameters
+
+    Returns
+    -------
+    Dict[str, Any]
+    """
+    if "columns" in node_parameters:
+        column_specs = node_parameters["columns"]
+        for column_spec in column_specs:
+            if "timestamp_schema" in column_spec and column_spec["timestamp_schema"] is None:
+                column_spec.pop("timestamp_schema")
+    return node_parameters

--- a/featurebyte/query_graph/node/schema.py
+++ b/featurebyte/query_graph/node/schema.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field, StrictStr, model_validator
 from featurebyte.common.doc_util import FBAutoDoc
 from featurebyte.enum import DBVarType, SourceType, StorageType
 from featurebyte.models.base import FeatureByteBaseModel, NameStr
+from featurebyte.query_graph.model.timestamp_schema import TimestampSchema
 from featurebyte.query_graph.sql.source_info import SourceInfo
 
 
@@ -407,3 +408,4 @@ class ColumnSpec(FeatureByteBaseModel):
 
     name: NameStr
     dtype: DBVarType
+    timestamp_schema: Optional[TimestampSchema] = None

--- a/tests/fixtures/offline_store_feature_table/feature_cluster_disabled_one_feature.json
+++ b/tests/fixtures/offline_store_feature_table/feature_cluster_disabled_one_feature.json
@@ -46,39 +46,48 @@
                     "columns": [
                         {
                             "dtype": "INT",
-                            "name": "col_int"
+                            "name": "col_int",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "FLOAT",
-                            "name": "col_float"
+                            "name": "col_float",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "CHAR",
-                            "name": "col_char"
+                            "name": "col_char",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "VARCHAR",
-                            "name": "col_text"
+                            "name": "col_text",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BINARY",
-                            "name": "col_binary"
+                            "name": "col_binary",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BOOL",
-                            "name": "col_boolean"
+                            "name": "col_boolean",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "event_timestamp"
+                            "name": "event_timestamp",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "created_at"
+                            "name": "created_at",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "INT",
-                            "name": "cust_id"
+                            "name": "cust_id",
+                            "timestamp_schema": null
                         }
                     ],
                     "event_timestamp_timezone_offset": null,

--- a/tests/fixtures/offline_store_feature_table/feature_cluster_one_feature.json
+++ b/tests/fixtures/offline_store_feature_table/feature_cluster_one_feature.json
@@ -42,39 +42,48 @@
                     "columns": [
                         {
                             "dtype": "INT",
-                            "name": "col_int"
+                            "name": "col_int",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "FLOAT",
-                            "name": "col_float"
+                            "name": "col_float",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "CHAR",
-                            "name": "col_char"
+                            "name": "col_char",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "VARCHAR",
-                            "name": "col_text"
+                            "name": "col_text",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BINARY",
-                            "name": "col_binary"
+                            "name": "col_binary",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BOOL",
-                            "name": "col_boolean"
+                            "name": "col_boolean",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "event_timestamp"
+                            "name": "event_timestamp",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "created_at"
+                            "name": "created_at",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "INT",
-                            "name": "cust_id"
+                            "name": "cust_id",
+                            "timestamp_schema": null
                         }
                     ],
                     "event_timestamp_timezone_offset": null,

--- a/tests/fixtures/offline_store_feature_table/feature_cluster_two_features.json
+++ b/tests/fixtures/offline_store_feature_table/feature_cluster_two_features.json
@@ -59,39 +59,48 @@
                     "columns": [
                         {
                             "dtype": "INT",
-                            "name": "col_int"
+                            "name": "col_int",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "FLOAT",
-                            "name": "col_float"
+                            "name": "col_float",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "CHAR",
-                            "name": "col_char"
+                            "name": "col_char",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "VARCHAR",
-                            "name": "col_text"
+                            "name": "col_text",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BINARY",
-                            "name": "col_binary"
+                            "name": "col_binary",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BOOL",
-                            "name": "col_boolean"
+                            "name": "col_boolean",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "event_timestamp"
+                            "name": "event_timestamp",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "created_at"
+                            "name": "created_at",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "INT",
-                            "name": "cust_id"
+                            "name": "cust_id",
+                            "timestamp_schema": null
                         }
                     ],
                     "event_timestamp_timezone_offset": null,

--- a/tests/fixtures/offline_store_feature_table/feature_cluster_with_internal_relationships.json
+++ b/tests/fixtures/offline_store_feature_table/feature_cluster_with_internal_relationships.json
@@ -100,47 +100,58 @@
                     "columns": [
                         {
                             "dtype": "INT",
-                            "name": "col_int"
+                            "name": "col_int",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "FLOAT",
-                            "name": "col_float"
+                            "name": "col_float",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BOOL",
-                            "name": "is_active"
+                            "name": "is_active",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "VARCHAR",
-                            "name": "col_text"
+                            "name": "col_text",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BINARY",
-                            "name": "col_binary"
+                            "name": "col_binary",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BOOL",
-                            "name": "col_boolean"
+                            "name": "col_boolean",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "effective_timestamp"
+                            "name": "effective_timestamp",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "end_timestamp"
+                            "name": "end_timestamp",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP",
-                            "name": "date_of_birth"
+                            "name": "date_of_birth",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "created_at"
+                            "name": "created_at",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "INT",
-                            "name": "cust_id"
+                            "name": "cust_id",
+                            "timestamp_schema": null
                         }
                     ],
                     "current_flag_column": "is_active",

--- a/tests/fixtures/request_payloads/dimension_table.json
+++ b/tests/fixtures/request_payloads/dimension_table.json
@@ -11,63 +11,72 @@
             "description": null,
             "dtype": "INT",
             "entity_id": null,
-            "name": "col_int"
+            "name": "col_int",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": "Float column",
             "dtype": "FLOAT",
             "entity_id": null,
-            "name": "col_float"
+            "name": "col_float",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": "Char column",
             "dtype": "CHAR",
             "entity_id": null,
-            "name": "col_char"
+            "name": "col_char",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": "Text column",
             "dtype": "VARCHAR",
             "entity_id": null,
-            "name": "col_text"
+            "name": "col_text",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "BINARY",
             "entity_id": null,
-            "name": "col_binary"
+            "name": "col_binary",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "BOOL",
             "entity_id": null,
-            "name": "col_boolean"
+            "name": "col_boolean",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": "Timestamp column",
             "dtype": "TIMESTAMP_TZ",
             "entity_id": null,
-            "name": "event_timestamp"
+            "name": "event_timestamp",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "TIMESTAMP_TZ",
             "entity_id": null,
-            "name": "created_at"
+            "name": "created_at",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "INT",
             "entity_id": null,
-            "name": "cust_id"
+            "name": "cust_id",
+            "timestamp_schema": null
         }
     ],
     "description": "test dimension table",

--- a/tests/fixtures/request_payloads/event_table.json
+++ b/tests/fixtures/request_payloads/event_table.json
@@ -11,63 +11,72 @@
             "description": null,
             "dtype": "INT",
             "entity_id": "63f94ed6ea1f050131379204",
-            "name": "col_int"
+            "name": "col_int",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": "Float column",
             "dtype": "FLOAT",
             "entity_id": null,
-            "name": "col_float"
+            "name": "col_float",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": "Char column",
             "dtype": "CHAR",
             "entity_id": null,
-            "name": "col_char"
+            "name": "col_char",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": "Text column",
             "dtype": "VARCHAR",
             "entity_id": null,
-            "name": "col_text"
+            "name": "col_text",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "BINARY",
             "entity_id": null,
-            "name": "col_binary"
+            "name": "col_binary",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "BOOL",
             "entity_id": null,
-            "name": "col_boolean"
+            "name": "col_boolean",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": "Timestamp column",
             "dtype": "TIMESTAMP_TZ",
             "entity_id": null,
-            "name": "event_timestamp"
+            "name": "event_timestamp",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "TIMESTAMP_TZ",
             "entity_id": null,
-            "name": "created_at"
+            "name": "created_at",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "INT",
             "entity_id": "63f94ed6ea1f050131379214",
-            "name": "cust_id"
+            "name": "cust_id",
+            "timestamp_schema": null
         }
     ],
     "default_feature_job_setting": {

--- a/tests/fixtures/request_payloads/feature_iet.json
+++ b/tests/fixtures/request_payloads/feature_iet.json
@@ -132,39 +132,48 @@
                     "columns": [
                         {
                             "dtype": "INT",
-                            "name": "col_int"
+                            "name": "col_int",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "FLOAT",
-                            "name": "col_float"
+                            "name": "col_float",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "CHAR",
-                            "name": "col_char"
+                            "name": "col_char",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "VARCHAR",
-                            "name": "col_text"
+                            "name": "col_text",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BINARY",
-                            "name": "col_binary"
+                            "name": "col_binary",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BOOL",
-                            "name": "col_boolean"
+                            "name": "col_boolean",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "event_timestamp"
+                            "name": "event_timestamp",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "created_at"
+                            "name": "created_at",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "INT",
-                            "name": "cust_id"
+                            "name": "cust_id",
+                            "timestamp_schema": null
                         }
                     ],
                     "event_timestamp_timezone_offset": null,

--- a/tests/fixtures/request_payloads/feature_item_event.json
+++ b/tests/fixtures/request_payloads/feature_item_event.json
@@ -36,39 +36,48 @@
                     "columns": [
                         {
                             "dtype": "INT",
-                            "name": "col_int"
+                            "name": "col_int",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "FLOAT",
-                            "name": "col_float"
+                            "name": "col_float",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "CHAR",
-                            "name": "col_char"
+                            "name": "col_char",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "VARCHAR",
-                            "name": "col_text"
+                            "name": "col_text",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BINARY",
-                            "name": "col_binary"
+                            "name": "col_binary",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BOOL",
-                            "name": "col_boolean"
+                            "name": "col_boolean",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "event_timestamp"
+                            "name": "event_timestamp",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "created_at"
+                            "name": "created_at",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "INT",
-                            "name": "cust_id"
+                            "name": "cust_id",
+                            "timestamp_schema": null
                         }
                     ],
                     "event_timestamp_timezone_offset": null,
@@ -96,27 +105,33 @@
                     "columns": [
                         {
                             "dtype": "INT",
-                            "name": "event_id_col"
+                            "name": "event_id_col",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "VARCHAR",
-                            "name": "item_id_col"
+                            "name": "item_id_col",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "VARCHAR",
-                            "name": "item_type"
+                            "name": "item_type",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "FLOAT",
-                            "name": "item_amount"
+                            "name": "item_amount",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "created_at"
+                            "name": "created_at",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "event_timestamp"
+                            "name": "event_timestamp",
+                            "timestamp_schema": null
                         }
                     ],
                     "event_id_column": "event_id_col",

--- a/tests/fixtures/request_payloads/feature_store_sample.json
+++ b/tests/fixtures/request_payloads/feature_store_sample.json
@@ -17,39 +17,48 @@
                     "columns": [
                         {
                             "dtype": "INT",
-                            "name": "col_int"
+                            "name": "col_int",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "FLOAT",
-                            "name": "col_float"
+                            "name": "col_float",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "CHAR",
-                            "name": "col_char"
+                            "name": "col_char",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "VARCHAR",
-                            "name": "col_text"
+                            "name": "col_text",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BINARY",
-                            "name": "col_binary"
+                            "name": "col_binary",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BOOL",
-                            "name": "col_boolean"
+                            "name": "col_boolean",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "event_timestamp"
+                            "name": "event_timestamp",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "created_at"
+                            "name": "created_at",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "INT",
-                            "name": "cust_id"
+                            "name": "cust_id",
+                            "timestamp_schema": null
                         }
                     ],
                     "event_timestamp_timezone_offset": null,

--- a/tests/fixtures/request_payloads/feature_sum_2h.json
+++ b/tests/fixtures/request_payloads/feature_sum_2h.json
@@ -28,39 +28,48 @@
                     "columns": [
                         {
                             "dtype": "INT",
-                            "name": "col_int"
+                            "name": "col_int",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "FLOAT",
-                            "name": "col_float"
+                            "name": "col_float",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "CHAR",
-                            "name": "col_char"
+                            "name": "col_char",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "VARCHAR",
-                            "name": "col_text"
+                            "name": "col_text",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BINARY",
-                            "name": "col_binary"
+                            "name": "col_binary",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BOOL",
-                            "name": "col_boolean"
+                            "name": "col_boolean",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "event_timestamp"
+                            "name": "event_timestamp",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "created_at"
+                            "name": "created_at",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "INT",
-                            "name": "cust_id"
+                            "name": "cust_id",
+                            "timestamp_schema": null
                         }
                     ],
                     "event_timestamp_timezone_offset": null,

--- a/tests/fixtures/request_payloads/feature_sum_30m.json
+++ b/tests/fixtures/request_payloads/feature_sum_30m.json
@@ -28,39 +28,48 @@
                     "columns": [
                         {
                             "dtype": "INT",
-                            "name": "col_int"
+                            "name": "col_int",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "FLOAT",
-                            "name": "col_float"
+                            "name": "col_float",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "CHAR",
-                            "name": "col_char"
+                            "name": "col_char",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "VARCHAR",
-                            "name": "col_text"
+                            "name": "col_text",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BINARY",
-                            "name": "col_binary"
+                            "name": "col_binary",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BOOL",
-                            "name": "col_boolean"
+                            "name": "col_boolean",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "event_timestamp"
+                            "name": "event_timestamp",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "created_at"
+                            "name": "created_at",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "INT",
-                            "name": "cust_id"
+                            "name": "cust_id",
+                            "timestamp_schema": null
                         }
                     ],
                     "event_timestamp_timezone_offset": null,

--- a/tests/fixtures/request_payloads/historical_feature_table.json
+++ b/tests/fixtures/request_payloads/historical_feature_table.json
@@ -49,39 +49,48 @@
                                 "columns": [
                                     {
                                         "dtype": "INT",
-                                        "name": "col_int"
+                                        "name": "col_int",
+                                        "timestamp_schema": null
                                     },
                                     {
                                         "dtype": "FLOAT",
-                                        "name": "col_float"
+                                        "name": "col_float",
+                                        "timestamp_schema": null
                                     },
                                     {
                                         "dtype": "CHAR",
-                                        "name": "col_char"
+                                        "name": "col_char",
+                                        "timestamp_schema": null
                                     },
                                     {
                                         "dtype": "VARCHAR",
-                                        "name": "col_text"
+                                        "name": "col_text",
+                                        "timestamp_schema": null
                                     },
                                     {
                                         "dtype": "BINARY",
-                                        "name": "col_binary"
+                                        "name": "col_binary",
+                                        "timestamp_schema": null
                                     },
                                     {
                                         "dtype": "BOOL",
-                                        "name": "col_boolean"
+                                        "name": "col_boolean",
+                                        "timestamp_schema": null
                                     },
                                     {
                                         "dtype": "TIMESTAMP_TZ",
-                                        "name": "event_timestamp"
+                                        "name": "event_timestamp",
+                                        "timestamp_schema": null
                                     },
                                     {
                                         "dtype": "TIMESTAMP_TZ",
-                                        "name": "created_at"
+                                        "name": "created_at",
+                                        "timestamp_schema": null
                                     },
                                     {
                                         "dtype": "INT",
-                                        "name": "cust_id"
+                                        "name": "cust_id",
+                                        "timestamp_schema": null
                                     }
                                 ],
                                 "event_timestamp_timezone_offset": null,

--- a/tests/fixtures/request_payloads/item_table.json
+++ b/tests/fixtures/request_payloads/item_table.json
@@ -11,42 +11,48 @@
             "description": null,
             "dtype": "INT",
             "entity_id": "63f94ed6ea1f050131379204",
-            "name": "event_id_col"
+            "name": "event_id_col",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "VARCHAR",
             "entity_id": null,
-            "name": "item_id_col"
+            "name": "item_id_col",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "VARCHAR",
             "entity_id": null,
-            "name": "item_type"
+            "name": "item_type",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "FLOAT",
             "entity_id": null,
-            "name": "item_amount"
+            "name": "item_amount",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "TIMESTAMP_TZ",
             "entity_id": null,
-            "name": "created_at"
+            "name": "created_at",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "TIMESTAMP_TZ",
             "entity_id": null,
-            "name": "event_timestamp"
+            "name": "event_timestamp",
+            "timestamp_schema": null
         }
     ],
     "description": "test item table",

--- a/tests/fixtures/request_payloads/scd_table.json
+++ b/tests/fixtures/request_payloads/scd_table.json
@@ -112,5 +112,6 @@
             "table_name": "scd_table"
         }
     },
+    "timestamp_schema": null,
     "type": "scd_table"
 }

--- a/tests/fixtures/request_payloads/scd_table.json
+++ b/tests/fixtures/request_payloads/scd_table.json
@@ -11,77 +11,88 @@
             "description": null,
             "dtype": "INT",
             "entity_id": null,
-            "name": "col_int"
+            "name": "col_int",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "FLOAT",
             "entity_id": null,
-            "name": "col_float"
+            "name": "col_float",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "BOOL",
             "entity_id": null,
-            "name": "is_active"
+            "name": "is_active",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "VARCHAR",
             "entity_id": null,
-            "name": "col_text"
+            "name": "col_text",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "BINARY",
             "entity_id": null,
-            "name": "col_binary"
+            "name": "col_binary",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "BOOL",
             "entity_id": null,
-            "name": "col_boolean"
+            "name": "col_boolean",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "TIMESTAMP_TZ",
             "entity_id": null,
-            "name": "effective_timestamp"
+            "name": "effective_timestamp",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "TIMESTAMP_TZ",
             "entity_id": null,
-            "name": "end_timestamp"
+            "name": "end_timestamp",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "TIMESTAMP",
             "entity_id": null,
-            "name": "date_of_birth"
+            "name": "date_of_birth",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "TIMESTAMP_TZ",
             "entity_id": null,
-            "name": "created_at"
+            "name": "created_at",
+            "timestamp_schema": null
         },
         {
             "critical_data_info": null,
             "description": null,
             "dtype": "INT",
             "entity_id": null,
-            "name": "cust_id"
+            "name": "cust_id",
+            "timestamp_schema": null
         }
     ],
     "current_flag_column": "is_active",

--- a/tests/fixtures/request_payloads/scd_table.json
+++ b/tests/fixtures/request_payloads/scd_table.json
@@ -112,6 +112,5 @@
             "table_name": "scd_table"
         }
     },
-    "timestamp_schema": null,
     "type": "scd_table"
 }

--- a/tests/fixtures/request_payloads/target.json
+++ b/tests/fixtures/request_payloads/target.json
@@ -28,39 +28,48 @@
                     "columns": [
                         {
                             "dtype": "INT",
-                            "name": "col_int"
+                            "name": "col_int",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "FLOAT",
-                            "name": "col_float"
+                            "name": "col_float",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "CHAR",
-                            "name": "col_char"
+                            "name": "col_char",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "VARCHAR",
-                            "name": "col_text"
+                            "name": "col_text",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BINARY",
-                            "name": "col_binary"
+                            "name": "col_binary",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "BOOL",
-                            "name": "col_boolean"
+                            "name": "col_boolean",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "event_timestamp"
+                            "name": "event_timestamp",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "TIMESTAMP_TZ",
-                            "name": "created_at"
+                            "name": "created_at",
+                            "timestamp_schema": null
                         },
                         {
                             "dtype": "INT",
-                            "name": "cust_id"
+                            "name": "cust_id",
+                            "timestamp_schema": null
                         }
                     ],
                     "event_timestamp_timezone_offset": null,

--- a/tests/unit/api/test_change_view.py
+++ b/tests/unit/api/test_change_view.py
@@ -333,6 +333,7 @@ def test_get_change_view__check_entity_id(snowflake_scd_table):
             "entity_id": entity_key.id,
             "name": "col_text",
             "semantic_id": columns_info_dict[0]["semantic_id"],
+            "timestamp_schema": None,
         },
         {
             "critical_data_info": None,
@@ -341,6 +342,7 @@ def test_get_change_view__check_entity_id(snowflake_scd_table):
             "entity_id": entity_eff_ts.id,
             "name": "new_effective_timestamp",
             "semantic_id": columns_info_dict[1]["semantic_id"],
+            "timestamp_schema": None,
         },
         {
             "critical_data_info": None,
@@ -349,6 +351,7 @@ def test_get_change_view__check_entity_id(snowflake_scd_table):
             "entity_id": None,
             "name": "past_effective_timestamp",
             "semantic_id": None,
+            "timestamp_schema": None,
         },
         {
             "critical_data_info": None,
@@ -357,6 +360,7 @@ def test_get_change_view__check_entity_id(snowflake_scd_table):
             "entity_id": entity_change.id,
             "name": "new_col_float",
             "semantic_id": columns_info_dict[3]["semantic_id"],
+            "timestamp_schema": None,
         },
         {
             "critical_data_info": None,
@@ -365,6 +369,7 @@ def test_get_change_view__check_entity_id(snowflake_scd_table):
             "entity_id": None,
             "name": "past_col_float",
             "semantic_id": None,
+            "timestamp_schema": None,
         },
     ]
 

--- a/tests/unit/api/test_dimension_table.py
+++ b/tests/unit/api/test_dimension_table.py
@@ -101,6 +101,7 @@ def dimension_table_dict_fixture(snowflake_database_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -109,6 +110,7 @@ def dimension_table_dict_fixture(snowflake_database_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": "Float column",
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -117,6 +119,7 @@ def dimension_table_dict_fixture(snowflake_database_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": "Char column",
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -125,6 +128,7 @@ def dimension_table_dict_fixture(snowflake_database_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": "Text column",
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -133,6 +137,7 @@ def dimension_table_dict_fixture(snowflake_database_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -141,6 +146,7 @@ def dimension_table_dict_fixture(snowflake_database_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -149,6 +155,7 @@ def dimension_table_dict_fixture(snowflake_database_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": "Timestamp column",
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -157,6 +164,7 @@ def dimension_table_dict_fixture(snowflake_database_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -165,6 +173,7 @@ def dimension_table_dict_fixture(snowflake_database_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
         ],
         "dimension_id_column": "col_int",

--- a/tests/unit/api/test_event_table.py
+++ b/tests/unit/api/test_event_table.py
@@ -62,6 +62,7 @@ def event_table_dict_fixture(snowflake_database_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -70,6 +71,7 @@ def event_table_dict_fixture(snowflake_database_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": "Float column",
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -78,6 +80,7 @@ def event_table_dict_fixture(snowflake_database_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": "Char column",
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -86,6 +89,7 @@ def event_table_dict_fixture(snowflake_database_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": "Text column",
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -94,6 +98,7 @@ def event_table_dict_fixture(snowflake_database_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -102,6 +107,7 @@ def event_table_dict_fixture(snowflake_database_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -110,6 +116,7 @@ def event_table_dict_fixture(snowflake_database_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": "Timestamp column",
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -118,6 +125,7 @@ def event_table_dict_fixture(snowflake_database_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -126,6 +134,7 @@ def event_table_dict_fixture(snowflake_database_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
         ],
         "event_timestamp_column": "event_timestamp",

--- a/tests/unit/api/test_item_table.py
+++ b/tests/unit/api/test_item_table.py
@@ -39,6 +39,7 @@ def item_table_dict_fixture(snowflake_database_table_item_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "dtype": "VARCHAR",
@@ -47,6 +48,7 @@ def item_table_dict_fixture(snowflake_database_table_item_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "dtype": "VARCHAR",
@@ -55,6 +57,7 @@ def item_table_dict_fixture(snowflake_database_table_item_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "dtype": "FLOAT",
@@ -63,6 +66,7 @@ def item_table_dict_fixture(snowflake_database_table_item_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "dtype": "TIMESTAMP_TZ",
@@ -71,6 +75,7 @@ def item_table_dict_fixture(snowflake_database_table_item_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "dtype": "TIMESTAMP_TZ",
@@ -79,6 +84,7 @@ def item_table_dict_fixture(snowflake_database_table_item_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
         ],
         "created_at": None,

--- a/tests/unit/api/test_scd_table.py
+++ b/tests/unit/api/test_scd_table.py
@@ -222,7 +222,6 @@ def scd_table_dict_fixture(snowflake_database_table_scd_table, user_id):
         "created_at": None,
         "updated_at": None,
         "user_id": user_id,
-        "timestamp_schema": None,
         "is_deleted": False,
     }
 

--- a/tests/unit/api/test_scd_table.py
+++ b/tests/unit/api/test_scd_table.py
@@ -120,6 +120,7 @@ def scd_table_dict_fixture(snowflake_database_table_scd_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -128,6 +129,7 @@ def scd_table_dict_fixture(snowflake_database_table_scd_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -136,6 +138,7 @@ def scd_table_dict_fixture(snowflake_database_table_scd_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -144,6 +147,7 @@ def scd_table_dict_fixture(snowflake_database_table_scd_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -152,6 +156,7 @@ def scd_table_dict_fixture(snowflake_database_table_scd_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -160,6 +165,7 @@ def scd_table_dict_fixture(snowflake_database_table_scd_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -168,6 +174,7 @@ def scd_table_dict_fixture(snowflake_database_table_scd_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -176,6 +183,7 @@ def scd_table_dict_fixture(snowflake_database_table_scd_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "critical_data_info": None,
@@ -184,6 +192,7 @@ def scd_table_dict_fixture(snowflake_database_table_scd_table, user_id):
                 "entity_id": None,
                 "name": "date_of_birth",
                 "semantic_id": None,
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -192,6 +201,7 @@ def scd_table_dict_fixture(snowflake_database_table_scd_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "entity_id": None,
@@ -200,6 +210,7 @@ def scd_table_dict_fixture(snowflake_database_table_scd_table, user_id):
                 "semantic_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
         ],
         "natural_key_column": "col_text",
@@ -211,6 +222,7 @@ def scd_table_dict_fixture(snowflake_database_table_scd_table, user_id):
         "created_at": None,
         "updated_at": None,
         "user_id": user_id,
+        "timestamp_schema": None,
         "is_deleted": False,
     }
 

--- a/tests/unit/api/test_table_column.py
+++ b/tests/unit/api/test_table_column.py
@@ -121,6 +121,7 @@ def _check_event_table_with_critical_data_info(event_table):
         "semantic_id": None,
         "critical_data_info": {"cleaning_operations": []},
         "description": None,
+        "timestamp_schema": None,
     }
     assert event_table.frame.node.type == NodeType.INPUT
 

--- a/tests/unit/core/test_frame.py
+++ b/tests/unit/core/test_frame.py
@@ -65,6 +65,7 @@ def test__getitem__list_of_str_key(dataframe):
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
         {
             "name": "VALUE",
@@ -73,6 +74,7 @@ def test__getitem__list_of_str_key(dataframe):
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
     ]
     assert sub_dataframe_dict["node_name"] == "project_1"
@@ -321,6 +323,7 @@ def test_multiple_statements(dataframe):
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
         {
             "name": "PRODUCT_ACTION",
@@ -329,6 +332,7 @@ def test_multiple_statements(dataframe):
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
         {
             "name": "VALUE",
@@ -337,6 +341,7 @@ def test_multiple_statements(dataframe):
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
         {
             "name": "MASK",
@@ -345,6 +350,7 @@ def test_multiple_statements(dataframe):
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
         {
             "name": "TIMESTAMP",
@@ -353,6 +359,7 @@ def test_multiple_statements(dataframe):
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
         {
             "name": "PROMOTION_START_DATE",
@@ -361,6 +368,7 @@ def test_multiple_statements(dataframe):
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
         {
             "name": "amount",
@@ -369,6 +377,7 @@ def test_multiple_statements(dataframe):
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
         {
             "name": "vip_customer",
@@ -377,6 +386,7 @@ def test_multiple_statements(dataframe):
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
     ]
     assert dataframe.columns == [

--- a/tests/unit/models/test_dimension_table.py
+++ b/tests/unit/models/test_dimension_table.py
@@ -26,6 +26,7 @@ def get_dimension_columns_info():
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
         {
             "name": "dimension_id",
@@ -34,6 +35,7 @@ def get_dimension_columns_info():
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
         {
             "name": "created_at",
@@ -42,6 +44,7 @@ def get_dimension_columns_info():
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
     ]
 

--- a/tests/unit/models/test_event_table.py
+++ b/tests/unit/models/test_event_table.py
@@ -31,6 +31,7 @@ def test_event_table_model(snowflake_feature_store, feature_job_setting):
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
         {
             "name": "event_date",
@@ -39,6 +40,7 @@ def test_event_table_model(snowflake_feature_store, feature_job_setting):
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
         {
             "name": "event_id",
@@ -47,6 +49,7 @@ def test_event_table_model(snowflake_feature_store, feature_job_setting):
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
         {
             "name": "created_at",
@@ -55,6 +58,7 @@ def test_event_table_model(snowflake_feature_store, feature_job_setting):
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
     ]
     event_table = EventTableModel(

--- a/tests/unit/models/test_scd_table.py
+++ b/tests/unit/models/test_scd_table.py
@@ -26,6 +26,7 @@ def get_scd_columns_info():
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
         {
             "name": "natural_id",
@@ -34,6 +35,7 @@ def get_scd_columns_info():
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
         {
             "name": "surrogate_id",
@@ -42,6 +44,7 @@ def get_scd_columns_info():
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
         {
             "name": "created_at",
@@ -50,6 +53,7 @@ def get_scd_columns_info():
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
         {
             "name": "effective_at",
@@ -58,6 +62,7 @@ def get_scd_columns_info():
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
         {
             "name": "end_at",
@@ -66,6 +71,7 @@ def get_scd_columns_info():
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
         {
             "name": "enabled",
@@ -74,6 +80,7 @@ def get_scd_columns_info():
             "semantic_id": None,
             "critical_data_info": None,
             "description": None,
+            "timestamp_schema": None,
         },
     ]
 

--- a/tests/unit/query_graph/conftest.py
+++ b/tests/unit/query_graph/conftest.py
@@ -1632,7 +1632,7 @@ def query_graph_single_node(
             "type": "input",
             "parameters": {
                 "type": "event_table",
-                "columns": [{"name": "column", "dtype": "FLOAT"}],
+                "columns": [{"name": "column", "dtype": "FLOAT", "timestamp_schema": None}],
                 "table_details": event_table_details.model_dump(),
                 "feature_store_details": snowflake_feature_store_details_dict,
                 "timestamp_column": None,

--- a/tests/unit/query_graph/model/test_table_data.py
+++ b/tests/unit/query_graph/model/test_table_data.py
@@ -190,9 +190,9 @@ def event_input_node_fixture(feature_store_details, event_table_data):
         "name": "temp",
         "parameters": {
             "columns": [
-                {"name": "event_timestamp", "dtype": "TIMESTAMP"},
-                {"name": "event_id", "dtype": "INT"},
-                {"name": "amount", "dtype": "FLOAT"},
+                {"name": "event_timestamp", "dtype": "TIMESTAMP", "timestamp_schema": None},
+                {"name": "event_id", "dtype": "INT", "timestamp_schema": None},
+                {"name": "amount", "dtype": "FLOAT", "timestamp_schema": None},
             ],
             "feature_store_details": {"type": feature_store_details.type, "details": None},
             "id": event_table_data.id,
@@ -228,9 +228,9 @@ def dimension_input_node_fixture(feature_store_details, dimension_table_data):
         "name": "temp",
         "parameters": {
             "columns": [
-                {"name": "user_id", "dtype": "INT"},
-                {"name": "gender", "dtype": "VARCHAR"},
-                {"name": "age", "dtype": "INT"},
+                {"name": "user_id", "dtype": "INT", "timestamp_schema": None},
+                {"name": "gender", "dtype": "VARCHAR", "timestamp_schema": None},
+                {"name": "age", "dtype": "INT", "timestamp_schema": None},
             ],
             "feature_store_details": {"type": feature_store_details.type, "details": None},
             "id": dimension_table_data.id,
@@ -372,6 +372,7 @@ def test_event_view_graph_node(event_table_data, event_input_node):
                 "entity_id": None,
                 "critical_data_info": None,
                 "description": None,
+                "timestamp_schema": None,
             },
             {
                 "name": "amount",
@@ -385,6 +386,7 @@ def test_event_view_graph_node(event_table_data, event_input_node):
                     ]
                 },
                 "description": None,
+                "timestamp_schema": None,
             },
         ],
     )

--- a/tests/unit/query_graph/model/test_table_data.py
+++ b/tests/unit/query_graph/model/test_table_data.py
@@ -166,8 +166,8 @@ def source_table_input_node_fixture(feature_store_details, source_table_data):
         "name": "temp",
         "parameters": {
             "columns": [
-                {"name": "col_int", "dtype": "INT"},
-                {"name": "col_float", "dtype": "FLOAT"},
+                {"name": "col_int", "dtype": "INT", "timestamp_schema": None},
+                {"name": "col_float", "dtype": "FLOAT", "timestamp_schema": None},
             ],
             "feature_store_details": {"type": feature_store_details.type, "details": None},
             "id": None,

--- a/tests/unit/query_graph/test_graph_node.py
+++ b/tests/unit/query_graph/test_graph_node.py
@@ -20,9 +20,9 @@ def input_node_params_fixture(snowflake_feature_store_details_dict, snowflake_ta
     return {
         "type": "source_table",
         "columns": [
-            {"name": "col_int", "dtype": "INT"},
-            {"name": "col_float", "dtype": "FLOAT"},
-            {"name": "col_varchar", "dtype": "VARCHAR"},
+            {"name": "col_int", "dtype": "INT", "timestamp_schema": None},
+            {"name": "col_float", "dtype": "FLOAT", "timestamp_schema": None},
+            {"name": "col_varchar", "dtype": "VARCHAR", "timestamp_schema": None},
         ],
         "feature_store_details": snowflake_feature_store_details_dict,
         "table_details": snowflake_table_details_dict,

--- a/tests/unit/query_graph/test_query_graph.py
+++ b/tests/unit/query_graph/test_query_graph.py
@@ -343,7 +343,8 @@ def test_query_graph__representation():
                         "columns": [
                             {
                                 "name": "column",
-                                "dtype": "INT"
+                                "dtype": "INT",
+                                "timestamp_schema": null
                             }
                         ],
                         "table_details": {

--- a/tests/unit/routes/test_context.py
+++ b/tests/unit/routes/test_context.py
@@ -125,15 +125,15 @@ class TestContextApi(BaseCatalogApiTestSuite):
             "output_type": "frame",
             "parameters": {
                 "columns": [
-                    {"dtype": "INT", "name": "col_int"},
-                    {"dtype": "FLOAT", "name": "col_float"},
-                    {"dtype": "CHAR", "name": "col_char"},
-                    {"dtype": "VARCHAR", "name": "col_text"},
-                    {"dtype": "BINARY", "name": "col_binary"},
-                    {"dtype": "BOOL", "name": "col_boolean"},
-                    {"dtype": "TIMESTAMP", "name": "event_timestamp"},
-                    {"dtype": "TIMESTAMP", "name": "created_at"},
-                    {"dtype": "INT", "name": "cust_id"},
+                    {"dtype": "INT", "name": "col_int", "timestamp_schema": None},
+                    {"dtype": "FLOAT", "name": "col_float", "timestamp_schema": None},
+                    {"dtype": "CHAR", "name": "col_char", "timestamp_schema": None},
+                    {"dtype": "VARCHAR", "name": "col_text", "timestamp_schema": None},
+                    {"dtype": "BINARY", "name": "col_binary", "timestamp_schema": None},
+                    {"dtype": "BOOL", "name": "col_boolean", "timestamp_schema": None},
+                    {"dtype": "TIMESTAMP", "name": "event_timestamp", "timestamp_schema": None},
+                    {"dtype": "TIMESTAMP", "name": "created_at", "timestamp_schema": None},
+                    {"dtype": "INT", "name": "cust_id", "timestamp_schema": None},
                 ],
                 "feature_store_details": {
                     "details": {

--- a/tests/unit/routes/test_feature_store.py
+++ b/tests/unit/routes/test_feature_store.py
@@ -364,6 +364,7 @@ class TestFeatureStoreApi(BaseApiTestSuite):
                 "entity_id": None,
                 "name": "a",
                 "semantic_id": None,
+                "timestamp_schema": None,
             },
             {
                 "critical_data_info": None,
@@ -372,6 +373,7 @@ class TestFeatureStoreApi(BaseApiTestSuite):
                 "entity_id": None,
                 "name": "b",
                 "semantic_id": None,
+                "timestamp_schema": None,
             },
             {
                 "critical_data_info": None,
@@ -380,6 +382,7 @@ class TestFeatureStoreApi(BaseApiTestSuite):
                 "entity_id": None,
                 "name": "c",
                 "semantic_id": None,
+                "timestamp_schema": None,
             },
         ]
 

--- a/tests/unit/routes/test_target_table.py
+++ b/tests/unit/routes/test_target_table.py
@@ -111,8 +111,13 @@ class TestTargetTableApi(BaseMaterializedTableTestSuite):
             "block_modification_by": [],
             "catalog_id": catalog_id,
             "columns_info": [
-                {"dtype": "TIMESTAMP", "entity_id": None, "name": "POINT_IN_TIME"},
-                {"dtype": "INT", "entity_id": None, "name": "cust_id"},
+                {
+                    "dtype": "TIMESTAMP",
+                    "entity_id": None,
+                    "name": "POINT_IN_TIME",
+                    "timestamp_schema": None,
+                },
+                {"dtype": "INT", "entity_id": None, "name": "cust_id", "timestamp_schema": None},
             ],
             "context_id": None,
             "created_at": json_dict["created_at"],


### PR DESCRIPTION
## Description

Add `timestamp_schema` field in `ColumnSpec` and node hash handling. This field will be populated in a subsequent PR for relevant tables such as `SCDTable`.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
