### PR TITLE
[chore] Reset semantic if add timestamp schema operation is added

### DIFF
--- a/.changelog/DEV-3989.yaml
+++ b/.changelog/DEV-3989.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: api
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Introduce AddTimestampSchema column cleaning operation"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/query_graph/node/cleaning_operation.py
+++ b/featurebyte/query_graph/node/cleaning_operation.py
@@ -121,7 +121,8 @@ class AddTimestampSchema(BaseCleaningOperation):
     the create_time_series_table method). In such cases, the timestamp schema has been specified and this
     operation is unnecessary.
 
-    Note that when used, this operation should be the last step in the cleaning operation list.
+    Note that when used, this operation should be the last step in the cleaning operation list. When this operation
+    is applied, the semantic type of the column will be reset to None.
 
     Parameters
     ----------

--- a/featurebyte/routes/common/base_table.py
+++ b/featurebyte/routes/common/base_table.py
@@ -21,6 +21,7 @@ from featurebyte.models.time_series_table import TimeSeriesTableModel
 from featurebyte.query_graph.model.column_info import ColumnInfo
 from featurebyte.query_graph.model.critical_data_info import CriticalDataInfo
 from featurebyte.query_graph.model.timestamp_schema import TimeZoneColumn
+from featurebyte.query_graph.node.cleaning_operation import AddTimestampSchema
 from featurebyte.routes.common.base import BaseDocumentController, PaginatedDocument
 from featurebyte.routes.task.controller import TaskController
 from featurebyte.schema.table import TableServiceUpdate, TableUpdate
@@ -345,6 +346,14 @@ class BaseTableDocumentController(
         for col_info in columns_info:
             if col_info.name == column_name:
                 setattr(col_info, field, data)
+
+                # if cleaning operations contain AddTimestampSchema, reset semantic_id
+                if field == "critical_data_info":
+                    assert isinstance(data, CriticalDataInfo)
+                    for clean_op in data.cleaning_operations:
+                        if isinstance(clean_op, AddTimestampSchema):
+                            col_info.semantic_id = None
+
                 column_exists = True
                 break
 


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
This PR updates the columns info update logic to reset column semantic if the timestamp schema cleaning operation is added.


## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
