### PR TITLE
[chore] Block user aggregating timestamp with referencing to other offset column

### DIFF
--- a/featurebyte/api/aggregator/base_aggregator.py
+++ b/featurebyte/api/aggregator/base_aggregator.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import List, Optional, Type, Union
 
-from featurebyte.api.aggregator.util import validate_value_to_be_aggregated
+from featurebyte.api.aggregator.util import validate_value_with_timestamp_schema
 from featurebyte.api.aggregator.vector_validator import validate_vector_aggregate_parameters
 from featurebyte.api.feature import Feature
 from featurebyte.api.target import Target
@@ -102,7 +102,7 @@ class BaseAggregator(ABC):
                 f"{method} aggregation method is not supported for {self.aggregation_method_name}"
             )
 
-        validate_value_to_be_aggregated(self.view.operation_structure, value_column)
+        validate_value_with_timestamp_schema(self.view.operation_structure, value_column)
         validate_vector_aggregate_parameters(self.view.columns_info, value_column, method)
 
     @staticmethod

--- a/featurebyte/api/aggregator/base_aggregator.py
+++ b/featurebyte/api/aggregator/base_aggregator.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import List, Optional, Type, Union
 
+from featurebyte.api.aggregator.util import validate_value_to_be_aggregated
 from featurebyte.api.aggregator.vector_validator import validate_vector_aggregate_parameters
 from featurebyte.api.feature import Feature
 from featurebyte.api.target import Target
@@ -101,6 +102,7 @@ class BaseAggregator(ABC):
                 f"{method} aggregation method is not supported for {self.aggregation_method_name}"
             )
 
+        validate_value_to_be_aggregated(self.view.operation_structure, value_column)
         validate_vector_aggregate_parameters(self.view.columns_info, value_column, method)
 
     @staticmethod

--- a/featurebyte/api/aggregator/util.py
+++ b/featurebyte/api/aggregator/util.py
@@ -6,6 +6,8 @@ import warnings
 from typing import Optional
 
 from featurebyte.common.utils import is_server_mode
+from featurebyte.exception import OperationNotSupportedError
+from featurebyte.query_graph.node.metadata.operation import OperationStructure
 from featurebyte.typing import OptionalScalar
 
 
