### PR TITLE
[chore] Avoid freezegun causing pydantic error when running tests locally

### DIFF
--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -542,3 +542,15 @@ def patch_alive_progress_fixture():
     yield patched
     for patcher in started_patchers:
         patcher.stop()
+
+
+@pytest.fixture
+def freeze_time_observation_table_task():
+    """
+    Freeze time for ObservationTableTask due to freezegun not working well with pydantic in some
+    cases (in this case, apparently only the ObservationTableTask)
+    """
+    frozen_datetime = "2011-03-08T15:37:00"
+    with patch("featurebyte.worker.task.observation_table.datetime") as mock_datetime:
+        mock_datetime.utcnow.return_value = pd.Timestamp(frozen_datetime).to_pydatetime()
+        yield

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -542,15 +542,3 @@ def patch_alive_progress_fixture():
     yield patched
     for patcher in started_patchers:
         patcher.stop()
-
-
-@pytest.fixture
-def freeze_time_observation_table_task():
-    """
-    Freeze time for ObservationTableTask due to freezegun not working well with pydantic in some
-    cases (in this case, apparently only the ObservationTableTask)
-    """
-    frozen_datetime = "2011-03-08T15:37:00"
-    with patch("featurebyte.worker.task.observation_table.datetime") as mock_datetime:
-        mock_datetime.utcnow.return_value = pd.Timestamp(frozen_datetime).to_pydatetime()
-        yield

--- a/tests/unit/api/test_event_view.py
+++ b/tests/unit/api/test_event_view.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from unittest import mock
 from unittest.mock import AsyncMock, patch
 
-import freezegun
 import pandas as pd
 import pytest
 from bson import ObjectId
@@ -837,7 +836,6 @@ def test_sdk_code_generation(saved_event_table, update_fixtures):
 
 
 @pytest.mark.usefixtures("patched_observation_table_service")
-@freezegun.freeze_time("2011-03-08T15:37:00")
 def test_create_observation_table_from_event_view__no_sample(
     snowflake_event_table, snowflake_execute_query, catalog, cust_id_entity
 ):
