### PR TITLE
[chore] Preserve original name in mutable operations

### DIFF
--- a/.changelog/DEV-3992.yaml
+++ b/.changelog/DEV-3992.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "fillna operation on a Target object now preserves the original target name automatically"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/core/series.py
+++ b/featurebyte/core/series.py
@@ -1273,6 +1273,7 @@ class Series(FrozenSeries):
             raise TypeError("Only boolean Series filtering is supported!")
 
         self._assert_assignment_valid(value)
+        original_name = self.name
         node_params = {}
         input_nodes = [self.node, key.node]
         if isinstance(value, Series):
@@ -1299,6 +1300,11 @@ class Series(FrozenSeries):
             # Update the current node as a PROJECT / ALIAS from the parent. This is to allow
             # readable column name during series preview
             self.node_name = self.parent[self.name].node_name
+        else:
+            # This could be for a target object. Set name to add an alias node so that the name
+            # is preserved.
+            if original_name is not None:
+                self.name = original_name
 
     @typechecked
     def fillna(self, other: Scalar) -> None:

--- a/tests/fixtures/sdk_code/feature_fraction.py
+++ b/tests/fixtures/sdk_code/feature_fraction.py
@@ -22,6 +22,7 @@ feat = item_view.groupby(by_keys=["event_id_col"], category=None).aggregate(
 )
 feat_1 = feat.copy()
 feat_1[feat.isnull()] = 0
+feat_1.name = "sum_item_amount"
 event_table = EventTable.get_by_id(ObjectId("{table_id}"))
 event_view = event_table.get_view(
     view_mode="manual",

--- a/tests/unit/api/aggregator/test_forward_aggregator.py
+++ b/tests/unit/api/aggregator/test_forward_aggregator.py
@@ -116,6 +116,31 @@ def test_forward_aggregate(forward_aggregator, offset):
     assert operation_structure.output_category == "target"
 
 
+def test_fillna_preserve_target_name(forward_aggregator):
+    """
+    Test forward_aggregate.
+    """
+    target = forward_aggregator.forward_aggregate(
+        "col_float",
+        AggFunc.SUM,
+        "7d",
+        "col_float_target",
+    )
+    target.fillna(0)
+    assert target.name == "col_float_target"
+    target.save()
+
+    # Must be ALIAS node type and not CONDITIONAL
+    target_model = target.cached_model
+    node = target_model.graph.get_node_by_name(target_model.node_name)
+    assert node.model_dump() == {
+        "name": "alias_1",
+        "type": NodeType.ALIAS,
+        "output_type": "series",
+        "parameters": {"name": "col_float_target"},
+    }
+
+
 def test_prepare_node_parameters(forward_aggregator):
     """
     Test prepare node parameters


### PR DESCRIPTION
## Description

This updates the `__setitem__` method in `Series` to preserve the original object's name after mutable operations such as `fillna`. Without this, doing `fillna` on a `Target` object without setting name explicitly causes issues in the generated sql. There is an assumption that feature / target objects should always have PROJECT or ALIAS node types.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