@@ -34,3 +36,32 @@ def conditional_set_skip_fill_na(skip_fill_na: Optional[bool], fill_value: Optio
     if skip_fill_na is None:
         return fill_value is None
     return skip_fill_na
+
+
+def validate_value_to_be_aggregated(
+    operation_structure: OperationStructure, value_column: Optional[str]
+) -> None:
+    """
+    Validate value column to be aggregated
+
+    Parameters
+    ----------
+    operation_structure: OperationStructure
+        Operation structure
+    value_column: str
+        Value column name to be aggregated
+
+    Raises
+    ------
+    OperationNotSupportedError
+        If the value column has a timezone offset column
+    """
+    if value_column is None:
+        return
+
+    column = next(col for col in operation_structure.columns if col.name == value_column)
+    timestamp_schema = column.dtype_info.timestamp_schema
+    if timestamp_schema and timestamp_schema.has_timezone_offset_column:
+        raise OperationNotSupportedError(
+            f"Aggregation of column '{value_column}' is not supported because it has a timezone offset column"
+        )

--- a/featurebyte/api/aggregator/util.py
+++ b/featurebyte/api/aggregator/util.py
@@ -38,11 +38,11 @@ def conditional_set_skip_fill_na(skip_fill_na: Optional[bool], fill_value: Optio
     return skip_fill_na
 
 
-def validate_value_to_be_aggregated(
+def validate_value_with_timestamp_schema(
     operation_structure: OperationStructure, value_column: Optional[str]
 ) -> None:
     """
-    Validate value column to be aggregated
+    Validate value column with timestamp schema
 
     Parameters
     ----------
@@ -63,5 +63,6 @@ def validate_value_to_be_aggregated(
     timestamp_schema = column.dtype_info.timestamp_schema
     if timestamp_schema and timestamp_schema.has_timezone_offset_column:
         raise OperationNotSupportedError(
-            f"Aggregation of column '{value_column}' is not supported because it has a timezone offset column"
+            f"Aggregation of column '{value_column}' is not supported because "
+            f"it references a timezone offset column."
         )

--- a/featurebyte/core/series.py
+++ b/featurebyte/core/series.py
@@ -22,7 +22,6 @@ from featurebyte.core.util import SeriesBinaryOperator, series_unary_operation
 from featurebyte.enum import DBVarType
 from featurebyte.query_graph.enum import NodeOutputType, NodeType
 from featurebyte.query_graph.model.dtype import DBVarTypeInfo
-from featurebyte.query_graph.node.metadata.operation import NodeOutputCategory
 from featurebyte.typing import Scalar, ScalarSequence, Timestamp, is_scalar_nan
 
 FrozenSeriesT = TypeVar("FrozenSeriesT", bound="FrozenSeries")
@@ -153,17 +152,6 @@ class FrozenSeries(
         )
 
     @property
-    def node_output_category(self) -> NodeOutputCategory:
-        """
-        Get the output category of the series
-
-        Returns
-        -------
-        NodeOutputCategory
-        """
-        return self.operation_structure.output_category
-
-    @property
     def dtype_info(self) -> DBVarTypeInfo:
         """
         Get the DBVarTypeInfo of the series
@@ -172,10 +160,7 @@ class FrozenSeries(
         -------
         DBVarTypeInfo
         """
-        operation_structure = self.operation_structure
-        if self.node_output_category == NodeOutputCategory.VIEW:
-            return operation_structure.columns[0].dtype_info
-        return operation_structure.aggregations[0].dtype_info
+        return self.operation_structure.series_output_dtype_info
 
     @property
     def binary_op_output_class_priority(self) -> int:

--- a/featurebyte/exception.py
+++ b/featurebyte/exception.py
@@ -84,6 +84,12 @@ class QueryNotSupportedError(NotImplementedError):
     """
 
 
+class OperationNotSupportedError(NotImplementedError):
+    """
+    Raise when the operation is not supported
+    """
+
+
 class BaseUnprocessableEntityError(FeatureByteException):
     """
     Base exception class for 422 Unprocessable Entity responses

--- a/featurebyte/query_graph/model/timestamp_schema.py
+++ b/featurebyte/query_graph/model/timestamp_schema.py
@@ -53,3 +53,16 @@ class TimestampSchema(FeatureByteBaseModel):
         if self.is_utc_time is False and self.timezone is None:
             raise ValueError("Timezone must be provided for local time")
         return self
+
+    @property
+    def has_timezone_offset_column(self) -> bool:
+        """
+        Whether the timestamp schema has a timezone offset column
+
+        Returns
+        -------
+        bool
+        """
+        if self.timezone and isinstance(self.timezone, TimeZoneColumn):
+            return True
+        return False

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -11,7 +11,14 @@ import pytest
 from bson.objectid import ObjectId
 from pandas.testing import assert_frame_equal
 
-from featurebyte import Catalog, RequestColumn, TargetNamespace, UseCase
+from featurebyte import (
+    Catalog,
+    RequestColumn,
+    TargetNamespace,
+    TimeInterval,
+    TimestampSchema,
+    UseCase,
+)
 from featurebyte.api.base_table import TableColumn
 from featurebyte.api.entity import Entity
 from featurebyte.api.event_table import EventTable
@@ -20,6 +27,7 @@ from featurebyte.api.item_table import ItemTable
 from featurebyte.api.source_table import SourceTable
 from featurebyte.config import Configurations
 from featurebyte.models.feature_store import TableStatus
+from featurebyte.query_graph.model.timestamp_schema import TimeZoneColumn
 
 
 @pytest.fixture()
@@ -223,8 +231,35 @@ def saved_time_series_table_fixture(snowflake_time_series_table, catalog):
     assert snowflake_time_series_table.status == TableStatus.PUBLIC_DRAFT
     assert isinstance(snowflake_time_series_table.created_at, datetime)
     assert isinstance(snowflake_time_series_table.tabular_source.feature_store_id, ObjectId)
-
     yield snowflake_time_series_table
+
+
+@pytest.fixture(name="snowflake_time_series_table_with_tz_offset_column")
+def snowflake_time_series_table_fixture(
+    snowflake_database_time_series_table,
+    catalog,
+    cust_id_entity,
+    transaction_entity,
+    mock_detect_and_update_column_dtypes,
+):
+    """TimeSeriesTable object fixture"""
+    _ = catalog, mock_detect_and_update_column_dtypes
+    time_series_table = snowflake_database_time_series_table.create_time_series_table(
+        name="sf_time_series_table",
+        series_id_column="col_int",
+        reference_datetime_column="date",
+        reference_datetime_schema=TimestampSchema(
+            timezone=TimeZoneColumn(column_name="col_text", type="offset"),
+            format_string="YYYY-MM-DD HH24:MI:SS",
+        ),
+        time_interval=TimeInterval(value=1, unit="DAY"),
+        record_creation_timestamp_column="created_at",
+        description="test time series table",
+    )
+    time_series_table.store_id.as_entity(cust_id_entity.name)
+    time_series_table.col_int.as_entity(transaction_entity.name)
+    assert time_series_table.frame.node.parameters.id == time_series_table.id
+    yield time_series_table
 
 
 @pytest.fixture(name="snowflake_scd_table_v2")

--- a/tests/unit/api/test_aggregate_over.py
+++ b/tests/unit/api/test_aggregate_over.py
@@ -8,6 +8,7 @@ import pytest
 from bson import ObjectId
 
 from featurebyte.enum import DBVarType
+from featurebyte.exception import OperationNotSupportedError
 from featurebyte.models import FeatureModel
 from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.model.feature_job_setting import (
@@ -407,3 +408,27 @@ def test_non_time_series_view_aggregate_over__only_str_window__non_cron_feature_
         str(exc_info.value)
         == "feature_job_setting must be FeatureJobSetting for non-TimeSeriesView"
     )
+
+
+def test_time_series_view_aggregate_over_timestamp_with_offset_column(
+    snowflake_time_series_table_with_tz_offset_column,
+):
+    """
+    Test aggregate_over for time series view
+    """
+    view = snowflake_time_series_table_with_tz_offset_column.get_view()
+    with pytest.raises(OperationNotSupportedError) as exc_info:
+        view.groupby("store_id").aggregate_over(
+            value_column="date",
+            method="latest",
+            windows=[CalendarWindow(unit="MONTH", size=3)],
+            feature_names=["col_float_sum_3month"],
+            feature_job_setting=CronFeatureJobSetting(
+                crontab="0 8 1 * *",
+            ),
+        )["col_float_sum_3month"]
+
+    expected_msg = (
+        "Aggregation of column 'date' is not supported because it has a timezone offset column"
+    )
+    assert str(exc_info.value) == expected_msg

--- a/tests/unit/api/test_aggregate_over.py
+++ b/tests/unit/api/test_aggregate_over.py
@@ -414,7 +414,7 @@ def test_time_series_view_aggregate_over_timestamp_with_offset_column(
     snowflake_time_series_table_with_tz_offset_column,
 ):
     """
-    Test aggregate_over for time series view
+    Test aggregate_over over time series column with timezone offset column
     """
     view = snowflake_time_series_table_with_tz_offset_column.get_view()
     with pytest.raises(OperationNotSupportedError) as exc_info:
@@ -428,7 +428,5 @@ def test_time_series_view_aggregate_over_timestamp_with_offset_column(
             ),
         )["col_float_sum_3month"]
 
-    expected_msg = (
-        "Aggregation of column 'date' is not supported because it has a timezone offset column"
-    )
+    expected_msg = "Aggregation of column 'date' is not supported because it references a timezone offset column."
     assert str(exc_info.value) == expected_msg


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
This PR prevents user to aggregate on timestamp column referencing on other offset column.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
