### PR TITLE
[DEV-3995] Support calendar aggregation for event tables

### DIFF
--- a/featurebyte/api/aggregator/window_aggregator.py
+++ b/featurebyte/api/aggregator/window_aggregator.py
@@ -41,10 +41,6 @@ class WindowAggregator(BaseAggregator):
         return [EventView, ItemView, ChangeView, TimeSeriesView]
 
     @property
-    def is_time_series_aggregation(self) -> bool:
-        return isinstance(self.view, TimeSeriesView)
-
-    @property
     def aggregation_method_name(self) -> str:
         return "aggregate_over"
 
@@ -52,7 +48,7 @@ class WindowAggregator(BaseAggregator):
         self,
         value_column: Optional[str],
         method: str,
-        windows: List[Optional[str] | CalendarWindow],
+        windows: List[Optional[str]] | List[CalendarWindow],
         feature_names: List[str],
         timestamp_column: Optional[str] = None,
         feature_job_setting: Optional[FeatureJobSetting | CronFeatureJobSetting] = None,
@@ -126,7 +122,11 @@ class WindowAggregator(BaseAggregator):
         )
         assert method is not None
         agg_method = construct_agg_func(agg_func=cast(AggFunc, method))
-        aggregation_node = self._add_aggregation_node(agg_method.type, node_params)
+        aggregation_node = self._add_aggregation_node(
+            agg_func=agg_method.type,
+            is_calendar_aggregation=self.is_calendar_aggregation(windows),
+            node_params=node_params,
+        )
         assert isinstance(feature_names, list)
 
         items = []
@@ -144,11 +144,15 @@ class WindowAggregator(BaseAggregator):
         feature_group = FeatureGroup(items)
         return feature_group
 
+    @classmethod
+    def is_calendar_aggregation(cls, windows: List[Optional[str]] | List[CalendarWindow]) -> bool:
+        return all(isinstance(window, CalendarWindow) for window in windows)
+
     def _validate_parameters(
         self,
         value_column: Optional[str],
         method: str,
-        windows: list[Optional[str] | CalendarWindow],
+        windows: List[Optional[str]] | List[CalendarWindow],
         feature_names: list[str],
         feature_job_setting: Optional[FeatureJobSetting | CronFeatureJobSetting],
         fill_value: OptionalScalar,
@@ -157,9 +161,7 @@ class WindowAggregator(BaseAggregator):
     ) -> None:
         self._validate_method_and_value_column(method=method, value_column=value_column)
         self._validate_fill_value_and_skip_fill_na(fill_value=fill_value, skip_fill_na=skip_fill_na)
-
-        if not isinstance(windows, list) or len(windows) == 0:
-            raise ValueError(f"windows is required and should be a non-empty list; got {windows}")
+        self._validate_windows(windows)
 
         if not isinstance(feature_names, list):
             raise ValueError(
@@ -174,25 +176,22 @@ class WindowAggregator(BaseAggregator):
         if len(windows) != len(set(feature_names)) or len(set(windows)) != len(feature_names):
             raise ValueError("Window sizes or feature names contains duplicated value(s).")
 
-        number_of_unbounded_windows = len([w for w in windows if w is None])
-
-        if self.is_time_series_aggregation:
-            if number_of_unbounded_windows > 0:
-                raise ValueError("Unbounded window is not supported for time series aggregation")
+        if self.is_calendar_aggregation(windows):
             if offset is not None:
-                offset_unit = self._validate_time_series_window("offset", offset)
+                offset_unit = self._validate_calendar_window("offset", offset)
             else:
                 offset_unit = None
             for window in windows:
                 assert window is not None  # due to the above check
-                self._validate_time_series_window("windows", window, compatible_unit=offset_unit)
+                self._validate_calendar_window("windows", window, compatible_unit=offset_unit)
             if feature_job_setting is not None and not isinstance(
                 feature_job_setting, CronFeatureJobSetting
             ):
                 raise ValueError(
-                    "feature_job_setting must be CronFeatureJobSetting for TimeSeriesView"
+                    "feature_job_setting must be CronFeatureJobSetting for calendar aggregation"
                 )
         else:
+            number_of_unbounded_windows = len([w for w in windows if w is None])
             if number_of_unbounded_windows > 0:
                 if method != AggFunc.LATEST:
                     raise ValueError('Unbounded window is only supported for the "latest" method')
@@ -206,54 +205,71 @@ class WindowAggregator(BaseAggregator):
                 feature_job_setting, FeatureJobSetting
             ):
                 raise ValueError(
-                    "feature_job_setting must be FeatureJobSetting for non-TimeSeriesView"
+                    "feature_job_setting must be FeatureJobSetting for non-calendar aggregation"
                 )
             parsed_feature_job_setting = FeatureJobSetting(
-                **self._get_job_setting_params(feature_job_setting)
+                **self._get_job_setting_params(feature_job_setting, windows=windows)
             )
 
