### PR TITLE
[chore] Fix missing reference_timezone field in generated code

### DIFF
--- a/featurebyte/query_graph/node/generic.py
+++ b/featurebyte/query_graph/node/generic.py
@@ -2178,6 +2178,7 @@ class TimeSeriesWindowAggregateNode(AggregationOpStructMixin):
         feature_job_setting: ObjectClass = ClassEnum.CRON_FEATURE_JOB_SETTING(
             crontab=fjs.get_cron_expression(),
             timezone=fjs.timezone,
+            reference_timezone=fjs.reference_timezone,
         )
         windows = [
             ClassEnum.CALENDAR_WINDOW(

--- a/tests/fixtures/sdk_code/ts_window_aggregate_feature.py
+++ b/tests/fixtures/sdk_code/ts_window_aggregate_feature.py
@@ -20,7 +20,7 @@ grouped = time_series_view.groupby(
     windows=[CalendarWindow(unit="MONTH", size=3)],
     feature_names=["col_float_sum_3month"],
     feature_job_setting=CronFeatureJobSetting(
-        crontab="0 8 1 * *", timezone="Etc/UTC"
+        crontab="0 8 1 * *", timezone="Etc/UTC", reference_timezone=None
     ),
     skip_fill_na=True,
     offset=None,

--- a/tests/unit/api/test_timestamp_timezone_tuple.py
+++ b/tests/unit/api/test_timestamp_timezone_tuple.py
@@ -92,7 +92,7 @@ def test_dt_accessor(feat_timestamp_tz_tuple, snowflake_time_series_table_with_t
             windows=[CalendarWindow(unit="MONTH", size=3)],
             feature_names=["col_float_sum_3month"],
             feature_job_setting=CronFeatureJobSetting(
-                crontab="0 8 1 * *", timezone="Etc/UTC"
+                crontab="0 8 1 * *", timezone="Etc/UTC", reference_timezone=None
             ),
             skip_fill_na=True,
             offset=None,


### PR DESCRIPTION
## Description

Fix missing `reference_timezone` field in the generated code for `CronFeatureJobSetting` which can cause inconsistent feature definitions error.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
