### PR TITLE
[DEV-3952] Support post-aggregation date difference with timestamp tuple

### DIFF
--- a/featurebyte/api/view.py
+++ b/featurebyte/api/view.py
@@ -555,11 +555,16 @@ class ViewColumn(Series, SampleMixin):
                 "Column must have a timezone column associated with it to zip the columns."
             )
 
+        # Must have a timestamp schema because the column has an associated timezone column
+        timestamp_schema = self.dtype_info.timestamp_schema
+        assert timestamp_schema is not None
+
         return series_binary_operation(
             input_series=self,
             other=self._parent[timezone_column_name],  # type: ignore
             node_type=NodeType.ZIP_TIMESTAMP_TZ_TUPLE,
             output_var_type=DBVarType.TIMESTAMP_TZ_TUPLE,
+            additional_node_params={"timestamp_schema": timestamp_schema},
         )
 
 

--- a/featurebyte/query_graph/node/binary.py
+++ b/featurebyte/query_graph/node/binary.py
@@ -12,6 +12,7 @@ from featurebyte.query_graph.enum import NodeOutputType, NodeType
 from featurebyte.query_graph.model.dtype import DBVarTypeInfo, DBVarTypeMetadata
 from featurebyte.query_graph.model.timestamp_schema import (
     ExtendedTimestampSchema,
+    TimestampSchema,
     TimestampTupleSchema,
     TimezoneOffsetSchema,
 )
