### PR TITLE
[DEV-3977] Limit number of categories in cross aggregation output

### DIFF
--- a/tests/fixtures/aggregator/expected_forward_aggregator.sql
+++ b/tests/fixtures/aggregator/expected_forward_aggregator.sql
@@ -21,28 +21,47 @@ LEFT JOIN (
     ) AS "_fb_internal_serving_cust_id_other_serving_key_forward_sum_value_cust_id_other_key_col_float_input_1"
   FROM (
     SELECT
-      REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
-      REQ."serving_cust_id" AS "serving_cust_id",
-      REQ."other_serving_key" AS "other_serving_key",
-      SOURCE_TABLE."col_float" AS "col_float",
-      SUM(SOURCE_TABLE."value") AS "_fb_internal_serving_cust_id_other_serving_key_forward_sum_value_cust_id_other_key_col_float_input_1_inner"
-    FROM "REQUEST_TABLE_POINT_IN_TIME_serving_cust_id_other_serving_key" AS REQ
-    INNER JOIN (
+      "POINT_IN_TIME",
+      "serving_cust_id",
+      "other_serving_key",
+      "col_float",
+      "_fb_internal_serving_cust_id_other_serving_key_forward_sum_value_cust_id_other_key_col_float_input_1_inner"
+    FROM (
       SELECT
-        *
-      FROM tab
-    ) AS SOURCE_TABLE
-      ON (
-        DATE_PART(EPOCH_SECOND, SOURCE_TABLE."timestamp_col") > DATE_PART(EPOCH_SECOND, REQ."POINT_IN_TIME")
-        AND DATE_PART(EPOCH_SECOND, SOURCE_TABLE."timestamp_col") <= DATE_PART(EPOCH_SECOND, REQ."POINT_IN_TIME") + 604800
+        "POINT_IN_TIME",
+        "serving_cust_id",
+        "other_serving_key",
+        "col_float",
+        "_fb_internal_serving_cust_id_other_serving_key_forward_sum_value_cust_id_other_key_col_float_input_1_inner",
+        ROW_NUMBER() OVER (PARTITION BY "POINT_IN_TIME", "serving_cust_id", "other_serving_key" ORDER BY "_fb_internal_serving_cust_id_other_serving_key_forward_sum_value_cust_id_other_key_col_float_input_1_inner" DESC) AS "__fb_object_agg_row_number"
+      FROM (
+        SELECT
+          REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
+          REQ."serving_cust_id" AS "serving_cust_id",
+          REQ."other_serving_key" AS "other_serving_key",
+          SOURCE_TABLE."col_float" AS "col_float",
+          SUM(SOURCE_TABLE."value") AS "_fb_internal_serving_cust_id_other_serving_key_forward_sum_value_cust_id_other_key_col_float_input_1_inner"
+        FROM "REQUEST_TABLE_POINT_IN_TIME_serving_cust_id_other_serving_key" AS REQ
+        INNER JOIN (
+          SELECT
+            *
+          FROM tab
+        ) AS SOURCE_TABLE
+          ON (
+            DATE_PART(EPOCH_SECOND, SOURCE_TABLE."timestamp_col") > DATE_PART(EPOCH_SECOND, REQ."POINT_IN_TIME")
+            AND DATE_PART(EPOCH_SECOND, SOURCE_TABLE."timestamp_col") <= DATE_PART(EPOCH_SECOND, REQ."POINT_IN_TIME") + 604800
+          )
+          AND REQ."serving_cust_id" = SOURCE_TABLE."cust_id"
+          AND REQ."other_serving_key" = SOURCE_TABLE."other_key"
+        GROUP BY
+          REQ."POINT_IN_TIME",
+          REQ."serving_cust_id",
+          REQ."other_serving_key",
+          SOURCE_TABLE."col_float"
       )
-      AND REQ."serving_cust_id" = SOURCE_TABLE."cust_id"
-      AND REQ."other_serving_key" = SOURCE_TABLE."other_key"
-    GROUP BY
-      REQ."POINT_IN_TIME",
-      REQ."serving_cust_id",
-      REQ."other_serving_key",
-      SOURCE_TABLE."col_float"
+    )
+    WHERE
+      "__fb_object_agg_row_number" <= 50000
   ) AS INNER_
   GROUP BY
     INNER_."POINT_IN_TIME",

--- a/tests/fixtures/expected_preview_sql_category.sql
+++ b/tests/fixtures/expected_preview_sql_category.sql
@@ -119,40 +119,57 @@ WITH REQUEST_TABLE AS (
         "POINT_IN_TIME",
         "CUSTOMER_ID",
         "product_type",
-        SUM(sum_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f) / SUM(count_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f) AS "inner__fb_internal_CUSTOMER_ID_window_w7200_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f"
+        "inner__fb_internal_CUSTOMER_ID_window_w7200_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f"
       FROM (
         SELECT
-          REQ."POINT_IN_TIME",
-          REQ."CUSTOMER_ID",
-          TILE.INDEX,
-          TILE.count_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f,
-          TILE.sum_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f,
-          TILE."product_type"
-        FROM "REQUEST_TABLE_W7200_F3600_BS900_M1800_CUSTOMER_ID" AS REQ
-        INNER JOIN TILE_F3600_M1800_B900_FEB86FDFF3B041DC98880F9B22EE9078FBCF5226 AS TILE
-          ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 2) = FLOOR(TILE.INDEX / 2)
-          AND REQ."CUSTOMER_ID" = TILE."cust_id"
-        WHERE
-          TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
-        UNION ALL
-        SELECT
-          REQ."POINT_IN_TIME",
-          REQ."CUSTOMER_ID",
-          TILE.INDEX,
-          TILE.count_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f,
-          TILE.sum_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f,
-          TILE."product_type"
-        FROM "REQUEST_TABLE_W7200_F3600_BS900_M1800_CUSTOMER_ID" AS REQ
-        INNER JOIN TILE_F3600_M1800_B900_FEB86FDFF3B041DC98880F9B22EE9078FBCF5226 AS TILE
-          ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 2) - 1 = FLOOR(TILE.INDEX / 2)
-          AND REQ."CUSTOMER_ID" = TILE."cust_id"
-        WHERE
-          TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+          "POINT_IN_TIME",
+          "CUSTOMER_ID",
+          "product_type",
+          "inner__fb_internal_CUSTOMER_ID_window_w7200_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f",
+          ROW_NUMBER() OVER (PARTITION BY "POINT_IN_TIME", "CUSTOMER_ID" ORDER BY "inner__fb_internal_CUSTOMER_ID_window_w7200_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f" DESC NULLS LAST) AS "__fb_object_agg_row_number"
+        FROM (
+          SELECT
+            "POINT_IN_TIME",
+            "CUSTOMER_ID",
+            "product_type",
+            SUM(sum_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f) / SUM(count_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f) AS "inner__fb_internal_CUSTOMER_ID_window_w7200_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f"
+          FROM (
+            SELECT
+              REQ."POINT_IN_TIME",
+              REQ."CUSTOMER_ID",
+              TILE.INDEX,
+              TILE.count_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f,
+              TILE.sum_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f,
+              TILE."product_type"
+            FROM "REQUEST_TABLE_W7200_F3600_BS900_M1800_CUSTOMER_ID" AS REQ
+            INNER JOIN TILE_F3600_M1800_B900_FEB86FDFF3B041DC98880F9B22EE9078FBCF5226 AS TILE
+              ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 2) = FLOOR(TILE.INDEX / 2)
+              AND REQ."CUSTOMER_ID" = TILE."cust_id"
+            WHERE
+              TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+            UNION ALL
+            SELECT
+              REQ."POINT_IN_TIME",
+              REQ."CUSTOMER_ID",
+              TILE.INDEX,
+              TILE.count_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f,
+              TILE.sum_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f,
+              TILE."product_type"
+            FROM "REQUEST_TABLE_W7200_F3600_BS900_M1800_CUSTOMER_ID" AS REQ
+            INNER JOIN TILE_F3600_M1800_B900_FEB86FDFF3B041DC98880F9B22EE9078FBCF5226 AS TILE
+              ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 2) - 1 = FLOOR(TILE.INDEX / 2)
+              AND REQ."CUSTOMER_ID" = TILE."cust_id"
+            WHERE
+              TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+          )
+          GROUP BY
+            "POINT_IN_TIME",
+            "CUSTOMER_ID",
+            "product_type"
+        )
       )
