### PR TITLE
[chore] Update `pd.to_datetime` to include `utc=True` in on demand feature view codes

### DIFF
--- a/featurebyte/query_graph/node/date.py
+++ b/featurebyte/query_graph/node/date.py
@@ -153,7 +153,7 @@ class DatetimeExtractNode(BaseSeriesOutputNode):
             dt_var_name = var_name_generator.convert_to_variable_name(
                 variable_name_prefix=offset_adj_var_name_prefix, node_name=None
             )
-            expr = ExpressionStr(f"pd.to_datetime({ts_operand}) + {offset_operand}")
+            expr = ExpressionStr(f"pd.to_datetime({ts_operand}, utc=True) + {offset_operand}")
             statements.append((dt_var_name, expr))
         else:
             dt_var_name = ts_operand
@@ -169,8 +169,8 @@ class DatetimeExtractNode(BaseSeriesOutputNode):
     ) -> Tuple[List[StatementT], VarNameExpressionInfo]:
         def _datetime_proper_expr(dt_var_name: str, prop: str) -> str:
             if prop == "week":
-                return f"pd.to_datetime({dt_var_name}).dt.isocalendar().week"
-            return f"pd.to_datetime({dt_var_name}).dt.{prop}"
+                return f"pd.to_datetime({dt_var_name}, utc=True).dt.isocalendar().week"
+            return f"pd.to_datetime({dt_var_name}, utc=True).dt.{prop}"
 
         return self._derive_on_demand_view_or_user_defined_function_helper(
             node_inputs,
@@ -189,7 +189,7 @@ class DatetimeExtractNode(BaseSeriesOutputNode):
             node_inputs,
             var_name_generator,
             offset_adj_var_name_prefix="feat",
-            expr_func=lambda dt_var_name, prop: f"pd.to_datetime({dt_var_name}).{prop}",
+            expr_func=lambda dt_var_name, prop: f"pd.to_datetime({dt_var_name}, utc=True).{prop}",
         )
 
 
@@ -345,7 +345,7 @@ class DateDifferenceNode(BaseSeriesOutputNode):
             expr = ExpressionStr(f"{left_operand} - {right_operand}")
         else:
             expr = ExpressionStr(
-                f"pd.to_datetime({left_operand}) - pd.to_datetime({right_operand})"
+                f"pd.to_datetime({left_operand}, utc=True) - pd.to_datetime({right_operand}, utc=True)"
             )
         return statements, expr
 
@@ -534,7 +534,7 @@ class DateAddNode(BaseSeriesOutputNode):
             expr = ExpressionStr(f"{left_operand} + {right_operand}")
         else:
             expr = ExpressionStr(
-                f"pd.to_datetime({left_operand}) + pd.to_timedelta({right_operand})"
+                f"pd.to_datetime({left_operand}, utc=True) + pd.to_timedelta({right_operand})"
             )
         return statements, expr
 
@@ -619,7 +619,7 @@ class ToTimestampFromEpochNode(BaseSeriesOutputNode):
         if var_name_generator.should_insert_function(function_name=func_name):
             func_string = f"""
             def {func_name}(values):
-                return pd.to_datetime(values, unit='s')
+                return pd.to_datetime(values, unit='s', utc=True)
             """
             statements.append(StatementStr(textwrap.dedent(func_string)))
 

--- a/tests/fixtures/on_demand_function/req_col_ttl_and_non_ttl.sql
+++ b/tests/fixtures/on_demand_function/req_col_ttl_and_non_ttl.sql
@@ -22,9 +22,9 @@ def user_defined_function(
         if request_col_1 is None
         else pd.to_datetime(request_col_1, utc=True)
     )
