### PR TITLE
[DEV-3998] Support event timestamp schema for event timestamp column (cherry-pick)

### DIFF
--- a/.changelog/DEV-3998.yaml
+++ b/.changelog/DEV-3998.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Support timestamp schema for event timestamp column"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/api/aggregator/window_aggregator.py
+++ b/featurebyte/api/aggregator/window_aggregator.py
@@ -17,6 +17,7 @@ from featurebyte.api.view import View
 from featurebyte.api.window_validator import validate_window
 from featurebyte.enum import AggFunc, TimeIntervalUnit
 from featurebyte.query_graph.enum import NodeOutputType, NodeType
+from featurebyte.query_graph.model.dtype import DBVarTypeMetadata
 from featurebyte.query_graph.model.feature_job_setting import (
     CronFeatureJobSetting,
     FeatureJobSetting,
@@ -320,7 +321,15 @@ class WindowAggregator(BaseAggregator):
             else:
                 assert self.view.timestamp_column is not None
                 reference_datetime_column = self.view.timestamp_column
-                reference_datetime_metadata = None
+                if (
+                    isinstance(self.view, EventView)
+                    and self.view.event_timestamp_schema is not None
+                ):
+                    reference_datetime_metadata = DBVarTypeMetadata(
+                        timestamp_schema=self.view.event_timestamp_schema
+                    )
+                else:
+                    reference_datetime_metadata = None
                 time_interval = None
             params.update({
                 "reference_datetime_column": reference_datetime_column,

--- a/featurebyte/api/event_table.py
+++ b/featurebyte/api/event_table.py
@@ -23,6 +23,7 @@ from featurebyte.models.event_table import EventTableModel
 from featurebyte.query_graph.graph import GlobalQueryGraph
 from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
 from featurebyte.query_graph.model.table import AllTableDataT, EventTableData
+from featurebyte.query_graph.model.timestamp_schema import TimestampSchema
 from featurebyte.query_graph.node.cleaning_operation import ColumnCleaningOperation
 from featurebyte.query_graph.node.input import InputNode
 from featurebyte.query_graph.node.nested import ViewMetadata
@@ -85,6 +86,10 @@ class EventTable(TableApiObject):
     internal_event_timestamp_timezone_offset_column: Optional[StrictStr] = Field(
         alias="event_timestamp_timezone_offset_column", default=None
     )
+    internal_event_timestamp_schema: Optional[TimestampSchema] = Field(
+        alias="event_timestamp_schema",
+        default=None,
+    )
 
     # pydantic validators
     _model_validator = model_validator(mode="after")(
@@ -95,7 +100,7 @@ class EventTable(TableApiObject):
                     "internal_record_creation_timestamp_column",
                     DBVarType.supported_timestamp_types(),
                 ),
-                ("internal_event_timestamp_column", DBVarType.supported_timestamp_types()),
+                ("internal_event_timestamp_column", DBVarType.supported_datetime_types()),
                 ("internal_event_id_column", DBVarType.supported_id_types()),
             ],
         )
@@ -213,6 +218,7 @@ class EventTable(TableApiObject):
             node_name=inserted_graph_node.name,
             default_feature_job_setting=self.default_feature_job_setting,
             event_id_column=self.event_id_column,
+            event_timestamp_schema=self.event_timestamp_schema,
         )
 
     @property
@@ -242,6 +248,20 @@ class EventTable(TableApiObject):
             return self.cached_model.event_timestamp_column
         except RecordRetrievalException:
             return self.internal_event_timestamp_column
+
+    @property
+    def event_timestamp_schema(self) -> Optional[TimestampSchema]:
+        """
+        Timestamp schema of the event timestamp column
+
+        Returns
+        -------
+        Optional[TimestampSchema]
+        """
+        try:
+            return self.cached_model.event_timestamp_schema
+        except RecordRetrievalException:
+            return self.internal_event_timestamp_schema
 
     @property
     def event_id_column(self) -> Optional[str]:

--- a/featurebyte/api/event_view.py
+++ b/featurebyte/api/event_view.py
@@ -18,6 +18,7 @@ from featurebyte.exception import EventViewMatchingEntityColumnNotFound
 from featurebyte.query_graph.enum import GraphNodeType, NodeOutputType, NodeType
 from featurebyte.query_graph.model.column_info import ColumnInfo
 from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
+from featurebyte.query_graph.model.timestamp_schema import TimestampSchema, TimeZoneColumn
 from featurebyte.query_graph.node.input import EventTableInputNodeParameters, InputNode
 from featurebyte.typing import validate_type_is_feature
 
@@ -71,6 +72,7 @@ class EventView(View, GroupByMixin, RawMixin):
         frozen=True,
         description="Returns the name of the column representing the event key of the Event view.",
     )
+    event_timestamp_schema: Optional[TimestampSchema] = Field(frozen=True)
 
     @property
     def timestamp_column(self) -> str:
