### PR TITLE
[chore] Fix batch feature table recreate fails when parent table is deleted

### DIFF
--- a/featurebyte/models/batch_feature_table.py
+++ b/featurebyte/models/batch_feature_table.py
@@ -4,12 +4,16 @@ BatchFeatureTable related model(s)
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import List, Optional
 
 import pymongo
 from pydantic import Field
 
-from featurebyte.models.base import PydanticObjectId
+from featurebyte.models.base import (
+    PydanticObjectId,
+    UniqueConstraintResolutionSignature,
+    UniqueValuesConstraint,
+)
 from featurebyte.models.batch_request_table import BatchRequestInput
 from featurebyte.models.materialized_table import MaterializedTableModel
 
@@ -22,7 +26,7 @@ class BatchFeatureTableModel(MaterializedTableModel):
     batch_request_table_id: Optional[PydanticObjectId]
     request_input: Optional[BatchRequestInput] = Field(default=None)
     deployment_id: PydanticObjectId
-    parent_batch_feature_table_id: Optional[PydanticObjectId] = Field(default=None)
+    parent_batch_feature_table_name: Optional[str] = Field(default=None)
 
     class Settings(MaterializedTableModel.Settings):
         """
@@ -31,7 +35,21 @@ class BatchFeatureTableModel(MaterializedTableModel):
 
         collection_name: str = "batch_feature_table"
 
+        unique_constraints: List[UniqueValuesConstraint] = [
+            UniqueValuesConstraint(
+                fields=("_id",),
+                conflict_fields_signature={"id": ["_id"]},
+                resolution_signature=UniqueConstraintResolutionSignature.GET_NAME,
+            ),
+            UniqueValuesConstraint(
+                fields=("name", "deployment_id"),
+                conflict_fields_signature={"name": ["name"]},
+                resolution_signature=UniqueConstraintResolutionSignature.GET_NAME,
+            ),
+        ]
+
         indexes = MaterializedTableModel.Settings.indexes + [
+            pymongo.operations.IndexModel("deployment_id"),
             [
                 ("name", pymongo.TEXT),
                 ("description", pymongo.TEXT),

--- a/featurebyte/schema/worker/task/batch_feature_table.py
+++ b/featurebyte/schema/worker/task/batch_feature_table.py
@@ -9,7 +9,6 @@ from typing import ClassVar, Optional
 from pydantic import Field
 
 from featurebyte.enum import WorkerCommand
-from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.batch_feature_table import BatchFeatureTableModel
 from featurebyte.schema.batch_feature_table import BatchFeatureTableCreate
 from featurebyte.schema.worker.task.base import BaseTaskPayload, TaskPriority, TaskType
@@ -29,4 +28,4 @@ class BatchFeatureTableTaskPayload(BaseTaskPayload, BatchFeatureTableCreate):
     # instance variables
     task_type: TaskType = Field(default=TaskType.CPU_TASK)
     priority: TaskPriority = Field(default=TaskPriority.CRITICAL)
-    parent_batch_feature_table_id: Optional[PydanticObjectId] = Field(default=None)
+    parent_batch_feature_table_name: Optional[str] = Field(default=None)

--- a/featurebyte/worker/task/batch_feature_table.py
+++ b/featurebyte/worker/task/batch_feature_table.py
@@ -140,7 +140,7 @@ class BatchFeatureTableTask(DataWarehouseMixin, BaseTask[BatchFeatureTableTaskPa
                     deployment_id=payload.deployment_id,
                     columns_info=columns_info,
                     num_rows=num_rows,
-                    parent_batch_feature_table_id=payload.parent_batch_feature_table_id,
+                    parent_batch_feature_table_name=payload.parent_batch_feature_table_name,
                 )
                 await self.batch_feature_table_service.create_document(batch_feature_table_model)
         finally:

--- a/tests/unit/routes/test_batch_feature_table.py
+++ b/tests/unit/routes/test_batch_feature_table.py
@@ -311,7 +311,7 @@ class TestBatchFeatureTableApi(BaseMaterializedTableTestSuite):
         response = test_api_client.get(response_dict["output_path"])
         recreate_response_dict = response.json()
         assert recreate_response_dict["name"] == "batch_feature_table [2024-02-13T00:00:00]"
-        assert recreate_response_dict["parent_batch_feature_table_id"] == id_before
+        assert recreate_response_dict["parent_batch_feature_table_name"] == "batch_feature_table"
 
         # should no longer reference the original batch request table
         assert recreate_response_dict["batch_request_table_id"] is None
@@ -352,7 +352,10 @@ class TestBatchFeatureTableApi(BaseMaterializedTableTestSuite):
             recreate_response_dict["name"]
             == "batch_feature_table_with_request_input [2024-02-13T00:00:00]"
         )
-        assert recreate_response_dict["parent_batch_feature_table_id"] == id_before
+        assert (
+            recreate_response_dict["parent_batch_feature_table_name"]
+            == "batch_feature_table_with_request_input"
+        )
         id_recreated = recreate_response_dict["_id"]
 
         # recreate the batch feature table from the recreated batch feature table
@@ -371,4 +374,7 @@ class TestBatchFeatureTableApi(BaseMaterializedTableTestSuite):
             recreate_response_dict["name"]
             == "batch_feature_table_with_request_input [2024-02-14T00:00:00]"
         )
-        assert recreate_response_dict["parent_batch_feature_table_id"] == id_before
+        assert (
+            recreate_response_dict["parent_batch_feature_table_name"]
+            == "batch_feature_table_with_request_input"
+        )


### PR DESCRIPTION
## Description

Batch feature table recreate tries to get name from parent table which can fail if the parent table is deleted.

This PR make the following changes:
- Store the name of the parent batch feature table instead of the identifier so the original parent table does not need to exist to generate the name of the new batch feature table
- Update the uniqueness constraints of batch feature table name so that the name only needs to be unique for a specific deployment

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
