### PR TITLE
[DEV-3993] Fix scd_helper to account for end timestamp column when available

### DIFF
--- a/.changelog/DEV-3993.yaml
+++ b/.changelog/DEV-3993.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix SCD joins to take end timestamp column into account when available"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/scd_table.py
+++ b/featurebyte/api/scd_table.py
@@ -237,6 +237,8 @@ class SCDTable(TableApiObject):
             effective_timestamp_column=self.effective_timestamp_column,
             end_timestamp_column=self.end_timestamp_column,
             current_flag_column=self.current_flag_column,
+            effective_timestamp_schema=self.effective_timestamp_schema,
+            end_timestamp_schema=self.end_timestamp_schema,
         )
 
     def get_change_view(

--- a/featurebyte/api/scd_view.py
+++ b/featurebyte/api/scd_view.py
@@ -13,6 +13,7 @@ from featurebyte.common.doc_util import FBAutoDoc
 from featurebyte.exception import JoinViewMismatchError
 from featurebyte.logging import get_logger
 from featurebyte.query_graph.enum import GraphNodeType
+from featurebyte.query_graph.model.timestamp_schema import TimestampSchema, TimeZoneColumn
 from featurebyte.query_graph.node.generic import SCDBaseParameters
 
 logger = get_logger(__name__)
@@ -56,6 +57,8 @@ class SCDView(View, GroupByMixin, RawMixin):
     surrogate_key_column: Optional[str] = Field(frozen=True)
     end_timestamp_column: Optional[str] = Field(frozen=True)
     current_flag_column: Optional[str] = Field(frozen=True)
+    effective_timestamp_schema: Optional[TimestampSchema] = Field(frozen=True)
+    end_timestamp_schema: Optional[TimestampSchema] = Field(frozen=True)
 
     @property
     def timestamp_column(self) -> Optional[str]:
@@ -80,6 +83,16 @@ class SCDView(View, GroupByMixin, RawMixin):
 
     def _get_additional_inherited_columns(self) -> set[str]:
         columns = {self.effective_timestamp_column}
+        if self.end_timestamp_column:
+            columns.add(self.end_timestamp_column)
+        if self.effective_timestamp_schema is not None and isinstance(
+            self.effective_timestamp_schema.timezone, TimeZoneColumn
+        ):
+            columns.add(self.effective_timestamp_schema.timezone.column_name)
+        if self.end_timestamp_schema is not None and isinstance(
+            self.end_timestamp_schema.timezone, TimeZoneColumn
+        ):
+            columns.add(self.end_timestamp_schema.timezone.column_name)
         return columns
 
     @property
@@ -98,6 +111,8 @@ class SCDView(View, GroupByMixin, RawMixin):
             "effective_timestamp_column": self.effective_timestamp_column,
             "end_timestamp_column": self.end_timestamp_column,
             "current_flag_column": self.current_flag_column,
+            "effective_timestamp_schema": self.effective_timestamp_schema,
+            "end_timestamp_schema": self.end_timestamp_schema,
         })
         return params
 

--- a/featurebyte/query_graph/sql/aggregator/base_lookup.py
+++ b/featurebyte/query_graph/sql/aggregator/base_lookup.py
@@ -320,6 +320,12 @@ class BaseLookupAggregator(NonTileBasedAggregator[LookupSpecT]):
                 join_keys=[lookup_specs[0].entity_column],
                 input_columns=[spec.input_column_name for spec in lookup_specs],
                 output_columns=agg_result_names,
