### PR TITLE
[DEV-3998] Add event_timestamp_schema to EventTableInputNodeParameters

### DIFF
--- a/.changelog/DEV-3998.yaml
+++ b/.changelog/DEV-3998.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Support timestamp schema for event timestamp column"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/models/entity_universe.py
+++ b/featurebyte/models/entity_universe.py
@@ -332,19 +332,21 @@ class ItemAggregateNodeEntityUniverseConstructor(BaseEntityUniverseConstructor):
 
         # Get the EventTable's event timestamp column
         event_timestamp_column = None
+        event_timestamp_schema = None
         for input_node in graph.iterate_nodes(graph_node, NodeType.INPUT):
             if (
                 isinstance(input_node.parameters, EventTableInputNodeParameters)
                 and input_node.parameters.id == event_table_id
             ):
                 event_timestamp_column = input_node.parameters.timestamp_column
+                event_timestamp_schema = input_node.parameters.event_timestamp_schema
                 break
         assert event_timestamp_column is not None
 
         # Construct a filter to be applied to the EventTable
         event_table_timestamp_filter = EventTableTimestampFilter(
             timestamp_column_name=event_timestamp_column,
-            timestamp_schema=None,  # TODO: Extract the correct timestamp schema
+            timestamp_schema=event_timestamp_schema,
             event_table_id=event_table_id,
             start_timestamp_placeholder_name=LAST_MATERIALIZED_TIMESTAMP_PLACEHOLDER,
             end_timestamp_placeholder_name=CURRENT_FEATURE_TIMESTAMP_PLACEHOLDER,

--- a/featurebyte/query_graph/enum.py
+++ b/featurebyte/query_graph/enum.py
@@ -162,6 +162,7 @@ class NodeType(StrEnum):
             cls.DT_EXTRACT,
             cls.DATE_DIFF,
             cls.DATE_ADD,
+            cls.INPUT,
         }
 
 

--- a/featurebyte/query_graph/model/node_hash_util.py
+++ b/featurebyte/query_graph/model/node_hash_util.py
@@ -128,4 +128,8 @@ def exclude_non_aggregation_with_timestamp_node_timestamp_metadata(
         if node_parameters.get("left_timestamp_metadata") is None:
             node_parameters.pop("left_timestamp_metadata", None)
 
+    if node_type == NodeType.INPUT:
+        if node_parameters.get("event_timestamp_schema") is None:
+            node_parameters.pop("event_timestamp_schema", None)
+
     return node_parameters

--- a/featurebyte/query_graph/model/table.py
+++ b/featurebyte/query_graph/model/table.py
@@ -88,6 +88,7 @@ class EventTableData(BaseTableData):
                 "feature_store_details": {"type": feature_store_details.type},
                 "event_timestamp_timezone_offset": self.event_timestamp_timezone_offset,
                 "event_timestamp_timezone_offset_column": self.event_timestamp_timezone_offset_column,
+                "event_timestamp_schema": self.event_timestamp_schema,
                 **self._get_common_input_node_parameters(),
             },
         )

--- a/featurebyte/query_graph/node/input.py
+++ b/featurebyte/query_graph/node/input.py
@@ -240,6 +240,7 @@ class EventTableInputNodeParameters(BaseInputNodeParameters):
     id_column: Optional[InColumnStr] = Field(default=None)  # DEV-556: this should be compulsory
     event_timestamp_timezone_offset: Optional[str] = Field(default=None)
     event_timestamp_timezone_offset_column: Optional[InColumnStr] = Field(default=None)
+    event_timestamp_schema: Optional[TimestampSchema] = Field(default=None)
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/fixtures/offline_store_feature_table/feature_cluster_disabled_one_feature.json
+++ b/tests/fixtures/offline_store_feature_table/feature_cluster_disabled_one_feature.json
@@ -90,6 +90,7 @@
                             "name": "cust_id"
                         }
                     ],
+                    "event_timestamp_schema": null,
                     "event_timestamp_timezone_offset": null,
                     "event_timestamp_timezone_offset_column": null,
                     "feature_store_details": {

--- a/tests/fixtures/offline_store_feature_table/feature_cluster_one_feature.json
+++ b/tests/fixtures/offline_store_feature_table/feature_cluster_one_feature.json
@@ -86,6 +86,7 @@
                             "name": "cust_id"
                         }
                     ],
+                    "event_timestamp_schema": null,
                     "event_timestamp_timezone_offset": null,
                     "event_timestamp_timezone_offset_column": null,
                     "feature_store_details": {

--- a/tests/fixtures/offline_store_feature_table/feature_cluster_two_features.json
+++ b/tests/fixtures/offline_store_feature_table/feature_cluster_two_features.json
@@ -103,6 +103,7 @@
                             "name": "cust_id"
                         }
                     ],
