### PR TITLE
[DEV-4052] Re-initialize invalid session during query execution for DataBricks

### DIFF
--- a/.changelog/DEV-4052.yaml
+++ b/.changelog/DEV-4052.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: session
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Handle session lost in DataBricks connection with retry using re-initialized connection"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/session/base.py
+++ b/featurebyte/session/base.py
@@ -547,8 +547,7 @@ class BaseSession(BaseModel):
         dataframe = self.fetch_query_result_impl(cursor)
         yield pa.record_batch(dataframe)
 
-    @staticmethod
-    def _execute_query(cursor: Any, query: str, **kwargs: Any) -> Any:
+    def _execute_query(self, cursor: Any, query: str, **kwargs: Any) -> Any:
         return cursor.execute(query, **kwargs)
 
     async def get_async_query_generator(

--- a/featurebyte/session/bigquery.py
+++ b/featurebyte/session/bigquery.py
@@ -304,8 +304,7 @@ class BigQuerySession(BaseSession):
     def dataset_ref(self) -> DatasetReference:
         return DatasetReference(project=self.project_name, dataset_id=self.dataset_name)
 
-    @staticmethod
-    def _execute_query(cursor: Any, query: str, **kwargs: Any) -> Any:
+    def _execute_query(self, cursor: Any, query: str, **kwargs: Any) -> Any:
         job_id = str(uuid.uuid4())
         cursor.job_id = job_id
         return cursor.execute(query, job_id=job_id, **kwargs)

--- a/featurebyte/session/spark.py
+++ b/featurebyte/session/spark.py
@@ -141,8 +141,7 @@ class SparkSession(BaseSparkSession):
             return True
         return False
 
-    @staticmethod
-    def _execute_query(cursor: Any, query: str, **kwargs: Any) -> Any:
+    def _execute_query(self, cursor: Any, query: str, **kwargs: Any) -> Any:
         cursor.execute(query, async_=True)
         response = cursor.poll()
         while response.operationState in (

--- a/tests/integration/session/test_databricks_unity.py
+++ b/tests/integration/session/test_databricks_unity.py
@@ -4,6 +4,7 @@ This module contains session to DataBricks Unity integration tests.
 
 import os
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
 from bson import ObjectId
@@ -152,3 +153,16 @@ async def test_oauth_credential(
         )
     results = await db_session.execute_query("SHOW DATABASES")
     assert results is not None
+
+
+@pytest.mark.parametrize("source_type", ["databricks_unity"], indirect=True)
+@pytest.mark.asyncio
+async def test_session_lost(config, session_without_datasets):
+    """
+    Test the session lost and re-initialization
+    """
+    _ = config
+    session = session_without_datasets
+    # simulate the session handle has an invalid session id
+    session.connection._session_handle.sessionId.guid = uuid4().bytes
+    await session.list_tables(database_name="demo_datasets", schema_name="grocery")


### PR DESCRIPTION
## Description

Long SQL queries on Azure hosted DataBricks seem to run into a situation where connection session is lost
```
databricks.sql.exc.DatabaseError: Invalid SessionHandle: SessionHandle [165008b9-a099-48aa-95f4-42544134405c]
```

This PR introduces a re-initialization of the session and retry of the failed query when this happens

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
