### PR TITLE
[chore] Add try-catch to model deserialization (catalog cleanup task)

### DIFF
--- a/featurebyte/worker/task/catalog_cleanup.py
+++ b/featurebyte/worker/task/catalog_cleanup.py
@@ -273,6 +273,9 @@ class CatalogCleanupTask(BaseTask[CatalogCleanupTaskPayload]):
                     warehouse_tables.update(obj.warehouse_tables)
                     remote_file_paths.update(obj.remote_storage_paths)
                 except ValidationError as exc:
+                    if is_development_mode():
+                        raise
+
                     # failed to parse the document, probably due to schema changes
                     logger.info(
                         "Failed to parse document %s (%s): %s",

--- a/featurebyte/worker/task/catalog_cleanup.py
+++ b/featurebyte/worker/task/catalog_cleanup.py
@@ -12,6 +12,8 @@ from functools import cached_property
 from pathlib import Path
 from typing import Any, Type
 
+from pydantic import ValidationError
+
 import featurebyte.models
 from featurebyte.common.env_util import is_development_mode
 from featurebyte.common.progress import ProgressCallbackType, get_ranged_progress_callback
@@ -265,10 +267,20 @@ class CatalogCleanupTask(BaseTask[CatalogCleanupTaskPayload]):
             warehouse_tables = set()
             remote_file_paths = set()
             async for doc_dict in docs:
-                obj = model_class(**doc_dict)
-                assert isinstance(obj, FeatureByteCatalogBaseDocumentModel)
-                warehouse_tables.update(obj.warehouse_tables)
-                remote_file_paths.update(obj.remote_storage_paths)
+                try:
+                    obj = model_class(**doc_dict)
+                    assert isinstance(obj, FeatureByteCatalogBaseDocumentModel)
+                    warehouse_tables.update(obj.warehouse_tables)
+                    remote_file_paths.update(obj.remote_storage_paths)
+                except ValidationError as exc:
+                    # failed to parse the document, probably due to schema changes
+                    logger.info(
+                        "Failed to parse document %s (%s): %s",
+                        collection_name,
+                        doc_dict["_id"],
+                        exc,
+                    )
+                    pass
 
             # cleanup the warehouse tables & remote files
             await mongo_progress_callback(


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
This PR adds try-catch to model deserialization in catalog cleanup task. By doing so, older records that break backward compatibility won't block the catalog cleanup task.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
