### PR TITLE
[chore] Fix pyarrow conversion for decimal in databricks

### DIFF
--- a/featurebyte/core/accessor/datetime.py
+++ b/featurebyte/core/accessor/datetime.py
@@ -419,11 +419,11 @@ class DatetimeAccessor:
         >>> view["TimestampSecond"] = view["Timestamp"].dt.second
         >>> view.preview(5).filter(regex="Timestamp")
                     Timestamp  TimestampSecond
-        0 2022-01-03 12:28:58               58
-        1 2022-01-03 16:32:15               15
-        2 2022-01-07 16:20:04                4
-        3 2022-01-10 16:18:32               32
-        4 2022-01-12 17:36:23               23
+        0 2022-01-03 12:28:58             58.0
+        1 2022-01-03 16:32:15             15.0
+        2 2022-01-07 16:20:04              4.0
+        3 2022-01-10 16:18:32             32.0
+        4 2022-01-12 17:36:23             23.0
         """
         return self._make_operation("second")
 

--- a/featurebyte/session/base_spark.py
+++ b/featurebyte/session/base_spark.py
@@ -61,7 +61,7 @@ pa_type_mapping = {
     "DOUBLE": pa.float64(),
     "FLOAT": pa.float32(),
     # https://spark.apache.org/docs/3.5.0/api/python/reference/pyspark.sql/api/pyspark.sql.types.DecimalType.html
-    "DECIMAL": pa.decimal128(38, 18),
+    "DECIMAL": pa.float64(),  # this is used when scale information is not available
     "INTERVAL": pa.duration("ns"),
     "NULL": pa.null(),
     "TIMESTAMP": pa.timestamp("us", tz=None),

--- a/featurebyte/session/databricks.py
+++ b/featurebyte/session/databricks.py
@@ -219,5 +219,5 @@ class DatabricksSession(BaseSparkSession):
                     # return empty table to ensure correct schema is returned
                     yield pa.record_batch([[]] * len(schema), schema=schema)
                     break
-                for batch in table.cast(schema).to_batches():
+                for batch in table.cast(schema, safe=False).to_batches():
                     yield batch

--- a/featurebyte/session/databricks.py
+++ b/featurebyte/session/databricks.py
@@ -202,7 +202,7 @@ class DatabricksSession(BaseSparkSession):
             schema = self._get_schema_from_cursor(cursor)
 
         if schema:
-            return cursor.fetchall_arrow().cast(schema).to_pandas()
+            return cursor.fetchall_arrow().cast(schema, safe=False).to_pandas()
 
         return None
 

--- a/featurebyte/session/spark.py
+++ b/featurebyte/session/spark.py
@@ -309,7 +309,11 @@ class SparkSession(BaseSparkSession):
         records = cursor.fetchall()
         if not records:
             return pa.record_batch([[]] * len(schema), schema=schema).to_pandas()
-        return pa.table(list(zip(*records)), schema=schema).to_pandas()
+        return (
+            pa.table(list(zip(*records)), names=[field.name for field in schema])
+            .cast(schema, safe=False)
+            .to_pandas()
+        )
 
     async def fetch_query_stream_impl(self, cursor: Any) -> AsyncGenerator[pa.RecordBatch, None]:
         # fetch results in batches

--- a/tests/integration/session/test_databricks_unity.py
+++ b/tests/integration/session/test_databricks_unity.py
@@ -7,12 +7,28 @@ from unittest.mock import patch
 
 import pytest
 from bson import ObjectId
+from numpy.testing import assert_allclose
 
 from featurebyte.models.credential import AccessTokenCredential, CredentialModel
 from featurebyte.session.databricks_unity import (
     DatabricksUnitySchemaInitializer,
     DatabricksUnitySession,
 )
+
+
+@pytest.mark.parametrize("source_type", ["databricks_unity"], indirect=True)
+@pytest.mark.asyncio
+async def test_decimal_casting(session_without_datasets):
+    """
+    Test large decimal without scale information
+    """
+    session = session_without_datasets
+    # In this case, the cursor's description doesn't provide the scale information for the decimal.
+    # Make sure the conversion via pyarrow doesn't fail.
+    df = await session.execute_query(
+        "SELECT CAST(123456789012345678901234567890123456.90 AS DECIMAL(38, 2)) AS result"
+    )
+    assert_allclose(df["result"].iloc[0], 1.2345678901234568e35)
 
 
 @pytest.mark.parametrize("source_type", ["databricks_unity"], indirect=True)


### PR DESCRIPTION
## Description

Fix pyarrow conversion for decimal types in databricks when the precision is not defined.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
