### PR TITLE
[DEV-3930] Rework CronHelper to match usage pattern in get_historical_features

### DIFF
--- a/featurebyte/models/periodic_task.py
+++ b/featurebyte/models/periodic_task.py
@@ -40,6 +40,26 @@ class Crontab(FeatureByteBaseModel):
     month_of_year: Union[str, int]
     day_of_week: Union[str, int]
 
+    def __hash__(self) -> int:
+        return hash((
+            self.minute,
+            self.hour,
+            self.day_of_month,
+            self.month_of_year,
+            self.day_of_week,
+        ))
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Crontab):
+            return False
+        return (
+            self.minute == other.minute
+            and self.hour == other.hour
+            and self.day_of_month == other.day_of_month
+            and self.month_of_year == other.month_of_year
+            and self.day_of_week == other.day_of_week
+        )
+
 
 class PeriodicTask(FeatureByteCatalogBaseDocumentModel):
     """

--- a/featurebyte/query_graph/model/feature_job_setting.py
+++ b/featurebyte/query_graph/model/feature_job_setting.py
@@ -287,6 +287,14 @@ class CronFeatureJobSetting(FeatureByteBaseModel):
 
         return self
 
+    def __hash__(self) -> int:
+        return hash((self.crontab, self.timezone))
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, CronFeatureJobSetting):
+            return False
+        return self.crontab == other.crontab and self.timezone == other.timezone
+
 
 def feature_job_setting_discriminator(value: Any) -> Literal["interval", "cron"]:
     """

