### PR TITLE
[DEV-3933] Fix concurrent materialization of feature lists with overlapping features

### DIFF
--- a/.changelog/DEV-3933.yaml
+++ b/.changelog/DEV-3933.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix concurrent materialization of feature lists with overlapping features"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -398,8 +398,10 @@ class FeatureTableCacheService:
                 if definition.feature_name is not None
                 and definition.feature_name.upper() not in existing_columns
             ]
-            await db_session.execute_query_long_running(
-                adapter.alter_table_add_columns(table_expr, columns_expr)
+            # While "column already exist" error is not expected, still retry to handle other errors
+            # such as rate limiting (occurring in tests for BigQuery)
+            await db_session.retry_sql(
+                adapter.alter_table_add_columns(table_expr, columns_expr),
             )
 
     async def _materialize_and_update_cache(  # pylint: disable=too-many-arguments

--- a/tests/integration/api/test_historical_features.py
+++ b/tests/integration/api/test_historical_features.py
@@ -85,7 +85,12 @@ async def test_get_historical_feature_tables_parallel(
         feature_table_name = f"my_feature_table_{i}"
         feature_table = fb.HistoricalFeatureTable.get(feature_table_name)
         df_preview = feature_table.preview()
-        assert df_preview.columns.tolist() == ["POINT_IN_TIME", "üser id", f"my_feature_{i}"]
+        assert df_preview.columns.tolist() == [
+            "POINT_IN_TIME",
+            "üser id",
+            "common_feature",
+            f"my_feature_{i}",
+        ]
 
     # Check feature cache metadata and table are expected
     cached_definitions = await feature_table_cache_metadata_service.get_cached_definitions(


### PR DESCRIPTION
## Description

This fixes an error that can occur on concurrent materialization of feature lists with overlapping features. The fix ensures that we only insert non-existing columns when updating the columns of a feature cache table.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