-      GROUP BY
-        "POINT_IN_TIME",
-        "CUSTOMER_ID",
-        "product_type"
+      WHERE
+        "__fb_object_agg_row_number" <= 50000
     ) AS INNER_
     GROUP BY
       INNER_."POINT_IN_TIME",
@@ -178,40 +195,57 @@ WITH REQUEST_TABLE AS (
         "POINT_IN_TIME",
         "CUSTOMER_ID",
         "product_type",
-        SUM(sum_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f) / SUM(count_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f) AS "inner__fb_internal_CUSTOMER_ID_window_w172800_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f"
+        "inner__fb_internal_CUSTOMER_ID_window_w172800_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f"
       FROM (
         SELECT
-          REQ."POINT_IN_TIME",
-          REQ."CUSTOMER_ID",
-          TILE.INDEX,
-          TILE.count_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f,
-          TILE.sum_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f,
-          TILE."product_type"
-        FROM "REQUEST_TABLE_W172800_F3600_BS900_M1800_CUSTOMER_ID" AS REQ
-        INNER JOIN TILE_F3600_M1800_B900_FEB86FDFF3B041DC98880F9B22EE9078FBCF5226 AS TILE
-          ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 48) = FLOOR(TILE.INDEX / 48)
-          AND REQ."CUSTOMER_ID" = TILE."cust_id"
-        WHERE
-          TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
-        UNION ALL
-        SELECT
-          REQ."POINT_IN_TIME",
-          REQ."CUSTOMER_ID",
-          TILE.INDEX,
-          TILE.count_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f,
-          TILE.sum_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f,
-          TILE."product_type"
-        FROM "REQUEST_TABLE_W172800_F3600_BS900_M1800_CUSTOMER_ID" AS REQ
-        INNER JOIN TILE_F3600_M1800_B900_FEB86FDFF3B041DC98880F9B22EE9078FBCF5226 AS TILE
-          ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 48) - 1 = FLOOR(TILE.INDEX / 48)
-          AND REQ."CUSTOMER_ID" = TILE."cust_id"
-        WHERE
-          TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+          "POINT_IN_TIME",
+          "CUSTOMER_ID",
+          "product_type",
+          "inner__fb_internal_CUSTOMER_ID_window_w172800_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f",
+          ROW_NUMBER() OVER (PARTITION BY "POINT_IN_TIME", "CUSTOMER_ID" ORDER BY "inner__fb_internal_CUSTOMER_ID_window_w172800_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f" DESC NULLS LAST) AS "__fb_object_agg_row_number"
+        FROM (
+          SELECT
+            "POINT_IN_TIME",
+            "CUSTOMER_ID",
+            "product_type",
+            SUM(sum_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f) / SUM(count_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f) AS "inner__fb_internal_CUSTOMER_ID_window_w172800_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f"
+          FROM (
+            SELECT
+              REQ."POINT_IN_TIME",
+              REQ."CUSTOMER_ID",
+              TILE.INDEX,
+              TILE.count_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f,
+              TILE.sum_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f,
+              TILE."product_type"
+            FROM "REQUEST_TABLE_W172800_F3600_BS900_M1800_CUSTOMER_ID" AS REQ
+            INNER JOIN TILE_F3600_M1800_B900_FEB86FDFF3B041DC98880F9B22EE9078FBCF5226 AS TILE
+              ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 48) = FLOOR(TILE.INDEX / 48)
+              AND REQ."CUSTOMER_ID" = TILE."cust_id"
+            WHERE
+              TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+            UNION ALL
+            SELECT
+              REQ."POINT_IN_TIME",
+              REQ."CUSTOMER_ID",
+              TILE.INDEX,
+              TILE.count_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f,
+              TILE.sum_value_avg_dfee6d136c6d6db110606afd33ae34deb9b5e96f,
+              TILE."product_type"
+            FROM "REQUEST_TABLE_W172800_F3600_BS900_M1800_CUSTOMER_ID" AS REQ
+            INNER JOIN TILE_F3600_M1800_B900_FEB86FDFF3B041DC98880F9B22EE9078FBCF5226 AS TILE
+              ON FLOOR(REQ.__FB_LAST_TILE_INDEX / 48) - 1 = FLOOR(TILE.INDEX / 48)
+              AND REQ."CUSTOMER_ID" = TILE."cust_id"
+            WHERE
+              TILE.INDEX >= REQ.__FB_FIRST_TILE_INDEX AND TILE.INDEX < REQ.__FB_LAST_TILE_INDEX
+          )
+          GROUP BY
+            "POINT_IN_TIME",
+            "CUSTOMER_ID",
+            "product_type"
+        )
       )