@@ -117,6 +119,10 @@ class EventView(View, GroupByMixin, RawMixin):
         columns = {self.timestamp_column}
         if self.timestamp_timezone_offset_column is not None:
             columns.add(self.timestamp_timezone_offset_column)
+        if self.event_timestamp_schema is not None and isinstance(
+            self.event_timestamp_schema.timezone, TimeZoneColumn
+        ):
+            columns.add(self.event_timestamp_schema.timezone.column_name)
         return columns
 
     @property
@@ -146,6 +152,7 @@ class EventView(View, GroupByMixin, RawMixin):
         params.update({
             "default_feature_job_setting": self.default_feature_job_setting,
             "event_id_column": self.event_id_column,
+            "event_timestamp_schema": self.event_timestamp_schema,
         })
         return params
 

--- a/featurebyte/api/groupby.py
+++ b/featurebyte/api/groupby.py
@@ -136,7 +136,7 @@ class GroupBy:
         self,
         value_column: Optional[str],
         method: Union[AggFunc, str],
-        windows: List[Optional[str] | CalendarWindow],
+        windows: List[Optional[str]] | List[CalendarWindow],
         feature_names: List[str],
         timestamp_column: Optional[str] = None,
         feature_job_setting: Optional[FeatureJobSetting | CronFeatureJobSetting] = None,

--- a/featurebyte/api/source_table.py
+++ b/featurebyte/api/source_table.py
@@ -460,6 +460,7 @@ class SourceTable(AbstractTableData):
         event_timestamp_timezone_offset_column: Optional[str] = None,
         record_creation_timestamp_column: Optional[str] = None,
         description: Optional[str] = None,