-            if windows is not None:
-                for window in windows:
-                    if window is not None:
-                        if isinstance(window, CalendarWindow):
-                            raise ValueError("CalendarWindow is only supported for TimeSeriesView")
-                        validate_window(window, parsed_feature_job_setting.period)
+            # Because of _validate_windows, we know that windows is a list of str or None
+            for window in windows:
+                if window is not None:
+                    assert isinstance(window, str)
+                    validate_window(window, parsed_feature_job_setting.period)
 
             if offset is not None:
                 if isinstance(offset, CalendarWindow):
-                    raise ValueError("CalendarWindow is only supported for TimeSeriesView")
+                    raise ValueError("CalendarWindow is only supported for calendar aggregation")
                 validate_window(offset, parsed_feature_job_setting.period)
 
-    def _validate_time_series_window(
+    @classmethod
+    def _validate_windows(cls, windows: List[Optional[str]] | List[CalendarWindow]) -> None:
+        if not isinstance(windows, list) or len(windows) == 0:
+            raise ValueError(f"windows is required and should be a non-empty list; got {windows}")
+
+        is_calendar = isinstance(windows[0], CalendarWindow)
+        if is_calendar:
+            for window in windows:
+                if not isinstance(window, CalendarWindow):
+                    raise ValueError("Please specify windows as only CalendarWindow")
+        else:
+            for window in windows:
+                if not isinstance(window, str) and window is not None:
+                    raise ValueError("Please specify windows as only str or None")
+
+    def _validate_calendar_window(
         self,
         param_type: Literal["windows", "offset"],
         window: str | CalendarWindow,
         compatible_unit: Optional[TimeIntervalUnit] = None,
     ) -> TimeIntervalUnit:
         if not isinstance(window, CalendarWindow):
+            # TODO: can remove since window must be CalendarWindow?
             if param_type == "windows":
                 raise ValueError(
-                    f"Please specify {param_type} as a list of CalendarWindow for TimeSeriesView"
+                    f"Please specify {param_type} as a list of CalendarWindow for calendar aggregation"
                 )
             else:
                 raise ValueError(
-                    f"Please specify {param_type} as CalendarWindow for TimeSeriesView"
+                    f"Please specify {param_type} as CalendarWindow for calendar aggregation"
                 )
         view = self.view
-        assert isinstance(view, TimeSeriesView)
         unit = TimeIntervalUnit(window.unit)
         if compatible_unit is not None and unit != compatible_unit:
             raise ValueError(
                 f"Window unit ({window.unit}) must be the same as the offset unit ({compatible_unit})"
             )
-        if unit < TimeIntervalUnit(view.time_interval.unit):
-            raise ValueError(
-                f"Window unit ({window.unit}) cannot be smaller than the table's time interval unit ({view.time_interval.unit})"
-            )
+        if isinstance(view, TimeSeriesView):
+            if unit < TimeIntervalUnit(view.time_interval.unit):
+                raise ValueError(
+                    f"Window unit ({window.unit}) cannot be smaller than the table's time interval unit ({view.time_interval.unit})"
+                )
         return unit
 
     def _get_job_setting_params(
-        self, feature_job_setting: Optional[FeatureJobSetting | CronFeatureJobSetting]
+        self,
+        feature_job_setting: Optional[FeatureJobSetting | CronFeatureJobSetting],
+        windows: list[Optional[str]] | list[CalendarWindow],
     ) -> dict[str, Any]:
         if feature_job_setting is not None:
             return feature_job_setting.model_dump()
@@ -265,20 +281,32 @@ class WindowAggregator(BaseAggregator):
                 f"feature_job_setting is required as the {type(self.view).__name__} does not "
                 "have a default feature job setting"
             )