-      GROUP BY
-        "POINT_IN_TIME",
-        "CUSTOMER_ID",
-        "product_type"
+      WHERE
+        "__fb_object_agg_row_number" <= 50000
     ) AS INNER_
     GROUP BY
       INNER_."POINT_IN_TIME",

--- a/tests/unit/query_graph/sql/fixtures/snowflake_double_vector_agg_only.py
+++ b/tests/unit/query_graph/sql/fixtures/snowflake_double_vector_agg_only.py
@@ -27,44 +27,63 @@ SNOWFLAKE_DOUBLE_VECTOR_AGG_ONLY_QUERY = textwrap.dedent(
           ) AS "result_1"
         FROM (
           SELECT
-            VECTOR_T0."serving_name" AS "serving_name",
-            VECTOR_T0."POINT_IN_TIME" AS "POINT_IN_TIME",
-            VECTOR_T0."value_by" AS "value_by",
-            VECTOR_T0."result_0" AS "result_0",
-            VECTOR_T1."result_1" AS "result_1"
+            "serving_name",
+            "POINT_IN_TIME",
+            "value_by",
+            "result_0_inner",
+            "result_1_inner"
           FROM (
             SELECT
-              INITIAL_DATA."serving_name" AS "serving_name",
-              INITIAL_DATA."POINT_IN_TIME" AS "POINT_IN_TIME",
-              AGG_0."VECTOR_AGG_RESULT" AS "result_0"
+              "serving_name",
+              "POINT_IN_TIME",
+              "value_by",
+              "result_0_inner",
+              "result_1_inner",
+              ROW_NUMBER() OVER (PARTITION BY "serving_name", "POINT_IN_TIME" ORDER BY "result_0_inner" DESC) AS "__fb_object_agg_row_number"
             FROM (
               SELECT
-                REQ."serving_name" AS "serving_name",
-                REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
-                TABLE."parent" AS parent
-              FROM REQ
-            ) AS INITIAL_DATA, TABLE(
-              VECTOR_AGGREGATE_MAX(parent) OVER (PARTITION BY INITIAL_DATA."serving_name", INITIAL_DATA."POINT_IN_TIME")
-            ) AS "AGG_0"
-          ) AS VECTOR_T0
-          INNER JOIN (
-            SELECT
-              INITIAL_DATA."serving_name" AS "serving_name",
-              INITIAL_DATA."POINT_IN_TIME" AS "POINT_IN_TIME",
-              AGG_1."VECTOR_AGG_RESULT" AS "result_1"
-            FROM (
-              SELECT
-                REQ."serving_name" AS "serving_name",
-                REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
-                TABLE."parent" AS parent
-              FROM REQ
-            ) AS INITIAL_DATA, TABLE(
-              VECTOR_AGGREGATE_MAX(parent) OVER (PARTITION BY INITIAL_DATA."serving_name", INITIAL_DATA."POINT_IN_TIME")
-            ) AS "AGG_1"
-          ) AS VECTOR_T1
-            ON VECTOR_T0."serving_name" = VECTOR_T1."serving_name"
-            AND VECTOR_T0."POINT_IN_TIME" = VECTOR_T1."POINT_IN_TIME"
-            AND VECTOR_T0."value_by" = VECTOR_T1."value_by"
+                VECTOR_T0."serving_name" AS "serving_name",
+                VECTOR_T0."POINT_IN_TIME" AS "POINT_IN_TIME",
+                VECTOR_T0."value_by" AS "value_by",
+                VECTOR_T0."result_0" AS "result_0",
+                VECTOR_T1."result_1" AS "result_1"
+              FROM (
+                SELECT
+                  INITIAL_DATA."serving_name" AS "serving_name",
+                  INITIAL_DATA."POINT_IN_TIME" AS "POINT_IN_TIME",
+                  AGG_0."VECTOR_AGG_RESULT" AS "result_0"
+                FROM (
+                  SELECT
+                    REQ."serving_name" AS "serving_name",
+                    REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
+                    TABLE."parent" AS parent
+                  FROM REQ
+                ) AS INITIAL_DATA, TABLE(
+                  VECTOR_AGGREGATE_MAX(parent) OVER (PARTITION BY INITIAL_DATA."serving_name", INITIAL_DATA."POINT_IN_TIME")
+                ) AS "AGG_0"
+              ) AS VECTOR_T0
+              INNER JOIN (
+                SELECT
+                  INITIAL_DATA."serving_name" AS "serving_name",
+                  INITIAL_DATA."POINT_IN_TIME" AS "POINT_IN_TIME",
+                  AGG_1."VECTOR_AGG_RESULT" AS "result_1"
+                FROM (
+                  SELECT
+                    REQ."serving_name" AS "serving_name",
+                    REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
+                    TABLE."parent" AS parent
+                  FROM REQ
+                ) AS INITIAL_DATA, TABLE(
+                  VECTOR_AGGREGATE_MAX(parent) OVER (PARTITION BY INITIAL_DATA."serving_name", INITIAL_DATA."POINT_IN_TIME")
+                ) AS "AGG_1"
+              ) AS VECTOR_T1
+                ON VECTOR_T0."serving_name" = VECTOR_T1."serving_name"
+                AND VECTOR_T0."POINT_IN_TIME" = VECTOR_T1."POINT_IN_TIME"
+                AND VECTOR_T0."value_by" = VECTOR_T1."value_by"
+            )
+          )
+          WHERE
+            "__fb_object_agg_row_number" <= 50000
         ) AS INNER_
         GROUP BY
           INNER_."serving_name",