+                    "event_timestamp_schema": null,
                     "event_timestamp_timezone_offset": null,
                     "event_timestamp_timezone_offset_column": null,
                     "feature_store_details": {

--- a/tests/fixtures/request_payloads/feature_iet.json
+++ b/tests/fixtures/request_payloads/feature_iet.json
@@ -176,6 +176,7 @@
                             "name": "cust_id"
                         }
                     ],
+                    "event_timestamp_schema": null,
                     "event_timestamp_timezone_offset": null,
                     "event_timestamp_timezone_offset_column": null,
                     "feature_store_details": {

--- a/tests/fixtures/request_payloads/feature_item_event.json
+++ b/tests/fixtures/request_payloads/feature_item_event.json
@@ -80,6 +80,7 @@
                             "name": "cust_id"
                         }
                     ],
+                    "event_timestamp_schema": null,
                     "event_timestamp_timezone_offset": null,
                     "event_timestamp_timezone_offset_column": null,
                     "feature_store_details": {

--- a/tests/fixtures/request_payloads/feature_store_sample.json
+++ b/tests/fixtures/request_payloads/feature_store_sample.json
@@ -61,6 +61,7 @@
                             "name": "cust_id"
                         }
                     ],
+                    "event_timestamp_schema": null,
                     "event_timestamp_timezone_offset": null,
                     "event_timestamp_timezone_offset_column": null,
                     "feature_store_details": {

--- a/tests/fixtures/request_payloads/feature_sum_2h.json
+++ b/tests/fixtures/request_payloads/feature_sum_2h.json
@@ -72,6 +72,7 @@
                             "name": "cust_id"
                         }
                     ],
+                    "event_timestamp_schema": null,
                     "event_timestamp_timezone_offset": null,
                     "event_timestamp_timezone_offset_column": null,
                     "feature_store_details": {

--- a/tests/fixtures/request_payloads/feature_sum_30m.json
+++ b/tests/fixtures/request_payloads/feature_sum_30m.json
@@ -72,6 +72,7 @@
                             "name": "cust_id"
                         }
                     ],
+                    "event_timestamp_schema": null,
                     "event_timestamp_timezone_offset": null,
                     "event_timestamp_timezone_offset_column": null,
                     "feature_store_details": {

--- a/tests/fixtures/request_payloads/historical_feature_table.json
+++ b/tests/fixtures/request_payloads/historical_feature_table.json
@@ -93,6 +93,7 @@
                                         "name": "cust_id"
                                     }
                                 ],
+                                "event_timestamp_schema": null,
                                 "event_timestamp_timezone_offset": null,
                                 "event_timestamp_timezone_offset_column": null,
                                 "feature_store_details": {

--- a/tests/fixtures/request_payloads/target.json
+++ b/tests/fixtures/request_payloads/target.json
@@ -72,6 +72,7 @@
                             "name": "cust_id"
                         }
                     ],
