### PR TITLE
[chore] Add support for private key without passphrase in integration test

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -196,13 +196,16 @@ def credentials_mapping():
     Credentials for integration testing
     """
     try:
+        passphrase = os.getenv("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE", os.getenv("SNOWFLAKE_PASSWORD"))
+        if not passphrase:
+            passphrase = None
         username_private_key = CredentialModel(
             name="snowflake_featurestore",
             feature_store_id=ObjectId(),
             database_credential=PrivateKeyCredential(
                 username=os.getenv("SNOWFLAKE_USER"),
                 private_key=os.getenv("SNOWFLAKE_PRIVATE_KEY"),
-                passphrase=os.getenv("SNOWFLAKE_PASSWORD"),
+                passphrase=passphrase,
             ),
         )
     except ValidationError:


### PR DESCRIPTION
## Description

Set `SNOWFLAKE_PRIVATE_KEY_PASSPHRASE` to an empty string to use a private key without passphrase in integration test.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