+        event_timestamp_schema: Optional[TimestampSchema] = None,
         _id: Optional[ObjectId] = None,
     ) -> EventTable:
         """
@@ -496,6 +497,8 @@ class SourceTable(AbstractTableData):
             The optional column for the timestamp when a record was created.
         description: Optional[str]
             The optional description for the new table.
+        event_timestamp_schema: Optional[TimestampSchema]
+            The optional timestamp schema for the event timestamp column.
         _id: Optional[ObjectId]
             Identity value for constructed object. This should only be used for cases where we want to create an
             event table with a specific ID. This should not be a common operation, and is typically used in tests
@@ -532,6 +535,7 @@ class SourceTable(AbstractTableData):
             event_id_column=event_id_column,
             event_timestamp_timezone_offset=event_timestamp_timezone_offset,
             event_timestamp_timezone_offset_column=event_timestamp_timezone_offset_column,
+            event_timestamp_schema=event_timestamp_schema,
             description=description,
             _id=_id,
         )

--- a/featurebyte/models/entity_universe.py
+++ b/featurebyte/models/entity_universe.py
@@ -377,6 +377,7 @@ class ItemAggregateNodeEntityUniverseConstructor(BaseEntityUniverseConstructor):
         # Construct a filter to be applied to the EventTable
         event_table_timestamp_filter = EventTableTimestampFilter(
             timestamp_column_name=event_timestamp_column,
+            timestamp_schema=None,  # TODO: Extract the correct timestamp schema
             event_table_id=event_table_id,
             start_timestamp_placeholder_name=LAST_MATERIALIZED_TIMESTAMP_PLACEHOLDER,
             end_timestamp_placeholder_name=CURRENT_FEATURE_TIMESTAMP_PLACEHOLDER,

--- a/featurebyte/models/entity_universe.py
+++ b/featurebyte/models/entity_universe.py
@@ -365,19 +365,21 @@ class ItemAggregateNodeEntityUniverseConstructor(BaseEntityUniverseConstructor):
 
         # Get the EventTable's event timestamp column
         event_timestamp_column = None
+        event_timestamp_schema = None
         for input_node in graph.iterate_nodes(graph_node, NodeType.INPUT):
             if (
                 isinstance(input_node.parameters, EventTableInputNodeParameters)
                 and input_node.parameters.id == event_table_id
             ):
                 event_timestamp_column = input_node.parameters.timestamp_column
+                event_timestamp_schema = input_node.parameters.event_timestamp_schema
                 break
         assert event_timestamp_column is not None
 
         # Construct a filter to be applied to the EventTable
         event_table_timestamp_filter = EventTableTimestampFilter(
             timestamp_column_name=event_timestamp_column,
-            timestamp_schema=None,  # TODO: Extract the correct timestamp schema
+            timestamp_schema=event_timestamp_schema,
             event_table_id=event_table_id,
             start_timestamp_placeholder_name=LAST_MATERIALIZED_TIMESTAMP_PLACEHOLDER,
             end_timestamp_placeholder_name=CURRENT_FEATURE_TIMESTAMP_PLACEHOLDER,

--- a/featurebyte/models/entity_universe.py
+++ b/featurebyte/models/entity_universe.py
@@ -631,13 +631,14 @@ class TimeSeriesWindowAggregateNodeEntityUniverseConstructor(BaseEntityUniverseC
                     window.to_months(),
                 )
 
-            timestamp_expr = self.adapter.normalize_timestamp_before_comparison(
-                convert_timestamp_to_local(
-                    quoted_identifier(node.parameters.reference_datetime_column),
+            timestamp_expr = quoted_identifier(node.parameters.reference_datetime_column)
+            if node.parameters.reference_datetime_schema is not None:
+                timestamp_expr = convert_timestamp_to_local(
+                    timestamp_expr,
                     node.parameters.reference_datetime_schema,
                     self.adapter,
-                ),
-            )
+                )
+            timestamp_expr = self.adapter.normalize_timestamp_before_comparison(timestamp_expr)
             filtered_aggregate_input_expr = self.aggregate_input_expr.where(
                 expressions.and_(
                     expressions.GTE(

--- a/featurebyte/models/event_table.py
+++ b/featurebyte/models/event_table.py
@@ -9,7 +9,7 @@ from typing import Any, ClassVar, List, Optional, Tuple, Type
 
 from pydantic import Field, model_validator
 
-from featurebyte.common.validator import construct_data_model_validator
+from featurebyte.common.validator import ColumnToTimestampSchema, construct_data_model_validator
 from featurebyte.enum import DBVarType
 from featurebyte.models.base import FeatureByteBaseModel
 from featurebyte.models.feature_store import TableModel
@@ -69,10 +69,13 @@ class EventTableModel(EventTableData, TableModel):
         construct_data_model_validator(
             columns_info_key="columns_info",
             expected_column_field_name_type_pairs=[
-                ("event_timestamp_column", DBVarType.supported_timestamp_types()),
+                ("event_timestamp_column", DBVarType.supported_datetime_types()),
                 ("record_creation_timestamp_column", DBVarType.supported_timestamp_types()),
                 ("event_id_column", DBVarType.supported_id_types()),
                 ("event_timestamp_timezone_offset_column", {DBVarType.VARCHAR}),
+            ],
+            column_to_timestamp_schema_pairs=[
+                ColumnToTimestampSchema("event_timestamp_column", "event_timestamp_schema"),
             ],
         )
     )

--- a/featurebyte/query_graph/enum.py
+++ b/featurebyte/query_graph/enum.py
@@ -162,6 +162,7 @@ class NodeType(StrEnum):
             cls.DT_EXTRACT,
             cls.DATE_DIFF,
             cls.DATE_ADD,
+            cls.INPUT,
         }
 
 

--- a/featurebyte/query_graph/model/node_hash_util.py
+++ b/featurebyte/query_graph/model/node_hash_util.py
@@ -128,4 +128,8 @@ def exclude_non_aggregation_with_timestamp_node_timestamp_metadata(
         if node_parameters.get("left_timestamp_metadata") is None:
             node_parameters.pop("left_timestamp_metadata", None)
 
+    if node_type == NodeType.INPUT:
+        if node_parameters.get("event_timestamp_schema") is None:
+            node_parameters.pop("event_timestamp_schema", None)
+
     return node_parameters

--- a/featurebyte/query_graph/model/table.py
+++ b/featurebyte/query_graph/model/table.py
@@ -70,6 +70,7 @@ class EventTableData(BaseTableData):
     event_id_column: Optional[StrictStr]
     event_timestamp_timezone_offset: Optional[StrictStr] = Field(default=None)
     event_timestamp_timezone_offset_column: Optional[StrictStr] = Field(default=None)
+    event_timestamp_schema: Optional[TimestampSchema] = Field(default=None)
 
     @property
     def primary_key_columns(self) -> List[str]:

--- a/featurebyte/query_graph/model/table.py
+++ b/featurebyte/query_graph/model/table.py
@@ -88,6 +88,7 @@ class EventTableData(BaseTableData):
                 "feature_store_details": {"type": feature_store_details.type},
                 "event_timestamp_timezone_offset": self.event_timestamp_timezone_offset,
                 "event_timestamp_timezone_offset_column": self.event_timestamp_timezone_offset_column,
+                "event_timestamp_schema": self.event_timestamp_schema,
                 **self._get_common_input_node_parameters(),
             },
         )

--- a/featurebyte/query_graph/node/generic.py
+++ b/featurebyte/query_graph/node/generic.py
@@ -2073,8 +2073,8 @@ class TimeSeriesWindowAggregateParameters(BaseGroupbyParameters):
 
     windows: List[CalendarWindow]
     reference_datetime_column: InColumnStr
-    reference_datetime_metadata: DBVarTypeMetadata
-    time_interval: TimeInterval
+    reference_datetime_metadata: Optional[DBVarTypeMetadata]
+    time_interval: Optional[TimeInterval]
     names: List[OutColumnStr]
     feature_job_setting: CronFeatureJobSetting
     offset: Optional[CalendarWindow] = None
@@ -2091,7 +2091,7 @@ class TimeSeriesWindowAggregateParameters(BaseGroupbyParameters):
         return self.reference_datetime_column
 
     @property
-    def reference_datetime_schema(self) -> TimestampSchema:
+    def reference_datetime_schema(self) -> Optional[TimestampSchema]:
         """
         Get reference datetime schema
 
