### PR TITLE
[chore] Split task manager integration tests as separate job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -204,6 +204,79 @@ jobs:
           path: .test_durations.1.${{ matrix.pytest-group }}
           overwrite: true
           include-hidden-files: true
+  test-integration-task-manager:
+    needs:
+      - build-jar
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - 3.10.14
+        pytest-group:
+          - 1
+    env:
+      PYTEST_SPLITS: 1  # This needs to be EQ the count of strategy.matrix.pytest-group
+    steps:
+      - uses: actions/checkout@v4
+      - uses: arduino/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v3
+        with:
+          poetry-version: 1.8.2
+      - name: Configure Poetry
+        run: poetry config virtualenvs.in-project true
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
+      - name: Install packages needed for build
+        run: |-
+          sudo apt-get update
+          sudo apt-get install libkrb5-dev libsasl2-dev libpython3-dev g++ gcc
+      - name: Install wkhtmltopdf
+        run: |-
+          sudo apt-get update
+          sudo apt-get install wkhtmltopdf
+      - name: Download hive-udf
+        uses: actions/download-artifact@v4
+        with:
+          name: hive-udf
+          path: featurebyte/sql/spark/
+      - name: Run tests
+        env:
+          PYTEST_GROUP: ${{ matrix.pytest-group }}
+        run: task test-integration-task-manager
+      - name: Renaming test assets
+        run: |
+          mv .coverage .coverage.1b.${{ matrix.pytest-group }}
+          mv pytest.xml.1b pytest.xml.1b.${{ matrix.pytest-group }}
+          mv .test_durations .test_durations.1b.${{ matrix.pytest-group }}
+      - name: Upload test results
+        uses: actions/upload-artifact@v4.5.0
+        with:
+          name: python-${{ matrix.python-version }}-pytest.xml.1b.${{ matrix.pytest-group }}
+          path: pytest.xml.1b.${{ matrix.pytest-group }}
+          overwrite: true
+      - name: Upload coverage results
+        uses: actions/upload-artifact@v4.5.0
+        with:
+          name: python-${{ matrix.python-version }}-.coverage.1b.${{ matrix.pytest-group }}
+          path: .coverage.1b.${{ matrix.pytest-group }}
+          overwrite: true
+          include-hidden-files: true
+      - name: Upload test durations
+        uses: actions/upload-artifact@v4.5.0
+        with:
+          name: python-${{ matrix.python-version }}-.test_durations.1b.${{ matrix.pytest-group }}
+          path: .test_durations.1b.${{ matrix.pytest-group }}
+          overwrite: true
+          include-hidden-files: true
   test-integration-spark:
     needs:
       - build-jar

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -130,7 +130,25 @@ tasks:
       REDIS_URI: redis://localhost:36379
     cmds:
       - task: test-setup
-      - poetry run pytest --timeout=360 --timeout-method=thread --junitxml=pytest.xml.1 --cov=featurebyte tests/integration --source-types none,snowflake --splits={{.PYTEST_SPLITS}} --group={{.PYTEST_GROUP}} --store-durations --clean-durations
+      - poetry run pytest --timeout=360 --timeout-method=thread --junitxml=pytest.xml.1 --cov=featurebyte tests/integration --source-types none,snowflake --splits={{.PYTEST_SPLITS}} --group={{.PYTEST_GROUP}} --store-durations --clean-durations --ignore=tests/integration/worker/test_task_manager.py
+      - task: test-teardown
+
+  test-integration-task-manager:
+    desc: Runs integration tests against Snowflake
+    deps:
+      - task: install
+    vars:
+      # Default to 1 split 1 group
+      PYTEST_GROUP:
+        sh: printenv PYTEST_GROUP || echo "1"
+      PYTEST_SPLITS:
+        sh: printenv PYTEST_SPLITS || echo "1"
+    env:
+      MONGODB_URI: mongodb://localhost:37017/?replicaSet=rs0
+      REDIS_URI: redis://localhost:36379
+    cmds:
+      - task: test-setup
+      - DISABLE_TASK_MANAGER_MOCK=1 poetry run pytest --timeout=360 --timeout-method=thread --junitxml=pytest.xml.1b --cov=featurebyte tests/integration/worker/test_task_manager.py --source-types none,snowflake --splits={{.PYTEST_SPLITS}} --group={{.PYTEST_GROUP}} --store-durations --clean-durations
       - task: test-teardown
 
   test-reset:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1974,12 +1974,12 @@ def dimension_view_fixture(dimension_table):
     return dimension_table.get_view()
 
 
-@pytest.fixture(autouse=True, scope="module")
-def mock_task_manager(request, persistent, storage):
+@pytest.fixture(autouse=True, scope="session")
+def mock_task_manager(persistent, storage):
     """
     Mock celery task manager for testing
     """
-    if request.module.__name__ == "test_task_manager":
+    if os.getenv("DISABLE_TASK_MANAGER_MOCK") == "1":
         yield
     else:
         task_status = {}


### PR DESCRIPTION
## Description

Run task manager integration tests as a separate job. This allows:

1. `session` scoped fixtures (event tables, time series tables, etc) in `integration/conftest.py` to be setup with the task manager properly mocked. This allows better test coverage. Otherwise, background tasks such as table validation are skipped during the fixtures setup.

2. Quicker test re-runs since some of the task manager integration tests can be flaky.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
