### PR TITLE
[chore] Add more validation for Time Series Table reference datetime schema

### DIFF
--- a/featurebyte/query_graph/model/timestamp_schema.py
+++ b/featurebyte/query_graph/model/timestamp_schema.py
@@ -21,7 +21,6 @@ class TimeZoneColumn(FeatureByteBaseModel):
 
     column_name: str
     type: Literal["offset", "timezone"]
-    format_string: Optional[str] = None
 
 
 class TimestampSchema(FeatureByteBaseModel):

--- a/featurebyte/service/time_series_table.py
+++ b/featurebyte/service/time_series_table.py
@@ -4,7 +4,9 @@ TimeSeriesTableService class
 
 from __future__ import annotations
 
+from featurebyte.exception import DocumentCreationError
 from featurebyte.models.time_series_table import TimeSeriesTableModel
+from featurebyte.query_graph.sql.adapter import get_sql_adapter
 from featurebyte.schema.time_series_table import TimeSeriesTableCreate, TimeSeriesTableServiceUpdate
 from featurebyte.service.base_table_document import BaseTableDocumentService
 
@@ -24,3 +26,20 @@ class TimeSeriesTableService(
     @property
     def class_name(self) -> str:
         return "TimeSeriesTable"
+
+    async def create_document(self, data: TimeSeriesTableCreate) -> TimeSeriesTableModel:
+        # retrieve feature store to check the feature_store_id is valid
+        feature_store = await self.feature_store_service.get_document(
+            document_id=data.tabular_source.feature_store_id
+        )
+        # check whether the document has time schema in the columns with string type
+        sql_adapter = get_sql_adapter(source_info=feature_store.get_source_info())
+
+        # if reference datetime column has a format string ensure it does not contain timezone information
+        if data.reference_datetime_schema.format_string is not None:
+            if sql_adapter.format_string_has_timezone(data.reference_datetime_schema.format_string):
+                raise DocumentCreationError(
+                    "Timezone information in time series table reference datetime column is not supported."
+                )
+
+        return await super().create_document(data=data)

--- a/tests/unit/routes/test_time_series_table.py
+++ b/tests/unit/routes/test_time_series_table.py
@@ -496,3 +496,18 @@ class TestTimeSeriesTableApi(BaseTableApiTestSuite):
         # check deleted table
         response = test_api_client.get(f"{self.base_route}/{doc_id}")
         assert response.status_code == HTTPStatus.NOT_FOUND, response.json()
+
+    def test_create_with_unsupported_reference_timestamp_schema(self, test_api_client_persistent):
+        """
+        Test create with unsupported reference timestamp schema
+        """
+        test_api_client, _ = test_api_client_persistent
+        payload = self.payload.copy()
+        payload["reference_datetime_schema"]["format_string"] = "YYYY-MM-DD HH:MM:SS TZH:TZM"
+        response = test_api_client.post(self.base_route, json=payload)
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        response_json = response.json()
+        assert (
+            response_json["detail"]
+            == "Timezone information in time series table reference datetime column is not supported."
+        )


### PR DESCRIPTION

- Remove format_string from TimeZoneColumn 
- Add more validation for Time Series Table reference datetime schema to ensure timestamp does not contain timezone information

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
