### PR TITLE
[DEV-4018] Handle cron job setting in create_new_feature_version_using_source_settings

### DIFF
--- a/featurebyte/service/version.py
+++ b/featurebyte/service/version.py
@@ -19,6 +19,8 @@ from featurebyte.models.feature_list import FeatureListModel
 from featurebyte.models.proxy_table import ProxyTableModel
 from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.query_graph.model.feature_job_setting import (
+    CronFeatureJobSetting,
+    FeatureJobSetting,
     FeatureJobSettingUnion,
     TableFeatureJobSetting,
 )
@@ -119,6 +121,12 @@ class VersionService:
                             raise NoFeatureJobSettingInSourceError(
                                 f"No feature job setting found in source id {table_id}"
                             )
+                        # Replacing CronFeatureJobSetting with unconstrained FeatureJobSetting is
+                        # not supported
+                        if isinstance(
+                            agg_node.parameters.feature_job_setting, CronFeatureJobSetting
+                        ) and isinstance(feature_job_setting, FeatureJobSetting):
+                            feature_job_setting = None
                 else:
                     # use the provided feature job setting
                     assert table.name is not None, "Table name should not be None."

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2547,6 +2547,23 @@ def ts_window_aggregate_feature_fixture(snowflake_time_series_view_with_entity):
     return feature
 
 
+@pytest.fixture(name="ts_window_aggregate_feature_from_event_table")
+def ts_window_aggregate_feature_from_event_table_fixture(snowflake_event_view_with_entity):
+    """
+    Fixture for a time series aggregate feature derived from an EventTable
+    """
+    feature = snowflake_event_view_with_entity.groupby(by_keys="cust_id").aggregate_over(
+        value_column="col_float",
+        method="sum",
+        windows=[CalendarWindow(unit="MONTH", size=3)],
+        feature_names=["sum_3month"],
+        feature_job_setting=CronFeatureJobSetting(
+            crontab="0 8 1 * *",
+        ),
+    )["sum_3month"]
+    return feature
+
+
 @pytest.fixture(name="request_column_point_in_time")
 def request_column_point_in_time():
     """


### PR DESCRIPTION
## Description

Replacing `CronFeatureJobSetting` with `FeatureJobSetting` in aggregation nodes directly is not supported when creating new feature versions. This adds handling to prevent the error from occurring.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