@@ -2099,8 +2099,9 @@ class TimeSeriesWindowAggregateParameters(BaseGroupbyParameters):
         -------
         TimestampSchema
         """
-        assert self.reference_datetime_metadata.timestamp_schema is not None
-        return self.reference_datetime_metadata.timestamp_schema
+        if self.reference_datetime_metadata is not None:
+            return self.reference_datetime_metadata.timestamp_schema
+        return None
 
     @model_validator(mode="before")
     @classmethod

--- a/featurebyte/query_graph/node/input.py
+++ b/featurebyte/query_graph/node/input.py
@@ -240,6 +240,7 @@ class EventTableInputNodeParameters(BaseInputNodeParameters):
     id_column: Optional[InColumnStr] = Field(default=None)  # DEV-556: this should be compulsory
     event_timestamp_timezone_offset: Optional[str] = Field(default=None)
     event_timestamp_timezone_offset_column: Optional[InColumnStr] = Field(default=None)
+    event_timestamp_schema: Optional[TimestampSchema] = Field(default=None)
 
     @model_validator(mode="before")
     @classmethod

--- a/featurebyte/query_graph/sql/aggregator/time_series_window.py
+++ b/featurebyte/query_graph/sql/aggregator/time_series_window.py
@@ -312,11 +312,15 @@ class TimeSeriesWindowAggregator(NonTileBasedAggregator[TimeSeriesWindowAggregat
         -------
         Select
         """