+                    "event_timestamp_schema": null,
                     "event_timestamp_timezone_offset": null,
                     "event_timestamp_timezone_offset_column": null,
                     "feature_store_details": {

--- a/tests/unit/api/test_event_table.py
+++ b/tests/unit/api/test_event_table.py
@@ -1415,6 +1415,6 @@ def test_event_table_with_event_timestamp_schema(snowflake_event_table_with_time
     event_table = snowflake_event_table_with_timestamp_schema
     assert event_table.event_timestamp_schema.model_dump() == {
         "format_string": None,
-        "is_utc_time": True,
+        "is_utc_time": False,
         "timezone": {"column_name": "tz_offset", "type": "offset"},
     }

--- a/tests/unit/api/test_event_view.py
+++ b/tests/unit/api/test_event_view.py
@@ -1123,7 +1123,7 @@ def test_event_view_with_event_timestamp_schema(snowflake_event_table_with_times
     event_view = snowflake_event_table_with_timestamp_schema.get_view()
     assert event_view.event_timestamp_schema.model_dump() == {
         "format_string": None,
-        "is_utc_time": True,
+        "is_utc_time": False,
         "timezone": {"column_name": "tz_offset", "type": "offset"},
     }
     assert event_view.inherited_columns == {"col_int", "event_timestamp", "tz_offset"}

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1122,6 +1122,12 @@ def snowflake_item_table_id_2_fixture():
     return ObjectId("6337f9651050ee7d5980662e")
 
 
+@pytest.fixture(name="snowflake_item_table_with_timestamp_schema_id")
+def snowflake_item_table_with_timestamp_schema_id_fixture():
+    """Snowflake item table ID with timestamp schema"""
+    return ObjectId("67c9170033e0a38cbf517413")
+
+
 @pytest.fixture(name="snowflake_time_series_table_id")
 def snowflake_time_series_table_id_fixture():
     """Snowflake time series table ID"""
@@ -1239,7 +1245,7 @@ def snowflake_event_table_with_timestamp_schema_fixture(
         event_timestamp_column="event_timestamp",
         event_timestamp_timezone_offset_column="tz_offset",
         event_timestamp_schema=TimestampSchema(
-            is_utc_time=True,
+            is_utc_time=False,
             timezone=TimeZoneColumn(column_name="tz_offset", type="offset"),
         ),
         record_creation_timestamp_column="created_at",
@@ -1384,6 +1390,29 @@ def snowflake_item_table_with_timezone_offset_column_fixture(
         item_id_column="item_id_col",
         event_table_name=snowflake_event_table_with_tz_offset_column.name,
     )
+    yield item_table
+
+
+@pytest.fixture(name="snowflake_item_table_with_timestamp_schema")
+def snowflake_item_table_with_timestamp_schema_fixture(
+    snowflake_database_table_item_table,
+    mock_get_persistent,
+    snowflake_item_table_with_timestamp_schema_id,
+    snowflake_event_table_with_timestamp_schema,
+):
+    """
+    Snowflake ItemTable object fixture
+    """
+    _ = mock_get_persistent
+    item_table = snowflake_database_table_item_table.create_item_table(
+        name="sf_item_table",
+        event_id_column="event_id_col",
+        item_id_column="item_id_col",
+        event_table_name=snowflake_event_table_with_timestamp_schema.name,
+        description="test item table",
+        _id=snowflake_item_table_with_timestamp_schema_id,
+    )
+    assert item_table.frame.node.parameters.id == item_table.id
     yield item_table
 
 
@@ -2094,6 +2123,28 @@ def filtered_non_time_based_feature_fixture(snowflake_item_table, transaction_en
         value_column="item_amount",
         method=AggFunc.SUM,
         feature_name="non_time_time_sum_amount_feature_gt10",
+    )
+    feature.save()
+    return feature
+
+
+@pytest.fixture(name="non_time_based_feature_with_event_timestamp_schema")
+def non_time_based_feature_with_event_timestamp_schema(
+    snowflake_item_table_with_timestamp_schema, transaction_entity
+):
+    """
+    Get a non-time-based feature with event timestamp schema
+    """
+    snowflake_item_table_with_timestamp_schema.event_id_col.as_entity(transaction_entity.name)
+    item_table = ItemTable(**{
+        **snowflake_item_table_with_timestamp_schema.json_dict(),
+        "item_id_column": "item_id_col",
+    })
+    item_view = item_table.get_view(event_suffix="_event_table")
+    feature = item_view.groupby("event_id_col").aggregate(
+        value_column="item_amount",
+        method=AggFunc.SUM,
+        feature_name="non_time_time_sum_amount_feature",
     )
     feature.save()
     return feature

--- a/tests/unit/query_graph/conftest.py
+++ b/tests/unit/query_graph/conftest.py
@@ -1800,6 +1800,7 @@ def query_graph_single_node(
                 "id_column": None,
                 "event_timestamp_timezone_offset": None,
                 "event_timestamp_timezone_offset_column": None,
+                "event_timestamp_schema": None,
             },
             "output_type": "frame",
         }

--- a/tests/unit/query_graph/model/test_table_data.py
+++ b/tests/unit/query_graph/model/test_table_data.py
@@ -204,6 +204,7 @@ def event_input_node_fixture(feature_store_details, event_table_data):
             "type": "event_table",
             "event_timestamp_timezone_offset": None,
             "event_timestamp_timezone_offset_column": None,
+            "event_timestamp_schema": None,
         },
         "output_type": "frame",
     }

--- a/tests/unit/query_graph/test_query_graph.py
+++ b/tests/unit/query_graph/test_query_graph.py
@@ -367,7 +367,8 @@ def test_query_graph__representation():
                         "timestamp_column": null,
                         "id_column": null,
                         "event_timestamp_timezone_offset": null,
-                        "event_timestamp_timezone_offset_column": null
+                        "event_timestamp_timezone_offset_column": null,
+                        "event_timestamp_schema": null
                     }
                 }
             ]

--- a/tests/unit/routes/test_context.py
+++ b/tests/unit/routes/test_context.py
@@ -156,6 +156,7 @@ class TestContextApi(BaseCatalogApiTestSuite):
                 "type": "event_table",
                 "event_timestamp_timezone_offset": None,
                 "event_timestamp_timezone_offset_column": None,
+                "event_timestamp_schema": None,
             },
         }
 


### PR DESCRIPTION
## Description

This updates `EventTableInputNodeParameters` to include the `event_timestamp_schema` field. Hashing logic is updated to exclude the field if None for backward compatibility.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
