### PR TITLE
[chore] Make private key credential work with multi-line key copied from terminal

### DIFF
--- a/featurebyte/models/credential.py
+++ b/featurebyte/models/credential.py
@@ -213,6 +213,10 @@ class PrivateKeyCredential(BaseDatabaseCredential):
     def _format_private_key(self, values: Any) -> Any:
         # replace newline ascii characters with actual newline characters
         values["private_key"] = values["private_key"].replace("\\n", "\n")
+        # replace space before / after header / footer with newline characters
+        values["private_key"] = (
+            values["private_key"].replace(" -----", "\n-----").replace("----- ", "-----\n")
+        )
         return values
 
     @model_validator(mode="after")

--- a/tests/unit/models/test_credential.py
+++ b/tests/unit/models/test_credential.py
@@ -222,3 +222,47 @@ def test_private_key_credential_from_file_without_passphrase():
     assert credential.passphrase is None
     with open("tests/fixtures/rsa_key_no_passphrase.p8", "r") as file_obj:
         assert credential.private_key == file_obj.read()
+
+
+def test_private_key_credential():
+    """
+    Test PrivateKeyCredential copied from terminal (newlines converted to spaces)
+    """
+    credential = PrivateKeyCredential(
+        username="test",
+        private_key=(
+            "-----BEGIN PRIVATE KEY----- "
+            "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCq0H4LE8nuQXII "
+            "fnILujJhTAoSLzVS148q2+aNm2a3k3S2nYrG57q4BSmeB3qPl49qbbTH5mrEaH+s "
+            "Y0f2CV2wXfluM2Rr356j+LPBk1l9WObq23mN8YyI9as3JREInkLgNM7hkHH4Y/Pw "
+            "dsXmnNZblrxfDk6DhIJk7fDEhVgkyqssEThBPTK+O2vlREwqjsV+0JTJgzSo6pXx "
+            "rGUKdFs6p1L6Ll5B+4l6yZhM9zfOGDzRw0KN0Uiqqd3aV1VIqd6TEJXHlCxeY8x7 "
+            "9UA8j/KqYXW2umBWCSyZS07/0sLCZRYEW/lcnHXIMltBDiZxy7Vs58nHEmm32Exp "
+            "6Z5mh4wHAgMBAAECggEAIomDYrP+mUjsSKFgZ9SfCSM5yhF3g6eIEA9kX29zZlzP "
+            "NXlHLQ5/p2OL1aMHee8YFVnXOq/xGINUhUORskKUieuGWmzTuif9yIOpvNMRPhHy "
+            "prv3qOaVFsAtfTnmZsqxFOo4hk0RbjqvgQhS3V0Kznv83G9lGpx5TPT7QJEBkHaA "
+            "7aRaM4HSkflWV4zFdGw+oWP93Qw6/B0RquamFQ2+mtHIrPvn3LPDiC7CeEu/6H3j "
+            "1hQlIuuuBUPwZmekZL1pJF6BuhAndbjfWonMT9nXEygd0gqz566vyGWD1h/i7xcR "
+            "bHeII3rGiaIMySAY3byQ6FYJKA9eiQIUjfCLuuJ6sQKBgQDpsoqi5+BMjyl4FKXW "
+            "ymdqeR6OwqnLK7FMhpr/h+Nh/gan7nU17Zu55IbFR20krYTaF7YgZDBKfkHD3Z3F "
+            "3AFPw7O8/RGPEqOalFHCquYRHjlN30Pb23ZV8XoF3UYmEyyfWTPgX/kwWZt3l9ON "
+            "20VavTZQBVJyHBT+6Dk5lOZzOQKBgQC7HagztknKdvCQA3wIC0BQp6MVtphYE2kz "
+            "7423bfmr5AqHQGpCsE193gvAb3Z7Iz7lYj7WfNc0Nema79aLCBYBArhcSVf8aD2E "
+            "i3uPdyeS5hCu4Wb8Xe5TYRpnm8OOFFtm+JHlz1D9cL3n/DUg/EVt0HW7F8S/NUgN "
+            "2WCci/W5PwKBgQC6r07CXhs27XJCI7RrBhtg2cqIXocG7yteJ3UwRdxlzmiAxCPL "
+            "5bjt4dmrRKiykQ68rg5mh8Jv77YXgjTj9yDxGDO/+CWLtmcNOAisSpso94ztYToz "
+            "Kni4pQNGJgJArjaKQNcJGYHVlu9ztMxh2NTpbJczi1zWHQrEqrvz/LevOQKBgGaZ "
+            "/IFek1fRoFdXkctXYAzZ3zMozKB/BFDWKn9Kbn0yrhM73whyZAuAljEO7YjX6sUc "
+            "+hfinJ6kcVPj72CNLoOfWjhAf16ISjNDyJ0CWVDTlpJORopbdzOBK1lkr/ZYc0Yj "
+            "Rt0csOxHxdpPEVLlAa0VgXj1r4ypSrlNWQx+Ml9BAoGAG2oFDc0mcNCj8tPmcvOG "
+            "9qxUTH/bWFXZ8guR9sPHssb4l+nySBePceXJYaT6osDXvMOP840dZ62hgZZSXA5I "
+            "ClhgFWWIwwnOWtjx2nSqdtyUDnsIKtEj7qamNwAcqNIKnI5ai/MBgwuOyKtS9myX "
+            "3ydYyQWYhdq42BXQDMndUqM= "
+            "-----END PRIVATE KEY-----"
+        ),
+        passphrase=None,
+    )
+    assert credential.type == DatabaseCredentialType.PRIVATE_KEY
+
+    assert credential.username == "test"
+    assert credential.passphrase is None


### PR DESCRIPTION
## Description

Make private key credential work with multi-line key copied from terminal, where newlines are converted to spaces

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