-        reference_datetime_expr = convert_timestamp_to_local(
-            quoted_identifier(aggregation_spec.parameters.reference_datetime_column),
-            aggregation_spec.parameters.reference_datetime_schema,
-            self.adapter,
+        reference_datetime_expr = quoted_identifier(
+            aggregation_spec.parameters.reference_datetime_column
         )
+        if aggregation_spec.parameters.reference_datetime_schema is not None:
+            reference_datetime_expr = convert_timestamp_to_local(
+                reference_datetime_expr,
+                aggregation_spec.parameters.reference_datetime_schema,
+                self.adapter,
+            )
         if aggregation_spec.window.is_fixed_size():
             bucket_expr = self.adapter.to_epoch_seconds(reference_datetime_expr)
         else:

--- a/featurebyte/query_graph/sql/common.py
+++ b/featurebyte/query_graph/sql/common.py
@@ -13,6 +13,7 @@ from sqlglot import expressions
 from sqlglot.expressions import Expression, select
 
 from featurebyte.enum import SourceType
+from featurebyte.query_graph.model.timestamp_schema import TimestampSchema
 from featurebyte.query_graph.sql.dialects import get_dialect_from_source_type
 
 REQUEST_TABLE_NAME = "REQUEST_TABLE"
@@ -245,6 +246,7 @@ class EventTableTimestampFilter:
     """
 
     timestamp_column_name: str
+    timestamp_schema: Optional[TimestampSchema]
     event_table_id: ObjectId
     start_timestamp_placeholder_name: Optional[str] = None
     end_timestamp_placeholder_name: Optional[str] = None

--- a/featurebyte/query_graph/sql/entity_filter.py
+++ b/featurebyte/query_graph/sql/entity_filter.py
@@ -10,8 +10,10 @@ from sqlglot import expressions
 from sqlglot.expressions import Expression, Select, select
 
 from featurebyte.enum import InternalName
+from featurebyte.query_graph.model.dtype import DBVarTypeMetadata
 from featurebyte.query_graph.sql.adapter import BaseAdapter
 from featurebyte.query_graph.sql.common import get_qualified_column_identifier, quoted_identifier
+from featurebyte.query_graph.sql.timestamp_helper import convert_timestamp_to_utc
 
 
 def get_table_filtered_by_entity(
@@ -20,6 +22,7 @@ def get_table_filtered_by_entity(
     adapter: BaseAdapter,
     table_column_names: Optional[list[str]] = None,
     timestamp_column: Optional[str] = None,
+    timestamp_metadata: Optional[DBVarTypeMetadata] = None,
     distinct: bool = False,
 ) -> Select:
     """
@@ -46,6 +49,8 @@ def get_table_filtered_by_entity(
     timestamp_column: Optional[str]
         If specified, additionally filter using the timestamp column based on the start and end date
         specified in the entity table
+    timestamp_metadata: Optional[DBVarTypeMetadata]
+        Metadata for the timestamp column
     distinct: bool
         If set, select distinct entity values from the entity table. Applicable for entity tables
         with composite keys.
@@ -70,9 +75,14 @@ def get_table_filtered_by_entity(
         join_conditions.append(condition)
 
     if timestamp_column is not None:
-        normalized_timestamp_column = adapter.normalize_timestamp_before_comparison(
-            get_qualified_column_identifier(timestamp_column, "R")
-        )
+        timestamp_expr = get_qualified_column_identifier(timestamp_column, "R")
+        if timestamp_metadata is not None and timestamp_metadata.timestamp_schema is not None:
+            timestamp_expr = convert_timestamp_to_utc(
+                timestamp_expr,
+                timestamp_metadata.timestamp_schema,
+                adapter,
+            )
+        normalized_timestamp_column = adapter.normalize_timestamp_before_comparison(timestamp_expr)
         join_conditions.append(
             expressions.GTE(
                 this=normalized_timestamp_column,

--- a/featurebyte/query_graph/sql/interpreter/tile.py
+++ b/featurebyte/query_graph/sql/interpreter/tile.py
@@ -305,8 +305,14 @@ class TileSQLGenerator:
                 and column.table_id is not None
             ):
                 assert isinstance(column, SourceDataColumn), "SourceDataColumn expected"
+                timestamp_dtype_metadata = (
+                    input_filter_context.operation_structure.get_dtype_metadata(column.name)
+                )
                 return EventTableTimestampFilter(
                     timestamp_column_name=column.name,
+                    timestamp_schema=timestamp_dtype_metadata.timestamp_schema
+                    if timestamp_dtype_metadata
+                    else None,
                     event_table_id=column.table_id,
                 )
 

--- a/featurebyte/schema/event_table.py
+++ b/featurebyte/schema/event_table.py
@@ -13,6 +13,7 @@ from featurebyte.enum import TableDataType
 from featurebyte.models.base import FeatureByteBaseModel
 from featurebyte.models.event_table import EventTableModel
 from featurebyte.query_graph.model.feature_job_setting import FeatureJobSetting
+from featurebyte.query_graph.model.timestamp_schema import TimestampSchema
 from featurebyte.schema.common.base import PaginationMixin
 from featurebyte.schema.table import TableCreate, TableServiceUpdate, TableUpdate
 
@@ -27,6 +28,7 @@ class EventTableCreate(TableCreate):
     event_timestamp_column: StrictStr
     event_timestamp_timezone_offset: Optional[StrictStr] = Field(default=None)
     event_timestamp_timezone_offset_column: Optional[StrictStr] = Field(default=None)
+    event_timestamp_schema: Optional[TimestampSchema] = Field(default=None)
     default_feature_job_setting: Optional[FeatureJobSetting] = Field(default=None)
 
     # pydantic validators

--- a/tests/fixtures/offline_store_feature_table/feature_cluster_disabled_one_feature.json
+++ b/tests/fixtures/offline_store_feature_table/feature_cluster_disabled_one_feature.json
@@ -90,6 +90,7 @@
                             "name": "cust_id"
                         }
                     ],
+                    "event_timestamp_schema": null,
                     "event_timestamp_timezone_offset": null,
                     "event_timestamp_timezone_offset_column": null,
                     "feature_store_details": {

--- a/tests/fixtures/offline_store_feature_table/feature_cluster_one_feature.json
+++ b/tests/fixtures/offline_store_feature_table/feature_cluster_one_feature.json
@@ -86,6 +86,7 @@
                             "name": "cust_id"
                         }
                     ],
+                    "event_timestamp_schema": null,
                     "event_timestamp_timezone_offset": null,
                     "event_timestamp_timezone_offset_column": null,
                     "feature_store_details": {

--- a/tests/fixtures/offline_store_feature_table/feature_cluster_two_features.json
+++ b/tests/fixtures/offline_store_feature_table/feature_cluster_two_features.json
@@ -103,6 +103,7 @@
                             "name": "cust_id"
                         }
                     ],
+                    "event_timestamp_schema": null,
                     "event_timestamp_timezone_offset": null,
                     "event_timestamp_timezone_offset_column": null,
                     "feature_store_details": {

--- a/tests/fixtures/request_payloads/event_table.json
+++ b/tests/fixtures/request_payloads/event_table.json
@@ -88,6 +88,7 @@
     "description": "test event table",
     "event_id_column": "col_int",
     "event_timestamp_column": "event_timestamp",
+    "event_timestamp_schema": null,
     "event_timestamp_timezone_offset": null,
     "event_timestamp_timezone_offset_column": null,
     "name": "sf_event_table",

--- a/tests/fixtures/request_payloads/feature_iet.json
+++ b/tests/fixtures/request_payloads/feature_iet.json
@@ -176,6 +176,7 @@
                             "name": "cust_id"
                         }
                     ],
+                    "event_timestamp_schema": null,
                     "event_timestamp_timezone_offset": null,
                     "event_timestamp_timezone_offset_column": null,
                     "feature_store_details": {

--- a/tests/fixtures/request_payloads/feature_item_event.json
+++ b/tests/fixtures/request_payloads/feature_item_event.json
@@ -80,6 +80,7 @@
                             "name": "cust_id"
                         }
                     ],