+        if self.is_calendar_aggregation(windows):
+            if not isinstance(default_setting, CronFeatureJobSetting):
+                raise ValueError(
+                    "feature_job_setting must be CronFeatureJobSetting for calendar aggregation"
+                )
+        else:
+            if not isinstance(default_setting, FeatureJobSetting):
+                raise ValueError(
+                    "feature_job_setting must be FeatureJobSetting for non-calendar aggregation"
+                )
         return default_setting.model_dump()  # type: ignore[no-any-return]
 
     def _prepare_node_parameters(
         self,
         value_column: Optional[str],
         method: str,
-        windows: list[Optional[str] | CalendarWindow],
+        windows: list[Optional[str]] | list[CalendarWindow],
         offset: Optional[str | CalendarWindow],
         feature_names: Optional[list[str]],
         timestamp_column: Optional[str] = None,
         value_by_column: Optional[str] = None,
         feature_job_setting: Optional[FeatureJobSetting | CronFeatureJobSetting] = None,
     ) -> dict[str, Any]:
-        feature_job_setting_dict = self._get_job_setting_params(feature_job_setting)
+        feature_job_setting_dict = self._get_job_setting_params(
+            feature_job_setting, windows=windows
+        )
         params: dict[str, Any] = {
             "keys": self.keys,
             "parent": value_column,
@@ -291,14 +319,22 @@ class WindowAggregator(BaseAggregator):
             "serving_names": self.serving_names,
             "entity_ids": self.entity_ids,
         }
-        if self.is_time_series_aggregation:
-            assert isinstance(self.view, TimeSeriesView)
-            params.update({
-                "reference_datetime_column": self.view.reference_datetime_column,
-                "reference_datetime_metadata": self.view.operation_structure.get_dtype_metadata(
+        if self.is_calendar_aggregation(windows):
+            if isinstance(self.view, TimeSeriesView):
+                reference_datetime_column = self.view.reference_datetime_column
+                reference_datetime_metadata = self.view.operation_structure.get_dtype_metadata(
                     self.view.reference_datetime_column
-                ),
-                "time_interval": self.view.time_interval.model_dump(),
+                )
+                time_interval = self.view.time_interval
+            else:
+                assert self.view.timestamp_column is not None
+                reference_datetime_column = self.view.timestamp_column
+                reference_datetime_metadata = None
+                time_interval = None
+            params.update({
+                "reference_datetime_column": reference_datetime_column,
+                "reference_datetime_metadata": reference_datetime_metadata,
+                "time_interval": time_interval,
             })
         else:
             tile_id_version = int(os.environ.get("FEATUREBYTE_TILE_ID_VERSION", "2"))
@@ -312,8 +348,13 @@ class WindowAggregator(BaseAggregator):
             })
         return params
 
