### PR TITLE
[chore] Fix inconsistent feature definition error due to crontab

### DIFF
--- a/featurebyte/query_graph/node/generic.py
+++ b/featurebyte/query_graph/node/generic.py
@@ -11,6 +11,7 @@ from typing_extensions import Literal
 from featurebyte.common.model_util import parse_duration_string
 from featurebyte.enum import DBVarType
 from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
+from featurebyte.models.periodic_task import Crontab
 from featurebyte.query_graph.enum import NodeOutputType, NodeType
 from featurebyte.query_graph.model.dtype import DBVarTypeInfo, DBVarTypeMetadata
 from featurebyte.query_graph.model.feature_job_setting import (
@@ -2214,8 +2215,18 @@ class TimeSeriesWindowAggregateNode(AggregationOpStructMixin):
         else:
             blind_spot = fjs_blind_spot
 
+        if isinstance(fjs.crontab, Crontab):
+            crontab = ClassEnum.CRONTAB(
+                minute=fjs.crontab.minute,
+                hour=fjs.crontab.hour,
+                day_of_month=fjs.crontab.day_of_month,
+                month_of_year=fjs.crontab.month_of_year,
+                day_of_week=fjs.crontab.day_of_week,
+            )
+        else:
+            crontab = fjs.get_cron_expression()  # type: ignore
         feature_job_setting: ObjectClass = ClassEnum.CRON_FEATURE_JOB_SETTING(
-            crontab=fjs.get_cron_expression(),
+            crontab=crontab,
             timezone=fjs.timezone,
             reference_timezone=fjs.reference_timezone,
             blind_spot=blind_spot,

--- a/featurebyte/query_graph/node/metadata/sdk_code.py
+++ b/featurebyte/query_graph/node/metadata/sdk_code.py
@@ -247,6 +247,7 @@ class ClassEnum(Enum):
     # others
     COLUMN_INFO = ("featurebyte.query_graph.model.column_info", "ColumnInfo")
     FEATURE_JOB_SETTING = ("featurebyte", "FeatureJobSetting")
+    CRONTAB = ("featurebyte.models.periodic_task", "Crontab")
     CRON_FEATURE_JOB_SETTING = ("featurebyte", "CronFeatureJobSetting")
     TO_TIMEDELTA = ("featurebyte", "to_timedelta")
     TO_TIMESTAMP_FROM_EPOCH = ("featurebyte", "to_timestamp_from_epoch")

--- a/tests/fixtures/sdk_code/ts_window_aggregate_feature.py
+++ b/tests/fixtures/sdk_code/ts_window_aggregate_feature.py
@@ -3,6 +3,7 @@ from bson import ObjectId
 from featurebyte import CalendarWindow
 from featurebyte import CronFeatureJobSetting
 from featurebyte import TimeSeriesTable
+from featurebyte.models.periodic_task import Crontab
 
 time_series_table = TimeSeriesTable.get_by_id(
     ObjectId("{table_id}")
@@ -20,7 +21,9 @@ grouped = time_series_view.groupby(
     windows=[CalendarWindow(unit="MONTH", size=3)],
     feature_names=["col_float_sum_3month"],
     feature_job_setting=CronFeatureJobSetting(
-        crontab="0 8 1 * *",
+        crontab=Crontab(
+            minute=0, hour=8, day_of_month=1, month_of_year="*", day_of_week="*"
+        ),
         timezone="Etc/UTC",
         reference_timezone=None,
         blind_spot=CalendarWindow(unit="MONTH", size=1),

--- a/tests/unit/api/test_aggregate_over.py
+++ b/tests/unit/api/test_aggregate_over.py
@@ -210,15 +210,18 @@ def test_count_distinct_agg_func(snowflake_event_view_with_entity, cust_id_entit
     feature.save()
 
 
-def test_time_series_view_aggregate_over(snowflake_time_series_table_with_entity):
+@pytest.mark.parametrize("is_int_type_crontab", [True, False])
+def test_time_series_view_aggregate_over(
+    snowflake_time_series_table_with_entity, is_int_type_crontab
+):
     """
     Test aggregate_over for time series view
     """
     snowflake_time_series_table_with_entity.update_default_feature_job_setting(
         feature_job_setting=CronFeatureJobSetting(
             crontab=Crontab(
-                minute=0,
-                hour=1,
+                minute=0 if is_int_type_crontab else "0",
+                hour=1 if is_int_type_crontab else "1",
                 day_of_week="*",
                 day_of_month="*",
                 month_of_year="*",
@@ -260,8 +263,8 @@ def test_time_series_view_aggregate_over(snowflake_time_series_table_with_entity
             "names": ["col_float_sum_3month"],
             "feature_job_setting": {
                 "crontab": {
-                    "minute": 0,
-                    "hour": 1,
+                    "minute": 0 if is_int_type_crontab else "0",
+                    "hour": 1 if is_int_type_crontab else "1",
                     "day_of_month": "*",
                     "month_of_year": "*",
                     "day_of_week": "*",

--- a/tests/unit/api/test_timestamp_timezone_tuple.py
+++ b/tests/unit/api/test_timestamp_timezone_tuple.py
@@ -92,7 +92,9 @@ def test_dt_accessor(feat_timestamp_tz_tuple, snowflake_time_series_table_with_t
             windows=[CalendarWindow(unit="MONTH", size=3)],
             feature_names=["col_float_sum_3month"],
             feature_job_setting=CronFeatureJobSetting(
-                crontab="0 8 1 * *",
+                crontab=Crontab(
+                    minute=0, hour=8, day_of_month=1, month_of_year="*", day_of_week="*"
+                ),
                 timezone="Etc/UTC",
                 reference_timezone=None,
                 blind_spot=None,


### PR DESCRIPTION
## Description

Previously, feature saving would fail if the `Crontab` in the default feature job setting contains stringified integers.
## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
