### PR TITLE
[chore] Track queued tasks in persistent and support revoke

### DIFF
--- a/featurebyte/models/task.py
+++ b/featurebyte/models/task.py
@@ -94,15 +94,15 @@ class Task(FeatureByteBaseDocumentModel):
 
     id: UUID = Field(default_factory=uuid4, alias="_id")  # type: ignore
     status: str
-    result: str
+    result: Optional[str] = Field(default=None)
     traceback: Optional[str] = Field(default=None)
     children: List[str]
     start_time: Optional[datetime] = Field(default=None)
-    date_done: datetime
+    date_done: Optional[datetime] = Field(default=None)
     name: str
     args: List[Any]
     kwargs: Dict[str, Any]
-    worker: str
+    worker: Optional[str] = Field(default=None)
     retries: int
     queue: str
     progress: Optional[Dict[str, Any]] = Field(default=None)

--- a/featurebyte/persistent/base.py
+++ b/featurebyte/persistent/base.py
@@ -17,8 +17,10 @@ from typing import (
     List,
     Optional,
     Tuple,
+    Union,
     cast,
 )
+from uuid import UUID
 
 from bson import ObjectId
 from typing_extensions import Literal
@@ -63,7 +65,7 @@ class Persistent(ABC):
         document: Document,
         user_id: Optional[ObjectId],
         disable_audit: bool = False,
-    ) -> ObjectId:
+    ) -> Union[ObjectId, UUID]:
         """
         Insert record into collection. Note that when using this method inside a non BaseDocumentService,
         please use with caution as it does not inject user_id and catalog_id into the document automatically.
@@ -81,7 +83,7 @@ class Persistent(ABC):
 
         Returns
         -------
-        ObjectId
+        Union[ObjectId, UUID]
             Id of the inserted document
         """
         document["created_at"] = get_utc_now()
@@ -94,7 +96,7 @@ class Persistent(ABC):
         documents: Iterable[Document],
         user_id: Optional[ObjectId],
         disable_audit: bool = False,
-    ) -> list[ObjectId]:
+    ) -> list[Union[ObjectId, UUID]]:
         """
         Insert records into collection. Note that when using this method inside a non BaseDocumentService,
         please use with caution as it does not inject user_id and catalog_id into the document automatically.
@@ -112,7 +114,7 @@ class Persistent(ABC):
 
         Returns
         -------
-        list[ObjectId]
+        list[Union[ObjectId, UUID]]
             Ids of the inserted document
         """
         utc_now = get_utc_now()
@@ -700,13 +702,13 @@ class Persistent(ABC):
         yield self
 
     @abstractmethod
-    async def _insert_one(self, collection_name: str, document: Document) -> ObjectId:
+    async def _insert_one(self, collection_name: str, document: Document) -> Union[ObjectId, UUID]:
         pass
 
     @abstractmethod
     async def _insert_many(
         self, collection_name: str, documents: Iterable[Document]
-    ) -> list[ObjectId]:
+    ) -> list[Union[ObjectId, UUID]]:
         pass
 
     @abstractmethod

--- a/featurebyte/schema/task.py
+++ b/featurebyte/schema/task.py
@@ -82,6 +82,7 @@ class Task(FeatureByteBaseModel):
     progress: Optional[Dict[str, Any]] = Field(default=None)
     progress_history: Optional[ProgressHistory] = Field(default=None)
     child_task_ids: Optional[List[TaskId]] = Field(default=None)
+    queue: Optional[str] = Field(default=None)
 
 
 class TaskList(PaginationMixin):

--- a/featurebyte/service/task_manager.py
+++ b/featurebyte/service/task_manager.py
@@ -5,6 +5,7 @@ TaskManager service is responsible to submit task message
 from __future__ import annotations
 
 import datetime
+import json
 from typing import Any, Optional
 from uuid import UUID
 
@@ -100,6 +101,26 @@ class TaskManager:
             payload.task, kwargs=kwargs, queue=payload.queue, parent_id=parent_task_id
         )
 
+        # create task document in persistent to track pending tasks
+        await self.persistent.insert_one(
+            collection_name=TaskModel.collection_name(),
+            document={
+                "_id": str(task.id),
+                "name": payload.task,
+                "created_at": datetime.datetime.utcnow(),
+                "description": f"[Queued] {payload.command}",
+                "status": TaskStatus.PENDING,
+                "children": [],
+                "start_time": datetime.datetime.utcnow(),
+                "args": [],
+                "kwargs": kwargs,
+                "queue": payload.queue,
+                "retries": 0,
+            },
+            user_id=self.user.id,
+            disable_audit=True,
+        )
+
         if parent_task_id:
             await self._add_child_task_id(str(parent_task_id), str(task.id))
         return str(task.id)
@@ -145,6 +166,7 @@ class TaskManager:
             progress=document.get("progress"),
             progress_history=document.get("progress_history"),
             child_task_ids=document.get("child_task_ids"),
+            queue=document.get("queue"),
         )
 
     async def update_task_result(self, task_id: str, result: Any) -> None:
@@ -476,6 +498,29 @@ class TaskManager:
             raise TaskNotRevocableError(f'Task (id: "{task_id}") does not support revoke.')
         if task.status in TaskStatus.non_terminal():
             self.celery.control.revoke(task_id, reply=True, terminate=True, signal="SIGTERM")
+
+            # remove task from redis queue
+            queue = task.queue or "celery"
+            tasks = self.redis.lrange(queue, 0, -1)
+            if tasks:
+                for task_json in tasks:
+                    task_dict = json.loads(task_json)
+                    try:
+                        if task_dict.get("headers").get("id") == task_id:
+                            self.redis.lrem(queue, 1, task_json)
+                            break
+                    except AttributeError:
+                        pass
+
+            # update status to REVOKED
+            await self.persistent.update_one(
+                collection_name=TaskModel.collection_name(),
+                query_filter={"_id": task_id},
+                update={"$set": {"status": TaskStatus.REVOKED}},
+                user_id=self.user.id,
+                disable_audit=True,
+            )
+
             # revoke all child tasks
             if task.child_task_ids:
                 for child_task_id in task.child_task_ids:


### PR DESCRIPTION
## Description

- Track pending (queued but not received by workers) tasks in persistent so they are visible in task listings
- Support revoking of pending tasks


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
