### PR TITLE
[chore] Limit number of rows when validation timezone in table validation

### DIFF
--- a/featurebyte/service/base_table_validation.py
+++ b/featurebyte/service/base_table_validation.py
@@ -168,7 +168,10 @@ class BaseTableValidationService(Generic[Document, DocumentCreate, DocumentUpdat
                 ),
             )
             query_expr = (
-                select(column_expr).from_(source_table_expr).where(columns_not_null([column_name]))
+                select(column_expr)
+                .from_(source_table_expr)
+                .where(columns_not_null([column_name]))
+                .limit(num_records)
             )
             query = sql_to_string(query_expr, source_type=adapter.source_type)
             # check that the offset is valid for the first num_records


### PR DESCRIPTION
## Description

The `num_records` parameter was not used when validating timezone information. This causes the validation to run on the full table.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
