### PR TITLE
[chore] Skip cleaning up of temp tables on debug mode

### DIFF
--- a/featurebyte/common/env_util.py
+++ b/featurebyte/common/env_util.py
@@ -133,3 +133,15 @@ def is_io_worker() -> bool:
     bool
     """
     return "worker-io" in os.environ.get("HOSTNAME", "")
+
+
+def is_feature_query_debug_enabled() -> bool:
+    """
+    Check whether the feature query debugging is enabled
+
+    Returns
+    -------
+    bool
+        True if debugging is enabled, False otherwise
+    """
+    return os.environ.get("FEATUREBYTE_FEATURE_QUERY_DEBUG") == "1"


### PR DESCRIPTION
## Description

Adds a development option to disable cleaning up of temporary tables used by feature query for debugging purposes. The  behaviour is controlled by the environment variable `FEATUREBYTE_FEATURE_QUERY_DEBUG` (set to "1" to enable).

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