--- a/featurebyte/query_graph/sql/cron.py
+++ b/featurebyte/query_graph/sql/cron.py
@@ -64,6 +64,27 @@ def get_cron_feature_job_settings(
     return list(cron_feature_job_settings)
 
 
+def get_request_table_with_job_schedule_name(
+    request_table_name: str, feature_job_setting: CronFeatureJobSetting
+) -> str:
+    """
+    Get the name of the request table with the cron job schedule
+
+    Parameters
+    ----------
+    request_table_name: str
+        Request table name
+    feature_job_setting: CronFeatureJobSetting
+        Cron feature job setting to simulate
+
+    Returns
+    -------
+    str
+        Request table name with the cron job schedule
+    """
+    return f"{request_table_name}_{feature_job_setting.get_cron_expression()}_{feature_job_setting.timezone}"
+
+
 def get_request_table_joined_job_schedule_expr(
     request_table_name: str,
     request_table_columns: list[str],

--- a/featurebyte/query_graph/sql/cron.py
+++ b/featurebyte/query_graph/sql/cron.py
@@ -1,0 +1,154 @@
+"""
+Helpers for SQL generation related to cron feature jobs
+"""
+
+from dataclasses import dataclass
+
+from sqlglot import expressions
+
+from featurebyte.enum import InternalName, SpecialColumnName
+from featurebyte.query_graph.enum import NodeType
+from featurebyte.query_graph.graph import QueryGraph
+from featurebyte.query_graph.model.feature_job_setting import CronFeatureJobSetting
+from featurebyte.query_graph.node import Node
+from featurebyte.query_graph.node.generic import TimeSeriesWindowAggregateNode
+from featurebyte.query_graph.sql.adapter import BaseAdapter
+from featurebyte.query_graph.sql.common import quoted_identifier
+from featurebyte.query_graph.sql.scd_helper import Table, get_scd_join_expr
+
+
+@dataclass
+class JobScheduleTable:
+    """
+    Represents a registered job schedule table
+    """
+
+    table_name: str
+    cron_feature_job_setting: CronFeatureJobSetting
+
+
+@dataclass
+class JobScheduleTableSet:
+    """
+    Represents a collection of registered job schedule tables
+    """
+
+    tables: list[JobScheduleTable]
+
+    def get_table_name_for_cron_expression(self, cron_expression: str) -> str:
+        """
+        Get the table name for a given cron expression
+
+        Parameters
+        ----------
+        cron_expression: str
+            Cron expression
+
+        Returns
+        -------
+        str
+            Table name for the cron expression
+        """
+        for table in self.tables:
+            if table.cron_feature_job_setting.get_cron_expression() == cron_expression:
+                return table.table_name
+        raise ValueError(f"No table found for cron expression: {cron_expression}")
+
+
+def get_cron_feature_job_settings(
+    graph: QueryGraph, nodes: list[Node]
+) -> list[CronFeatureJobSetting]:
+    """
+    Get the unique cron feature job settings from the time series window aggregate nodes
+
+    Parameters
+    ----------
+    graph: QueryGraph
+        Query graph
+    nodes: list[Node]
+        List of nodes
+
+    Returns
+    -------
+    list[CronFeatureJobSetting]
+    """
+    cron_feature_job_settings = set()
+    for node in nodes:
+        for time_series_agg_node in graph.iterate_nodes(
+            node, NodeType.TIME_SERIES_WINDOW_AGGREGATE
+        ):
+            assert isinstance(time_series_agg_node, TimeSeriesWindowAggregateNode)
+            cron_feature_job_setting = time_series_agg_node.parameters.feature_job_setting
+            cron_feature_job_settings.add(cron_feature_job_setting)
+    return list(cron_feature_job_settings)
+
+
+def get_request_table_with_job_schedule_name(
+    request_table_name: str, feature_job_setting: CronFeatureJobSetting
+) -> str:
+    """
+    Get the name of the request table with the cron job schedule
+
+    Parameters
+    ----------
+    request_table_name: str
+        Request table name
+    feature_job_setting: CronFeatureJobSetting
+        Cron feature job setting to simulate
+
+    Returns
+    -------
+    str
+        Request table name with the cron job schedule
+    """
+    return f"{request_table_name}_{feature_job_setting.get_sanitized_cron_expression()}"
+
+
+def get_request_table_joined_job_schedule_expr(
+    request_table_name: str,
+    request_table_columns: list[str],
+    job_schedule_table_name: str,
+    adapter: BaseAdapter,
+) -> expressions.Select:
+    """
+    Get the sql expression that constructs a new request table by joining each row in the request
+    table to the latest row in the cron job schedule table where the job datetime is before the
+    point in time.
+
+    Parameters
+    ----------
+    request_table_name: str
+        Request table name
+    request_table_columns: list[str]
+        Request table columns
+    job_schedule_table_name: str
+        Job schedule table name
+    adapter: BaseAdapter
+        SQL adapter
+
+    Returns
+    -------
+    expressions.Select
+    """
+    left_table = Table(
+        expr=quoted_identifier(request_table_name),
+        timestamp_column=SpecialColumnName.POINT_IN_TIME,
+        join_keys=[],
+        input_columns=request_table_columns,
+        output_columns=request_table_columns,
+    )
+    right_table = Table(
+        expr=quoted_identifier(job_schedule_table_name),
+        timestamp_column=InternalName.CRON_JOB_SCHEDULE_DATETIME_UTC,
+        join_keys=[],
+        input_columns=[InternalName.CRON_JOB_SCHEDULE_DATETIME],
+        output_columns=[InternalName.CRON_JOB_SCHEDULE_DATETIME],
+    )
+    joined_expr = get_scd_join_expr(
+        left_table=left_table,
+        right_table=right_table,
+        join_type="left",
+        adapter=adapter,
+        allow_exact_match=False,
+    )
+    return joined_expr

--- a/featurebyte/query_graph/sql/cron.py
+++ b/featurebyte/query_graph/sql/cron.py
@@ -35,25 +35,6 @@ class JobScheduleTableSet:
 
     tables: list[JobScheduleTable]
 
-    def get_table_name_for_cron_expression(self, cron_expression: str) -> str:
-        """
-        Get the table name for a given cron expression
-
-        Parameters
-        ----------
-        cron_expression: str
-            Cron expression
-
-        Returns
-        -------
-        str
-            Table name for the cron expression
-        """
-        for table in self.tables:
-            if table.cron_feature_job_setting.get_cron_expression() == cron_expression:
-                return table.table_name
-        raise ValueError(f"No table found for cron expression: {cron_expression}")
-
 
 def get_cron_feature_job_settings(
     graph: QueryGraph, nodes: list[Node]
@@ -81,27 +62,6 @@ def get_cron_feature_job_settings(
             cron_feature_job_setting = time_series_agg_node.parameters.feature_job_setting
             cron_feature_job_settings.add(cron_feature_job_setting)
     return list(cron_feature_job_settings)
-
-
-def get_request_table_with_job_schedule_name(
-    request_table_name: str, feature_job_setting: CronFeatureJobSetting
-) -> str:
-    """
-    Get the name of the request table with the cron job schedule
-
-    Parameters
-    ----------
-    request_table_name: str
-        Request table name
-    feature_job_setting: CronFeatureJobSetting
-        Cron feature job setting to simulate
-
-    Returns
-    -------
-    str
-        Request table name with the cron job schedule
-    """
-    return f"{request_table_name}_{feature_job_setting.get_sanitized_cron_expression()}"
 
 
 def get_request_table_joined_job_schedule_expr(

--- a/tests/unit/query_graph/sql/test_cron.py
+++ b/tests/unit/query_graph/sql/test_cron.py
@@ -1,0 +1,36 @@
+"""
+Tests for featurebyte/query_graph/sql/cron.py
+"""
+
+from featurebyte import CronFeatureJobSetting, Crontab
+from featurebyte.query_graph.sql.cron import (
+    get_cron_feature_job_settings,
+    get_request_table_with_job_schedule_name,
+)
+
+
+def test_get_cron_feature_job_settings(global_graph, time_series_window_aggregate_feature_node):
+    """
+    Test get_cron_feature_job_settings
+    """
+    cron_feature_job_settings = get_cron_feature_job_settings(
+        global_graph,
+        [time_series_window_aggregate_feature_node, time_series_window_aggregate_feature_node],
+    )
+    assert cron_feature_job_settings == [
+        CronFeatureJobSetting(
+            crontab=Crontab(minute=0, hour=0, day_of_month="*", month_of_year="*", day_of_week="*"),
+            timezone="Etc/UTC",
+        )
+    ]
+
+
+def test_get_request_table_with_job_schedule_name():
+    """
+    Test get_request_table_with_job_schedule_name
+    """
+    table_name = get_request_table_with_job_schedule_name(
+        "request_table",
+        CronFeatureJobSetting(crontab="0 0 * * *", timezone="Asia/Singapore"),
+    )
+    assert table_name == "request_table_0 0 * * *_Asia/Singapore"


### PR DESCRIPTION
## Description

This updates `CronHelper` so that it can be more easily used in `get_historical_features` in a subsequent PR.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
