### PR TITLE
[DEV-3990] Fix ChangeView with timestamp schema error when joined with SCDView

### DIFF
--- a/featurebyte/query_graph/node/generic.py
+++ b/featurebyte/query_graph/node/generic.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from typing_extensions import Literal
 
 from featurebyte.common.model_util import parse_duration_string
+from featurebyte.enum import DBVarType
 from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
 from featurebyte.query_graph.enum import NodeOutputType, NodeType
 from featurebyte.query_graph.model.dtype import DBVarTypeInfo, DBVarTypeMetadata
@@ -1832,6 +1833,9 @@ class TrackChangesNode(BaseNode):
         columns = [natural_key_source_column]
         track_dtype = tracked_source_column.dtype_info
         valid_dtype = effective_timestamp_source_column.dtype_info
+        if valid_dtype is not None and valid_dtype.timestamp_schema is not None:
+            # Timestamp columns have been converted within the TRACK_CHANGES node
+            valid_dtype = DBVarTypeInfo(dtype=DBVarType.TIMESTAMP)
         transform_info = self.transform_info
         for column_name, dtype_info in [
             (self.parameters.previous_tracked_column_name, track_dtype),

--- a/tests/integration/api/test_change_view_operations.py
+++ b/tests/integration/api/test_change_view_operations.py
@@ -201,19 +201,20 @@ def test_change_view_custom_date_format_and_join(
     """
     change_view = scd_table_custom_date_format.get_change_view("User Status")
 
+    # Check that the timestamp column in the change view is used correctly downstream
     view = scd_table.get_view()
     joined_view = change_view.join(view)
     feature = joined_view.groupby("User ID").aggregate_over(
         value_column="User Status",
         method=AggFunc.NA_COUNT,
-        windows=["8w"],
-        feature_names=["count_8w"],
-    )["count_8w"]
+        windows=["1w"],
+        feature_names=["na_count_1w"],
+    )["na_count_1w"]
     preview_params = pd.DataFrame([
         {"POINT_IN_TIME": pd.Timestamp("2001-11-15 10:00:00"), "üser id": 1}
     ])
     df = feature.preview(preview_params)
     tz_localize_if_needed(df, source_type)
     expected = preview_params.copy()
-    expected["count_1w"] = np.nan
+    expected["na_count_1w"] = np.nan
     fb_assert_frame_equal(df, expected)

--- a/tests/integration/api/test_change_view_operations.py
+++ b/tests/integration/api/test_change_view_operations.py
@@ -191,3 +191,29 @@ def test_change_view_custom_date_format(scd_table_custom_date_format, source_typ
     expected = preview_params.copy()
     expected["count_1w"] = np.nan
     fb_assert_frame_equal(df, expected)
+
+
+def test_change_view_custom_date_format_and_join(
+    scd_table_custom_date_format, scd_table, source_type
+):
+    """
+    Test change view operations with an SCDTable with custom date format
+    """
+    change_view = scd_table_custom_date_format.get_change_view("User Status")
+
+    view = scd_table.get_view()
+    joined_view = change_view.join(view)
+    feature = joined_view.groupby("User ID").aggregate_over(
+        value_column="User Status",
+        method=AggFunc.NA_COUNT,
+        windows=["8w"],
+        feature_names=["count_8w"],
+    )["count_8w"]
+    preview_params = pd.DataFrame([
+        {"POINT_IN_TIME": pd.Timestamp("2001-11-15 10:00:00"), "üser id": 1}
+    ])
+    df = feature.preview(preview_params)
+    tz_localize_if_needed(df, source_type)
+    expected = preview_params.copy()
+    expected["count_1w"] = np.nan
+    fb_assert_frame_equal(df, expected)


### PR DESCRIPTION
## Description

This fixes an error related to ChangeView with timestamp schema with joined with another SCDView.

In `TRACK_CHANGES` node, special columns with timestamp schema are already converted to timestamp types. However, the timestamp columns of the ChangeView are still associated with the original timestamp schema, causing incorrect conversions in downstream operations.

To fix this, the dtype info is overwritten accordingly in the `TRACK_CHANGES` node to ensure correct handling.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
