### PR TITLE
[chore] Fix Crontab comparison to avoid duplicate table name

### DIFF
--- a/featurebyte/models/periodic_task.py
+++ b/featurebyte/models/periodic_task.py
@@ -98,22 +98,22 @@ class Crontab(FeatureByteBaseModel):
 
     def __hash__(self) -> int:
         return hash((
-            self.minute,
-            self.hour,
-            self.day_of_month,
-            self.month_of_year,
-            self.day_of_week,
+            str(self.minute),
+            str(self.hour),
+            str(self.day_of_month),
+            str(self.month_of_year),
+            str(self.day_of_week),
         ))
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Crontab):
             return False
         return (
-            self.minute == other.minute
-            and self.hour == other.hour
-            and self.day_of_month == other.day_of_month
-            and self.month_of_year == other.month_of_year
-            and self.day_of_week == other.day_of_week
+            str(self.minute) == str(other.minute)
+            and str(self.hour) == str(other.hour)
+            and str(self.day_of_month) == str(other.day_of_month)
+            and str(self.month_of_year) == str(other.month_of_year)
+            and str(self.day_of_week) == str(other.day_of_week)
         )
 
     def to_string_crontab(self) -> "Crontab":

--- a/tests/unit/query_graph/model/test_feature_job_setting.py
+++ b/tests/unit/query_graph/model/test_feature_job_setting.py
@@ -5,7 +5,7 @@ Test module for feature job setting
 import pytest
 from bson import ObjectId
 
-from featurebyte import CalendarWindow, FeatureJobSetting
+from featurebyte import CalendarWindow, Crontab, FeatureJobSetting
 from featurebyte.exception import CronFeatureJobSettingConversionError
 from featurebyte.query_graph.model.feature_job_setting import (
     CronFeatureJobSetting,
@@ -319,6 +319,19 @@ def test_to_feature_job_setting_non_fixed_size_blind_spot():
         (
             CronFeatureJobSetting(crontab="10 * * * *"),
             CronFeatureJobSetting(crontab="10 * * * *"),
+            True,
+        ),
+        (
+            CronFeatureJobSetting(
+                crontab=Crontab(
+                    minute=0, hour=0, day_of_month="*", month_of_year="*", day_of_week="*"
+                )
+            ),
+            CronFeatureJobSetting(
+                crontab=Crontab(
+                    minute="0", hour="0", day_of_month="*", month_of_year="*", day_of_week="*"
+                )
+            ),
             True,
         ),
         (

--- a/tests/unit/query_graph/sql/test_cron.py
+++ b/tests/unit/query_graph/sql/test_cron.py
@@ -48,3 +48,27 @@ def test_get_request_table_with_job_schedule_name_with_reference_tz():
         ),
     )
     assert table_name == "request_table_0 0 * * *_Asia/Singapore_Asia/Tokyo"
+
+
+def test_get_cron_feature_job_settings__blind_spot_handling(
+    global_graph,
+    time_series_window_aggregate_feature_node,
+    time_series_window_aggregate_with_blind_spot_feature_node,
+):
+    """
+    Test get_cron_feature_job_settings
+    """
+    cron_feature_job_settings = get_cron_feature_job_settings(
+        global_graph,
+        [
+            time_series_window_aggregate_feature_node,
+            time_series_window_aggregate_with_blind_spot_feature_node,
+        ],
+    )
+    assert cron_feature_job_settings == [
+        CronFeatureJobSetting(
+            crontab=Crontab(minute=0, hour=0, day_of_month="*", month_of_year="*", day_of_week="*"),
+            timezone="Etc/UTC",
+            reference_timezone="Asia/Singapore",
+        )
+    ]


### PR DESCRIPTION
## Description

Normalize all Crontab fields to strings when comparing and hashing. This prevents duplicate CTE name errors during time series feature materialization caused by Crontab definitions with mixed types.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