-    def _add_aggregation_node(self, agg_func: AggFunc, node_params: dict[str, Any]) -> Node:
-        if self.is_time_series_aggregation:
+    def _add_aggregation_node(
+        self,
+        agg_func: AggFunc,
+        is_calendar_aggregation: bool,
+        node_params: dict[str, Any],
+    ) -> Node:
+        if is_calendar_aggregation:
             return self.view.graph.add_operation(
                 node_type=NodeType.TIME_SERIES_WINDOW_AGGREGATE,
                 node_params=node_params,

--- a/featurebyte/api/aggregator/window_aggregator.py
+++ b/featurebyte/api/aggregator/window_aggregator.py
@@ -5,7 +5,7 @@ This module contains window aggregator related class
 from __future__ import annotations
 
 import os
-from typing import Any, List, Literal, Optional, Type, cast
+from typing import Any, List, Optional, Type, cast
 
 from featurebyte.api.aggregator.base_aggregator import BaseAggregator
 from featurebyte.api.change_view import ChangeView
@@ -178,12 +178,12 @@ class WindowAggregator(BaseAggregator):
 
         if self.is_calendar_aggregation(windows):
             if offset is not None:
-                offset_unit = self._validate_calendar_window("offset", offset)
+                offset_unit = self._validate_calendar_window(offset)
             else:
                 offset_unit = None
             for window in windows:
-                assert window is not None  # due to the above check
-                self._validate_calendar_window("windows", window, compatible_unit=offset_unit)
+                assert isinstance(window, CalendarWindow)  # due to the above check
+                self._validate_calendar_window(window, compatible_unit=offset_unit)
             if feature_job_setting is not None and not isinstance(
                 feature_job_setting, CronFeatureJobSetting
             ):
@@ -239,20 +239,11 @@ class WindowAggregator(BaseAggregator):
 
     def _validate_calendar_window(
         self,
-        param_type: Literal["windows", "offset"],
         window: str | CalendarWindow,
         compatible_unit: Optional[TimeIntervalUnit] = None,
     ) -> TimeIntervalUnit:
         if not isinstance(window, CalendarWindow):
-            # TODO: can remove since window must be CalendarWindow?
-            if param_type == "windows":
-                raise ValueError(
-                    f"Please specify {param_type} as a list of CalendarWindow for calendar aggregation"
-                )
-            else:
-                raise ValueError(
-                    f"Please specify {param_type} as CalendarWindow for calendar aggregation"
-                )
+            raise ValueError("Please specify offset as CalendarWindow for calendar aggregation")
         view = self.view
         unit = TimeIntervalUnit(window.unit)
         if compatible_unit is not None and unit != compatible_unit:

--- a/featurebyte/api/groupby.py
+++ b/featurebyte/api/groupby.py
@@ -135,7 +135,7 @@ class GroupBy:
         self,
         value_column: Optional[str],
         method: Union[AggFunc, str],
-        windows: List[Optional[str] | CalendarWindow],
+        windows: List[Optional[str]] | List[CalendarWindow],
         feature_names: List[str],
         timestamp_column: Optional[str] = None,
         feature_job_setting: Optional[FeatureJobSetting | CronFeatureJobSetting] = None,

--- a/featurebyte/models/entity_universe.py
+++ b/featurebyte/models/entity_universe.py
@@ -598,13 +598,14 @@ class TimeSeriesWindowAggregateNodeEntityUniverseConstructor(BaseEntityUniverseC
                     window.to_months(),
                 )
 
-            timestamp_expr = self.adapter.normalize_timestamp_before_comparison(
-                convert_timestamp_to_local(
-                    quoted_identifier(node.parameters.reference_datetime_column),
+            timestamp_expr = quoted_identifier(node.parameters.reference_datetime_column)
+            if node.parameters.reference_datetime_schema is not None:
+                timestamp_expr = convert_timestamp_to_local(
+                    timestamp_expr,
                     node.parameters.reference_datetime_schema,
                     self.adapter,
-                ),
-            )
+                )
+            timestamp_expr = self.adapter.normalize_timestamp_before_comparison(timestamp_expr)
             filtered_aggregate_input_expr = self.aggregate_input_expr.where(
                 expressions.and_(
                     expressions.GTE(

--- a/featurebyte/query_graph/node/generic.py
+++ b/featurebyte/query_graph/node/generic.py
@@ -2071,8 +2071,8 @@ class TimeSeriesWindowAggregateParameters(BaseGroupbyParameters):
 
     windows: List[CalendarWindow]
     reference_datetime_column: InColumnStr
-    reference_datetime_metadata: DBVarTypeMetadata
-    time_interval: TimeInterval
+    reference_datetime_metadata: Optional[DBVarTypeMetadata]
+    time_interval: Optional[TimeInterval]
     names: List[OutColumnStr]
     feature_job_setting: CronFeatureJobSetting
     offset: Optional[CalendarWindow] = None
@@ -2089,7 +2089,7 @@ class TimeSeriesWindowAggregateParameters(BaseGroupbyParameters):
         return self.reference_datetime_column
 
     @property
-    def reference_datetime_schema(self) -> TimestampSchema:
+    def reference_datetime_schema(self) -> Optional[TimestampSchema]:
         """
         Get reference datetime schema
 
@@ -2097,8 +2097,9 @@ class TimeSeriesWindowAggregateParameters(BaseGroupbyParameters):
         -------
         TimestampSchema
         """
-        assert self.reference_datetime_metadata.timestamp_schema is not None
-        return self.reference_datetime_metadata.timestamp_schema
+        if self.reference_datetime_metadata is not None:
+            return self.reference_datetime_metadata.timestamp_schema
+        return None
 
     @model_validator(mode="before")
     @classmethod

--- a/featurebyte/query_graph/sql/aggregator/time_series_window.py
+++ b/featurebyte/query_graph/sql/aggregator/time_series_window.py
@@ -312,11 +312,15 @@ class TimeSeriesWindowAggregator(NonTileBasedAggregator[TimeSeriesWindowAggregat
         -------
         Select
         """
-        reference_datetime_expr = convert_timestamp_to_local(
-            quoted_identifier(aggregation_spec.parameters.reference_datetime_column),
-            aggregation_spec.parameters.reference_datetime_schema,
-            self.adapter,
+        reference_datetime_expr = quoted_identifier(
+            aggregation_spec.parameters.reference_datetime_column
         )
+        if aggregation_spec.parameters.reference_datetime_schema is not None:
+            reference_datetime_expr = convert_timestamp_to_local(
+                reference_datetime_expr,
+                aggregation_spec.parameters.reference_datetime_schema,
+                self.adapter,
+            )
         if aggregation_spec.window.is_fixed_size():
             bucket_expr = self.adapter.to_epoch_seconds(reference_datetime_expr)
         else:

--- a/tests/integration/api/test_event_view_operations.py
+++ b/tests/integration/api/test_event_view_operations.py
@@ -17,13 +17,15 @@ from sqlglot import parse_one
 
 from featurebyte import (
     AggFunc,
+    CalendarWindow,
+    CronFeatureJobSetting,
     Entity,
     FeatureList,
     HistoricalFeatureTable,
     SourceType,
     to_timedelta,
 )
-from featurebyte.enum import InternalName
+from featurebyte.enum import InternalName, TimeIntervalUnit
 from featurebyte.exception import RecordCreationException
 from featurebyte.feature_manager.model import ExtendedFeatureModel
 from featurebyte.query_graph.sql.common import sql_to_string
@@ -1592,3 +1594,34 @@ def test_count_distinct_features(count_distinct_feature_group):
     ])
     pd.testing.assert_frame_equal(df_hist, expected, check_dtype=False)
     pd.testing.assert_frame_equal(fl_preview, expected, check_dtype=False)
+
+
+def test_event_view_calendar_aggregation(event_view):
+    """
+    Test calendar aggregation on EventView
+    """
+    feature = event_view.groupby("ÜSER ID").aggregate_over(
+        value_column=None,
+        method="count",
+        windows=[CalendarWindow(unit=TimeIntervalUnit.MONTH, size=2)],
+        feature_names=["count_calendar_2m"],
+        feature_job_setting=CronFeatureJobSetting(
+            crontab="0 8 * * *",
+            timezone="Asia/Singapore",
+        ),
+    )["count_calendar_2m"]
+    feature_list = FeatureList([feature], name="my_list")
+
+    # test historical feature computation
+    df_training_events = pd.DataFrame({
+        "POINT_IN_TIME": pd.to_datetime(["2001-01-02 10:00:00"] * 5),
+        "üser id": [1, 2, 3, 4, 5],
+    })
+    df_features = feature_list.compute_historical_features(observation_set=df_training_events)
+    df_expected = df_training_events.copy()
+    df_expected["count_calendar_2m"] = [9, 1, 7, 3, 5]
+    fb_assert_frame_equal(
+        df_features,
+        df_expected,
+        sort_by_columns=["POINT_IN_TIME", "üser id"],
+    )


### PR DESCRIPTION
## Description

This adds support for calendar aggregation for event tables:
* When `windows` is provided as a list of `CalendarWindow`, it activates calendar aggregation for event tables
* `feature_job_setting` must be an instance of `CronFeatureJobSetting`
* The constructed node type for the feature will be `TIME_SERIES_WINDOW_AGGREGATE`  where the underlying table is an event table instead of a time series table

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
