### PR TITLE
[DEV-3999] Support cron based default feature job setting for EventTable

### DIFF
--- a/.changelog/DEV-3999.yaml
+++ b/.changelog/DEV-3999.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Support cron based default feature job setting for EventTable"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/event_table.py
+++ b/featurebyte/api/event_table.py
@@ -21,7 +21,9 @@ from featurebyte.enum import DBVarType, TableDataType, ViewMode
 from featurebyte.exception import InvalidSettingsError, RecordRetrievalException
 from featurebyte.models.event_table import EventTableModel
 from featurebyte.query_graph.graph import GlobalQueryGraph
-from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
+from featurebyte.query_graph.model.feature_job_setting import (
+    FeatureJobSettingUnion,
+)
 from featurebyte.query_graph.model.table import AllTableDataT, EventTableData
 from featurebyte.query_graph.model.timestamp_schema import TimestampSchema
 from featurebyte.query_graph.node.cleaning_operation import ColumnCleaningOperation
@@ -73,7 +75,7 @@ class EventTable(TableApiObject):
     type: Literal[TableDataType.EVENT_TABLE] = TableDataType.EVENT_TABLE
 
     # pydantic instance variable (internal use)
-    internal_default_feature_job_setting: Optional[FeatureJobSetting] = Field(
+    internal_default_feature_job_setting: Optional[FeatureJobSettingUnion] = Field(
         alias="default_feature_job_setting", default=None
     )
     internal_event_timestamp_column: StrictStr = Field(alias="event_timestamp_column")
@@ -222,7 +224,7 @@ class EventTable(TableApiObject):
         )
 
     @property
-    def default_feature_job_setting(self) -> Optional[FeatureJobSetting]:
+    def default_feature_job_setting(self) -> Optional[FeatureJobSettingUnion]:
         """
         Default feature job setting of the EventTable
 
@@ -354,7 +356,9 @@ class EventTable(TableApiObject):
         return cls._get_by_id(id=id)
 
     @typechecked
-    def update_default_feature_job_setting(self, feature_job_setting: FeatureJobSetting) -> None:
+    def update_default_feature_job_setting(
+        self, feature_job_setting: FeatureJobSettingUnion
+    ) -> None:
         """
         Update default feature job setting
 

--- a/featurebyte/api/event_table.py
+++ b/featurebyte/api/event_table.py
@@ -364,8 +364,9 @@ class EventTable(TableApiObject):
 
         Parameters
         ----------
-        feature_job_setting: FeatureJobSetting
-            Feature job setting object
+        feature_job_setting: FeatureJobSettingUnion
+            Feature job setting object. It can be an instance of FeatureJobSetting or
+            CronFeatureJobSetting.
 
         Examples
         --------

--- a/featurebyte/api/event_view.py
+++ b/featurebyte/api/event_view.py
@@ -17,7 +17,9 @@ from featurebyte.enum import TableDataType
 from featurebyte.exception import EventViewMatchingEntityColumnNotFound
 from featurebyte.query_graph.enum import GraphNodeType, NodeOutputType, NodeType
 from featurebyte.query_graph.model.column_info import ColumnInfo
-from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
+from featurebyte.query_graph.model.feature_job_setting import (
+    FeatureJobSettingUnion,
+)
 from featurebyte.query_graph.model.timestamp_schema import TimestampSchema, TimeZoneColumn
 from featurebyte.query_graph.node.input import EventTableInputNodeParameters, InputNode
 from featurebyte.typing import validate_type_is_feature
@@ -58,7 +60,7 @@ class EventView(View, GroupByMixin, RawMixin):
     _view_graph_node_type: ClassVar[GraphNodeType] = GraphNodeType.EVENT_VIEW
 
     # pydantic instance variables