--- a/tests/unit/query_graph/sql/fixtures/snowflake_vector_agg_with_normal_agg.py
+++ b/tests/unit/query_graph/sql/fixtures/snowflake_vector_agg_with_normal_agg.py
@@ -27,41 +27,60 @@ SNOWFLAKE_VECTOR_AGG_WITH_NORMAL_AGG_QUERY = textwrap.dedent(
           ) AS "result_1"
         FROM (
           SELECT
-            VECTOR_T0."serving_name" AS "serving_name",
-            VECTOR_T0."POINT_IN_TIME" AS "POINT_IN_TIME",
-            VECTOR_T0."value_by" AS "value_by",
-            GROUP_BY_RESULT."result_1_inner" AS "result_1_inner",
-            VECTOR_T0."result_0" AS "result_0"
+            "serving_name",
+            "POINT_IN_TIME",
+            "value_by",
+            "result_0_inner",
+            "result_1_inner"
           FROM (
             SELECT
-              INITIAL_DATA."serving_name" AS "serving_name",
-              INITIAL_DATA."POINT_IN_TIME" AS "POINT_IN_TIME",
-              AGG_0."VECTOR_AGG_RESULT" AS "result_0"
+              "serving_name",
+              "POINT_IN_TIME",
+              "value_by",
+              "result_0_inner",
+              "result_1_inner",
+              ROW_NUMBER() OVER (PARTITION BY "serving_name", "POINT_IN_TIME" ORDER BY "result_0_inner" DESC) AS "__fb_object_agg_row_number"
             FROM (
               SELECT
-                REQ."serving_name" AS "serving_name",
-                REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
-                TABLE."parent" AS parent
-              FROM REQ
-            ) AS INITIAL_DATA, TABLE(
-              VECTOR_AGGREGATE_MAX(parent) OVER (PARTITION BY INITIAL_DATA."serving_name", INITIAL_DATA."POINT_IN_TIME")
-            ) AS "AGG_0"
-          ) AS VECTOR_T0
-          INNER JOIN (
-            SELECT
-              REQ."serving_name" AS "serving_name",
-              REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
-              REQ."value_by" AS "value_by",
-              MAX(TABLE."parent") AS "result_1_inner"
-            FROM REQ
-            GROUP BY
-              REQ."serving_name",
-              REQ."POINT_IN_TIME",
-              REQ."value_by"
-          ) AS GROUP_BY_RESULT
-            ON GROUP_BY_RESULT."serving_name" = VECTOR_T0."serving_name"
-            AND GROUP_BY_RESULT."POINT_IN_TIME" = VECTOR_T0."POINT_IN_TIME"
-            AND GROUP_BY_RESULT."value_by" = VECTOR_T0."value_by"
+                VECTOR_T0."serving_name" AS "serving_name",
+                VECTOR_T0."POINT_IN_TIME" AS "POINT_IN_TIME",
+                VECTOR_T0."value_by" AS "value_by",
+                GROUP_BY_RESULT."result_1_inner" AS "result_1_inner",
+                VECTOR_T0."result_0" AS "result_0"
+              FROM (
+                SELECT
+                  INITIAL_DATA."serving_name" AS "serving_name",
+                  INITIAL_DATA."POINT_IN_TIME" AS "POINT_IN_TIME",
+                  AGG_0."VECTOR_AGG_RESULT" AS "result_0"
+                FROM (
+                  SELECT
+                    REQ."serving_name" AS "serving_name",
+                    REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
+                    TABLE."parent" AS parent
+                  FROM REQ
+                ) AS INITIAL_DATA, TABLE(
+                  VECTOR_AGGREGATE_MAX(parent) OVER (PARTITION BY INITIAL_DATA."serving_name", INITIAL_DATA."POINT_IN_TIME")
+                ) AS "AGG_0"
+              ) AS VECTOR_T0
+              INNER JOIN (
+                SELECT
+                  REQ."serving_name" AS "serving_name",
+                  REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
+                  REQ."value_by" AS "value_by",
+                  MAX(TABLE."parent") AS "result_1_inner"
+                FROM REQ
+                GROUP BY
+                  REQ."serving_name",
+                  REQ."POINT_IN_TIME",
+                  REQ."value_by"
+              ) AS GROUP_BY_RESULT
+                ON GROUP_BY_RESULT."serving_name" = VECTOR_T0."serving_name"
+                AND GROUP_BY_RESULT."POINT_IN_TIME" = VECTOR_T0."POINT_IN_TIME"
+                AND GROUP_BY_RESULT."value_by" = VECTOR_T0."value_by"
+            )
+          )
+          WHERE
+            "__fb_object_agg_row_number" <= 50000
         ) AS INNER_
         GROUP BY
           INNER_."serving_name",

