### PR TITLE
[chore] Block invalid observation table to be used as default preview table & default EDA table

### DIFF
--- a/featurebyte/models/observation_table.py
+++ b/featurebyte/models/observation_table.py
@@ -192,6 +192,27 @@ class ObservationTableModel(MaterializedTableModel):
             return self.table_with_missing_data is None
         return True
 
+    @property
+    def invalid_reason(self) -> Optional[str]:
+        """
+        Get the reason why the observation table is invalid
+
+        Returns
+        -------
+        Optional[str]
+            The reason why the observation table is invalid
+        """
+        if self.is_valid:
+            return None
+
+        if isinstance(self.request_input, TargetInput):
+            reason = (
+                "The table has missing data. Please check the table with missing data for more details. "
+                "Please review the table for details and create a new table with all required data filled in."
+            )
+            return reason
+        return ""
+
     @field_validator("most_recent_point_in_time", "least_recent_point_in_time")
     @classmethod
     def _validate_most_recent_point_in_time(cls, value: Optional[str]) -> Optional[str]:

--- a/featurebyte/models/observation_table.py
+++ b/featurebyte/models/observation_table.py
@@ -176,8 +176,7 @@ class ObservationTableModel(MaterializedTableModel):
             return self.request_input.target_id
         return None
 
-    @property
-    def is_valid(self) -> bool:
+    def check_table_is_valid(self) -> bool:
         """
         Check if the observation table is valid
 
@@ -202,7 +201,7 @@ class ObservationTableModel(MaterializedTableModel):
         Optional[str]
             The reason why the observation table is invalid
         """
-        if self.is_valid:
+        if self.check_table_is_valid():
             return None
 
         if isinstance(self.request_input, TargetInput):

