### PR TITLE
[DEV-3993] Add SCD end timestamp handling only when the column is available

### DIFF
--- a/featurebyte/query_graph/sql/scd_helper.py
+++ b/featurebyte/query_graph/sql/scd_helper.py
@@ -114,6 +114,28 @@ class Table:
         )
 
 
+def has_end_timestamp_column(table: Table) -> bool:
+    """
+    Check if the table has an end timestamp column
+
+    Parameters
+    ----------
+    table: Table
+        Table to check
+
+    Returns
+    -------
+    bool
+    """
+    if table.end_timestamp_column:
+        if isinstance(table.expr, Select):
+            for col_expr in table.expr.expressions:
+                col_name = col_expr.alias or col_expr.name
+                if col_name == table.end_timestamp_column:
+                    return True
+    return False
+
+
 def get_scd_join_expr(
     left_table: Table,
     right_table: Table,
@@ -229,7 +251,7 @@ def get_scd_join_expr(
         ),
     ] + _key_cols_equality_conditions(right_table.join_keys)
 
-    if right_table.end_timestamp_column is not None:
+    if has_end_timestamp_column(right_table):
         end_timestamp_expr = get_qualified_column_identifier(right_table.end_timestamp_column, "R")
         if convert_timestamps_to_utc:
             end_timestamp_expr = _convert_to_utc_ntz(

--- a/featurebyte/query_graph/sql/scd_helper.py
+++ b/featurebyte/query_graph/sql/scd_helper.py
@@ -252,6 +252,7 @@ def get_scd_join_expr(
     ] + _key_cols_equality_conditions(right_table.join_keys)
 
     if has_end_timestamp_column(right_table):
+        assert right_table.end_timestamp_column is not None
         end_timestamp_expr = get_qualified_column_identifier(right_table.end_timestamp_column, "R")
         if convert_timestamps_to_utc:
             end_timestamp_expr = _convert_to_utc_ntz(

--- a/tests/fixtures/expected_preview_sql_timezone_offset_item_view_joined_scd_view.sql
+++ b/tests/fixtures/expected_preview_sql_timezone_offset_item_view_joined_scd_view.sql
@@ -202,5 +202,8 @@ LEFT JOIN (
 ) AS R
   ON L."__FB_LAST_TS" = R."effective_timestamp"
   AND L."__FB_KEY_COL_0" = R."col_text"
-  AND L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
+  AND (
+    L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
+    OR R."end_timestamp" IS NULL
+  )
 LIMIT 10

--- a/tests/fixtures/expected_tile_sql_complex_feature_push_down_eligible.sql
+++ b/tests/fixtures/expected_tile_sql_complex_feature_push_down_eligible.sql
@@ -166,7 +166,10 @@ WITH __FB_TILE_COMPUTE_INPUT_TABLE_NAME AS (
         ) AS R
           ON L."__FB_LAST_TS" = R."effective_timestamp"
           AND L."__FB_KEY_COL_0" = R."col_text"
-          AND L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
+          AND (
+            L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
+            OR R."end_timestamp" IS NULL
+          )
       ) AS REQ
       LEFT JOIN (
         SELECT

--- a/tests/fixtures/feature_materialize/initialize_new_columns_precomputed_lookup.sql
+++ b/tests/fixtures/feature_materialize/initialize_new_columns_precomputed_lookup.sql
@@ -233,7 +233,10 @@ WITH ENTITY_UNIVERSE AS (
     ) AS R
       ON L."__FB_LAST_TS" = R."effective_timestamp"
       AND L."__FB_KEY_COL_0" = R."col_text"
-      AND L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
+      AND (
+        L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
+        OR R."end_timestamp" IS NULL
+      )
   ) AS REQ
 )
 SELECT

--- a/tests/fixtures/feature_materialize/initialize_precomputed_lookup_feature_table.sql
+++ b/tests/fixtures/feature_materialize/initialize_precomputed_lookup_feature_table.sql
@@ -158,7 +158,10 @@ WITH ENTITY_UNIVERSE AS (
     ) AS R
       ON L."__FB_LAST_TS" = R."effective_timestamp"
       AND L."__FB_KEY_COL_0" = R."col_text"
-      AND L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
+      AND (
+        L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
+        OR R."end_timestamp" IS NULL
+      )
   ) AS REQ
 )
 SELECT

--- a/tests/fixtures/feature_materialize/initialize_precomputed_lookup_feature_table_missing_column.sql
+++ b/tests/fixtures/feature_materialize/initialize_precomputed_lookup_feature_table_missing_column.sql
@@ -156,7 +156,10 @@ WITH ENTITY_UNIVERSE AS (
     ) AS R
       ON L."__FB_LAST_TS" = R."effective_timestamp"
       AND L."__FB_KEY_COL_0" = R."col_text"
-      AND L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
+      AND (
+        L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
+        OR R."end_timestamp" IS NULL
+      )
   ) AS REQ
 )
 SELECT

--- a/tests/fixtures/feature_materialize/materialize_features_queries_internal_relationships.sql
+++ b/tests/fixtures/feature_materialize/materialize_features_queries_internal_relationships.sql
@@ -174,7 +174,10 @@ WITH ONLINE_REQUEST_TABLE AS (
     ) AS R
       ON L."__FB_LAST_TS" = R."effective_timestamp"
       AND L."__FB_KEY_COL_0" = R."col_text"