@@ -19,6 +20,7 @@ from featurebyte.query_graph.node.base import (
     BaseSeriesOutputWithAScalarParamNode,
     BinaryArithmeticOpNode,
     BinaryOpWithBoolOutputNode,
+    SingleValueNodeParameters,
 )
 from featurebyte.query_graph.node.metadata.config import (
     OnDemandFunctionCodeGenConfig,
@@ -262,11 +264,18 @@ class IsInNode(BaseSeriesOutputWithAScalarParamNode):
         return [], expr
 
 
+class ZipTimestampTZTupleNodeParameters(SingleValueNodeParameters):
+    """ZipTimestampTZTupleNodeParameters class"""
+
+    timestamp_schema: TimestampSchema
+
+
 class ZipTimestampTZTupleNode(BaseSeriesOutputWithAScalarParamNode):
     """ZipTimestampTZTupleNode class"""
 
     type: Literal[NodeType.ZIP_TIMESTAMP_TZ_TUPLE] = NodeType.ZIP_TIMESTAMP_TZ_TUPLE
     output_type: NodeOutputType = NodeOutputType.SERIES
+    parameters: ZipTimestampTZTupleNodeParameters
 
     @property
     def max_input_count(self) -> int:

--- a/featurebyte/query_graph/node/date.py
+++ b/featurebyte/query_graph/node/date.py
@@ -12,7 +12,7 @@ from featurebyte.enum import DBVarType
 from featurebyte.models.base import FeatureByteBaseModel
 from featurebyte.query_graph.enum import NodeOutputType, NodeType
 from featurebyte.query_graph.model.dtype import DBVarTypeInfo, DBVarTypeMetadata
-from featurebyte.query_graph.model.timestamp_schema import TimestampSchema
+from featurebyte.query_graph.model.timestamp_schema import TimestampSchema, TimestampTupleSchema
 from featurebyte.query_graph.node.base import (
     BaseSeriesOutputNode,
     BaseSeriesOutputWithSingleOperandNode,
@@ -263,6 +263,34 @@ class DateDifferenceParameters(FeatureByteBaseModel):
         """
         if self.right_timestamp_metadata:
             return self.right_timestamp_metadata.timestamp_schema
+        return None
+
+    @property
+    def left_timestamp_tuple_schema(self) -> Optional[TimestampTupleSchema]:
+        """
+        Left timestamp tuple schema
+
+        Returns
+        -------
+        Optional[TimestampTupleSchema]
+            Left timestamp tuple schema
+        """
+        if self.left_timestamp_metadata:
+            return self.left_timestamp_metadata.timestamp_tuple_schema
+        return None
+
+    @property
+    def right_timestamp_tuple_schema(self) -> Optional[TimestampTupleSchema]:
+        """
+        Right timestamp tuple schema
+
+        Returns
+        -------
+        Optional[TimestampTupleSchema]
+            Right timestamp tuple schema
+        """
+        if self.right_timestamp_metadata:
+            return self.right_timestamp_metadata.timestamp_tuple_schema
         return None
 
 

--- a/featurebyte/query_graph/sql/adapter/base.py
+++ b/featurebyte/query_graph/sql/adapter/base.py
@@ -1306,15 +1306,15 @@ class BaseAdapter(ABC):
 
     @classmethod
     def zip_timestamp_and_timezone(
-        cls, timestamp_expr: Expression, timezone_expr: Expression
+        cls, timestamp_utc_expr: Expression, timezone_expr: Expression
     ) -> Expression:
         """
         Zip a timestamp and a timezone together
 
         Parameters
         ----------
-        timestamp_expr: Expression
-            Timestamp expression
+        timestamp_utc_expr: Expression
+            Timestamp expression converted to UTC
         timezone_expr: Expression
             Timezone expression
 
@@ -1322,7 +1322,7 @@ class BaseAdapter(ABC):
         -------
         Expression
         """
-        timestamp_str_expr = cls.to_string_from_timestamp(timestamp_expr)
+        timestamp_str_expr = cls.to_string_from_timestamp(timestamp_utc_expr)
         return cls.zip_timestamp_string_and_timezone(timestamp_str_expr, timezone_expr)
 
     @classmethod

--- a/featurebyte/query_graph/sql/adapter/base.py
+++ b/featurebyte/query_graph/sql/adapter/base.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from numpy import format_float_positional
 from sqlglot import expressions
@@ -46,6 +46,10 @@ class BaseAdapter(ABC):
 
     TABLESAMPLE_SUPPORTS_VIEW = True
     TIMEZONE_DATE_FORMAT_EXPRESSIONS: List[str] = []
+
+    ISO_FORMAT_STRING = ""
+    ZIPPED_TIMESTAMP_FIELD = "timestamp"
+    ZIPPED_TIMEZONE_FIELD = "timezone"
 
     def __init__(self, source_info: SourceInfo):
         self.source_info = source_info
@@ -1186,6 +1190,22 @@ class BaseAdapter(ABC):
 
     @classmethod
     @abstractmethod
+    def to_string_from_timestamp(cls, expr: Expression) -> Expression:
+        """
+        Convert a timestamp to a string
+
+        Parameters
+        ----------
+        expr: Expression
+            Expression representing the timestamp
+
+        Returns
+        -------
+        Expression
+        """
+
+    @classmethod
+    @abstractmethod
     def convert_timezone_to_utc(
         cls, expr: Expression, timezone: Expression, timezone_type: Literal["name", "offset"]
     ) -> Expression:
@@ -1282,4 +1302,85 @@ class BaseAdapter(ABC):
         Returns
         -------
         Expression
+        """
+
+    @classmethod
+    def zip_timestamp_and_timezone(
+        cls, timestamp_expr: Expression, timezone_expr: Expression
+    ) -> Expression:
+        """
+        Zip a timestamp and a timezone together
+
+        Parameters
+        ----------
+        timestamp_expr: Expression
+            Timestamp expression
+        timezone_expr: Expression
+            Timezone expression
+
+        Returns
+        -------
+        Expression
+        """
+        timestamp_str_expr = cls.to_string_from_timestamp(timestamp_expr)
+        return cls.zip_timestamp_string_and_timezone(timestamp_str_expr, timezone_expr)
+
+    @classmethod
+    def unzip_timestamp_and_timezone(cls, zipped_expr: Expression) -> Tuple[Expression, Expression]:
+        """
+        Unzip a zipped timestamp and timezone column into two expressions, one for timestamp and one
+        for timezone.
+
+        Parameters
+        ----------
+        zipped_expr: Expression
+            Zipped expression
+
+        Returns
+        -------
+        Tuple[Expression, Expression]
+        """
+        timestamp_str_expr, timezone_offset_expr = cls.unzip_timestamp_string_and_timezone(
+            zipped_expr
+        )
+        timestamp_utc_expr = cls.to_timestamp_from_string(timestamp_str_expr, cls.ISO_FORMAT_STRING)
+        return timestamp_utc_expr, timezone_offset_expr
+
+    @classmethod
+    @abstractmethod
+    def zip_timestamp_string_and_timezone(
+        cls, timestamp_str_expr: Expression, timezone_expr: Expression
+    ) -> Expression:
+        """
+        Zip a timestamp encoded as ISO formatted string and a timezone together
+
+        Parameters
+        ----------
+        timestamp_str_expr: Expression
+            Timestamp stsring expression
+        timezone_expr: Expression
+            Timezone expression
+
+        Returns
+        -------
+        Expression
+        """
+
+    @classmethod
+    @abstractmethod
+    def unzip_timestamp_string_and_timezone(
+        cls, zipped_expr: Expression
+    ) -> Tuple[Expression, Expression]:
+        """
+        Unzip a zipped timestamp and timezone column into two expressions, one for timestamp and one
+        for timezone. The unzipped timestamp remains encoded as string in UTC.
+
+        Parameters
+        ----------
+        zipped_expr: Expression
+            Zipped expression
+
+        Returns
+        -------
+        Tuple[Expression, Expression]
         """

--- a/featurebyte/query_graph/sql/adapter/bigquery.py
+++ b/featurebyte/query_graph/sql/adapter/bigquery.py
@@ -5,7 +5,7 @@ BigQueryAdapter class
 from __future__ import annotations
 
 import re
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from sqlglot import expressions
 from sqlglot.expressions import Anonymous, Expression
@@ -15,7 +15,11 @@ from featurebyte.enum import DBVarType, SourceType, StrEnum, TimeIntervalUnit
 from featurebyte.query_graph.sql import expression as fb_expressions
 from featurebyte.query_graph.sql.adapter import BaseAdapter
 from featurebyte.query_graph.sql.ast.literal import make_literal_value
-from featurebyte.query_graph.sql.common import get_fully_qualified_function_call, sql_to_string
+from featurebyte.query_graph.sql.common import (
+    get_fully_qualified_function_call,
+    quoted_identifier,
+    sql_to_string,
+)
 from featurebyte.typing import DatetimeSupportedPropertyType
 
 
@@ -30,6 +34,7 @@ class BigQueryAdapter(BaseAdapter):
 
     # https://cloud.google.com/bigquery/docs/reference/standard-sql/format-elements#format_elements_date_time
     TIMEZONE_DATE_FORMAT_EXPRESSIONS = ["%z", "%Z", "%Ez"]
+    ISO_FORMAT_STRING = "%Y-%m-%dT%H:%M:%SZ"
 
     class DataType(StrEnum):
         """
@@ -391,3 +396,41 @@ class BigQueryAdapter(BaseAdapter):
             expression=make_literal_value(num_units),
             unit=expressions.Var(this="MONTH"),
         )
+
+    @classmethod
+    def to_string_from_timestamp(cls, expr: Expression) -> Expression:
+        return expressions.Anonymous(
+            this="FORMAT_DATETIME", expressions=[make_literal_value(cls.ISO_FORMAT_STRING), expr]
+        )
+
+    @classmethod
+    def zip_timestamp_string_and_timezone(
+        cls, timestamp_str_expr: Expression, timezone_expr: Expression
+    ) -> Expression:
+        return expressions.Anonymous(
+            this="STRUCT",
+            expressions=[
+                expressions.alias_(
+                    timestamp_str_expr,
+                    alias=cls.ZIPPED_TIMESTAMP_FIELD,
+                    quoted=True,
+                ),
+                expressions.alias_(
+                    timezone_expr,
+                    alias=cls.ZIPPED_TIMEZONE_FIELD,
+                    quoted=True,
+                ),
+            ],
+        )
+
+    @classmethod
+    def unzip_timestamp_string_and_timezone(
+        cls, zipped_expr: Expression
+    ) -> Tuple[Expression, Expression]:
+        timestamp_str_expr = expressions.Dot(
+            this=zipped_expr, expression=quoted_identifier(cls.ZIPPED_TIMESTAMP_FIELD)
+        )
+        timezone_expr = expressions.Dot(
+            this=zipped_expr, expression=quoted_identifier(cls.ZIPPED_TIMEZONE_FIELD)
+        )
+        return timestamp_str_expr, timezone_expr

--- a/featurebyte/query_graph/sql/adapter/snowflake.py
+++ b/featurebyte/query_graph/sql/adapter/snowflake.py
@@ -606,10 +606,17 @@ class SnowflakeAdapter(BaseAdapter):
     def unzip_timestamp_string_and_timezone(
         cls, zipped_expr: Expression
     ) -> Tuple[Expression, Expression]:
-        timestamp_str_expr = expressions.Anonymous(
-            this="GET", expressions=[zipped_expr, make_literal_value(cls.ZIPPED_TIMESTAMP_FIELD)]
+        timestamp_str_expr = cls.cast_to_string(
+            expressions.Anonymous(
+                this="GET",
+                expressions=[zipped_expr, make_literal_value(cls.ZIPPED_TIMESTAMP_FIELD)],
+            ),
+            None,
         )
-        timezone_expr = expressions.Anonymous(
-            this="GET", expressions=[zipped_expr, make_literal_value(cls.ZIPPED_TIMEZONE_FIELD)]
+        timezone_expr = cls.cast_to_string(
+            expressions.Anonymous(
+                this="GET", expressions=[zipped_expr, make_literal_value(cls.ZIPPED_TIMEZONE_FIELD)]
+            ),
+            None,
         )
         return timestamp_str_expr, timezone_expr

--- a/featurebyte/query_graph/sql/adapter/snowflake.py
+++ b/featurebyte/query_graph/sql/adapter/snowflake.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import re
 import string
-from typing import List, Optional, cast
+from typing import List, Optional, Tuple, cast
 
 from sqlglot import expressions
 from sqlglot.expressions import Expression, Identifier, Select, alias_, select
@@ -32,6 +32,8 @@ class SnowflakeAdapter(BaseAdapter):
 
     # https://docs.snowflake.com/en/sql-reference/data-types-datetime
     TIMEZONE_DATE_FORMAT_EXPRESSIONS = ["TZH", "TZM"]
+
+    ISO_FORMAT_STRING = 'YYYY-MM-DD"T"HH24:MI:SS"Z"'
 
     class SnowflakeDataType(StrEnum):
         """
@@ -574,3 +576,40 @@ class SnowflakeAdapter(BaseAdapter):
             this="DATEADD",
             expressions=["month", make_literal_value(-num_units), timestamp_expr],
         )
+
+    @classmethod
+    def to_string_from_timestamp(cls, expr: Expression) -> Expression:
+        assert cls.ISO_FORMAT_STRING
+        return expressions.Anonymous(
+            this="TO_CHAR",
+            expressions=[
+                expr,
+                make_literal_value(cls.ISO_FORMAT_STRING),
+            ],
+        )
+
+    @classmethod
+    def zip_timestamp_string_and_timezone(
+        cls, timestamp_str_expr: Expression, timezone_expr: Expression
+    ) -> Expression:
+        return expressions.Anonymous(
+            this="OBJECT_CONSTRUCT",
+            expressions=[
+                make_literal_value(cls.ZIPPED_TIMESTAMP_FIELD),
+                timestamp_str_expr,
+                make_literal_value(cls.ZIPPED_TIMEZONE_FIELD),
+                timezone_expr,
+            ],
+        )
+
+    @classmethod
+    def unzip_timestamp_string_and_timezone(
+        cls, zipped_expr: Expression
+    ) -> Tuple[Expression, Expression]:
+        timestamp_str_expr = expressions.Anonymous(
+            this="GET", expressions=[zipped_expr, make_literal_value(cls.ZIPPED_TIMESTAMP_FIELD)]
+        )
+        timezone_expr = expressions.Anonymous(
+            this="GET", expressions=[zipped_expr, make_literal_value(cls.ZIPPED_TIMEZONE_FIELD)]
+        )
+        return timestamp_str_expr, timezone_expr

--- a/featurebyte/query_graph/sql/ast/datetime.py
+++ b/featurebyte/query_graph/sql/ast/datetime.py
@@ -22,6 +22,7 @@ from featurebyte.query_graph.sql.ast.generic import ParsedExpressionNode, resolv
 from featurebyte.query_graph.sql.ast.literal import make_literal_value
 from featurebyte.query_graph.sql.ast.util import prepare_binary_op_input_nodes
 from featurebyte.query_graph.sql.timestamp_helper import (
+    convert_timestamp_timezone_tuple,
     convert_timestamp_to_local,
     convert_timestamp_to_utc,
 )
@@ -150,11 +151,31 @@ class DateDiffNode(ExpressionNode):
                     left_node.sql, parameters.left_timestamp_schema, context.adapter
                 ),
             )