-    feat_3 = pd.to_datetime(feat_2) - pd.to_datetime(feat_2)
-    feat_4 = pd.to_datetime(feat_2) + pd.to_timedelta(feat_3)
-    feat_5 = pd.to_datetime(feat_4) - pd.to_datetime(feat_1)
+    feat_3 = pd.to_datetime(feat_2, utc=True) - pd.to_datetime(feat_2, utc=True)
+    feat_4 = pd.to_datetime(feat_2, utc=True) + pd.to_timedelta(feat_3)
+    feat_5 = pd.to_datetime(feat_4, utc=True) - pd.to_datetime(feat_1, utc=True)
     feat_6 = (
         np.nan
         if pd.isna(feat_5)

--- a/tests/unit/api/test_offline_ingest_query_graph.py
+++ b/tests/unit/api/test_offline_ingest_query_graph.py
@@ -218,9 +218,11 @@ def test_feature__request_column_ttl_and_non_ttl_components(
         inputs.loc[~mask, "__feature_V231227__part0"] = np.nan
         feat = pd.to_datetime(inputs["__feature_V231227__part0"], utc=True)
         request_col = pd.to_datetime(inputs["POINT_IN_TIME"], utc=True)
-        feat_1 = pd.to_datetime(request_col) - pd.to_datetime(request_col)
-        feat_2 = pd.to_datetime(request_col) + pd.to_timedelta(feat_1)
-        feat_3 = pd.to_datetime(feat_2) - pd.to_datetime(feat)
+        feat_1 = pd.to_datetime(request_col, utc=True) - pd.to_datetime(
+            request_col, utc=True
+        )
+        feat_2 = pd.to_datetime(request_col, utc=True) + pd.to_timedelta(feat_1)
+        feat_3 = pd.to_datetime(feat_2, utc=True) - pd.to_datetime(feat, utc=True)
         feat_4 = pd.to_timedelta(feat_3).dt.total_seconds() // 86400
         feat_5 = pd.Series(
             np.where(
@@ -324,7 +326,9 @@ def test_feature__ttl_item_aggregate_request_column(
             inputs["__composite_feature_V231227__part0"], utc=True
         )
         request_col = pd.to_datetime(inputs["POINT_IN_TIME"], utc=True)
-        feat_1 = pd.to_datetime(request_col) - pd.to_datetime(feat)
+        feat_1 = pd.to_datetime(request_col, utc=True) - pd.to_datetime(
+            feat, utc=True
+        )
         feat_2 = pd.to_timedelta(feat_1).dt.total_seconds() // 86400
 
         # TTL handling for __composite_feature_V231227__part1 column
@@ -890,8 +894,10 @@ def test_time_series_feature_offline_ingest_query_graph(ts_window_aggregate_feat
     ) -> pd.DataFrame:
         df = pd.DataFrame()
         request_col = pd.to_datetime(inputs["POINT_IN_TIME"], utc=True)
-        feat = pd.to_datetime(request_col) - pd.to_datetime(request_col)
-        feat_1 = pd.to_datetime(request_col) + pd.to_timedelta(feat)
+        feat = pd.to_datetime(request_col, utc=True) - pd.to_datetime(
+            request_col, utc=True
+        )
+        feat_1 = pd.to_datetime(request_col, utc=True) + pd.to_timedelta(feat)
 
         # TTL handling for __{version_name}__part0 column with cron expression 0 8 1 * *
         cron = croniter.croniter("0 8 1 * *")
@@ -907,10 +913,10 @@ def test_time_series_feature_offline_ingest_query_graph(ts_window_aggregate_feat
         feat_2 = pd.Series(
             np.where(
                 pd.isna(inputs["__{version_name}__part0"])
-                | pd.isna((pd.to_datetime(feat_1).dt.day)),
+                | pd.isna((pd.to_datetime(feat_1, utc=True).dt.day)),
                 np.nan,
                 inputs["__{version_name}__part0"]
-                + (pd.to_datetime(feat_1).dt.day),
+                + (pd.to_datetime(feat_1, utc=True).dt.day),
             ),
             index=inputs["__{version_name}__part0"].index,
         )


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
This PR revises on demand feature view codes generation.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
