### PR TITLE
[chore] Fix feature type detection for non-embedding arrays

### DIFF
--- a/featurebyte/enum.py
+++ b/featurebyte/enum.py
@@ -156,6 +156,10 @@ class DBVarType(StrEnum):
     TIMEDELTA = "TIMEDELTA", "Time delta column"
     EMBEDDING = "EMBEDDING", "Embedding column"
     FLAT_DICT = "FLAT_DICT", "Flat dictionary column"
+    OBJECT = (
+        "OBJECT",
+        "Mixed-type column",
+    )  # used by aggregate features created from groupby with category parameter
 
     # specialized composite type
     TIMESTAMP_TZ_TUPLE = "TIMESTAMP_TZ_TUPLE", "Tuple of (timestamp, timezone offset)"
@@ -167,7 +171,6 @@ class DBVarType(StrEnum):
     BINARY = "BINARY", "Binary column"
     VOID = "VOID", "Void column"
     MAP = "MAP", "Map column"
-    OBJECT = "OBJECT", "Mixed-type column"
     STRUCT = "STRUCT", "Struct column"
 
     @classmethod
@@ -409,7 +412,10 @@ class FeatureType(StrEnum):
         -------
         set[DBVarType]
         """
-        return {DBVarType.DICT, DBVarType.MAP, DBVarType.OBJECT, DBVarType.STRUCT}
+        # DICT features are expected to be flat, contains only string keys and numeric values
+        # Only features created from groupby with category parameter with a dtype of OBJECT
+        # are certain to be of such type
+        return {DBVarType.OBJECT}
 
     @classmethod
     def valid_embedding_dtypes(cls) -> set[DBVarType]:

--- a/featurebyte/enum.py
+++ b/featurebyte/enum.py
@@ -420,7 +420,7 @@ class FeatureType(StrEnum):
         -------
         set[DBVarType]
         """
-        return {DBVarType.EMBEDDING, DBVarType.ARRAY}
+        return {DBVarType.EMBEDDING}
 
 
 class TargetType(StrEnum):

--- a/tests/unit/service/test_feature_type.py
+++ b/tests/unit/service/test_feature_type.py
@@ -22,7 +22,7 @@ from featurebyte.query_graph.enum import NodeType
         (DBVarType.TIMESTAMP_TZ, FeatureType.OTHERS),
         # (DBVarType.VARCHAR, FeatureType.TEXT),
         (DBVarType.ARRAY, FeatureType.OTHERS),
-        (DBVarType.DICT, FeatureType.DICT),
+        (DBVarType.DICT, FeatureType.OTHERS),
         (DBVarType.TIMEDELTA, FeatureType.NUMERIC),
         (DBVarType.EMBEDDING, FeatureType.EMBEDDING),
         (DBVarType.FLAT_DICT, FeatureType.OTHERS),
@@ -30,9 +30,9 @@ from featurebyte.query_graph.enum import NodeType
         (DBVarType.UNKNOWN, FeatureType.OTHERS),
         (DBVarType.BINARY, FeatureType.OTHERS),
         (DBVarType.VOID, FeatureType.OTHERS),
-        (DBVarType.MAP, FeatureType.DICT),
+        (DBVarType.MAP, FeatureType.OTHERS),
         (DBVarType.OBJECT, FeatureType.DICT),
-        (DBVarType.STRUCT, FeatureType.DICT),
+        (DBVarType.STRUCT, FeatureType.OTHERS),
     ],
 )
 def test_detect_feature_type(app_container, dtype, expected):

--- a/tests/unit/service/test_feature_type.py
+++ b/tests/unit/service/test_feature_type.py
@@ -21,7 +21,7 @@ from featurebyte.query_graph.enum import NodeType
         (DBVarType.TIMESTAMP, FeatureType.OTHERS),
         (DBVarType.TIMESTAMP_TZ, FeatureType.OTHERS),
         # (DBVarType.VARCHAR, FeatureType.TEXT),
-        (DBVarType.ARRAY, FeatureType.EMBEDDING),
+        (DBVarType.ARRAY, FeatureType.OTHERS),
         (DBVarType.DICT, FeatureType.DICT),
         (DBVarType.TIMEDELTA, FeatureType.NUMERIC),
         (DBVarType.EMBEDDING, FeatureType.EMBEDDING),


### PR DESCRIPTION
## Description

Fix feature type detection for non-embedding arrays and dict dtypes.

- Features of ARRAY type should not be detected as EMBEDDING feature since they do not have fixed lengths or contain only float values.
- Features of DICT and FLATDICT type (including deprecated MAP, STRUCT) should not be detected as  DICT feature since they may not be flat and may not have string keys or numeric values

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