--- a/featurebyte/routes/observation_table/controller.py
+++ b/featurebyte/routes/observation_table/controller.py
@@ -113,7 +113,8 @@ class ObservationTableController(
         """
         observation_table: ObservationTableModel = await self.get(document_id=document_id)
         return ObservationTableModelResponse(
-            **observation_table.model_dump(by_alias=True), is_valid=observation_table.is_valid
+            **observation_table.model_dump(by_alias=True),
+            is_valid=observation_table.check_table_is_valid(),
         )
 
     async def upload_observation_table(

--- a/featurebyte/routes/use_case/controller.py
+++ b/featurebyte/routes/use_case/controller.py
@@ -141,7 +141,7 @@ class UseCaseController(BaseDocumentController[UseCaseModel, UseCaseService, Use
                 observation_table = await self.observation_table_service.get_document(
                     document_id=obs_id
                 )
-                if not observation_table.is_valid:
+                if not observation_table.check_table_is_valid():
                     reason = ""
                     if observation_table.invalid_reason:
                         reason += observation_table.invalid_reason

--- a/tests/unit/api/test_event_view.py
+++ b/tests/unit/api/test_event_view.py
@@ -858,7 +858,7 @@ def test_create_observation_table_from_event_view__no_sample(
     assert observation_table.request_input.definition is not None
 
     # Check that the correct query was executed
-    _, kwargs = snowflake_execute_query.call_args_list[-6]
+    _, kwargs = snowflake_execute_query.call_args_list[-4]
     check_observation_table_creation_query(
         kwargs["query"],
         """
@@ -889,7 +889,7 @@ def test_create_observation_table_from_event_view__no_sample(
               "cust_id" IS NOT NULL
         """,
     )
-    _, kwargs = snowflake_execute_query.call_args_list[-4]
+    _, kwargs = snowflake_execute_query.call_args_list[-2]
     check_observation_table_creation_query(
         kwargs["query"],
         """
@@ -927,7 +927,7 @@ def test_create_observation_table_from_event_view__with_sample(
     assert observation_table.primary_entity_ids == [cust_id_entity.id]
 
     # Check that the correct query was executed
-    _, kwargs = snowflake_execute_query.call_args_list[-6]
+    _, kwargs = snowflake_execute_query.call_args_list[-4]
     check_observation_table_creation_query(
         kwargs["query"],
         """
@@ -965,7 +965,7 @@ def test_create_observation_table_from_event_view__with_sample(
         LIMIT 100
         """,
     )
-    _, kwargs = snowflake_execute_query.call_args_list[-4]
+    _, kwargs = snowflake_execute_query.call_args_list[-2]
     check_observation_table_creation_query(
         kwargs["query"],
         """

--- a/tests/unit/api/test_source_table.py
+++ b/tests/unit/api/test_source_table.py
@@ -212,7 +212,7 @@ def test_create_observation_table(
     assert observation_table.primary_entity_ids == [cust_id_entity.id]
 
     # Check that the correct query was executed
-    _, kwargs = snowflake_execute_query.call_args_list[-6]
+    _, kwargs = snowflake_execute_query.call_args_list[-4]
     check_observation_table_creation_query(
         kwargs["query"],
         """
@@ -236,7 +236,7 @@ def test_create_observation_table(
               "cust_id" IS NOT NULL
         """,
     )
-    _, kwargs = snowflake_execute_query.call_args_list[-4]
+    _, kwargs = snowflake_execute_query.call_args_list[-2]
     check_observation_table_creation_query(
         kwargs["query"],
         """
@@ -271,7 +271,7 @@ def test_create_observation_table_with_sample_rows(
     assert observation_table.name == "my_observation_table"
 
     # Check that the correct query was executed
-    _, kwargs = snowflake_execute_query.call_args_list[-6]
+    _, kwargs = snowflake_execute_query.call_args_list[-4]
     check_observation_table_creation_query(
         kwargs["query"],
         """
@@ -315,7 +315,7 @@ def test_create_observation_table_with_sample_rows(
         LIMIT 100
         """,
     )
-    _, kwargs = snowflake_execute_query.call_args_list[-4]
+    _, kwargs = snowflake_execute_query.call_args_list[-2]
     check_observation_table_creation_query(
         kwargs["query"],
         """

--- a/tests/unit/api/test_time_series_view.py
+++ b/tests/unit/api/test_time_series_view.py
@@ -339,7 +339,7 @@ def test_create_observation_table_from_time_series_view__no_sample(
     assert observation_table.request_input.definition is not None
 
     # Check that the correct query was executed
-    _, kwargs = snowflake_execute_query.call_args_list[-6]
+    _, kwargs = snowflake_execute_query.call_args_list[-4]
     check_observation_table_creation_query(
         kwargs["query"],
         """
@@ -370,7 +370,7 @@ def test_create_observation_table_from_time_series_view__no_sample(
               "cust_id" IS NOT NULL
         """,
     )
-    _, kwargs = snowflake_execute_query.call_args_list[-4]
+    _, kwargs = snowflake_execute_query.call_args_list[-2]
     check_observation_table_creation_query(
         kwargs["query"],
         """
@@ -410,7 +410,7 @@ def test_create_observation_table_from_time_series_view__with_sample(
     assert observation_table.primary_entity_ids == [cust_id_entity.id]
 
     # Check that the correct query was executed
-    _, kwargs = snowflake_execute_query.call_args_list[-6]
+    _, kwargs = snowflake_execute_query.call_args_list[-4]
     check_observation_table_creation_query(
         kwargs["query"],
         """
@@ -448,7 +448,7 @@ def test_create_observation_table_from_time_series_view__with_sample(
         LIMIT 100
         """,
     )
-    _, kwargs = snowflake_execute_query.call_args_list[-4]
+    _, kwargs = snowflake_execute_query.call_args_list[-2]
     check_observation_table_creation_query(
         kwargs["query"],
         """

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1688,6 +1688,22 @@ def freeze_time_observation_table_task_fixture():
         yield
 
 
+@pytest.fixture(name="patch_observation_table_task_get_table_with_missing_data", autouse=True)
+def patch_observation_table_task_get_table_with_missing_data_fixture():
+    """Patch ObservationTableTask.get_table_with_missing_data to return None"""
+    with (
+        patch(
+            "featurebyte.worker.task.observation_table.ObservationTableTask.get_table_with_missing_data"
+        ) as mock_observation_table_task_get_table_with_missing_data,
+        patch(
+            "featurebyte.worker.task.target_table.TargetTableTask.get_table_with_missing_data"
+        ) as mock_target_table_task_get_table_with_missing_data,
+    ):
+        mock_observation_table_task_get_table_with_missing_data.return_value = None
+        mock_target_table_task_get_table_with_missing_data.return_value = None
+        yield
+
+
 @pytest.fixture(name="patched_observation_table_service")
 def patched_observation_table_service_fixture(freeze_time_observation_table_task):
     """

--- a/tests/unit/routes/conftest.py
+++ b/tests/unit/routes/conftest.py
@@ -120,6 +120,7 @@ def create_observation_table_fixture(
         context_id=None,
         context_empty=False,
         entity_id=None,
+        table_with_missing_data=None,
     ):
         ob_table_id = ObjectId(ob_table_id)
 
@@ -171,6 +172,7 @@ def create_observation_table_fixture(
                 ],
                 "num_rows": 1000,
                 "most_recent_point_in_time": "2023-01-15T10:00:00",
+                "table_with_missing_data": table_with_missing_data,
                 "context_id": context_id,
                 "use_case_ids": use_case_ids,
                 "primary_entity_ids": primary_entity_ids,

--- a/tests/unit/routes/test_target_table.py
+++ b/tests/unit/routes/test_target_table.py
@@ -146,11 +146,8 @@ class TestTargetTableApi(BaseMaterializedTableTestSuite):
             "sample_from_timestamp": None,
             "sample_rows": None,
             "sample_to_timestamp": None,
-            "table_with_missing_data": {
-                **json_dict["location"]["table_details"],
-                "table_name": f"missing_data_{json_dict['location']['table_details']['table_name']}",
-            },
-            "is_valid": False,
+            "table_with_missing_data": None,
+            "is_valid": True,
         }
 
     @pytest.mark.parametrize(

--- a/tests/unit/worker/task/test_catalog_cleanup.py
+++ b/tests/unit/worker/task/test_catalog_cleanup.py
@@ -184,7 +184,6 @@ async def test_catalog_cleanup(
         "FEATURE_TABLE_CACHE",
         "HISTORICAL_FEATURE_TABLE",
         "OBSERVATION_TABLE",
-        "missing_data_OBSERVATION_TABLE",
     ]
 
     # check for remote files


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
This PR blocks invalid observation table to be used as default preview table & default EDA table.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
