### PR TITLE
[DEV-4058] Reduce cap on maximum categories during aggregation to 500

### DIFF
--- a/.changelog/DEV-4058.yaml
+++ b/.changelog/DEV-4058.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Reduce cap on number of most frequent categories to keep during aggregation to avoid creating too large feature tables"
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/query_graph/sql/adapter/base.py
+++ b/featurebyte/query_graph/sql/adapter/base.py
@@ -357,7 +357,7 @@ class BaseAdapter(ABC):
         # Limit number of categories to max_num_categories, ordering by the inner aggregated result
         # (the dict values)
         if max_num_categories is None:
-            max_num_categories = 50000
+            max_num_categories = 500
         ordering_column_name = "__fb_object_agg_row_number"
         ordering_expr = expressions.Window(
             this=expressions.RowNumber(),

--- a/tests/fixtures/aggregator/expected_forward_aggregator.sql
+++ b/tests/fixtures/aggregator/expected_forward_aggregator.sql
@@ -61,7 +61,7 @@ LEFT JOIN (
       )
     )
     WHERE
-      "__fb_object_agg_row_number" <= 50000
+      "__fb_object_agg_row_number" <= 500
   ) AS INNER_
   GROUP BY
     INNER_."POINT_IN_TIME",

--- a/tests/fixtures/aggregator/expected_forward_aggregator_offset.sql
+++ b/tests/fixtures/aggregator/expected_forward_aggregator_offset.sql
@@ -61,7 +61,7 @@ LEFT JOIN (
       )
     )
     WHERE
-      "__fb_object_agg_row_number" <= 50000
+      "__fb_object_agg_row_number" <= 500
   ) AS INNER_
   GROUP BY
     INNER_."POINT_IN_TIME",

--- a/tests/fixtures/expected_preview_sql_category.sql
+++ b/tests/fixtures/expected_preview_sql_category.sql
@@ -169,7 +169,7 @@ WITH REQUEST_TABLE AS (
         )
       )
       WHERE
-        "__fb_object_agg_row_number" <= 50000
+        "__fb_object_agg_row_number" <= 500
     ) AS INNER_
     GROUP BY
       INNER_."POINT_IN_TIME",
@@ -245,7 +245,7 @@ WITH REQUEST_TABLE AS (
         )
       )
       WHERE
-        "__fb_object_agg_row_number" <= 50000
+        "__fb_object_agg_row_number" <= 500
     ) AS INNER_
     GROUP BY
       INNER_."POINT_IN_TIME",

--- a/tests/fixtures/expected_preview_sql_category_multiple.sql
+++ b/tests/fixtures/expected_preview_sql_category_multiple.sql
@@ -203,7 +203,7 @@ WITH REQUEST_TABLE AS (
         )
       )
       WHERE
-        "__fb_object_agg_row_number" <= 50000
+        "__fb_object_agg_row_number" <= 500
     ) AS INNER_
     GROUP BY
       INNER_."POINT_IN_TIME",
@@ -277,7 +277,7 @@ WITH REQUEST_TABLE AS (
         )
       )
       WHERE
-        "__fb_object_agg_row_number" <= 50000
+        "__fb_object_agg_row_number" <= 500
     ) AS INNER_
     GROUP BY
       INNER_."POINT_IN_TIME",

--- a/tests/unit/query_graph/sql/fixtures/snowflake_double_vector_agg_only.py
+++ b/tests/unit/query_graph/sql/fixtures/snowflake_double_vector_agg_only.py
@@ -83,7 +83,7 @@ SNOWFLAKE_DOUBLE_VECTOR_AGG_ONLY_QUERY = textwrap.dedent(
             )
           )
           WHERE
-            "__fb_object_agg_row_number" <= 50000
+            "__fb_object_agg_row_number" <= 500
         ) AS INNER_
         GROUP BY
           INNER_."serving_name",

--- a/tests/unit/query_graph/sql/fixtures/snowflake_vector_agg_with_normal_agg.py
+++ b/tests/unit/query_graph/sql/fixtures/snowflake_vector_agg_with_normal_agg.py
@@ -80,7 +80,7 @@ SNOWFLAKE_VECTOR_AGG_WITH_NORMAL_AGG_QUERY = textwrap.dedent(
             )
           )
           WHERE
-            "__fb_object_agg_row_number" <= 50000
+            "__fb_object_agg_row_number" <= 500
         ) AS INNER_
         GROUP BY
           INNER_."serving_name",

--- a/tests/unit/query_graph/sql/test_groupby_helper.py
+++ b/tests/unit/query_graph/sql/test_groupby_helper.py
@@ -262,7 +262,7 @@ def test_get_groupby_expr__multiple_groupby_columns__non_snowflake_vector_aggrs(
                 )
               )
               WHERE
-                "__fb_object_agg_row_number" <= 50000
+                "__fb_object_agg_row_number" <= 500
             ) AS INNER_
             GROUP BY
               INNER_."serving_name",
@@ -335,7 +335,7 @@ def test_get_groupby_expr__multiple_groupby_columns__non_snowflake_vector_aggrs(
                 )
               )
               WHERE
-                "__fb_object_agg_row_number" <= 50000
+                "__fb_object_agg_row_number" <= 500
             ) AS INNER_
             GROUP BY
               INNER_."serving_name",
@@ -483,7 +483,7 @@ def test_get_groupby_expr(agg_func, parent_dtype, method, common_params, spark_s
             )
           )
           WHERE
-            "__fb_object_agg_row_number" <= 50000
+            "__fb_object_agg_row_number" <= 500
         ) AS INNER_
         GROUP BY
           INNER_."serving_name",

--- a/tests/unit/query_graph/test_asat_aggregator.py
+++ b/tests/unit/query_graph/test_asat_aggregator.py
@@ -596,7 +596,7 @@ def test_asat_aggregate_with_category(aggregation_spec_with_category, source_inf
               )
             )
             WHERE
-              "__fb_object_agg_row_number" <= 50000
+              "__fb_object_agg_row_number" <= 500
           ) AS INNER_
           GROUP BY
             INNER_."POINT_IN_TIME",

--- a/tests/unit/query_graph/test_item_aggregator.py
+++ b/tests/unit/query_graph/test_item_aggregator.py
@@ -183,7 +183,7 @@ def test_item_aggregation(aggregation_specs, source_info):
               )
             )
             WHERE
-              "__fb_object_agg_row_number" <= 50000
+              "__fb_object_agg_row_number" <= 500
           ) AS INNER_
           GROUP BY
             INNER_."new_serving_order_id"

--- a/tests/unit/query_graph/test_item_groupby.py
+++ b/tests/unit/query_graph/test_item_groupby.py
@@ -116,7 +116,7 @@ def test_item_groupby_sql_node(
                 )
               )
               WHERE
-                "__fb_object_agg_row_number" <= 50000
+                "__fb_object_agg_row_number" <= 500
             ) AS INNER_
             GROUP BY
               INNER_."order_id"


### PR DESCRIPTION
## Description

Reduce cap on maximum categories during aggregation to 500 to avoid creating very large feature tables

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