+                end_timestamp_column=scd_parameters.end_timestamp_column,
+                end_timestamp_schema=(
+                    scd_parameters.end_timestamp_metadata.timestamp_schema
+                    if scd_parameters.end_timestamp_metadata
+                    else None
+                ),
             )
             table_expr = self.get_scd_join_expr_for_lookup(
                 left_table,

--- a/featurebyte/query_graph/sql/ast/join.py
+++ b/featurebyte/query_graph/sql/ast/join.py
@@ -95,6 +95,8 @@ class SCDJoin(TableNode):
     left_output_columns: list[str]
     right_input_columns: list[str]
     right_output_columns: list[str]
+    end_timestamp_column: Optional[str]
+    end_timestamp_schema: Optional[TimestampSchema]
     join_type: Literal["left", "inner"]
     query_node_type = NodeType.JOIN
 
@@ -131,6 +133,8 @@ class SCDJoin(TableNode):
             join_keys=[self.right_on],
             input_columns=self.right_input_columns,
             output_columns=self.right_output_columns,
+            end_timestamp_column=self.end_timestamp_column,
+            end_timestamp_schema=self.end_timestamp_schema,
         )
         select_expr = get_scd_join_expr(
             left_table,
@@ -175,6 +179,12 @@ class SCDJoin(TableNode):
             if right_timestamp_metadata_dict is not None
             else None
         )
+        end_timestamp_metadata_dict = parameters["scd_parameters"].get("end_timestamp_metadata")
+        end_timestamp_schema = (
+            TimestampSchema(**end_timestamp_metadata_dict["timestamp_schema"])
+            if end_timestamp_metadata_dict is not None
+            else None
+        )
         node = SCDJoin(
             context=context,
             columns_map=columns_map,
@@ -191,5 +201,7 @@ class SCDJoin(TableNode):
             left_output_columns=parameters["left_output_columns"],
             right_input_columns=parameters["right_input_columns"],
             right_output_columns=parameters["right_output_columns"],
+            end_timestamp_column=parameters["scd_parameters"].get("end_timestamp_column"),
+            end_timestamp_schema=end_timestamp_schema,
         )
         return node

--- a/featurebyte/query_graph/sql/scd_helper.py
+++ b/featurebyte/query_graph/sql/scd_helper.py
@@ -45,6 +45,8 @@ class Table:
     join_keys: list[str]
     input_columns: list[str]
     output_columns: list[str]
+    end_timestamp_column: Optional[str] = None
+    end_timestamp_schema: Optional[TimestampSchema] = None
 
     @property
     def timestamp_column_expr(self) -> Expression:
@@ -213,6 +215,8 @@ def get_scd_join_expr(
             join_keys=right_table.join_keys,
             input_columns=right_table.input_columns,
             output_columns=right_table.output_columns,
+            end_timestamp_column=right_table.end_timestamp_column,
+            end_timestamp_schema=right_table.end_timestamp_schema,
         )
     right_subquery = right_table.as_subquery(alias="R")
 
@@ -223,6 +227,19 @@ def get_scd_join_expr(
             expression=get_qualified_column_identifier(right_table.timestamp_column, "R"),
         ),
     ] + _key_cols_equality_conditions(right_table.join_keys)
