### PR TITLE
[DEV-4019] Fix EventTable.info() for cron based default feature job setting

### DIFF
--- a/featurebyte/schema/info.py
+++ b/featurebyte/schema/info.py
@@ -28,6 +28,7 @@ from featurebyte.query_graph.model.critical_data_info import CriticalDataInfo
 from featurebyte.query_graph.model.feature_job_setting import (
     CronFeatureJobSetting,
     FeatureJobSetting,
+    FeatureJobSettingUnion,
 )
 from featurebyte.query_graph.model.time_series_table import TimeInterval
 from featurebyte.query_graph.model.timestamp_schema import TimestampSchema
@@ -199,7 +200,7 @@ class EventTableInfo(TableInfo):
 
     event_timestamp_column: str
     event_id_column: Optional[str]
-    default_feature_job_setting: Optional[FeatureJobSetting] = Field(default=None)
+    default_feature_job_setting: Optional[FeatureJobSettingUnion] = Field(default=None)
 
 
 class ItemTableInfo(TableInfo):

--- a/tests/unit/api/test_event_table.py
+++ b/tests/unit/api/test_event_table.py
@@ -354,6 +354,15 @@ def test_info__event_table_without_record_creation_date(
     _ = event_table.info()
 
 
+def test_info__cron_default_feature_job_setting(event_table_with_cron_feature_job_setting):
+    """
+    Test info on event table with cron default feature job setting
+    """
+    event_table = event_table_with_cron_feature_job_setting
+    info = event_table.info()
+    assert "crontab" in info["default_feature_job_setting"]
+
+
 def test_info(saved_event_table, cust_id_entity):
     """
     Test info


### PR DESCRIPTION
## Description

Previously `EventTable.info()` would error when the default feature job setting is cron based.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