--- a/tests/unit/query_graph/sql/test_groupby_helper.py
+++ b/tests/unit/query_graph/sql/test_groupby_helper.py
@@ -234,16 +234,35 @@ def test_get_groupby_expr__multiple_groupby_columns__non_snowflake_vector_aggrs(
               ) AS "result_1"
             FROM (
               SELECT
-                REQ."serving_name" AS "serving_name",
-                REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
-                REQ."value_by" AS "value_by",
-                {methods[0]}(TABLE."parent") AS "result_0_inner",
-                {methods[1]}(TABLE."parent") AS "result_1_inner"
-              FROM REQ
-              GROUP BY
-                REQ."serving_name",
-                REQ."POINT_IN_TIME",
-                REQ."value_by"
+                "serving_name",
+                "POINT_IN_TIME",
+                "value_by",
+                "result_0_inner",
+                "result_1_inner"
+              FROM (
+                SELECT
+                  "serving_name",
+                  "POINT_IN_TIME",
+                  "value_by",
+                  "result_0_inner",
+                  "result_1_inner",
+                  ROW_NUMBER() OVER (PARTITION BY "serving_name", "POINT_IN_TIME" ORDER BY "result_0_inner" DESC) AS "__fb_object_agg_row_number"
+                FROM (
+                  SELECT
+                    REQ."serving_name" AS "serving_name",
+                    REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
+                    REQ."value_by" AS "value_by",
+                    {methods[0]}(TABLE."parent") AS "result_0_inner",
+                    {methods[1]}(TABLE."parent") AS "result_1_inner"
+                  FROM REQ
+                  GROUP BY
+                    REQ."serving_name",
+                    REQ."POINT_IN_TIME",
+                    REQ."value_by"
+                )
+              )
+              WHERE
+                "__fb_object_agg_row_number" <= 50000
             ) AS INNER_
             GROUP BY
               INNER_."serving_name",