+
+    if right_table.end_timestamp_column is not None:
+        end_timestamp_expr = get_qualified_column_identifier(right_table.end_timestamp_column, "R")
+        if convert_timestamps_to_utc:
+            end_timestamp_expr = _convert_to_utc_ntz(
+                end_timestamp_expr, right_table.end_timestamp_schema, adapter
+            )
+        join_conditions.append(
+            expressions.LT(  # type: ignore[arg-type]
+                this=get_qualified_column_identifier(TS_COL, "L"),
+                expression=end_timestamp_expr,
+            )
+        )
 
     select_expr = select_expr.from_(left_subquery, copy=False).join(
         right_subquery,
@@ -432,12 +449,14 @@ def augment_table_with_effective_timestamp(
         select(
             *_key_cols_as_quoted_identifiers(num_join_keys),
             quoted_identifier(LAST_TS),
+            quoted_identifier(TS_COL),
             *[quoted_identifier(col) for col in left_table.output_columns],
         )
         .from_(
             select(
                 *_key_cols_as_quoted_identifiers(num_join_keys),
                 alias_(matched_effective_timestamp_expr, alias=LAST_TS, quoted=True),
+                quoted_identifier(TS_COL),
                 *[quoted_identifier(col) for col in left_table.output_columns],
                 quoted_identifier(EFFECTIVE_TS_COL),
             )

--- a/featurebyte/query_graph/sql/scd_helper.py
+++ b/featurebyte/query_graph/sql/scd_helper.py
@@ -237,8 +237,10 @@ def get_scd_join_expr(
             )
         join_conditions.append(
             expressions.LT(  # type: ignore[arg-type]
-                this=get_qualified_column_identifier(TS_COL, "L"),
-                expression=end_timestamp_expr,
+                this=adapter.normalize_timestamp_before_comparison(
+                    get_qualified_column_identifier(TS_COL, "L")
+                ),
+                expression=adapter.normalize_timestamp_before_comparison(end_timestamp_expr),
             )
         )
 

--- a/tests/fixtures/expected_preview_sql_timezone_offset_item_view_joined_scd_view.sql
+++ b/tests/fixtures/expected_preview_sql_timezone_offset_item_view_joined_scd_view.sql
@@ -52,6 +52,7 @@ FROM (
   SELECT
     "__FB_KEY_COL_0",
     "__FB_LAST_TS",
+    "__FB_TS_COL",
     "event_id_col",
     "item_id_col",
     "item_type",
@@ -65,6 +66,7 @@ FROM (
     SELECT
       "__FB_KEY_COL_0",
       LAG("__FB_EFFECTIVE_TS_COL") IGNORE NULLS OVER (PARTITION BY "__FB_KEY_COL_0" ORDER BY "__FB_TS_COL" NULLS FIRST, "__FB_TS_TIE_BREAKER_COL") AS "__FB_LAST_TS",
+      "__FB_TS_COL",
       "event_id_col",
       "item_id_col",
       "item_type",
@@ -198,5 +200,7 @@ LEFT JOIN (
     "effective_timestamp",
     "col_text"
 ) AS R
-  ON L."__FB_LAST_TS" = R."effective_timestamp" AND L."__FB_KEY_COL_0" = R."col_text"
+  ON L."__FB_LAST_TS" = R."effective_timestamp"
+  AND L."__FB_KEY_COL_0" = R."col_text"
+  AND L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
 LIMIT 10

--- a/tests/fixtures/expected_tile_sql_complex_feature_push_down_eligible.sql
+++ b/tests/fixtures/expected_tile_sql_complex_feature_push_down_eligible.sql
@@ -45,6 +45,7 @@ WITH __FB_TILE_COMPUTE_INPUT_TABLE_NAME AS (
           SELECT
             "__FB_KEY_COL_0",
             "__FB_LAST_TS",
+            "__FB_TS_COL",
             "col_int",
             "col_float",
             "col_char",
@@ -57,6 +58,7 @@ WITH __FB_TILE_COMPUTE_INPUT_TABLE_NAME AS (
             SELECT
               "__FB_KEY_COL_0",
               LAG("__FB_EFFECTIVE_TS_COL") IGNORE NULLS OVER (PARTITION BY "__FB_KEY_COL_0" ORDER BY "__FB_TS_COL", "__FB_TS_TIE_BREAKER_COL" NULLS LAST) AS "__FB_LAST_TS",
+              "__FB_TS_COL",
               "col_int",
               "col_float",
               "col_char",
@@ -162,7 +164,9 @@ WITH __FB_TILE_COMPUTE_INPUT_TABLE_NAME AS (
             "effective_timestamp",
             "col_text"
         ) AS R
-          ON L."__FB_LAST_TS" = R."effective_timestamp" AND L."__FB_KEY_COL_0" = R."col_text"
+          ON L."__FB_LAST_TS" = R."effective_timestamp"
+          AND L."__FB_KEY_COL_0" = R."col_text"
+          AND L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
       ) AS REQ
       LEFT JOIN (
         SELECT

--- a/tests/fixtures/feature_materialize/initialize_new_columns_precomputed_lookup.sql
+++ b/tests/fixtures/feature_materialize/initialize_new_columns_precomputed_lookup.sql
@@ -142,12 +142,14 @@ WITH ENTITY_UNIVERSE AS (
       SELECT
         "__FB_KEY_COL_0",
         "__FB_LAST_TS",
+        "__FB_TS_COL",
         "POINT_IN_TIME",
         "cust_id"
       FROM (
         SELECT
           "__FB_KEY_COL_0",
           LAG("__FB_EFFECTIVE_TS_COL") IGNORE NULLS OVER (PARTITION BY "__FB_KEY_COL_0" ORDER BY "__FB_TS_COL" NULLS FIRST, "__FB_TS_TIE_BREAKER_COL") AS "__FB_LAST_TS",
+          "__FB_TS_COL",
           "POINT_IN_TIME",
           "cust_id",
           "__FB_EFFECTIVE_TS_COL"
@@ -229,7 +231,9 @@ WITH ENTITY_UNIVERSE AS (
         "effective_timestamp",
         "col_text"
     ) AS R
-      ON L."__FB_LAST_TS" = R."effective_timestamp" AND L."__FB_KEY_COL_0" = R."col_text"
+      ON L."__FB_LAST_TS" = R."effective_timestamp"
+      AND L."__FB_KEY_COL_0" = R."col_text"
+      AND L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
   ) AS REQ
 )
 SELECT

--- a/tests/fixtures/feature_materialize/initialize_precomputed_lookup_feature_table.sql
+++ b/tests/fixtures/feature_materialize/initialize_precomputed_lookup_feature_table.sql
@@ -67,12 +67,14 @@ WITH ENTITY_UNIVERSE AS (
       SELECT
         "__FB_KEY_COL_0",
         "__FB_LAST_TS",
+        "__FB_TS_COL",
         "POINT_IN_TIME",
         "cust_id"
       FROM (
         SELECT
           "__FB_KEY_COL_0",
           LAG("__FB_EFFECTIVE_TS_COL") IGNORE NULLS OVER (PARTITION BY "__FB_KEY_COL_0" ORDER BY "__FB_TS_COL" NULLS FIRST, "__FB_TS_TIE_BREAKER_COL") AS "__FB_LAST_TS",
+          "__FB_TS_COL",
           "POINT_IN_TIME",
           "cust_id",
           "__FB_EFFECTIVE_TS_COL"
@@ -154,7 +156,9 @@ WITH ENTITY_UNIVERSE AS (
         "effective_timestamp",
         "col_text"
     ) AS R
-      ON L."__FB_LAST_TS" = R."effective_timestamp" AND L."__FB_KEY_COL_0" = R."col_text"
+      ON L."__FB_LAST_TS" = R."effective_timestamp"
+      AND L."__FB_KEY_COL_0" = R."col_text"
+      AND L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
   ) AS REQ
 )
 SELECT

--- a/tests/fixtures/feature_materialize/initialize_precomputed_lookup_feature_table_missing_column.sql
+++ b/tests/fixtures/feature_materialize/initialize_precomputed_lookup_feature_table_missing_column.sql
@@ -65,12 +65,14 @@ WITH ENTITY_UNIVERSE AS (
       SELECT
         "__FB_KEY_COL_0",
         "__FB_LAST_TS",
+        "__FB_TS_COL",
         "POINT_IN_TIME",
         "cust_id"
       FROM (
         SELECT
           "__FB_KEY_COL_0",
           LAG("__FB_EFFECTIVE_TS_COL") IGNORE NULLS OVER (PARTITION BY "__FB_KEY_COL_0" ORDER BY "__FB_TS_COL" NULLS FIRST, "__FB_TS_TIE_BREAKER_COL") AS "__FB_LAST_TS",
+          "__FB_TS_COL",
           "POINT_IN_TIME",
           "cust_id",
           "__FB_EFFECTIVE_TS_COL"
@@ -152,7 +154,9 @@ WITH ENTITY_UNIVERSE AS (
         "effective_timestamp",
         "col_text"
     ) AS R
-      ON L."__FB_LAST_TS" = R."effective_timestamp" AND L."__FB_KEY_COL_0" = R."col_text"
+      ON L."__FB_LAST_TS" = R."effective_timestamp"
+      AND L."__FB_KEY_COL_0" = R."col_text"
+      AND L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
   ) AS REQ
 )
 SELECT

--- a/tests/fixtures/feature_materialize/materialize_features_queries_internal_relationships.sql
+++ b/tests/fixtures/feature_materialize/materialize_features_queries_internal_relationships.sql
@@ -78,6 +78,7 @@ WITH ONLINE_REQUEST_TABLE AS (
       SELECT
         "__FB_KEY_COL_0",
         "__FB_LAST_TS",
+        "__FB_TS_COL",
         "__FB_TABLE_ROW_INDEX",
         "cust_id",
         "POINT_IN_TIME"
@@ -85,6 +86,7 @@ WITH ONLINE_REQUEST_TABLE AS (
         SELECT
           "__FB_KEY_COL_0",
           LAG("__FB_EFFECTIVE_TS_COL") IGNORE NULLS OVER (PARTITION BY "__FB_KEY_COL_0" ORDER BY "__FB_TS_COL" NULLS FIRST, "__FB_TS_TIE_BREAKER_COL") AS "__FB_LAST_TS",
+          "__FB_TS_COL",
           "__FB_TABLE_ROW_INDEX",
           "cust_id",
           "POINT_IN_TIME",
@@ -170,7 +172,9 @@ WITH ONLINE_REQUEST_TABLE AS (
         "effective_timestamp",
         "col_text"
     ) AS R
-      ON L."__FB_LAST_TS" = R."effective_timestamp" AND L."__FB_KEY_COL_0" = R."col_text"
+      ON L."__FB_LAST_TS" = R."effective_timestamp"
+      AND L."__FB_KEY_COL_0" = R."col_text"
+      AND L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
   ) AS REQ
 ), "REQUEST_TABLE_POINT_IN_TIME_cust_id_000000000000000000000000" AS (
   SELECT DISTINCT

--- a/tests/fixtures/feature_materialize/scheduled_materialize_features_precomputed_lookup.sql
+++ b/tests/fixtures/feature_materialize/scheduled_materialize_features_precomputed_lookup.sql
@@ -138,12 +138,14 @@ WITH ENTITY_UNIVERSE AS (
       SELECT
         "__FB_KEY_COL_0",
         "__FB_LAST_TS",
+        "__FB_TS_COL",
         "POINT_IN_TIME",
         "cust_id"
       FROM (
         SELECT
           "__FB_KEY_COL_0",
           LAG("__FB_EFFECTIVE_TS_COL") IGNORE NULLS OVER (PARTITION BY "__FB_KEY_COL_0" ORDER BY "__FB_TS_COL" NULLS FIRST, "__FB_TS_TIE_BREAKER_COL") AS "__FB_LAST_TS",
+          "__FB_TS_COL",
           "POINT_IN_TIME",
           "cust_id",
           "__FB_EFFECTIVE_TS_COL"
@@ -225,7 +227,9 @@ WITH ENTITY_UNIVERSE AS (
         "effective_timestamp",
         "col_text"
     ) AS R
-      ON L."__FB_LAST_TS" = R."effective_timestamp" AND L."__FB_KEY_COL_0" = R."col_text"
+      ON L."__FB_LAST_TS" = R."effective_timestamp"
+      AND L."__FB_KEY_COL_0" = R."col_text"
+      AND L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
   ) AS REQ
 )
 SELECT

--- a/tests/fixtures/offline_store_feature_table/cust_id_to_gender_universe.sql
+++ b/tests/fixtures/offline_store_feature_table/cust_id_to_gender_universe.sql
@@ -40,12 +40,14 @@ WITH ENTITY_UNIVERSE AS (
       SELECT
         "__FB_KEY_COL_0",
         "__FB_LAST_TS",
+        "__FB_TS_COL",
         "POINT_IN_TIME",
         "cust_id"
       FROM (
         SELECT
           "__FB_KEY_COL_0",
           LAG("__FB_EFFECTIVE_TS_COL") IGNORE NULLS OVER (PARTITION BY "__FB_KEY_COL_0" ORDER BY "__FB_TS_COL" NULLS FIRST, "__FB_TS_TIE_BREAKER_COL") AS "__FB_LAST_TS",
+          "__FB_TS_COL",
           "POINT_IN_TIME",
           "cust_id",
           "__FB_EFFECTIVE_TS_COL"
@@ -127,7 +129,9 @@ WITH ENTITY_UNIVERSE AS (
         "effective_timestamp",
         "col_text"
     ) AS R
-      ON L."__FB_LAST_TS" = R."effective_timestamp" AND L."__FB_KEY_COL_0" = R."col_text"
+      ON L."__FB_LAST_TS" = R."effective_timestamp"
+      AND L."__FB_KEY_COL_0" = R."col_text"
+      AND L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
   ) AS REQ
 )
 SELECT

--- a/tests/integration/api/test_scd_view_operations.py
+++ b/tests/integration/api/test_scd_view_operations.py
@@ -258,6 +258,85 @@ async def test_feature_derived_from_multiple_scd_joins(session, data_source, sou
     fb_assert_frame_equal(df, expected, dict_like_columns=["state_code_counts_30d"])
 
 
+@pytest.mark.asyncio
+async def test_end_timestamp_column(session, data_source, source_type, config):
+    """
+    Self-contained test case to test handling of end timestamp column
+    """
+    df_events = pd.DataFrame({
+        "ts": pd.to_datetime([
+            "2022-03-20 10:00:00",
+            "2022-04-20 10:00:00",
+            "2022-05-20 10:00:00",
+        ]),
+        "cust_id": [1000, 1000, 1000],
+        "event_id": [1, 2, 3],
+    })
+    df_scd = pd.DataFrame({
+        "effective_ts": pd.to_datetime([
+            "2022-03-01 10:00:00",
+            "2022-04-01 10:00:00",
+            "2022-05-01 10:00:00",
+        ]),
+        "end_ts": pd.to_datetime([
+            "2022-04-01 10:00:00",
+            "2022-05-01 10:00:00",
+            "2022-05-05 10:00:00",
+        ]),
+        "scd_cust_id": [1000, 1000, 1000],
+        "scd_value": [1, 2, 3],
+    })
+    table_prefix = "TEST_SCD_END_TIMESTAMP"
+
+    def _quote(col_name) -> str:
+        return sql_to_string(quoted_identifier(col_name), source_type=session.source_type)
+
+    # Register event table
+    table_name = f"{table_prefix}_EVENT"
+    await session.register_table(table_name, df_events)
+
+    # Register scd table
+    table_name = f"{table_prefix}_SCD"
+    await session.register_table(table_name, df_scd)
+
+    event_source_table = data_source.get_source_table(
+        table_name=f"{table_prefix}_EVENT",
+        database_name=session.database_name,
+        schema_name=session.schema_name,
+    )
+    event_table = event_source_table.create_event_table(
+        name=f"{source_type}_{table_prefix}_EVENT_DATA",
+        event_id_column="event_id",
+        event_timestamp_column="ts",
+    )
+    event_view = event_table.get_view()
+    scd_source_table = data_source.get_source_table(
+        table_name=f"{table_prefix}_SCD",
+        database_name=session.database_name,
+        schema_name=session.schema_name,
+    )
+    scd_table = scd_source_table.create_scd_table(
+        name=f"{source_type}_{table_prefix}_SCD_DATA",
+        natural_key_column="scd_cust_id",
+        effective_timestamp_column="effective_ts",
+        end_timestamp_column="end_ts",
+    )
+    scd_view = scd_table.get_view()
+    event_view = event_view.join(scd_view, on="cust_id", rsuffix="_latest")
+    df_actual = event_view.preview()
+    df_expected = pd.DataFrame({
+        "ts": pd.to_datetime([
+            "2022-03-20 10:00:00",
+            "2022-04-20 10:00:00",
+            "2022-05-20 10:00:00",
+        ]),
+        "cust_id": [1000, 1000, 1000],
+        "event_id": [1, 2, 3],
+        "scd_value_latest": [1, 2, np.nan],
+    })
+    fb_assert_frame_equal(df_actual, df_expected)
+
+
 def test_event_view_join_scd_view__preview_view(
     event_table, scd_table, expected_dataframe_scd_join
 ):

--- a/tests/integration/api/test_scd_view_operations.py
+++ b/tests/integration/api/test_scd_view_operations.py
@@ -330,6 +330,7 @@ async def test_end_timestamp_column(
     )
     scd_table["scd_cust_id"].as_entity(entity.name)
 
+    # Check SCD joins. Note the last row in the expected result is NaN because of the end timestamp.
     scd_view = scd_table.get_view()
     event_view = event_view.join(scd_view, on="cust_id", rsuffix="_latest")
     df_actual = event_view.preview()
@@ -345,6 +346,8 @@ async def test_end_timestamp_column(
     })
     fb_assert_frame_equal(df_actual, df_expected)
 
+    # Check SCD lookup feature. Note the last row in the expected result is NaN because of the end
+    # timestamp.
     feature = scd_view["scd_value"].as_feature("test_end_timestamp_feature")
     feature.save()
     feature_list = FeatureList([feature], "my_list")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1781,6 +1781,22 @@ def scd_table_timestamp_format_string_fixture(source_type):
     return "yyyy|MM|dd"
 
 
+@pytest.fixture(name="scd_table_timestamp_format_string_with_time", scope="session")
+def scd_table_timestamp_format_string_with_time_fixture(
+    scd_table_timestamp_format_string, source_type
+):
+    """
+    Fixture for custom date format string that is platform specific (with time components)
+    """
+    if source_type == SourceType.SNOWFLAKE:
+        time_format = "HH24:MI:SS"
+    elif source_type == SourceType.BIGQUERY:
+        time_format = "%H:%M:%S"
+    else:
+        time_format = "HH:mm:ss"
+    return f"{scd_table_timestamp_format_string}|{time_format}"
+
+
 @pytest.fixture(name="scd_table_timestamp_with_tz_format_string", scope="session")
 def scd_table_timestamp_with_tz_format_string_fixture(source_type):
     """

--- a/tests/integration/session/test_databricks_unity.py
+++ b/tests/integration/session/test_databricks_unity.py
@@ -65,7 +65,18 @@ async def test_list_tables(config, session_without_datasets):
     def _sort_by_name(_tables):
         return sorted(_tables, key=lambda x: x["name"])
 
-    assert _sort_by_name([table.model_dump() for table in tables]) == _sort_by_name([
+    def _filter_grocery(_tables):
+        # Make the test more robust against randomly added tables by filtering by certain keywords
+        out = []
+        for table in _tables:
+            table_name = table["name"]
+            if "grocery" in table_name or "invoiceitems" in table_name:
+                out.append(table)
+        return out
+
+    assert _filter_grocery(
+        _sort_by_name([table.model_dump() for table in tables])
+    ) == _sort_by_name([
         {
             "name": "invoiceitems",
             "description": "The grocery item details within each invoice, including the "

--- a/tests/unit/api/test_scd_view.py
+++ b/tests/unit/api/test_scd_view.py
@@ -226,7 +226,7 @@ def test_scd_view_inherited__columns(snowflake_scd_view):
     timestamp column
     """
     subset_view = snowflake_scd_view[["col_float"]]
-    assert subset_view.columns == ["col_float", "col_text", "effective_timestamp"]
+    assert subset_view.columns == ["col_float", "col_text", "effective_timestamp", "end_timestamp"]
 
 
 def test_scd_view_as_feature__special_column(


### PR DESCRIPTION
## Description

This fixes an issue in `scd_helper` (i.e. SCD joins and lookup features) to use the end timestamp column information when available.

## Related Issue

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
