### PR TITLE
[DEV-3945] Validate calendar window unit is compatible with time interval

### DIFF
--- a/featurebyte/enum.py
+++ b/featurebyte/enum.py
@@ -114,20 +114,20 @@ class StrEnum(str, Enum):
         return str(self.value)
 
 
-class TimeIntervalUnit(StrEnum):
+class TimeIntervalUnit(OrderedStrEnum):
     """
     The TimeIntervalUnit enum class specifies supported time interval units
     """
 
     __fbautodoc__ = FBAutoDoc(proxy_class="featurebyte.TimeIntervalUnit")
 
-    MINUTE = "MINUTE", "minute"
-    HOUR = "HOUR", "hour"
-    DAY = "DAY", "day"
-    WEEK = "WEEK", "week"
-    MONTH = "MONTH", "month"
-    QUARTER = "QUARTER", "quarter"
-    YEAR = "YEAR", "year"
+    MINUTE = "MINUTE"
+    HOUR = "HOUR"
+    DAY = "DAY"
+    WEEK = "WEEK"
+    MONTH = "MONTH"
+    QUARTER = "QUARTER"
+    YEAR = "YEAR"
 
 
 class DBVarType(StrEnum):

--- a/tests/unit/api/test_aggregate_over.py
+++ b/tests/unit/api/test_aggregate_over.py
@@ -315,27 +315,46 @@ def test_time_series_view_aggregate_over__only_feature_window(
     assert str(exc_info.value) == expected
 
 
-def test_time_series_view_aggregate_over__invalid_window_unit(
-    snowflake_time_series_view_with_entity,
+@pytest.mark.parametrize(
+    "window_unit, is_allowed",
+    [
+        ("MINUTE", False),
+        ("HOUR", False),
+        ("DAY", True),
+        ("MONTH", True),
+        ("QUARTER", True),
+        ("YEAR", True),
+    ],
+)
+def test_time_series_view_aggregate_over__validate_window_unit(
+    snowflake_time_series_view_with_entity, window_unit, is_allowed
 ):
     """
-    Test aggregate_over for time series view only accepts CronFeatureJobSetting
+    Test aggregate_over for time series view validates the compatibility between table's time
+    interval and window unit
     """
     view = snowflake_time_series_view_with_entity
-    with pytest.raises(ValueError) as exc_info:
+
+    def do_aggregate_over():
         _ = view.groupby("store_id").aggregate_over(
             value_column="col_float",
             method="sum",
-            windows=[CalendarWindow(unit="HOUR", size=3)],
-            feature_names=["col_float_sum_3hour"],
+            windows=[CalendarWindow(unit=window_unit, size=3)],
+            feature_names=["col_float_sum"],
             feature_job_setting=CronFeatureJobSetting(
                 crontab="0 8 1 * *",
             ),
         )
-    assert (
-        str(exc_info.value)
-        == "Window unit HOUR cannot be smaller than the table's time interval unit DAY"
-    )
+
+    if not is_allowed:
+        with pytest.raises(ValueError) as exc_info:
+            do_aggregate_over()
+        assert (
+            str(exc_info.value)
+            == f"Window unit {window_unit} cannot be smaller than the table's time interval unit DAY"
+        )
+    else:
+        do_aggregate_over()
 
 
 @pytest.mark.parametrize("is_offset", [True, False])

--- a/tests/unit/api/test_aggregate_over.py
+++ b/tests/unit/api/test_aggregate_over.py
@@ -315,6 +315,29 @@ def test_time_series_view_aggregate_over__only_feature_window(
     assert str(exc_info.value) == expected
 
 
+def test_time_series_view_aggregate_over__invalid_window_unit(
+    snowflake_time_series_view_with_entity,
+):
+    """
+    Test aggregate_over for time series view only accepts CronFeatureJobSetting
+    """
+    view = snowflake_time_series_view_with_entity
+    with pytest.raises(ValueError) as exc_info:
+        _ = view.groupby("store_id").aggregate_over(
+            value_column="col_float",
+            method="sum",
+            windows=[CalendarWindow(unit="HOUR", size=3)],
+            feature_names=["col_float_sum_3hour"],
+            feature_job_setting=CronFeatureJobSetting(
+                crontab="0 8 1 * *",
+            ),
+        )
+    assert (
+        str(exc_info.value)
+        == "Window unit HOUR cannot be smaller than the table's time interval unit DAY"
+    )
+
+
 @pytest.mark.parametrize("is_offset", [True, False])
 def test_non_time_series_view_aggregate_over__only_str_window(
     snowflake_event_view_with_entity, is_offset


### PR DESCRIPTION
## Description

This adds validation in `aggregate_over` on TimeSeriesView to check that the window unit is compatible with TimeSeriesTable's time interval.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
