### PR TITLE
[chore] Ignore timestamp precision truncation in snowflake session retrieve

### DIFF
--- a/featurebyte/session/snowflake.py
+++ b/featurebyte/session/snowflake.py
@@ -264,7 +264,7 @@ class SnowflakeSession(BaseSession):
         try:
             schema = self._get_schema_from_cursor(cursor)
             for table in cursor.fetch_arrow_batches():
-                for batch in table.cast(schema).to_batches():
+                for batch in table.cast(schema, safe=False).to_batches():
                     yield batch
             # return empty table to ensure correct schema is returned
             yield pa.record_batch(

--- a/tests/integration/session/test_base.py
+++ b/tests/integration/session/test_base.py
@@ -291,3 +291,13 @@ async def test_timestamp_with_large_date(config, session_without_datasets):
     query = "SELECT CAST('9999-12-31T05:00:00.123456' AS TIMESTAMP) AS TIMESTAMP"
     result = await session.execute_query(query)
     assert result.TIMESTAMP.tolist()[0] == pd.Timestamp("9999-12-31 05:00:00.123456")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("source_type", ["snowflake"], indirect=True)
+async def test_timestamp_with_high_precision_date(config, session_without_datasets):
+    _ = config
+    session = session_without_datasets
+    query = "SELECT CAST('2012-12-31T05:00:00.123456123' AS TIMESTAMP) AS TIMESTAMP"
+    result = await session.execute_query(query)
+    assert result.TIMESTAMP.tolist()[0] == pd.Timestamp("2012-12-31 05:00:00.123456")


### PR DESCRIPTION
## Description

Ignore timestamp precision truncation in snowflake session retrieve as it causes query to fail 

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