@@ -288,16 +307,35 @@ def test_get_groupby_expr__multiple_groupby_columns__non_snowflake_vector_aggrs(
               ) AS "result_1"
             FROM (
               SELECT
-                REQ."serving_name" AS "serving_name",
-                REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
-                REQ."value_by" AS "value_by",
-                {methods[0]}(TABLE."parent") AS "result_0_inner",
-                {methods[1]}(TABLE."parent") AS "result_1_inner"
-              FROM REQ
-              GROUP BY
-                REQ."serving_name",
-                REQ."POINT_IN_TIME",
-                REQ."value_by"
+                "serving_name",
+                "POINT_IN_TIME",
+                "value_by",
+                "result_0_inner",
+                "result_1_inner"
+              FROM (
+                SELECT
+                  "serving_name",
+                  "POINT_IN_TIME",
+                  "value_by",
+                  "result_0_inner",
+                  "result_1_inner",
+                  ROW_NUMBER() OVER (PARTITION BY "serving_name", "POINT_IN_TIME" ORDER BY "result_0_inner" DESC) AS "__fb_object_agg_row_number"
+                FROM (
+                  SELECT
+                    REQ."serving_name" AS "serving_name",
+                    REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
+                    REQ."value_by" AS "value_by",
+                    {methods[0]}(TABLE."parent") AS "result_0_inner",
+                    {methods[1]}(TABLE."parent") AS "result_1_inner"
+                  FROM REQ
+                  GROUP BY
+                    REQ."serving_name",
+                    REQ."POINT_IN_TIME",
+                    REQ."value_by"
+                )
+              )
+              WHERE
+                "__fb_object_agg_row_number" <= 50000
             ) AS INNER_
             GROUP BY
               INNER_."serving_name",