+                    "event_timestamp_schema": null,
                     "event_timestamp_timezone_offset": null,
                     "event_timestamp_timezone_offset_column": null,
                     "feature_store_details": {

--- a/tests/fixtures/request_payloads/feature_store_sample.json
+++ b/tests/fixtures/request_payloads/feature_store_sample.json
@@ -61,6 +61,7 @@
                             "name": "cust_id"
                         }
                     ],
+                    "event_timestamp_schema": null,
                     "event_timestamp_timezone_offset": null,
                     "event_timestamp_timezone_offset_column": null,
                     "feature_store_details": {

--- a/tests/fixtures/request_payloads/feature_sum_2h.json
+++ b/tests/fixtures/request_payloads/feature_sum_2h.json
@@ -72,6 +72,7 @@
                             "name": "cust_id"
                         }
                     ],
+                    "event_timestamp_schema": null,
                     "event_timestamp_timezone_offset": null,
                     "event_timestamp_timezone_offset_column": null,
                     "feature_store_details": {

--- a/tests/fixtures/request_payloads/feature_sum_30m.json
+++ b/tests/fixtures/request_payloads/feature_sum_30m.json
@@ -72,6 +72,7 @@
                             "name": "cust_id"
                         }
                     ],
+                    "event_timestamp_schema": null,
                     "event_timestamp_timezone_offset": null,
                     "event_timestamp_timezone_offset_column": null,
                     "feature_store_details": {

--- a/tests/fixtures/request_payloads/historical_feature_table.json
+++ b/tests/fixtures/request_payloads/historical_feature_table.json
@@ -93,6 +93,7 @@
                                         "name": "cust_id"
                                     }
                                 ],
+                                "event_timestamp_schema": null,
                                 "event_timestamp_timezone_offset": null,
                                 "event_timestamp_timezone_offset_column": null,
                                 "feature_store_details": {

--- a/tests/fixtures/request_payloads/target.json
+++ b/tests/fixtures/request_payloads/target.json
@@ -88,6 +88,7 @@
                             "name": "cust_id"
                         }
                     ],