-    default_feature_job_setting: Optional[FeatureJobSetting] = Field(
+    default_feature_job_setting: Optional[FeatureJobSettingUnion] = Field(
         frozen=True,
         description="Returns the default feature job setting for the view.\n\n"
         "The Default Feature Job Setting establishes the default setting used by "

--- a/featurebyte/api/item_table.py
+++ b/featurebyte/api/item_table.py
@@ -23,7 +23,9 @@ from featurebyte.exception import RecordRetrievalException
 from featurebyte.models.base import FeatureByteBaseDocumentModel, PydanticObjectId
 from featurebyte.models.item_table import ItemTableModel
 from featurebyte.query_graph.graph import GlobalQueryGraph
-from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
+from featurebyte.query_graph.model.feature_job_setting import (
+    FeatureJobSettingUnion,
+)
 from featurebyte.query_graph.model.table import AllTableDataT, ItemTableData
 from featurebyte.query_graph.node.cleaning_operation import ColumnCleaningOperation
 from featurebyte.query_graph.node.input import InputNode
@@ -331,7 +333,7 @@ class ItemTable(TableApiObject):
 
     @property
     @cachedmethod(cache=operator.attrgetter("_cache"), key=get_default_job_setting_cache_key)
-    def default_feature_job_setting(self) -> Optional[FeatureJobSetting]:
+    def default_feature_job_setting(self) -> Optional[FeatureJobSettingUnion]:
         """
         Returns the default feature job setting for the table.
 
@@ -343,7 +345,7 @@ class ItemTable(TableApiObject):
 
         Returns
         -------
-        Optional[FeatureJobSetting]
+        Optional[FeatureJobSettingUnion]
         """
         try:
             return EventTable.get_by_id(self.event_table_id).default_feature_job_setting

--- a/featurebyte/api/item_view.py
+++ b/featurebyte/api/item_view.py
@@ -14,7 +14,9 @@ from featurebyte.common.doc_util import FBAutoDoc
 from featurebyte.enum import TableDataType
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.query_graph.enum import GraphNodeType
-from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
+from featurebyte.query_graph.model.feature_job_setting import (
+    FeatureJobSettingUnion,
+)
 from featurebyte.query_graph.model.table import ItemTableData
 from featurebyte.query_graph.node.metadata.operation import DerivedDataColumn
 
@@ -66,7 +68,7 @@ class ItemView(View, GroupByMixin, RawMixin):
         "of the Event Table related to the Item "
         "view.",
     )
-    default_feature_job_setting: Optional[FeatureJobSetting] = Field(
+    default_feature_job_setting: Optional[FeatureJobSettingUnion] = Field(
         frozen=True,
         description="Returns the default feature job setting for the view.\n\n"
         "The Default Feature Job Setting establishes the default setting used "

--- a/featurebyte/exception.py
+++ b/featurebyte/exception.py
@@ -569,3 +569,9 @@ class CronFeatureJobSettingConversionError(FeatureByteException):
     """
     Raise when there is an error when converting a CronFeatureJobSetting to a FeatureJobSetting
     """
+
+
+class InvalidDefaultFeatureJobSettingError(FeatureByteException):
+    """
+    Raise when the default feature job setting is invalid
+    """

--- a/featurebyte/models/event_table.py
+++ b/featurebyte/models/event_table.py
@@ -15,7 +15,10 @@ from featurebyte.models.base import FeatureByteBaseModel
 from featurebyte.models.feature_store import TableModel
 from featurebyte.query_graph.graph_node.base import GraphNode
 from featurebyte.query_graph.model.column_info import ColumnInfo
-from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
+from featurebyte.query_graph.model.feature_job_setting import (
+    FeatureJobSetting,
+    FeatureJobSettingUnion,
+)
 from featurebyte.query_graph.model.table import EventTableData
 from featurebyte.query_graph.node.input import InputNode
 from featurebyte.query_graph.node.nested import ViewMetadata
@@ -61,7 +64,7 @@ class EventTableModel(EventTableData, TableModel):
         Datetime when the EventTable object was last updated
     """
 
-    default_feature_job_setting: Optional[FeatureJobSetting] = Field(default=None)
+    default_feature_job_setting: Optional[FeatureJobSettingUnion] = Field(default=None)
     _table_data_class: ClassVar[Type[EventTableData]] = EventTableData
 
     # pydantic validators

--- a/featurebyte/query_graph/model/feature_job_setting.py
+++ b/featurebyte/query_graph/model/feature_job_setting.py
@@ -251,7 +251,7 @@ class FeatureJobSetting(BaseFeatureJobSetting):
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, CronFeatureJobSetting):
-            return False
+            return other == self
         if not isinstance(other, FeatureJobSetting):
             return NotImplemented
         return self.to_seconds() == other.to_seconds()
@@ -562,6 +562,12 @@ class CronFeatureJobSetting(BaseFeatureJobSetting):
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, CronFeatureJobSetting):
+            if isinstance(other, FeatureJobSetting):
+                try:
+                    converted = self.to_feature_job_setting()
+                    return converted == other
+                except CronFeatureJobSettingConversionError:
+                    return False
             return False
         return (
             self.crontab == other.crontab

--- a/featurebyte/query_graph/model/feature_job_setting.py
+++ b/featurebyte/query_graph/model/feature_job_setting.py
@@ -504,14 +504,10 @@ class CronFeatureJobSetting(BaseFeatureJobSetting):
         """
         # Ensure we are working in UTC
         if "UTC" not in self.timezone:
-            raise CronFeatureJobSettingConversionError(
-                "Conversion is only supported for UTC timezone."
-            )
+            raise CronFeatureJobSettingConversionError("timezone must be UTC")
 
         if self.blind_spot is None:
-            raise CronFeatureJobSettingConversionError(
-                "Conversion is only supported when blind_spot is specified"
-            )
+            raise CronFeatureJobSettingConversionError("blind_spot is not specified")
 
         # Define the Unix epoch start time
         epoch_time = datetime(1970, 1, 1)
@@ -539,7 +535,7 @@ class CronFeatureJobSetting(BaseFeatureJobSetting):
             # If we find multiple interval values, fail immediately
             if len(interval_set) > 1:
                 raise CronFeatureJobSettingConversionError(
-                    "The cron schedule does not result in a fixed interval."
+                    "cron schedule does not result in a fixed interval"
                 )
 
             # Stop if we reach our max checking period (2 years)

--- a/featurebyte/query_graph/model/graph.py
+++ b/featurebyte/query_graph/model/graph.py
@@ -16,6 +16,7 @@ from featurebyte.query_graph.model.node_hash_util import (
     exclude_aggregation_and_lookup_node_timestamp_metadata,
     exclude_default_timestamp_metadata,
     exclude_non_aggregation_with_timestamp_node_timestamp_metadata,
+    handle_time_series_window_aggregate_node_parameters,
 )
 from featurebyte.query_graph.node import Node, construct_node
 from featurebyte.query_graph.node.generic import AliasNode, ProjectNode
@@ -256,6 +257,8 @@ class QueryGraphModel(FeatureByteBaseModel):
             # introduced.
             if node_parameters.get("offset") is None:
                 node_parameters.pop("offset", None)
+        if node.type == NodeType.TIME_SERIES_WINDOW_AGGREGATE:
+            handle_time_series_window_aggregate_node_parameters(node_parameters)
         if node.type in NodeType.aggregation_and_lookup_node_types():
             exclude_aggregation_and_lookup_node_timestamp_metadata(
                 node_type=node.type, node_parameters=node_parameters

--- a/featurebyte/query_graph/model/node_hash_util.py
+++ b/featurebyte/query_graph/model/node_hash_util.py
@@ -133,3 +133,19 @@ def exclude_non_aggregation_with_timestamp_node_timestamp_metadata(
             node_parameters.pop("event_timestamp_schema", None)
 
     return node_parameters
+
+
+def handle_time_series_window_aggregate_node_parameters(node_parameters: Dict[str, Any]) -> None:
+    """
+    Handle time series window aggregate node parameters
+
+    Parameters
+    ----------
+    node_parameters: Dict[str, Any]
+        Node parameters
+    """
+    # Consider None blind_spot in CronFeatureJobSetting as the same as not provided for backward
+    # compatibility
+    feature_job_setting = node_parameters.get("feature_job_setting", {})
+    if feature_job_setting.get("blind_spot") is None:
+        feature_job_setting.pop("blind_spot", None)

--- a/featurebyte/query_graph/node/generic.py
+++ b/featurebyte/query_graph/node/generic.py
@@ -710,7 +710,7 @@ class BaseWindowAggregateParameters(BaseGroupbyParameters):
 
     @model_validator(mode="before")
     @classmethod
-    def _convert_node_parameters_format(cls, values: Any) -> Any:
+    def _convert_feature_job_setting(cls, values: Any) -> Any:
         if isinstance(values, BaseModel):
             values = values.model_dump(by_alias=True)
 
@@ -724,8 +724,6 @@ class BaseWindowAggregateParameters(BaseGroupbyParameters):
             except ValidationError:
                 # Assume feature job setting is already non-cron based and valid
                 return values
-            except TypeError:
-                raise
             values["feature_job_setting"] = cron_job_setting.to_feature_job_setting()
 
         return values

--- a/featurebyte/schema/event_table.py
+++ b/featurebyte/schema/event_table.py
@@ -12,7 +12,10 @@ from featurebyte.common.model_util import validate_timezone_offset_string
 from featurebyte.enum import TableDataType
 from featurebyte.models.base import FeatureByteBaseModel
 from featurebyte.models.event_table import EventTableModel
-from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
+from featurebyte.query_graph.model.feature_job_setting import (
+    FeatureJobSetting,
+    FeatureJobSettingUnion,
+)
 from featurebyte.query_graph.model.timestamp_schema import TimestampSchema
 from featurebyte.schema.common.base import PaginationMixin
 from featurebyte.schema.table import TableCreate, TableServiceUpdate, TableUpdate
@@ -72,7 +75,7 @@ class EventTableUpdateMixin(FeatureByteBaseModel):
     EventTable specific update schema
     """
 
-    default_feature_job_setting: Optional[FeatureJobSetting] = Field(default=None)
+    default_feature_job_setting: Optional[FeatureJobSettingUnion] = Field(default=None)
 
 
 class EventTableUpdate(EventTableUpdateMixin, TableUpdate):

--- a/featurebyte/service/event_table.py
+++ b/featurebyte/service/event_table.py
@@ -4,7 +4,16 @@ EventTableService class
 
 from __future__ import annotations
 
+from typing import Optional
+
+from bson import ObjectId
+
+from featurebyte.exception import (
+    CronFeatureJobSettingConversionError,
+    InvalidDefaultFeatureJobSettingError,
+)
 from featurebyte.models.event_table import EventTableModel
+from featurebyte.query_graph.model.feature_job_setting import CronFeatureJobSetting
 from featurebyte.schema.event_table import EventTableCreate, EventTableServiceUpdate
 from featurebyte.service.base_table_document import BaseTableDocumentService
 
@@ -22,3 +31,33 @@ class EventTableService(
     @property
     def class_name(self) -> str:
         return "EventTable"
+
+    async def update_document(
+        self,
+        document_id: ObjectId,
+        data: EventTableServiceUpdate,
+        exclude_none: bool = True,
+        document: Optional[EventTableModel] = None,
+        return_document: bool = True,
+        skip_block_modification_check: bool = False,
+        populate_remote_attributes: bool = True,
+    ) -> Optional[EventTableModel]:
+        if isinstance(data, EventTableServiceUpdate) and isinstance(
+            data.default_feature_job_setting, CronFeatureJobSetting
+        ):
+            try:
+                _ = data.default_feature_job_setting.to_feature_job_setting()
+            except CronFeatureJobSettingConversionError as e:
+                raise InvalidDefaultFeatureJobSettingError(
+                    "The provided CronFeatureJobSetting cannot be used as a default feature job "
+                    f"setting ({str(e)})"
+                ) from e
+        return await super().update_document(
+            document_id=document_id,
+            data=data,
+            exclude_none=exclude_none,
+            document=document,
+            return_document=return_document,
+            skip_block_modification_check=skip_block_modification_check,
+            populate_remote_attributes=populate_remote_attributes,
+        )

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -314,11 +314,22 @@ def event_table_with_cron_feature_job_setting_fixture(saved_event_table):
     """
     Fixture for an EventTable with a CronFeatureJobSetting as the default feature job setting
     """
-    assert saved_event_table.default_feature_job_setting is None
     saved_event_table.update_default_feature_job_setting(
         feature_job_setting=CronFeatureJobSetting(crontab="0 0 * * *", reference_timezone="Etc/UTC")
     )
     yield saved_event_table
+
+
+@pytest.fixture(name="item_table_with_cron_feature_job_setting")
+def item_table_with_cron_feature_job_setting_fixture(
+    snowflake_item_table, event_table_with_cron_feature_job_setting
+):
+    """
+    Fixture for an ItemTable whose EventTable has a CronFeatureJobSetting as the default feature job
+    setting.
+    """
+    _ = event_table_with_cron_feature_job_setting
+    yield snowflake_item_table
 
 
 @pytest.fixture()

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -315,7 +315,11 @@ def event_table_with_cron_feature_job_setting_fixture(saved_event_table):
     Fixture for an EventTable with a CronFeatureJobSetting as the default feature job setting
     """
     saved_event_table.update_default_feature_job_setting(
-        feature_job_setting=CronFeatureJobSetting(crontab="0 0 * * *", reference_timezone="Etc/UTC")
+        feature_job_setting=CronFeatureJobSetting(
+            crontab="0 0 * * *",
+            reference_timezone="Etc/UTC",
+            blind_spot="600s",
+        )
     )
     yield saved_event_table
 

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -3,6 +3,7 @@ Common test fixtures used across api test directories
 """
 
 import textwrap
+import time
 from datetime import datetime
 from unittest.mock import Mock, patch
 
@@ -327,13 +328,21 @@ def event_table_with_cron_feature_job_setting_fixture(saved_event_table, cust_id
 
 @pytest.fixture(name="item_table_with_cron_feature_job_setting")
 def item_table_with_cron_feature_job_setting_fixture(
-    snowflake_item_table, event_table_with_cron_feature_job_setting
+    snowflake_item_table,
+    saved_event_table,
 ):
     """
     Fixture for an ItemTable whose EventTable has a CronFeatureJobSetting as the default feature job
     setting.
     """
-    _ = event_table_with_cron_feature_job_setting
+    saved_event_table.update_default_feature_job_setting(
+        feature_job_setting=CronFeatureJobSetting(
+            crontab="0 0 * * *",
+            reference_timezone="Etc/UTC",
+            blind_spot="600s",
+        )
+    )
+    time.sleep(1)
     yield snowflake_item_table
 
 

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -27,6 +27,7 @@ from featurebyte.api.item_table import ItemTable
 from featurebyte.api.source_table import SourceTable
 from featurebyte.config import Configurations
 from featurebyte.models.feature_store import TableStatus
+from featurebyte.query_graph.model.feature_job_setting import CronFeatureJobSetting
 from featurebyte.query_graph.model.timestamp_schema import TimeZoneColumn
 
 
@@ -306,6 +307,18 @@ def snowflake_item_table_fixture(
         _id=snowflake_item_table_id,
     )
     yield item_table
+
+
+@pytest.fixture(name="event_table_with_cron_feature_job_setting")
+def event_table_with_cron_feature_job_setting_fixture(saved_event_table):
+    """
+    Fixture for an EventTable with a CronFeatureJobSetting as the default feature job setting
+    """
+    assert saved_event_table.default_feature_job_setting is None
+    saved_event_table.update_default_feature_job_setting(
+        feature_job_setting=CronFeatureJobSetting(crontab="0 0 * * *", reference_timezone="Etc/UTC")
+    )
+    yield saved_event_table
 
 
 @pytest.fixture()

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -310,7 +310,7 @@ def snowflake_item_table_fixture(
 
 
 @pytest.fixture(name="event_table_with_cron_feature_job_setting")
-def event_table_with_cron_feature_job_setting_fixture(saved_event_table):
+def event_table_with_cron_feature_job_setting_fixture(saved_event_table, cust_id_entity):
     """
     Fixture for an EventTable with a CronFeatureJobSetting as the default feature job setting
     """
@@ -321,6 +321,7 @@ def event_table_with_cron_feature_job_setting_fixture(saved_event_table):
             blind_spot="600s",
         )
     )
+    saved_event_table.cust_id.as_entity(cust_id_entity.name)
     yield saved_event_table
 
 

--- a/tests/unit/api/test_event_table.py
+++ b/tests/unit/api/test_event_table.py
@@ -653,6 +653,7 @@ def test_update_default_job_setting__cron_feature_job_setting(
     assert event_table.default_feature_job_setting == CronFeatureJobSetting(
         crontab="0 0 * * *",
         reference_timezone="Etc/UTC",
+        blind_spot="600s",
     )
     client = config.get_client()
     response = client.get(url=f"/event_table/{event_table.id}")
@@ -667,7 +668,27 @@ def test_update_default_job_setting__cron_feature_job_setting(
         },
         "timezone": "Etc/UTC",
         "reference_timezone": "Etc/UTC",
+        "blind_spot": "600s",
     }
+
+
+def test_update_default_job_setting__cron_feature_job_setting_invalid(
+    saved_event_table, config, mock_api_object_cache
+):
+    """
+    Test update default job setting using CronFeatureJobSetting
+    """
+    _ = mock_api_object_cache
+    with pytest.raises(RecordUpdateException) as exc:
+        saved_event_table.update_default_feature_job_setting(
+            feature_job_setting=CronFeatureJobSetting(
+                crontab="0 0 1 * *", reference_timezone="Etc/UTC", blind_spot="600s"
+            )
+        )
+    assert (
+        str(exc.value)
+        == "The provided CronFeatureJobSetting cannot be used as a default feature job setting (cron schedule does not result in a fixed interval)"
+    )
 
 
 @pytest.fixture(name="mock_celery")

--- a/tests/unit/api/test_event_table.py
+++ b/tests/unit/api/test_event_table.py
@@ -642,26 +642,20 @@ def test_update_default_job_setting__feature_job_setting_analysis_failure__event
 
 
 def test_update_default_job_setting__cron_feature_job_setting(
-    saved_event_table, config, mock_api_object_cache
+    event_table_with_cron_feature_job_setting, config, mock_api_object_cache
 ):
     """
     Test update default job setting using CronFeatureJobSetting
     """
     _ = mock_api_object_cache
 
-    assert saved_event_table.default_feature_job_setting is None
-    saved_event_table.update_default_feature_job_setting(
-        feature_job_setting=CronFeatureJobSetting(crontab="0 0 * * *", reference_timezone="Etc/UTC")
-    )
-    assert saved_event_table.saved is True
-
-    # check updated feature job settings stored at the persistent & memory
-    assert saved_event_table.default_feature_job_setting == CronFeatureJobSetting(
+    event_table = event_table_with_cron_feature_job_setting
+    assert event_table.default_feature_job_setting == CronFeatureJobSetting(
         crontab="0 0 * * *",
         reference_timezone="Etc/UTC",
     )
     client = config.get_client()
-    response = client.get(url=f"/event_table/{saved_event_table.id}")
+    response = client.get(url=f"/event_table/{event_table.id}")
     assert response.status_code == 200
     assert response.json()["default_feature_job_setting"] == {
         "crontab": {

--- a/tests/unit/api/test_event_table.py
+++ b/tests/unit/api/test_event_table.py
@@ -30,7 +30,10 @@ from featurebyte.exception import (
     RecordUpdateException,
 )
 from featurebyte.models.event_table import EventTableModel
-from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
+from featurebyte.query_graph.model.feature_job_setting import (
+    CronFeatureJobSetting,
+    FeatureJobSetting,
+)
 from featurebyte.query_graph.node.cleaning_operation import (
     AddTimestampSchema,
     DisguisedValueImputation,
@@ -636,6 +639,41 @@ def test_update_default_job_setting__feature_job_setting_analysis_failure__event
         snowflake_event_table.initialize_default_feature_job_setting()
     expected_msg = f'EventTable (id: "{snowflake_event_table.id}") not found. Please save the EventTable object first.'
     assert expected_msg in str(exc)
+
+
+def test_update_default_job_setting__cron_feature_job_setting(
+    saved_event_table, config, mock_api_object_cache
+):
+    """
+    Test update default job setting using CronFeatureJobSetting
+    """
+    _ = mock_api_object_cache
+
+    assert saved_event_table.default_feature_job_setting is None
+    saved_event_table.update_default_feature_job_setting(
+        feature_job_setting=CronFeatureJobSetting(crontab="0 0 * * *", reference_timezone="Etc/UTC")
+    )
+    assert saved_event_table.saved is True
+
+    # check updated feature job settings stored at the persistent & memory
+    assert saved_event_table.default_feature_job_setting == CronFeatureJobSetting(
+        crontab="0 0 * * *",
+        reference_timezone="Etc/UTC",
+    )
+    client = config.get_client()
+    response = client.get(url=f"/event_table/{saved_event_table.id}")
+    assert response.status_code == 200
+    assert response.json()["default_feature_job_setting"] == {
+        "crontab": {
+            "minute": 0,
+            "hour": 0,
+            "day_of_month": "*",
+            "month_of_year": "*",
+            "day_of_week": "*",
+        },
+        "timezone": "Etc/UTC",
+        "reference_timezone": "Etc/UTC",
+    }
 
 
 @pytest.fixture(name="mock_celery")

--- a/tests/unit/api/test_event_view.py
+++ b/tests/unit/api/test_event_view.py
@@ -24,7 +24,10 @@ from featurebyte.models.base import PydanticObjectId
 from featurebyte.query_graph.enum import NodeOutputType, NodeType
 from featurebyte.query_graph.model.column_info import ColumnInfo
 from featurebyte.query_graph.model.common_table import TableDetails, TabularSource
-from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
+from featurebyte.query_graph.model.feature_job_setting import (
+    CronFeatureJobSetting,
+    FeatureJobSetting,
+)
 from featurebyte.query_graph.node.cleaning_operation import (
     DisguisedValueImputation,
     MissingValueImputation,
@@ -1127,3 +1130,15 @@ def test_event_view_with_event_timestamp_schema(snowflake_event_table_with_times
         "timezone": {"column_name": "tz_offset", "type": "offset"},
     }
     assert event_view.inherited_columns == {"col_int", "event_timestamp", "tz_offset"}
+
+
+def test_event_view_cron_feature_job_setting(event_table_with_cron_feature_job_setting):
+    """
+    Test event view with cron feature job setting
+    """
+    event_table = event_table_with_cron_feature_job_setting
+    event_view = event_table.get_view()
+    assert event_view.default_feature_job_setting == CronFeatureJobSetting(
+        crontab="0 0 * * *",
+        reference_timezone="Etc/UTC",
+    )

--- a/tests/unit/api/test_item_view.py
+++ b/tests/unit/api/test_item_view.py
@@ -14,6 +14,7 @@ from featurebyte.exception import RecordCreationException, RepeatedColumnNamesEr
 from featurebyte.models.feature_namespace import FeatureReadiness
 from featurebyte.query_graph.enum import NodeOutputType, NodeType
 from featurebyte.query_graph.model.feature_job_setting import (
+    CronFeatureJobSetting,
     FeatureJobSetting,
     TableFeatureJobSetting,
 )
@@ -1235,3 +1236,14 @@ def test_item_view_sample_table_node(snowflake_item_table):
     sample_table_node = view.graph.get_sample_table_node(view.node_name)
     assert sample_table_node.parameters.type == TableDataType.EVENT_TABLE
     assert sample_table_node.parameters.id == view.event_table_id
+
+
+def test_item_view_with_cron_default_feature_job_setting(
+    item_table_with_cron_feature_job_setting,
+):
+    """Test ItemView with cron default feature job setting"""
+    view = item_table_with_cron_feature_job_setting.get_view()
+    assert view.default_feature_job_setting == CronFeatureJobSetting(
+        crontab="0 0 * * *",
+        reference_timezone="Etc/UTC",
+    )

--- a/tests/unit/api/test_item_view.py
+++ b/tests/unit/api/test_item_view.py
@@ -1246,4 +1246,5 @@ def test_item_view_with_cron_default_feature_job_setting(
     assert view.default_feature_job_setting == CronFeatureJobSetting(
         crontab="0 0 * * *",
         reference_timezone="Etc/UTC",
+        blind_spot="600s",
     )

--- a/tests/unit/query_graph/model/test_feature_job_setting.py
+++ b/tests/unit/query_graph/model/test_feature_job_setting.py
@@ -255,7 +255,10 @@ def test_to_feature_job_setting_failure(crontab_expr):
     """Test that non-periodic cron schedules fail conversion"""
     cron_job = CronFeatureJobSetting(crontab=crontab_expr, blind_spot="200s", timezone="Etc/UTC")
 
-    with pytest.raises(CronFeatureJobSettingConversionError):
+    with pytest.raises(
+        CronFeatureJobSettingConversionError,
+        match="cron schedule does not result in a fixed interval",
+    ):
         cron_job.to_feature_job_setting()
 
 
@@ -269,9 +272,7 @@ def test_to_feature_job_setting_invalid_timezone(invalid_timezone):
         crontab="10 * * * *", blind_spot="200s", timezone=invalid_timezone
     )
 
-    with pytest.raises(
-        CronFeatureJobSettingConversionError, match="Conversion is only supported for UTC timezone."
-    ):
+    with pytest.raises(CronFeatureJobSettingConversionError, match="timezone must be UTC"):
         cron_job.to_feature_job_setting()
 
 
@@ -280,6 +281,6 @@ def test_to_feature_job_setting_missing_blind_spot():
     cron_job = CronFeatureJobSetting(crontab="10 * * * *", blind_spot=None, timezone="Etc/UTC")
     with pytest.raises(
         CronFeatureJobSettingConversionError,
-        match="Conversion is only supported when blind_spot is specified",
+        match="blind_spot is not specified",
     ):
         cron_job.to_feature_job_setting()

--- a/tests/unit/query_graph/model/test_feature_job_setting.py
+++ b/tests/unit/query_graph/model/test_feature_job_setting.py
@@ -284,3 +284,35 @@ def test_to_feature_job_setting_missing_blind_spot():
         match="blind_spot is not specified",
     ):
         cron_job.to_feature_job_setting()
+
+
+@pytest.mark.parametrize(
+    "setting_1,setting_2,expected",
+    [
+        (
+            CronFeatureJobSetting(crontab="10 * * * *"),
+            CronFeatureJobSetting(crontab="10 * * * *"),
+            True,
+        ),
+        (
+            CronFeatureJobSetting(crontab="10 * * * *", blind_spot="200s"),
+            FeatureJobSetting(period="3600s", offset="600s", blind_spot="200s"),
+            True,
+        ),
+        (
+            CronFeatureJobSetting(crontab="10 * * * 1", blind_spot="200s"),
+            FeatureJobSetting(period="3600s", offset="600s", blind_spot="200s"),
+            False,
+        ),
+    ],
+)
+def test_feature_job_setting_comparison(setting_1, setting_2, expected):
+    """
+    Test comparison of feature job settings
+    """
+    if expected:
+        assert setting_1 == setting_2
+        assert setting_2 == setting_1
+    else:
+        assert setting_1 != setting_2
+        assert setting_2 != setting_1


### PR DESCRIPTION
## Description

This adds support for setting a cron based default feature job setting for EventTable.

Changes:

* Allow default feature job setting to have `CronFeatureJobSetting` type
* Validate that the cron based feature job setting can be converted to `FeatureJobSetting` during table update
* In `aggregate_over`, convert `CronFeatureJobSetting` to `FeatureJobSetting` for non-calendar aggregation

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
