### PR TITLE
[chore] Reduce redundant time points in get_cron_job_schedule

### DIFF
--- a/featurebyte/service/cron_helper.py
+++ b/featurebyte/service/cron_helper.py
@@ -174,8 +174,7 @@ class CronHelper:
         end_local = end.astimezone(tz)
         cron_expr = cron_feature_job_setting.get_cron_expression()
 
-        # Get job schedules before start_local (cover two cycles in case start_local is on the
-        # schedule).
+        # Get job schedules before start_local
         cron = croniter(expr_format=cron_expr, start_time=start_local)
         job_schedule = [cron.get_prev(datetime), cron.get_prev(datetime)]
 

--- a/tests/integration/session/test_databricks_unity.py
+++ b/tests/integration/session/test_databricks_unity.py
@@ -61,7 +61,11 @@ async def test_list_tables(config, session_without_datasets):
     session = session_without_datasets
 
     tables = await session.list_tables(database_name="demo_datasets", schema_name="grocery")
-    assert [table.model_dump() for table in tables] == [
+
+    def _sort_by_name(_tables):
+        return sorted(_tables, key=lambda x: x["name"])
+
+    assert _sort_by_name([table.model_dump() for table in tables]) == _sort_by_name([
         {
             "name": "invoiceitems",
             "description": "The grocery item details within each invoice, including the "
@@ -83,4 +87,4 @@ async def test_list_tables(config, session_without_datasets):
             "name": "grocerycustomer",
             "description": "Customer details, including their name, address, and date of birth.",
         },
-    ]
+    ])

--- a/tests/unit/service/test_cron_helper.py
+++ b/tests/unit/service/test_cron_helper.py
@@ -46,8 +46,6 @@ def test_get_cron_schedule(cron_helper):
     )
     tzinfo = pytz.timezone("Etc/UTC")
     assert datetimes == [
-        datetime(2023, 12, 18, 10, 0, tzinfo=tzinfo),
-        datetime(2023, 12, 25, 10, 0, tzinfo=tzinfo),
         datetime(2024, 1, 1, 10, 0, tzinfo=tzinfo),
         datetime(2024, 1, 8, 10, 0, tzinfo=tzinfo),
         datetime(2024, 1, 15, 10, 0, tzinfo=tzinfo),
@@ -167,9 +165,6 @@ async def test_register_request_table_with_job_schedule(
     ]
     if reference_timezone is None:
         expected_schedules = [
-            Timestamp("2023-12-18 10:00:00"),
-            Timestamp("2023-12-25 10:00:00"),
-            Timestamp("2024-01-01 10:00:00"),
             Timestamp("2024-01-08 10:00:00"),
             Timestamp("2024-01-15 10:00:00"),
             Timestamp("2024-01-22 10:00:00"),
@@ -180,9 +175,6 @@ async def test_register_request_table_with_job_schedule(
     else:
         assert reference_timezone == "Asia/Singapore"
         expected_schedules = [
-            Timestamp("2023-12-18 09:00:00"),
-            Timestamp("2023-12-25 09:00:00"),
-            Timestamp("2024-01-01 09:00:00"),
             Timestamp("2024-01-08 09:00:00"),
             Timestamp("2024-01-15 09:00:00"),
             Timestamp("2024-01-22 09:00:00"),
@@ -192,9 +184,6 @@ async def test_register_request_table_with_job_schedule(
         ]
     assert df_schedule[InternalName.CRON_JOB_SCHEDULE_DATETIME].to_list() == expected_schedules
     assert df_schedule[InternalName.CRON_JOB_SCHEDULE_DATETIME_UTC].to_list() == [
-        Timestamp("2023-12-18 01:00:00"),
-        Timestamp("2023-12-25 01:00:00"),
-        Timestamp("2024-01-01 01:00:00"),
         Timestamp("2024-01-08 01:00:00"),
         Timestamp("2024-01-15 01:00:00"),
         Timestamp("2024-01-22 01:00:00"),


### PR DESCRIPTION
## Description

This updates `get_cron_job_schedule` to not use a hardcoded interval when determining the earliest simulated job schedule. This reduces the number of redundant time points in its output.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