+                    "event_timestamp_schema": null,
                     "event_timestamp_timezone_offset": null,
                     "event_timestamp_timezone_offset_column": null,
                     "feature_store_details": {

--- a/tests/integration/api/test_scd_view_operations.py
+++ b/tests/integration/api/test_scd_view_operations.py
@@ -260,7 +260,7 @@ async def test_feature_derived_from_multiple_scd_joins(session, data_source, sou
 
 @pytest.mark.asyncio
 async def test_end_timestamp_column(
-    session, data_source, source_type, config, scd_table_timestamp_format_string_with_time
+    session, data_source, source_type, config, timestamp_format_string_with_time
 ):
     """
     Self-contained test case to test handling of end timestamp column
@@ -323,7 +323,7 @@ async def test_end_timestamp_column(
         effective_timestamp_column="effective_ts",
         end_timestamp_column="end_ts",
         end_timestamp_schema=TimestampSchema(
-            format_string=scd_table_timestamp_format_string_with_time,
+            format_string=timestamp_format_string_with_time,
             is_utc_time=True,
         ),
     )
@@ -914,7 +914,7 @@ def test_timestamp_schema_validation(
     scd_data_tabular_source_custom_date_with_tz_format,
     scd_table_name_custom_date_with_tz_format,
     scd_table_timestamp_with_tz_format_string,
-    scd_table_timestamp_format_string,
+    timestamp_format_string,
     config,
 ):
     """Test timestamp schema validation for SCD table"""
@@ -981,7 +981,7 @@ def test_timestamp_schema_validation(
         effective_timestamp_column="effective_timestamp",
         surrogate_key_column="ID",
         effective_timestamp_schema=TimestampSchema(
-            format_string=scd_table_timestamp_format_string,
+            format_string=timestamp_format_string,
             timezone="America/New_York",
         ),
     )
@@ -1005,7 +1005,7 @@ def test_timestamp_schema_validation(
         effective_timestamp_column="effective_timestamp",
         surrogate_key_column="ID",
         effective_timestamp_schema=TimestampSchema(
-            format_string=scd_table_timestamp_format_string,
+            format_string=timestamp_format_string,
             timezone=TimeZoneColumn(column_name="timezone_offset", type="offset"),
         ),
     )
@@ -1029,7 +1029,7 @@ def test_timestamp_schema_validation(
         effective_timestamp_column="effective_timestamp",
         surrogate_key_column="ID",
         effective_timestamp_schema=TimestampSchema(
-            format_string=scd_table_timestamp_format_string,
+            format_string=timestamp_format_string,
             timezone=TimeZoneColumn(column_name="invalid_timezone_offset", type="offset"),
         ),
     )

--- a/tests/integration/api/test_serving_parent_features.py
+++ b/tests/integration/api/test_serving_parent_features.py
@@ -48,7 +48,7 @@ def event_entity_fixture():
 
 @pytest_asyncio.fixture(name="tables", scope="session")
 async def tables_fixture(
-    session, data_source, customer_entity, event_entity, scd_table_timestamp_format_string_with_time
+    session, data_source, customer_entity, event_entity, timestamp_format_string_with_time
 ):
     """
     Fixture for a feature that can be obtained from a child entity using one or more joins
@@ -115,9 +115,7 @@ async def tables_fixture(
         name=f"{table_prefix}_scd_table_1",
         natural_key_column="scd_cust_id",
         effective_timestamp_column="effective_ts",
-        effective_timestamp_schema=TimestampSchema(
-            format_string=scd_table_timestamp_format_string_with_time
-        ),
+        effective_timestamp_schema=TimestampSchema(format_string=timestamp_format_string_with_time),
     )
     scd_table_1["scd_cust_id"].as_entity(customer_entity.name)
     scd_table_1["scd_city"].as_entity(city_entity.name)

--- a/tests/integration/feature_store_integration/test_feature_materialize.py
+++ b/tests/integration/feature_store_integration/test_feature_materialize.py
@@ -927,7 +927,7 @@ async def test_feast_registry(
         f"Most Frequent Item Type by Order_{version}": ["type_24"],
         f"User Status Feature_{version}": ["STÀTUS_CODE_26"],
         f"Complex Feature by User_{version}": ["STÀTUS_CODE_26_1"],
-        f"Relative Frequency 7d_{version}": [0.5652173757553101],
+        f"Relative Frequency 7d_{version}": [0.6086956262588501],
         f"Latest Amount by User_{version}": [91.31999969482422],
         f"Latest Amount by User Offset 1d_{version}": [10.229999542236328],
         f"Number of Distinct Product Action 48h_{version}": [5],
@@ -1126,7 +1126,7 @@ def expected_features_order_id_T3850(source_type):
         "Most Frequent Item Type by Order": "type_24",
         "User Status Feature": "STÀTUS_CODE_26",
         "order_id": "T3850",
-        "Relative Frequency 7d": 0.5652173757553101,
+        "Relative Frequency 7d": 0.6086956262588501,
         "Number of Distinct Product Action 48h": 5,
     }
     if source_type == SourceType.DATABRICKS_UNITY:

--- a/tests/integration/query_graph/test_timestamp_handler.py
+++ b/tests/integration/query_graph/test_timestamp_handler.py
@@ -59,7 +59,7 @@ from featurebyte.query_graph.sql.timestamp_helper import (
 @pytest.mark.asyncio
 async def test_convert_timestamp_to_utc(
     session_without_datasets,
-    scd_table_timestamp_format_string,
+    timestamp_format_string,
     timestamp_value,
     timezone_offset_column,
     timestamp_schema,
@@ -69,7 +69,7 @@ async def test_convert_timestamp_to_utc(
     Test different specification of timestamp schema when constructing SCDTable
     """
     if timestamp_schema.format_string == "<date_format_placeholder>":
-        timestamp_schema.format_string = scd_table_timestamp_format_string
+        timestamp_schema.format_string = timestamp_format_string
     session = session_without_datasets
     df_scd = pd.DataFrame({
         "effective_timestamp_column": pd.Series([timestamp_value]),
@@ -151,7 +151,7 @@ async def test_convert_timestamp_to_utc(
 @pytest.mark.asyncio
 async def test_convert_timestamp_to_local(
     session_without_datasets,
-    scd_table_timestamp_format_string,
+    timestamp_format_string,
     timestamp_value,
     timezone_offset_column,
     timestamp_schema,
@@ -161,7 +161,7 @@ async def test_convert_timestamp_to_local(
     Test timestamp_helper's convert_timestamp_to_local function
     """
     if timestamp_schema.format_string == "<date_format_placeholder>":
-        timestamp_schema.format_string = scd_table_timestamp_format_string
+        timestamp_schema.format_string = timestamp_format_string
     session = session_without_datasets
     df_scd = pd.DataFrame({
         "effective_timestamp_column": pd.Series([timestamp_value]),

--- a/tests/unit/api/test_event_table.py
+++ b/tests/unit/api/test_event_table.py
@@ -148,6 +148,7 @@ def event_table_dict_fixture(snowflake_database_table, user_id):
         "user_id": user_id,
         "event_timestamp_timezone_offset": None,
         "event_timestamp_timezone_offset_column": None,
+        "event_timestamp_schema": None,
         "is_deleted": False,
     }
 
@@ -911,6 +912,7 @@ def test_default_feature_job_setting_history(saved_event_table):
         "catalog_id",
         "event_timestamp_timezone_offset",
         "event_timestamp_timezone_offset_column",
+        "event_timestamp_schema",
         "block_modification_by",
         "is_deleted",
         "validation",
@@ -1422,3 +1424,15 @@ def test_add_timestamp_schema_validation(saved_event_table):
         'Timestamp schema timezone offset column "col_text" cannot be the same as the column name'
     )
     assert expected in str(exc.value)
+
+
+def test_event_table_with_event_timestamp_schema(snowflake_event_table_with_timestamp_schema):
+    """
+    Test creating EventTable with event timestamp schema
+    """
+    event_table = snowflake_event_table_with_timestamp_schema
+    assert event_table.event_timestamp_schema.model_dump() == {
+        "format_string": None,
+        "is_utc_time": True,
+        "timezone": {"column_name": "tz_offset", "type": "offset"},
+    }

--- a/tests/unit/api/test_event_table.py
+++ b/tests/unit/api/test_event_table.py
@@ -1433,6 +1433,6 @@ def test_event_table_with_event_timestamp_schema(snowflake_event_table_with_time
     event_table = snowflake_event_table_with_timestamp_schema
     assert event_table.event_timestamp_schema.model_dump() == {
         "format_string": None,
-        "is_utc_time": True,
+        "is_utc_time": False,
         "timezone": {"column_name": "tz_offset", "type": "offset"},
     }

--- a/tests/unit/api/test_event_view.py
+++ b/tests/unit/api/test_event_view.py
@@ -1114,3 +1114,16 @@ def test_event_view_as_feature(
     ingest_graphs = offline_store_info.extract_offline_store_ingest_query_graphs()
     assert len(ingest_graphs) == 1
     assert ingest_graphs[0].offline_store_table_name == "cat1_transaction_id_1d"
+
+
+def test_event_view_with_event_timestamp_schema(snowflake_event_table_with_timestamp_schema):
+    """
+    Test event view with event timestamp schema
+    """
+    event_view = snowflake_event_table_with_timestamp_schema.get_view()
+    assert event_view.event_timestamp_schema.model_dump() == {
+        "format_string": None,
+        "is_utc_time": True,
+        "timezone": {"column_name": "tz_offset", "type": "offset"},
+    }
+    assert event_view.inherited_columns == {"col_int", "event_timestamp", "tz_offset"}

--- a/tests/unit/api/test_event_view.py
+++ b/tests/unit/api/test_event_view.py
@@ -1123,7 +1123,7 @@ def test_event_view_with_event_timestamp_schema(snowflake_event_table_with_times
     event_view = snowflake_event_table_with_timestamp_schema.get_view()
     assert event_view.event_timestamp_schema.model_dump() == {
         "format_string": None,
-        "is_utc_time": True,
+        "is_utc_time": False,
         "timezone": {"column_name": "tz_offset", "type": "offset"},
     }
     assert event_view.inherited_columns == {"col_int", "event_timestamp", "tz_offset"}

--- a/tests/unit/models/test_event_table.py
+++ b/tests/unit/models/test_event_table.py
@@ -90,6 +90,7 @@ def test_event_table_model(snowflake_feature_store, feature_job_setting):
         },
         "columns_info": columns_info,
         "event_timestamp_column": "event_date",
+        "event_timestamp_schema": None,
         "event_id_column": "event_id",
         "id": event_table.id,
         "name": "my_event_table",

--- a/tests/unit/query_graph/conftest.py
+++ b/tests/unit/query_graph/conftest.py
@@ -1800,6 +1800,7 @@ def query_graph_single_node(
                 "id_column": None,
                 "event_timestamp_timezone_offset": None,
                 "event_timestamp_timezone_offset_column": None,
+                "event_timestamp_schema": None,
             },
             "output_type": "frame",
         }

--- a/tests/unit/query_graph/model/test_table_data.py
+++ b/tests/unit/query_graph/model/test_table_data.py
@@ -204,6 +204,7 @@ def event_input_node_fixture(feature_store_details, event_table_data):
             "type": "event_table",
             "event_timestamp_timezone_offset": None,
             "event_timestamp_timezone_offset_column": None,
+            "event_timestamp_schema": None,
         },
         "output_type": "frame",
     }

--- a/tests/unit/query_graph/test_query_graph.py
+++ b/tests/unit/query_graph/test_query_graph.py
@@ -367,7 +367,8 @@ def test_query_graph__representation():
                         "timestamp_column": null,
                         "id_column": null,
                         "event_timestamp_timezone_offset": null,
-                        "event_timestamp_timezone_offset_column": null
+                        "event_timestamp_timezone_offset_column": null,
+                        "event_timestamp_schema": null
                     }
                 }
             ]

--- a/tests/unit/routes/test_context.py
+++ b/tests/unit/routes/test_context.py
@@ -156,6 +156,7 @@ class TestContextApi(BaseCatalogApiTestSuite):
                 "type": "event_table",
                 "event_timestamp_timezone_offset": None,
                 "event_timestamp_timezone_offset_column": None,
+                "event_timestamp_schema": None,
             },
         }
 


### PR DESCRIPTION
## Description

Cherry pick changes required to support event timestamp schema for event timestamp column:

* https://github.com/featurebyte/featurebyte/pull/2852 (not strictly required, but this reduces divergence from main branch and merge conflicts)
* https://github.com/featurebyte/featurebyte/pull/2859
* https://github.com/featurebyte/featurebyte/pull/2862

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