-      AND L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
+      AND (
+        L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
+        OR R."end_timestamp" IS NULL
+      )
   ) AS REQ
 ), "REQUEST_TABLE_POINT_IN_TIME_cust_id_000000000000000000000000" AS (
   SELECT DISTINCT

--- a/tests/fixtures/feature_materialize/scheduled_materialize_features_precomputed_lookup.sql
+++ b/tests/fixtures/feature_materialize/scheduled_materialize_features_precomputed_lookup.sql
@@ -229,7 +229,10 @@ WITH ENTITY_UNIVERSE AS (
     ) AS R
       ON L."__FB_LAST_TS" = R."effective_timestamp"
       AND L."__FB_KEY_COL_0" = R."col_text"
-      AND L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
+      AND (
+        L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
+        OR R."end_timestamp" IS NULL
+      )
   ) AS REQ
 )
 SELECT

--- a/tests/fixtures/offline_store_feature_table/cust_id_to_gender_universe.sql
+++ b/tests/fixtures/offline_store_feature_table/cust_id_to_gender_universe.sql
@@ -131,7 +131,10 @@ WITH ENTITY_UNIVERSE AS (
     ) AS R
       ON L."__FB_LAST_TS" = R."effective_timestamp"
       AND L."__FB_KEY_COL_0" = R."col_text"
-      AND L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
+      AND (
+        L."__FB_TS_COL" < CAST(CONVERT_TIMEZONE('UTC', R."end_timestamp") AS TIMESTAMP)
+        OR R."end_timestamp" IS NULL
+      )
   ) AS REQ
 )
 SELECT

--- a/tests/integration/api/test_scd_view_operations.py
+++ b/tests/integration/api/test_scd_view_operations.py
@@ -270,23 +270,26 @@ async def test_end_timestamp_column(
             "2022-03-20 10:00:00",
             "2022-04-20 10:00:00",
             "2022-05-20 10:00:00",
+            "2022-06-20 10:00:00",
         ]),
-        "cust_id": [1000, 1000, 1000],
-        "event_id": [1, 2, 3],
+        "cust_id": [1000, 1000, 1000, 1000],
+        "event_id": [1, 2, 3, 4],
     })
     df_scd = pd.DataFrame({
         "effective_ts": pd.to_datetime([
             "2022-03-01 10:00:00",
             "2022-04-01 10:00:00",
             "2022-05-01 10:00:00",
+            "2022-06-01 10:00:00",
         ]),
         "end_ts": [
             "2022|04|01|10:00:00",
             "2022|05|01|10:00:00",
             "2022|05|05|10:00:00",
+            None,
         ],
-        "scd_cust_id": [1000, 1000, 1000],
-        "scd_value": [1, 2, 3],
+        "scd_cust_id": [1000, 1000, 1000, 1000],
+        "scd_value": [1, 2, 3, 4],
     })
     table_prefix = "TEST_SCD_END_TIMESTAMP"
 
@@ -330,7 +333,7 @@ async def test_end_timestamp_column(
     )
     scd_table["scd_cust_id"].as_entity(entity.name)
 
-    # Check SCD joins. Note the last row in the expected result is NaN because of the end timestamp.
+    # Check SCD joins. Note the 3rd row in the expected result is NaN because of the end timestamp.
     scd_view = scd_table.get_view()
     event_view = event_view.join(scd_view, on="cust_id", rsuffix="_latest")
     df_actual = event_view.preview()
@@ -339,14 +342,15 @@ async def test_end_timestamp_column(
             "2022-03-20 10:00:00",
             "2022-04-20 10:00:00",
             "2022-05-20 10:00:00",
+            "2022-06-20 10:00:00",
         ]),
-        "cust_id": [1000, 1000, 1000],
-        "event_id": [1, 2, 3],
-        "scd_value_latest": [1, 2, np.nan],
+        "cust_id": [1000, 1000, 1000, 1000],
+        "event_id": [1, 2, 3, 4],
+        "scd_value_latest": [1, 2, np.nan, 4],
     })
     fb_assert_frame_equal(df_actual, df_expected)
 
-    # Check SCD lookup feature. Note the last row in the expected result is NaN because of the end
+    # Check SCD lookup feature. Note the 3rd row in the expected result is NaN because of the end
     # timestamp.
     feature = scd_view["scd_value"].as_feature("test_end_timestamp_feature")
     feature.save()
@@ -356,12 +360,13 @@ async def test_end_timestamp_column(
             "2022-03-20 10:00:00",
             "2022-04-20 10:00:00",
             "2022-05-20 10:00:00",
+            "2022-06-20 10:00:00",
         ]),
-        "test_end_timestamp_column_cust_id": [1000, 1000, 1000],
+        "test_end_timestamp_column_cust_id": [1000, 1000, 1000, 1000],
     })
     df_features = feature_list.compute_historical_features(df_observation)
     df_expected = df_observation.copy()
-    df_expected["test_end_timestamp_feature"] = [1, 2, np.nan]
+    df_expected["test_end_timestamp_feature"] = [1, 2, np.nan, 4]
     fb_assert_frame_equal(df_features, df_expected)
 
 


### PR DESCRIPTION
## Description

This updates SCD end timestamp handling to skip the filter when the column is not available for any unexpected reasons.

Also fixes the handling for null values in the end timestamp column (treated to be valid records).

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
