### PR TITLE
[chore] Fix test_list_tables for databricks_unity

### DIFF
--- a/tests/integration/session/test_databricks_unity.py
+++ b/tests/integration/session/test_databricks_unity.py
@@ -61,7 +61,11 @@ async def test_list_tables(config, session_without_datasets):
     session = session_without_datasets
 
     tables = await session.list_tables(database_name="demo_datasets", schema_name="grocery")
-    assert [table.model_dump() for table in tables] == [
+
+    def _sort_by_name(_tables):
+        return sorted(_tables, key=lambda x: x["name"])
+
+    assert _sort_by_name([table.model_dump() for table in tables]) == _sort_by_name([
         {
             "name": "invoiceitems",
             "description": "The grocery item details within each invoice, including the "
@@ -83,4 +87,4 @@ async def test_list_tables(config, session_without_datasets):
             "name": "grocerycustomer",
             "description": "Customer details, including their name, address, and date of birth.",
         },
-    ]
+    ])


### PR DESCRIPTION
## Description

Fix failing test:

```
FAILED tests/integration/session/test_databricks_unity.py::test_list_tables[databricks_unity] - AssertionError: assert [***'descriptio...roduct'***, ...] == [***'descriptio...stomer'***, ...]
  At index 0 diff: ***'name': '__grocerycustomer', 'description': None*** != ***'name': 'invoiceitems', 'description': 'The grocery item details within each invoice, including the quantity, total cost, discount applied, and product ID.'***
  Full diff:
    [
  +  ***'description': None, 'name': '__grocerycustomer'***,
  +  ***'description': None, 'name': '__groceryinvoice'***,
  +  ***'description': None, 'name': '__invoiceitems'***,
  +  ***'description': 'Customer details, including their name, address, and date of '
  +                  'birth.',
  +   'name': 'grocerycustomer'***,
  +  ***'description': 'Grocery invoice details, containing the timestamp and the '
  +                  'total amount of the invoice.',
  +   'name': 'groceryinvoice'***,
  +  ***'description': 'The product group description for each grocery product.',
  +   'name': 'groceryproduct'***,
     ***'description': 'The grocery item details within each invoice, including the '
                     'quantity, total cost, discount applied, and product ID.',
      'name': 'invoiceitems'***,
  -  ***'description': 'The product group description for each grocery product.',
  -   'name': 'groceryproduct'***,
  -  ***'description': None, 'name': '__invoiceitems'***,
  -  ***'description': None, 'name': '__groceryinvoice'***,
  -  ***'description': 'Grocery invoice details, containing the timestamp and the '
  -                  'total amount of the invoice.',
  -   'name': 'groceryinvoice'***,
  -  ***'description': None, 'name': '__grocerycustomer'***,
  -  ***'description': 'Customer details, including their name, address, and date of '
  -                  'birth.',
  -   'name': 'grocerycustomer'***,
    ]
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
