### PR TITLE
[DEV-4045] Check actual number of cached columns in cache table

### DIFF
--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -459,6 +459,7 @@ class FeatureTableCacheService:
             await self.feature_table_cache_metadata_service.get_or_create_feature_table_cache(
                 observation_table_id=observation_table.id,
                 num_columns_to_insert=len(non_cached_nodes),
+                session=db_session,
             )
         )
         feature_table_cache_exists = await self._feature_table_cache_exists(

--- a/tests/unit/service/test_feature_table_cache.py
+++ b/tests/unit/service/test_feature_table_cache.py
@@ -817,7 +817,9 @@ async def test_get_feature_query(
     async def _insert_definitions(definitions):
         cache_metadata = (
             await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
-                observation_table_id=observation_table.id, num_columns_to_insert=len(definitions)
+                observation_table_id=observation_table.id,
+                num_columns_to_insert=len(definitions),
+                session=mock_snowflake_session,
             )
         )
         await feature_table_cache_metadata_service.update_feature_table_cache(

--- a/tests/unit/service/test_feature_table_cache_metadata.py
+++ b/tests/unit/service/test_feature_table_cache_metadata.py
@@ -351,7 +351,7 @@ async def test_update_feature_table_cache_updates_feature_id(
 
 @patch(
     "featurebyte.service.feature_table_cache_metadata.FEATUREBYTE_FEATURE_TABLE_CACHE_MAX_COLUMNS",
-    2,
+    6,
 )
 @pytest.mark.asyncio
 async def test_get_or_create_feature_table_cache_exceed_limit(

--- a/tests/unit/service/test_feature_table_cache_metadata.py
+++ b/tests/unit/service/test_feature_table_cache_metadata.py
@@ -50,6 +50,7 @@ async def test_get_or_create_feature_table_cache_creates_from_scratch(
     feature_table_cache_metadata_service,
     observation_table_service,
     observation_table,
+    mock_snowflake_session,
 ):
     """test get_or_create_feature_table_cache method"""
     observation_table_doc = await observation_table_service.create_document(observation_table)
@@ -57,6 +58,7 @@ async def test_get_or_create_feature_table_cache_creates_from_scratch(
     document = await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
         observation_table_id=observation_table_doc.id,
         num_columns_to_insert=1,
+        session=mock_snowflake_session,
     )
     assert document.id
     assert document.observation_table_id == observation_table_doc.id
@@ -72,6 +74,7 @@ async def test_get_or_create_feature_table_cache_returns_existing(
     feature_table_cache_metadata_service,
     observation_table_service,
     observation_table,
+    mock_snowflake_session,
 ):
     """test get_or_create_feature_table_cache method"""
     observation_table_doc = await observation_table_service.create_document(observation_table)
@@ -97,6 +100,7 @@ async def test_get_or_create_feature_table_cache_returns_existing(
     get_document = await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
         observation_table_id=observation_table_doc.id,
         num_columns_to_insert=1,
+        session=mock_snowflake_session,
     )
     assert document == get_document
 
@@ -106,6 +110,7 @@ async def test_update_feature_table_cache_from_scratch(
     feature_table_cache_metadata_service,
     observation_table_service,
     observation_table,
+    mock_snowflake_session,
 ):
     """test update_feature_table_cache method"""
     observation_table_doc = await observation_table_service.create_document(observation_table)
@@ -113,6 +118,7 @@ async def test_update_feature_table_cache_from_scratch(
     document = await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
         observation_table_id=observation_table_doc.id,
         num_columns_to_insert=1,
+        session=mock_snowflake_session,
     )
     assert document.observation_table_id == observation_table_doc.id
     assert document.table_name.startswith(MaterializedTableNamePrefix.FEATURE_TABLE_CACHE)
@@ -138,6 +144,7 @@ async def test_update_feature_table_cache_from_scratch(
     document = await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
         observation_table_id=observation_table_doc.id,
         num_columns_to_insert=1,
+        session=mock_snowflake_session,
     )
     assert document.observation_table_id == observation_table_doc.id
     assert document.table_name.startswith(MaterializedTableNamePrefix.FEATURE_TABLE_CACHE)
@@ -160,6 +167,7 @@ async def test_update_feature_table_cache_add_features(
     feature_table_cache_metadata_service,
     observation_table_service,
     observation_table,
+    mock_snowflake_session,
 ):
     """test update_feature_table_cache method"""
     observation_table_doc = await observation_table_service.create_document(observation_table)
@@ -177,7 +185,9 @@ async def test_update_feature_table_cache_add_features(
         ),
     ]
     document = await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
-        observation_table_id=observation_table_doc.id, num_columns_to_insert=2
+        observation_table_id=observation_table_doc.id,
+        num_columns_to_insert=2,
+        session=mock_snowflake_session,
     )
     await feature_table_cache_metadata_service.update_feature_table_cache(
         cache_metadata_id=document.id,
@@ -246,6 +256,7 @@ async def test_update_feature_table_cache_updates_feature_id(
     feature_table_cache_metadata_service,
     observation_table_service,
     observation_table,
+    mock_snowflake_session,
 ):
     """test update_feature_table_cache method"""
     observation_table_doc = await observation_table_service.create_document(observation_table)
@@ -262,7 +273,9 @@ async def test_update_feature_table_cache_updates_feature_id(
         ),
     ]
     document = await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
-        observation_table_id=observation_table_doc.id, num_columns_to_insert=2
+        observation_table_id=observation_table_doc.id,
+        num_columns_to_insert=2,
+        session=mock_snowflake_session,
     )
     await feature_table_cache_metadata_service.update_feature_table_cache(
         cache_metadata_id=document.id,
@@ -345,6 +358,7 @@ async def test_get_or_create_feature_table_cache_exceed_limit(
     feature_table_cache_metadata_service,
     observation_table_service,
     observation_table,
+    mock_snowflake_session,
 ):
     """
     Test get_or_create_feature_table_cache to create multiple tables when column limit is exceeded
@@ -364,7 +378,9 @@ async def test_get_or_create_feature_table_cache_exceed_limit(
         ),
     ]
     cache_metadata = await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
-        observation_table_id=observation_table_doc.id, num_columns_to_insert=len(definitions)
+        observation_table_id=observation_table_doc.id,
+        num_columns_to_insert=len(definitions),
+        session=mock_snowflake_session,
     )
     await feature_table_cache_metadata_service.update_feature_table_cache(
         cache_metadata_id=cache_metadata.id,
@@ -384,7 +400,9 @@ async def test_get_or_create_feature_table_cache_exceed_limit(
         ),
     ]
     cache_metadata = await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
-        observation_table_id=observation_table_doc.id, num_columns_to_insert=len(definitions)
+        observation_table_id=observation_table_doc.id,
+        num_columns_to_insert=len(definitions),
+        session=mock_snowflake_session,
     )
     await feature_table_cache_metadata_service.update_feature_table_cache(
         cache_metadata_id=cache_metadata.id,
@@ -422,7 +440,9 @@ async def test_get_or_create_feature_table_cache_exceed_limit(
         ),
     ]
     cache_metadata = await feature_table_cache_metadata_service.get_or_create_feature_table_cache(
-        observation_table_id=observation_table_doc.id, num_columns_to_insert=len(definitions)
+        observation_table_id=observation_table_doc.id,
+        num_columns_to_insert=len(definitions),
+        session=mock_snowflake_session,
     )
     await feature_table_cache_metadata_service.update_feature_table_cache(
         cache_metadata_id=cache_metadata.id,


### PR DESCRIPTION
## Description

Update `get_or_create_feature_table_cache` to:

* Check the actual number of columns in the cache table before proceeding
* Account for row index column and other columns in the observation table when checking for the columns limit

This is to handle any inconsistent metadata that are out of sync with the cache tables on the warehouse.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