@@ -905,7 +903,6 @@ def test_create_observation_table_from_event_view__no_sample(
 
 
 @pytest.mark.usefixtures("patched_observation_table_service")
-@freezegun.freeze_time("2011-03-08T15:37:00")
 def test_create_observation_table_from_event_view__with_sample(
     snowflake_event_table_with_entity, snowflake_execute_query, cust_id_entity
 ):

--- a/tests/unit/api/test_source_table.py
+++ b/tests/unit/api/test_source_table.py
@@ -4,7 +4,6 @@ Unit test for SourceTable
 
 from unittest.mock import AsyncMock, Mock, patch
 
-import freezegun
 import pandas as pd
 import pytest
 
@@ -192,7 +191,6 @@ def test_get_or_create_scd_table__create(snowflake_database_table_scd_table, cat
 
 
 @pytest.mark.usefixtures("patched_observation_table_service")
-@freezegun.freeze_time("2011-03-08T15:37:00")
 def test_create_observation_table(
     snowflake_database_table, snowflake_execute_query, catalog, cust_id_entity, mock_log_handler
 ):
@@ -201,12 +199,14 @@ def test_create_observation_table(
     """
     _ = catalog
 
-    observation_table = snowflake_database_table.create_observation_table(
-        "my_observation_table",
-        columns=["event_timestamp", "cust_id"],
-        columns_rename_mapping={"event_timestamp": "POINT_IN_TIME"},
-        primary_entities=[cust_id_entity.name],
-    )
+    with patch("featurebyte.worker.task.observation_table.datetime") as mock_datetime:
+        mock_datetime.utcnow.return_value = pd.Timestamp("2011-03-08T15:37:00").to_pydatetime()
+        observation_table = snowflake_database_table.create_observation_table(
+            "my_observation_table",
+            columns=["event_timestamp", "cust_id"],
+            columns_rename_mapping={"event_timestamp": "POINT_IN_TIME"},
+            primary_entities=[cust_id_entity.name],
+        )
 
     # Check return type
     assert isinstance(observation_table, ObservationTable)
@@ -252,22 +252,23 @@ def test_create_observation_table(
 
 
 @pytest.mark.usefixtures("patched_observation_table_service")
-@freezegun.freeze_time("2011-03-08T15:37:00")
 def test_create_observation_table_with_sample_rows(
     snowflake_database_table, snowflake_execute_query, catalog
 ):
     """
     Test creating ObservationTable from SourceTable with sampling
     """
-    with patch(
-        "featurebyte.models.request_input.BaseRequestInput.get_row_count",
-        AsyncMock(return_value=1000),
-    ):
-        observation_table = snowflake_database_table.create_observation_table(
-            "my_observation_table",
-            sample_rows=100,
-            columns_rename_mapping={"event_timestamp": "POINT_IN_TIME"},
-        )
+    with patch("featurebyte.worker.task.observation_table.datetime") as mock_datetime:
+        mock_datetime.utcnow.return_value = pd.Timestamp("2011-03-08T15:37:00").to_pydatetime()
+        with patch(
+            "featurebyte.models.request_input.BaseRequestInput.get_row_count",
+            AsyncMock(return_value=1000),
+        ):
+            observation_table = snowflake_database_table.create_observation_table(
+                "my_observation_table",
+                sample_rows=100,
+                columns_rename_mapping={"event_timestamp": "POINT_IN_TIME"},
+            )
 
     # Check return type
     assert isinstance(observation_table, ObservationTable)

--- a/tests/unit/api/test_source_table.py
+++ b/tests/unit/api/test_source_table.py
@@ -190,7 +190,7 @@ def test_get_or_create_scd_table__create(snowflake_database_table_scd_table, cat
     assert scd_table.current_flag_column == "is_active"
 
 
-@pytest.mark.usefixtures("patched_observation_table_service", "freeze_time_observation_table_task")
+@pytest.mark.usefixtures("patched_observation_table_service")
 def test_create_observation_table(
     snowflake_database_table, snowflake_execute_query, catalog, cust_id_entity, mock_log_handler
 ):
@@ -249,7 +249,7 @@ def test_create_observation_table(
     )
 
 
-@pytest.mark.usefixtures("patched_observation_table_service", "freeze_time_observation_table_task")
+@pytest.mark.usefixtures("patched_observation_table_service")
 def test_create_observation_table_with_sample_rows(
     snowflake_database_table, snowflake_execute_query, catalog
 ):

--- a/tests/unit/api/test_source_table.py
+++ b/tests/unit/api/test_source_table.py
@@ -4,7 +4,6 @@ Unit test for SourceTable
 
 from unittest.mock import AsyncMock, Mock, patch
 
-import freezegun
 import pandas as pd
 import pytest
 
@@ -191,8 +190,7 @@ def test_get_or_create_scd_table__create(snowflake_database_table_scd_table, cat
     assert scd_table.current_flag_column == "is_active"
 
 
-@pytest.mark.usefixtures("patched_observation_table_service")
-@freezegun.freeze_time("2011-03-08T15:37:00")
+@pytest.mark.usefixtures("patched_observation_table_service", "freeze_time_observation_table_task")
 def test_create_observation_table(
     snowflake_database_table, snowflake_execute_query, catalog, cust_id_entity, mock_log_handler
 ):
@@ -251,8 +249,7 @@ def test_create_observation_table(
     )
 
 
-@pytest.mark.usefixtures("patched_observation_table_service")
-@freezegun.freeze_time("2011-03-08T15:37:00")
+@pytest.mark.usefixtures("patched_observation_table_service", "freeze_time_observation_table_task")
 def test_create_observation_table_with_sample_rows(
     snowflake_database_table, snowflake_execute_query, catalog
 ):

--- a/tests/unit/api/test_time_series_view.py
+++ b/tests/unit/api/test_time_series_view.py
@@ -6,7 +6,6 @@ import textwrap
 from unittest import mock
 from unittest.mock import AsyncMock, patch
 
-import freezegun
 import pandas as pd
 import pytest
 
@@ -315,8 +314,7 @@ def test_sdk_code_generation(saved_time_series_table, update_fixtures):
     )
 
 
-@pytest.mark.usefixtures("patched_observation_table_service")
-@freezegun.freeze_time("2011-03-08T15:37:00")
+@pytest.mark.usefixtures("patched_observation_table_service", "freeze_time_observation_table_task")
 def test_create_observation_table_from_time_series_view__no_sample(
     snowflake_time_series_table, snowflake_execute_query, catalog, cust_id_entity
 ):
@@ -382,10 +380,11 @@ def test_create_observation_table_from_time_series_view__no_sample(
     )
 
 
-@pytest.mark.usefixtures("patched_observation_table_service")
-@freezegun.freeze_time("2011-03-08T15:37:00")
+@pytest.mark.usefixtures("patched_observation_table_service", "freeze_time_observation_table_task")
 def test_create_observation_table_from_time_series_view__with_sample(
-    snowflake_time_series_table_with_entity, snowflake_execute_query, cust_id_entity
+    snowflake_time_series_table_with_entity,
+    snowflake_execute_query,
+    cust_id_entity,
 ):
     """
     Test creating ObservationTable from an TimeSeriesView

--- a/tests/unit/api/test_time_series_view.py
+++ b/tests/unit/api/test_time_series_view.py
@@ -314,7 +314,7 @@ def test_sdk_code_generation(saved_time_series_table, update_fixtures):
     )
 
 
-@pytest.mark.usefixtures("patched_observation_table_service", "freeze_time_observation_table_task")
+@pytest.mark.usefixtures("patched_observation_table_service")
 def test_create_observation_table_from_time_series_view__no_sample(
     snowflake_time_series_table, snowflake_execute_query, catalog, cust_id_entity
 ):
@@ -380,7 +380,7 @@ def test_create_observation_table_from_time_series_view__no_sample(
     )
 
 
-@pytest.mark.usefixtures("patched_observation_table_service", "freeze_time_observation_table_task")
+@pytest.mark.usefixtures("patched_observation_table_service")
 def test_create_observation_table_from_time_series_view__with_sample(
     snowflake_time_series_table_with_entity,
     snowflake_execute_query,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1542,8 +1542,20 @@ def snowflake_scd_view_with_entity_fixture(snowflake_scd_table_with_entity):
     return snowflake_scd_table_with_entity.get_view()
 
 
+@pytest.fixture(name="freeze_time_observation_table_task")
+def freeze_time_observation_table_task_fixture():
+    """
+    Freeze time for ObservationTableTask due to freezegun not working well with pydantic in some
+    cases (in this case, apparently only the ObservationTableTask)
+    """
+    frozen_datetime = "2011-03-08T15:37:00"
+    with patch("featurebyte.worker.task.observation_table.datetime") as mock_datetime:
+        mock_datetime.utcnow.return_value = pd.Timestamp(frozen_datetime).to_pydatetime()
+        yield
+
+
 @pytest.fixture(name="patched_observation_table_service")
-def patched_observation_table_service_fixture():
+def patched_observation_table_service_fixture(freeze_time_observation_table_task):
     """
     Patch ObservationTableService.validate_materialized_table_and_get_metadata
     """


### PR DESCRIPTION
## Description

Workaround to avoid these errors when running the tests locally:

```
FAILED tests/unit/api/test_source_table.py::test_create_observation_table - featurebyte.exception.RecordCreationException: Unable to generate pydantic-core schema for <class 'datetime.datetime'>. Set `arbitrary_types_allowed=True` in the model_config to ignore this error or implement `__get_pydantic_core_schema__` on your type to full...
FAILED tests/unit/api/test_source_table.py::test_create_observation_table_with_sample_rows - featurebyte.exception.RecordCreationException: Unable to generate pydantic-core schema for <class 'datetime.datetime'>. Set `arbitrary_types_allowed=True` in the model_config to ignore this error or implement `__get_pydantic_core_schema__` on your type to full...
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