@@ -420,15 +458,32 @@ def test_get_groupby_expr(agg_func, parent_dtype, method, common_params, spark_s
           ) AS "result"
         FROM (
           SELECT
-            REQ."serving_name" AS "serving_name",
-            REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
-            REQ."value_by" AS "value_by",
-            {method}(TABLE."parent") AS "result_inner"
-          FROM REQ
-          GROUP BY
-            REQ."serving_name",
-            REQ."POINT_IN_TIME",
-            REQ."value_by"
+            "serving_name",
+            "POINT_IN_TIME",
+            "value_by",
+            "result_inner"
+          FROM (
+            SELECT
+              "serving_name",
+              "POINT_IN_TIME",
+              "value_by",
+              "result_inner",
+              ROW_NUMBER() OVER (PARTITION BY "serving_name", "POINT_IN_TIME" ORDER BY "result_inner" DESC) AS "__fb_object_agg_row_number"
+            FROM (
+              SELECT
+                REQ."serving_name" AS "serving_name",
+                REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
+                REQ."value_by" AS "value_by",
+                {method}(TABLE."parent") AS "result_inner"
+              FROM REQ
+              GROUP BY
+                REQ."serving_name",
+                REQ."POINT_IN_TIME",
+                REQ."value_by"
+            )
+          )
+          WHERE
+            "__fb_object_agg_row_number" <= 50000
         ) AS INNER_
         GROUP BY
           INNER_."serving_name",