+        elif parameters.left_timestamp_tuple_schema:
+            left_node = ParsedExpressionNode.from_expression_node(
+                left_node,
+                convert_timestamp_timezone_tuple(
+                    zipped_expr=left_node.sql,
+                    target_tz="utc",
+                    timestamp_tuple_schema=parameters.left_timestamp_tuple_schema,
+                    adapter=context.adapter,
+                ),
+            )
         if parameters.right_timestamp_schema:
             right_node = ParsedExpressionNode.from_expression_node(
                 right_node,
                 convert_timestamp_to_utc(
                     right_node.sql, parameters.right_timestamp_schema, context.adapter
+                ),
+            )
+        elif parameters.right_timestamp_tuple_schema:
+            right_node = ParsedExpressionNode.from_expression_node(
+                right_node,
+                convert_timestamp_timezone_tuple(
+                    zipped_expr=right_node.sql,
+                    target_tz="utc",
+                    timestamp_tuple_schema=parameters.right_timestamp_tuple_schema,
+                    adapter=context.adapter,
                 ),
             )
         node = cls(

--- a/featurebyte/query_graph/sql/ast/zip_timestamp.py
+++ b/featurebyte/query_graph/sql/ast/zip_timestamp.py
@@ -1,0 +1,36 @@
+"""
+SQL node for ZipTimestampTZTupleNode
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlglot import Expression
+
+from featurebyte.query_graph.enum import NodeType
+from featurebyte.query_graph.sql.ast.base import ExpressionNode, SQLNodeContext
+from featurebyte.query_graph.sql.ast.util import prepare_binary_op_input_nodes
+
+
+@dataclass
+class ZipTimestampTZTupleNode(ExpressionNode):
+    """Node for zip_timestamp_tz_tuple operation"""
+
+    timestamp_node: ExpressionNode
+    timezone_offset_node: ExpressionNode
+    query_node_type = NodeType.ZIP_TIMESTAMP_TZ_TUPLE
+
+    @property
+    def sql(self) -> Expression:
+        raise
+
+    @classmethod
+    def build(cls, context: SQLNodeContext) -> ZipTimestampTZTupleNode:
+        table_node, left_node, right_node = prepare_binary_op_input_nodes(context)
+        return ZipTimestampTZTupleNode(
+            context=context,
+            table_node=table_node,
+            timestamp_node=left_node,
+            timezone_offset_node=right_node,
+        )

--- a/featurebyte/query_graph/sql/ast/zip_timestamp.py
+++ b/featurebyte/query_graph/sql/ast/zip_timestamp.py
@@ -9,8 +9,11 @@ from dataclasses import dataclass
 from sqlglot import Expression
 
 from featurebyte.query_graph.enum import NodeType
+from featurebyte.query_graph.model.timestamp_schema import TimestampSchema
+from featurebyte.query_graph.node.binary import ZipTimestampTZTupleNodeParameters
 from featurebyte.query_graph.sql.ast.base import ExpressionNode, SQLNodeContext
 from featurebyte.query_graph.sql.ast.util import prepare_binary_op_input_nodes
+from featurebyte.query_graph.sql.timestamp_helper import convert_timestamp_to_utc
 
 
 @dataclass
@@ -19,18 +22,28 @@ class ZipTimestampTZTupleNode(ExpressionNode):
 
     timestamp_node: ExpressionNode
     timezone_offset_node: ExpressionNode
+    timestamp_schema: TimestampSchema
     query_node_type = NodeType.ZIP_TIMESTAMP_TZ_TUPLE
 
     @property
     def sql(self) -> Expression:
-        raise
+        timestamp_utc_expr = convert_timestamp_to_utc(
+            column_expr=self.timestamp_node.sql,
+            timestamp_schema=self.timestamp_schema,
+            adapter=self.context.adapter,
+        )
+        return self.context.adapter.zip_timestamp_and_timezone(
+            timestamp_utc_expr, self.timezone_offset_node.sql
+        )
 
     @classmethod
     def build(cls, context: SQLNodeContext) -> ZipTimestampTZTupleNode:
         table_node, left_node, right_node = prepare_binary_op_input_nodes(context)
+        parameters = ZipTimestampTZTupleNodeParameters(**context.parameters)
         return ZipTimestampTZTupleNode(
             context=context,
             table_node=table_node,
             timestamp_node=left_node,
             timezone_offset_node=right_node,
+            timestamp_schema=parameters.timestamp_schema,
         )

--- a/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_bigquery.sql
+++ b/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_bigquery.sql
@@ -1,7 +1,7 @@
 (
-  DATEDIFF(
-    microsecond,
-    TO_TIMESTAMP(CAST(GET(zipped_column_2, 'timestamp') AS STRING), 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
-    TO_TIMESTAMP(CAST(GET(zipped_column_1, 'timestamp') AS STRING), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+  TIMESTAMP_DIFF(
+    CAST(CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', zipped_column_1.`timestamp`) AS DATETIME) AS DATETIME),
+    CAST(CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', zipped_column_2.`timestamp`) AS DATETIME) AS DATETIME),
+    MICROSECOND
   ) * CAST(1 AS INT64) / CAST(1000000 AS INT64)
 )

--- a/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_bigquery.sql
+++ b/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_bigquery.sql
@@ -1,0 +1,7 @@
+(
+  DATEDIFF(
+    microsecond,
+    TO_TIMESTAMP(CAST(GET(zipped_column_2, 'timestamp') AS STRING), 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+    TO_TIMESTAMP(CAST(GET(zipped_column_1, 'timestamp') AS STRING), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+  ) * CAST(1 AS INT64) / CAST(1000000 AS INT64)
+)

--- a/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_databricks_unity.sql
+++ b/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_databricks_unity.sql
@@ -1,0 +1,7 @@
+(
+  DATEDIFF(
+    microsecond,
+    TO_TIMESTAMP(CAST(GET(zipped_column_2, 'timestamp') AS STRING), 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+    TO_TIMESTAMP(CAST(GET(zipped_column_1, 'timestamp') AS STRING), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+  ) * CAST(1 AS BIGINT) / CAST(1000000 AS BIGINT)
+)

--- a/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_databricks_unity.sql
+++ b/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_databricks_unity.sql
@@ -1,7 +1,7 @@
 (
   DATEDIFF(
     microsecond,
-    TO_TIMESTAMP(CAST(GET(zipped_column_2, 'timestamp') AS STRING), 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
-    TO_TIMESTAMP(CAST(GET(zipped_column_1, 'timestamp') AS STRING), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+    TO_TIMESTAMP(zipped_column_2.timestamp, 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''),
+    TO_TIMESTAMP(zipped_column_1.timestamp, 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\'')
   ) * CAST(1 AS BIGINT) / CAST(1000000 AS BIGINT)
 )

--- a/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_snowflake.sql
+++ b/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_snowflake.sql
@@ -1,0 +1,7 @@
+(
+  DATEDIFF(
+    microsecond,
+    TO_TIMESTAMP(CAST(GET(zipped_column_2, 'timestamp') AS VARCHAR), 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+    TO_TIMESTAMP(CAST(GET(zipped_column_1, 'timestamp') AS VARCHAR), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+  ) * CAST(1 AS BIGINT) / CAST(1000000 AS BIGINT)
+)

--- a/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_spark.sql
+++ b/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_spark.sql
@@ -1,7 +1,5 @@
 (
-  DATEDIFF(
-    microsecond,
-    TO_TIMESTAMP(CAST(GET(zipped_column_2, 'timestamp') AS STRING), 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
-    TO_TIMESTAMP(CAST(GET(zipped_column_1, 'timestamp') AS STRING), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+  (
+    CAST(CAST(TO_TIMESTAMP(zipped_column_1.timestamp, 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\'') AS TIMESTAMP) AS DOUBLE) * 1000000.0 - CAST(CAST(TO_TIMESTAMP(zipped_column_2.timestamp, 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\'') AS TIMESTAMP) AS DOUBLE) * 1000000.0
   ) * CAST(1 AS BIGINT) / CAST(1000000 AS BIGINT)
 )

--- a/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_spark.sql
+++ b/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_spark.sql
@@ -1,0 +1,7 @@
+(
+  DATEDIFF(
+    microsecond,
+    TO_TIMESTAMP(CAST(GET(zipped_column_2, 'timestamp') AS STRING), 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+    TO_TIMESTAMP(CAST(GET(zipped_column_1, 'timestamp') AS STRING), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+  ) * CAST(1 AS BIGINT) / CAST(1000000 AS BIGINT)
+)

--- a/tests/fixtures/query_graph/test_zip_timestamp/zip_timestamp_bigquery.sql
+++ b/tests/fixtures/query_graph/test_zip_timestamp/zip_timestamp_bigquery.sql
@@ -1,0 +1,7 @@
+STRUCT(
+  FORMAT_DATETIME(
+    '%Y-%m-%dT%H:%M:%SZ',
+    CAST(TIMESTAMP(CAST(`timestamp_col` AS DATETIME), `tz_col`) AS DATETIME)
+  ) AS `timestamp`,
+  `tz_col` AS `timezone`
+)

--- a/tests/fixtures/query_graph/test_zip_timestamp/zip_timestamp_databricks_unity.sql
+++ b/tests/fixtures/query_graph/test_zip_timestamp/zip_timestamp_databricks_unity.sql
@@ -1,0 +1,6 @@
+NAMED_STRUCT(
+  'timestamp',
+  DATE_FORMAT(TO_UTC_TIMESTAMP(`timestamp_col`, `tz_col`), 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''),
+  'timezone',
+  `tz_col`
+)

--- a/tests/fixtures/query_graph/test_zip_timestamp/zip_timestamp_snowflake.sql
+++ b/tests/fixtures/query_graph/test_zip_timestamp/zip_timestamp_snowflake.sql
@@ -1,0 +1,6 @@
+OBJECT_CONSTRUCT(
+  'timestamp',
+  TO_CHAR(CONVERT_TIMEZONE("tz_col", 'UTC', "timestamp_col"), 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+  'timezone',
+  "tz_col"
+)

--- a/tests/fixtures/query_graph/test_zip_timestamp/zip_timestamp_spark.sql
+++ b/tests/fixtures/query_graph/test_zip_timestamp/zip_timestamp_spark.sql
@@ -1,0 +1,6 @@
+NAMED_STRUCT(
+  'timestamp',
+  DATE_FORMAT(TO_UTC_TIMESTAMP(`timestamp_col`, `tz_col`), 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''),
+  'timezone',
+  `tz_col`
+)

--- a/tests/integration/api/test_time_series_view_operations.py
+++ b/tests/integration/api/test_time_series_view_operations.py
@@ -212,7 +212,7 @@ def test_aggregate_over_post_aggregate_with_tz_column(time_series_table_tz_colum
     preview_params = pd.DataFrame([
         {
             "POINT_IN_TIME": pd.Timestamp("2001-01-10 10:00:00"),
-            "series2_id": "S0",
+            "series_id_2": "S0",
         }
     ])
     feature_list = FeatureList([feature_1, feature_2], "test_feature_list")
@@ -224,7 +224,8 @@ def test_aggregate_over_post_aggregate_with_tz_column(time_series_table_tz_colum
     # datetime during that period is "2001-01-09 00:00:00" Asia/Singapore, converted to UTC is
     # "2001-01-08 16:00:00". The difference with the point in time "2001-01-10 10:00:00" UTC is
     # 8 + 24 + 10 = 42 hours.
-    expected["hour_since_latest_reference_datetime"] = [0.35]
+    expected["hour_since_latest_reference_datetime"] = [42]
+    expected["hour_since_latest_reference_datetime_reversed"] = [-42]
     fb_assert_frame_equal(df_features, expected)
 
 

--- a/tests/integration/api/test_time_series_view_operations.py
+++ b/tests/integration/api/test_time_series_view_operations.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import pandas as pd
 import pytest
 
-from featurebyte import CalendarWindow, CronFeatureJobSetting, FeatureList
+from featurebyte import CalendarWindow, CronFeatureJobSetting, FeatureList, RequestColumn
 from featurebyte.schema.feature_list import OnlineFeaturesRequestPayload
 from tests.util.helper import fb_assert_frame_equal
 
@@ -183,6 +183,48 @@ def test_aggregate_over_latest(time_series_table):
     # features should aggregate the values from "2001-01-03" to "2001-01-09" inclusive.
     expected["value_col_sum_7d"] = [0.35]
     expected["value_col_latest_7d"] = [0.08]
+    fb_assert_frame_equal(df_features, expected)
+
+
+def test_aggregate_over_post_aggregate_with_tz_column(time_series_table_tz_column):
+    """
+    Test TimeSeriesView aggregate_over using the latest method for reference_datetime_column with a
+    timezone offset column
+    """
+    view = time_series_table_tz_column.get_view()
+    latest_reference_datetime = view.groupby("series_id_col").aggregate_over(
+        value_column="reference_datetime_col",
+        method="latest",
+        windows=[CalendarWindow(unit="DAY", size=7)],
+        feature_names=["my_feature"],
+        feature_job_setting=CronFeatureJobSetting(
+            crontab="0 8 * * *",
+            timezone="Asia/Singapore",
+        ),
+    )["my_feature"]
+
+    feature_1 = (RequestColumn.point_in_time() - latest_reference_datetime).dt.hour
+    feature_1.name = "hour_since_latest_reference_datetime"
+
+    feature_2 = (latest_reference_datetime - RequestColumn.point_in_time()).dt.hour
+    feature_2.name = "hour_since_latest_reference_datetime_reversed"
+
+    preview_params = pd.DataFrame([
+        {
+            "POINT_IN_TIME": pd.Timestamp("2001-01-10 10:00:00"),
+            "series2_id": "S0",
+        }
+    ])
+    feature_list = FeatureList([feature_1, feature_2], "test_feature_list")
+    df_features = feature_list.compute_historical_features(preview_params)
+    expected = preview_params.copy()
+    # Point in time of "2001-01-10 10:00:00" UTC is "2001-01-10 18:00:00" Asia/Singapore, at which
+    # point the last feature job is at "2001-01-10 10:00:00" Asia/Singapore. Hence, the features
+    # should aggregate the values from "2001-01-03" to "2001-01-09" inclusive. Latest reference
+    # datetime during that period is "2001-01-09 00:00:00" Asia/Singapore, converted to UTC is
+    # "2001-01-08 16:00:00". The difference with the point in time "2001-01-10 10:00:00" UTC is
+    # 8 + 24 + 10 = 42 hours.
+    expected["hour_since_latest_reference_datetime"] = [0.35]
     fb_assert_frame_equal(df_features, expected)
 
 

--- a/tests/unit/query_graph/sql/ast/test_datetime_diff.py
+++ b/tests/unit/query_graph/sql/ast/test_datetime_diff.py
@@ -88,6 +88,7 @@ def test_date_difference_timestamp_tuple_schema(input_node, source_type, update_
             ).model_dump(),
         },
         input_sql_nodes=input_nodes,
+        source_type=source_type,
     )
     node = DateDiffNode.build(context)
     actual = sql_to_string(node.sql, source_type)

--- a/tests/unit/query_graph/sql/ast/test_datetime_diff.py
+++ b/tests/unit/query_graph/sql/ast/test_datetime_diff.py
@@ -1,0 +1,101 @@
+"""
+Test cases for DateDiffNode sql generation
+"""
+
+import pytest
+
+from featurebyte.enum import DBVarType
+from featurebyte.query_graph.model.dtype import DBVarTypeMetadata
+from featurebyte.query_graph.model.timestamp_schema import (
+    ExtendedTimestampSchema,
+    TimestampSchema,
+    TimestampTupleSchema,
+    TimezoneOffsetSchema,
+)
+from featurebyte.query_graph.sql.ast.datetime import DateDiffNode
+from featurebyte.query_graph.sql.common import sql_to_string
+from tests.source_types import SNOWFLAKE_SPARK_DATABRICKS_UNITY_BIGQUERY
+from tests.unit.query_graph.util import make_context, make_str_expression_node
+from tests.util.helper import assert_equal_with_expected_fixture
+
+
+@pytest.fixture(params=SNOWFLAKE_SPARK_DATABRICKS_UNITY_BIGQUERY)
+def source_type(request):
+    """
+    Fixture to parametrize source types
+    """
+    return request.param
+
+
+def test_date_difference(input_node):
+    """Test DateDiff node"""
+    column1 = make_str_expression_node(table_node=input_node, expr="a")
+    column2 = make_str_expression_node(table_node=input_node, expr="b")
+    input_nodes = [column1, column2]
+    context = make_context(parameters={}, input_sql_nodes=input_nodes)
+    node = DateDiffNode.build(context)
+    assert node.sql.sql() == (
+        "(DATEDIFF(microsecond, b, a) * CAST(1 AS BIGINT) / CAST(1000000 AS BIGINT))"
+    )
+
+
+def test_date_difference_timestamp_schema(input_node):
+    """Test DateDiff node handling of timestamp_schema"""
+    column1 = make_str_expression_node(table_node=input_node, expr="a")
+    column2 = make_str_expression_node(table_node=input_node, expr="b")
+    input_nodes = [column1, column2]
+    context = make_context(
+        parameters={
+            "left_timestamp_metadata": DBVarTypeMetadata(
+                timestamp_schema=TimestampSchema(format_string="%Y-%m-%d")
+            ).model_dump(),
+            "right_timestamp_metadata": DBVarTypeMetadata(
+                timestamp_schema=TimestampSchema(format_string="%Y|%m|%d")
+            ).model_dump(),
+        },
+        input_sql_nodes=input_nodes,
+    )
+    node = DateDiffNode.build(context)
+    assert node.sql.sql() == (
+        "(DATEDIFF(microsecond, TO_TIMESTAMP(b, '%Y|%m|%d'), TO_TIMESTAMP(a, '%Y-%m-%d')) * CAST(1 AS BIGINT) / CAST(1000000 AS BIGINT))"
+    )
+
+
+def test_date_difference_timestamp_tuple_schema(input_node, source_type, update_fixtures):
+    """Test DateDiff node handling of timestamp tuple schema"""
+    column1 = make_str_expression_node(table_node=input_node, expr="zipped_column_1")
+    column2 = make_str_expression_node(table_node=input_node, expr="zipped_column_2")
+    input_nodes = [column1, column2]
+    context = make_context(
+        parameters={
+            "left_timestamp_metadata": DBVarTypeMetadata(
+                timestamp_tuple_schema=TimestampTupleSchema(
+                    timestamp_schema=ExtendedTimestampSchema(
+                        dtype=DBVarType.VARCHAR,
+                        format_string="%Y-%m-%d",
+                    ),
+                    timezone_offset_schema=TimezoneOffsetSchema(dtype=DBVarType.VARCHAR),
+                )
+            ).model_dump(),
+            "right_timestamp_metadata": DBVarTypeMetadata(
+                timestamp_tuple_schema=TimestampTupleSchema(
+                    timestamp_schema=ExtendedTimestampSchema(
+                        dtype=DBVarType.VARCHAR,
+                        format_string="%Y|%m|%d",
+                    ),
+                    timezone_offset_schema=TimezoneOffsetSchema(dtype=DBVarType.VARCHAR),
+                )
+            ).model_dump(),
+        },
+        input_sql_nodes=input_nodes,
+    )
+    node = DateDiffNode.build(context)
+    actual = sql_to_string(node.sql, source_type)
+    fixture_filename = (
+        f"tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_{source_type}.sql"
+    )
+    assert_equal_with_expected_fixture(
+        actual,
+        fixture_filename,
+        update_fixtures,
+    )

--- a/tests/unit/query_graph/sql/ast/test_generic_function.py
+++ b/tests/unit/query_graph/sql/ast/test_generic_function.py
@@ -3,7 +3,7 @@ Test generic function node
 """
 
 from featurebyte.query_graph.sql.ast.function import GenericFunctionNode
-from tests.unit.query_graph.test_sql import make_context, make_str_expression_node
+from tests.unit.query_graph.util import make_context, make_str_expression_node
 
 
 def test_generic_function(input_node):

--- a/tests/unit/query_graph/sql/ast/test_generic_sql.py
+++ b/tests/unit/query_graph/sql/ast/test_generic_sql.py
@@ -6,7 +6,7 @@ import pytest
 
 from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.sql.ast.generic import Conditional
-from tests.unit.query_graph.test_sql import make_context, make_str_expression_node
+from tests.unit.query_graph.util import make_context, make_str_expression_node
 
 
 def test_conditional__scalar_parameter(input_node):

--- a/tests/unit/query_graph/sql/ast/test_zip_timestamp.py
+++ b/tests/unit/query_graph/sql/ast/test_zip_timestamp.py
@@ -1,0 +1,57 @@
+"""
+Test cases for ZipTimestampTZTupleNode
+"""
+
+import pytest
+
+from featurebyte.query_graph.model.timestamp_schema import (
+    TimestampSchema,
+    TimeZoneColumn,
+)
+from featurebyte.query_graph.sql.ast.generic import ParsedExpressionNode
+from featurebyte.query_graph.sql.ast.zip_timestamp import ZipTimestampTZTupleNode
+from featurebyte.query_graph.sql.common import quoted_identifier, sql_to_string
+from tests.source_types import SNOWFLAKE_SPARK_DATABRICKS_UNITY_BIGQUERY
+from tests.unit.query_graph.util import make_context
+from tests.util.helper import assert_equal_with_expected_fixture
+
+
+@pytest.fixture(params=SNOWFLAKE_SPARK_DATABRICKS_UNITY_BIGQUERY)
+def source_type(request):
+    """
+    Fixture to parametrize source types
+    """
+    return request.param
+
+
+def test_zip_timestamp_sql(input_node, source_type, update_fixtures):
+    """
+    Test ZipTimestampTZTupleNode sql generation
+    """
+    timestamp_node = ParsedExpressionNode(
+        context=make_context(), table_node=input_node, expr=quoted_identifier("timestamp_col")
+    )
+    timezone_offset_node = ParsedExpressionNode(
+        context=make_context(), table_node=input_node, expr=quoted_identifier("tz_col")
+    )
+    input_nodes = [timestamp_node, timezone_offset_node]
+    context = make_context(
+        parameters={
+            "timestamp_schema": TimestampSchema(
+                timezone=TimeZoneColumn(column_name="tz_col", type="timezone"),
+            ),
+        },
+        input_sql_nodes=input_nodes,
+        source_type=source_type,
+    )
+
+    node = ZipTimestampTZTupleNode.build(context)
+    actual = sql_to_string(node.sql, source_type)
+    fixture_filename = (
+        f"tests/fixtures/query_graph/test_zip_timestamp/zip_timestamp_{source_type}.sql"
+    )
+    assert_equal_with_expected_fixture(
+        actual,
+        fixture_filename,
+        update_fixtures,
+    )

--- a/tests/unit/query_graph/test_extract_operation_structure.py
+++ b/tests/unit/query_graph/test_extract_operation_structure.py
@@ -1406,7 +1406,12 @@ def test_zip_timestamp_timezone_tuple_operation_structure(
     )
     zip_ts_tz_tuple = global_graph.add_operation(
         node_type=NodeType.ZIP_TIMESTAMP_TZ_TUPLE,
-        node_params={},
+        node_params={
+            "timestamp_schema": TimestampSchema(
+                format_string="%Y-%m-%d %H:%M:%S",
+                timezone=TimeZoneColumn(column_name="timezone", type="offset"),
+            )
+        },
         node_output_type=NodeOutputType.SERIES,
         input_nodes=[proj_eff_ts, proj_tz],
     )
@@ -1448,7 +1453,9 @@ def test_zip_timestamp_timezone_tuple_operation_structure(
             "name": None,
             "node_name": "zip_timestamp_tz_tuple_1",
             "node_names": {"input_1", "project_1", "project_2", "zip_timestamp_tz_tuple_1"},
-            "transforms": ["zip_timestamp_tz_tuple"],
+            "transforms": [
+                "zip_timestamp_tz_tuple(timestamp_schema={'format_string': '%Y-%m-%d %H:%M:%S', 'is_utc_time': None, 'timezone': {'column_name': 'timezone', 'type': 'offset'}})"
+            ],
             "type": "derived",
         }
     ]


### PR DESCRIPTION
## Description

This adds support for post-aggregation date difference operations involving the internal timestamp tuple type. Changes:

1. Implement sql generation for `ZIP_TIMESTAMP_TZ_TUPLE` node
2. Implement adapter methods to extract timestamp and timezone from zipped tuple
3. Update `DATE_DIFF` node to handle timestamp tuple type

## Related Issue

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
