### PR TITLE
[chore] Validate blind_spot field in cron feature job setting

### DIFF
--- a/featurebyte/query_graph/model/feature_job_setting.py
+++ b/featurebyte/query_graph/model/feature_job_setting.py
@@ -415,7 +415,8 @@ class CronFeatureJobSetting(BaseFeatureJobSetting):
 
     @model_validator(mode="after")
     def _validate_cron_expression(self) -> "CronFeatureJobSetting":
-        """Validate cron expression
+        """
+        Validate cron expression
 
         Raises
         ------
@@ -448,6 +449,27 @@ class CronFeatureJobSetting(BaseFeatureJobSetting):
         if isinstance(self.crontab.minute, str) and not self.crontab.minute.isdigit():
             raise ValueError("Cron schedule more frequent than hourly is not supported.")
 
+        return self
+
+    @model_validator(mode="after")
+    def _validate_blind_spot(self) -> "CronFeatureJobSetting":
+        """
+        Validate blind spot
+
+        Raises
+        ------
+        ValueError
+            If the blind spot is invalid
+
+        Returns
+        -------
+        CronFeatureJobSetting
+        """
+        if isinstance(self.blind_spot, str):
+            try:
+                parse_duration_string(self.blind_spot)
+            except ValueError as e:
+                raise ValueError(f"Invalid blind spot: {self.blind_spot} ({str(e)})")
         return self
 
     def extract_offline_store_feature_table_name_postfix(self, max_length: int) -> str:

--- a/tests/unit/query_graph/model/test_feature_job_setting.py
+++ b/tests/unit/query_graph/model/test_feature_job_setting.py
@@ -115,6 +115,15 @@ def test_cron_feature_job_setting__too_frequent_crontab(invalid_crontab):
     assert expected_msg in str(exc_info.value)
 
 
+def test_cron_feature_job_setting__invalid_blind_spot():
+    """Test cron feature job setting with invalid crontab expression"""
+    with pytest.raises(ValueError) as exc_info:
+        CronFeatureJobSetting(crontab="0 * * * *", blind_spot="NaNs")
+
+    expected_msg = "Invalid blind spot: NaNs (unit abbreviation w/o a number)"
+    assert expected_msg in str(exc_info.value)
+
+
 def test_table_feature_job_setting_deserialization():
     """Test feature job setting deserialization"""
     data_1 = {


### PR DESCRIPTION
## Description

Add validation for `blind_spot` in `CronFeatureJobSetting` when the field is provided as a string.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