--- a/tests/unit/query_graph/test_asat_aggregator.py
+++ b/tests/unit/query_graph/test_asat_aggregator.py
@@ -524,7 +524,7 @@ def test_same_source_different_keys(aggregation_specs_same_source_different_keys
     assert result.updated_table_expr.sql(pretty=True) == expected
 
 
-def test_asat_aggregate_with_cateogry(aggregation_spec_with_category, source_info):
+def test_asat_aggregate_with_category(aggregation_spec_with_category, source_info):
     """
     Test AsAtAggregator with category parameter
     """
@@ -559,27 +559,44 @@ def test_asat_aggregate_with_cateogry(aggregation_spec_with_category, source_inf
             ) AS "_fb_internal_serving_cust_id_as_at_sum_value_cust_id_category_col_input_1"
           FROM (
             SELECT
-              REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
-              REQ."serving_cust_id" AS "serving_cust_id",
-              SCD."category_col" AS "category_col",
-              SUM(SCD."value") AS "_fb_internal_serving_cust_id_as_at_sum_value_cust_id_category_col_input_1_inner"
-            FROM "REQUEST_TABLE_POINT_IN_TIME_serving_cust_id" AS REQ
-            INNER JOIN (
+              "POINT_IN_TIME",
+              "serving_cust_id",
+              "category_col",
+              "_fb_internal_serving_cust_id_as_at_sum_value_cust_id_category_col_input_1_inner"
+            FROM (
               SELECT
-                *
-              FROM SCD_TABLE
-            ) AS SCD
-              ON REQ."serving_cust_id" = SCD."cust_id"
-              AND (
-                SCD."effective_ts" <= REQ."POINT_IN_TIME"
-                AND (
-                  SCD."end_ts" > REQ."POINT_IN_TIME" OR SCD."end_ts" IS NULL
-                )
+                "POINT_IN_TIME",
+                "serving_cust_id",
+                "category_col",
+                "_fb_internal_serving_cust_id_as_at_sum_value_cust_id_category_col_input_1_inner",
+                ROW_NUMBER() OVER (PARTITION BY "POINT_IN_TIME", "serving_cust_id" ORDER BY "_fb_internal_serving_cust_id_as_at_sum_value_cust_id_category_col_input_1_inner" DESC) AS "__fb_object_agg_row_number"
+              FROM (
+                SELECT
+                  REQ."POINT_IN_TIME" AS "POINT_IN_TIME",
+                  REQ."serving_cust_id" AS "serving_cust_id",
+                  SCD."category_col" AS "category_col",
+                  SUM(SCD."value") AS "_fb_internal_serving_cust_id_as_at_sum_value_cust_id_category_col_input_1_inner"
+                FROM "REQUEST_TABLE_POINT_IN_TIME_serving_cust_id" AS REQ
+                INNER JOIN (
+                  SELECT
+                    *
+                  FROM SCD_TABLE
+                ) AS SCD
+                  ON REQ."serving_cust_id" = SCD."cust_id"
+                  AND (
+                    SCD."effective_ts" <= REQ."POINT_IN_TIME"
+                    AND (
+                      SCD."end_ts" > REQ."POINT_IN_TIME" OR SCD."end_ts" IS NULL
+                    )
+                  )
+                GROUP BY
+                  REQ."POINT_IN_TIME",
+                  REQ."serving_cust_id",
+                  SCD."category_col"
               )
-            GROUP BY
-              REQ."POINT_IN_TIME",
-              REQ."serving_cust_id",
-              SCD."category_col"
+            )
+            WHERE
+              "__fb_object_agg_row_number" <= 50000
           ) AS INNER_
           GROUP BY
             INNER_."POINT_IN_TIME",


### PR DESCRIPTION
## Description

Enforce a maximum number of categories in cross aggregation output to avoid UDF out of memory errors.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
