### PR TITLE
[chore] allow credentials to be deleted

### DIFF
--- a/featurebyte/routes/credential/controller.py
+++ b/featurebyte/routes/credential/controller.py
@@ -159,11 +159,33 @@ class CredentialController(
         )
         if other_credentials["data"]:
             await self.delete(document_id=document_id)
-        else:
-            raise DocumentDeletionError(
-                f"Cannot delete the last credential for feature store (ID: {feature_store_id}). "
-                "Please create a new credential before deleting this one to ensure continued access."
-            )
+            return
+
+        # Allow deletion if the featurestore is currently deleted
+        # NOTE: This will be converted to a is_deleted flag in the future
+        #     : This is to ensure that a proper cleanup of featurestore resources is completed
+        #     : before allowing deletion of the last credential
+        # We are looking at calling all underlying catalogs, tagged to the featurestore to be marked as is_deleted
+        # Cleaning them up before allowing the deletion of the last credential & last feature_store
+        feature_stores = await self.feature_store_service.list_documents(
+            query_filter={"_id": feature_store_id}
+        )
+        if len(feature_stores) == 0:
+            await self.delete(document_id=document_id)
+            return
+
+        # Allow deletion of credential if the user is not the feature store owner
+        # User's credentials are not used to perform background/cleaning ops
+        feature_store = feature_stores[0]
+        if feature_store.owner_id != credential.owner_id:
+            await self.delete(document_id=document_id)
+            return
+
+        # This is the last credential for the feature store
+        raise DocumentDeletionError(
+            f"Cannot delete the last credential for feature store (ID: {feature_store_id}). "
+            "Please create a new credential before deleting this one to ensure continued access."
+        )
 
     async def get_info(
         self,

--- a/featurebyte/routes/credential/controller.py
+++ b/featurebyte/routes/credential/controller.py
@@ -177,7 +177,7 @@ class CredentialController(
         # Allow deletion of credential if the user is not the feature store owner
         # User's credentials are not used to perform background/cleaning ops
         feature_store = feature_stores[0]
-        if feature_store.owner_id != credential.owner_id:
+        if feature_store.user_id != credential.user_id:
             await self.delete(document_id=document_id)
             return
 

--- a/tests/unit/api/test_credential.py
+++ b/tests/unit/api/test_credential.py
@@ -9,7 +9,11 @@ import pandas as pd
 import pytest
 from bson import ObjectId
 
-from featurebyte import AccessTokenCredential, S3StorageCredential, UsernamePasswordCredential
+from featurebyte import (
+    AccessTokenCredential,
+    S3StorageCredential,
+    UsernamePasswordCredential,
+)
 from featurebyte.api.credential import Credential
 from featurebyte.exception import RecordDeletionException, RecordRetrievalException
 from featurebyte.models.credential import CredentialModel
@@ -65,6 +69,25 @@ def test_credential_creation__success(snowflake_feature_store, credential):
             "s3_secret_access_key": "********",
         },
     )
+
+    # delete the credential should work now
+    credential.delete()
+
+
+def test_credential_delete__success(snowflake_feature_store, credential):
+    """
+    Credential deletion success after featurestore is deleted
+    """
+    with pytest.raises(RecordDeletionException) as exc:
+        credential.delete()
+
+    expected = (
+        f"Cannot delete the last credential for feature store (ID: {snowflake_feature_store.id}). "
+        "Please create a new credential before deleting this one to ensure continued access."
+    )
+    assert expected in str(exc.value)
+
+    snowflake_feature_store.delete()
 
     # delete the credential should work now
     credential.delete()


### PR DESCRIPTION
## Description

FeatureStore credentials are still holding a dangling reference to a non-existent featurestore.
We intend to do a cleanup job in the future but at the moment we are going to allow deletion and it is up to the user to cleanup any orphaned resources.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
