### PR TITLE
[DEV-3959] Validate compatibility of window and offset unit and format_string

### DIFF
--- a/featurebyte/query_graph/model/timestamp_schema.py
+++ b/featurebyte/query_graph/model/timestamp_schema.py
@@ -66,6 +66,8 @@ class TimestampSchema(FeatureByteBaseModel):
         - **BigQuery:** (example: "%Y-%m-%d %H:%M:%S")
             [BigQuery Date and Time Functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/format-elements#format_elements_date_time)
 
+        If the timestamp column is not of type string, `format_string` is not required and should not be provided.
+
     timezone: Union[TimezoneName, TimezoneOffsetColumn]
         The time zones are defined by the [International Time Zone Database](https://www.iana.org/time-zones)
         (commonly known as the IANA Time Zone Database or tz database). The default value is "Etc/UTC".

--- a/featurebyte/query_graph/node/schema.py
+++ b/featurebyte/query_graph/node/schema.py
@@ -428,14 +428,18 @@ class ColumnSpec(FeatureByteBaseModel):
                 f"Column {self.name} is of type {self.dtype} (expected: {expected_dtypes})"
             )
 
-        # invalid setting: missing format_string for VARCHAR timestamp
-        if (
-            self.dtype == DBVarType.VARCHAR
-            and self.dtype_metadata.timestamp_schema.format_string is None
-        ):
-            raise ValueError(
-                f"format_string is required in the timestamp_schema for column {self.name}"
-            )
+        if self.dtype == DBVarType.VARCHAR:
+            # invalid setting: missing format_string for VARCHAR timestamp
+            if self.dtype_metadata.timestamp_schema.format_string is None:
+                raise ValueError(
+                    f"format_string is required in the timestamp_schema for column {self.name}"
+                )
+        else:
+            # invalid setting: format_string provided but column is not string
+            if self.dtype_metadata.timestamp_schema.format_string:
+                raise ValueError(
+                    f"format_string is not supported in the timestamp_schema for non-string column {self.name}"
+                )
 
     @model_validator(mode="after")
     def _validate_string_timestamp_format_string(self) -> "ColumnSpec":

--- a/tests/unit/query_graph/model/test_timestamp_schema.py
+++ b/tests/unit/query_graph/model/test_timestamp_schema.py
@@ -50,7 +50,7 @@ def test_timezone_name__invalid():
     """
     with pytest.raises(ValueError) as e:
         TimestampSchema(timezone="my_timezone")
-    assert "Invalid timezone name" in str(e)
+    assert "Invalid timezone name" in str(e.value)
 
 
 def test_local_time_without_timezone():
@@ -59,7 +59,7 @@ def test_local_time_without_timezone():
     """
     with pytest.raises(ValueError) as e:
         TimestampSchema(is_utc_time=False, timezone=None)
-    assert "Timezone must be provided for local time" in str(e)
+    assert "Timezone must be provided for local time" in str(e.value)
 
 
 def test_invalid_ts_datetime_types(ts_schema_utc_without_timezone):
@@ -72,12 +72,12 @@ def test_invalid_ts_datetime_types(ts_schema_utc_without_timezone):
             dtype=DBVarType.INT,
             dtype_metadata=DBVarTypeMetadata(timestamp_schema=ts_schema_utc_without_timezone),
         )
-    assert "Column ts is of type INT (expected: [DATE, TIMESTAMP, VARCHAR])" in str(e)
+    assert "Column ts is of type INT (expected: [DATE, TIMESTAMP, VARCHAR])" in str(e.value)
 
 
-def test_invalid_string_datetime_without_format_string(ts_schema_utc_without_timezone):
+def test_string_datetime_missing_format_string(ts_schema_utc_without_timezone):
     """
-    Test invalid timestamp schema datetime types
+    Test string timestamp type missing format_string
     """
     with pytest.raises(ValueError) as e:
         ColumnSpec(
@@ -85,4 +85,21 @@ def test_invalid_string_datetime_without_format_string(ts_schema_utc_without_tim
             dtype=DBVarType.VARCHAR,
             dtype_metadata=DBVarTypeMetadata(timestamp_schema=TimestampSchema()),
         )
-    assert "format_string is required in the timestamp_schema for column ts" in str(e)
+    assert "format_string is required in the timestamp_schema for column ts" in str(e.value)
+
+
+def test_non_string_datetime_with_format_string(ts_schema_utc_without_timezone):
+    """
+    Test non-string timestamp type with unnecessary format_string
+    """
+    with pytest.raises(ValueError) as e:
+        ColumnSpec(
+            name="ts",
+            dtype=DBVarType.TIMESTAMP,
+            dtype_metadata=DBVarTypeMetadata(
+                timestamp_schema=TimestampSchema(format_string="YYYY-MM-DD")
+            ),
+        )
+    assert "format_string is not supported in the timestamp_schema for non-string column ts" in str(
+        e.value
+    )


### PR DESCRIPTION
## Description

This adds the following validation for time series table / view:

1. Validate window unit is the same as offset unit in `aggregate_over`
2. Validate `format_string` is not provided for non-string types

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
