### PR TITLE
[DEV-4063] Fix conversion of bool dtype to physical data type

### DIFF
--- a/.changelog/DEV-4063.yaml
+++ b/.changelog/DEV-4063.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix boolean features and targets being materialized as string types in the database."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/featurebyte/query_graph/sql/adapter/bigquery.py
+++ b/featurebyte/query_graph/sql/adapter/bigquery.py
@@ -42,6 +42,7 @@ class BigQueryAdapter(BaseAdapter):
         """
 
         FLOAT = "FLOAT64"
+        BOOLEAN = "BOOLEAN"
         OBJECT = "JSON"
         TIMESTAMP = "TIMESTAMP"
         STRING = "STRING"
@@ -52,6 +53,7 @@ class BigQueryAdapter(BaseAdapter):
         mapping = {
             DBVarType.INT: cls.DataType.FLOAT,
             DBVarType.FLOAT: cls.DataType.FLOAT,
+            DBVarType.BOOL: cls.DataType.BOOLEAN,
             DBVarType.VARCHAR: cls.DataType.STRING,
             DBVarType.TIMESTAMP: cls.DataType.TIMESTAMP,
             DBVarType.TIMESTAMP_TZ: cls.DataType.TIMESTAMP,

--- a/featurebyte/query_graph/sql/adapter/databricks.py
+++ b/featurebyte/query_graph/sql/adapter/databricks.py
@@ -36,6 +36,7 @@ class DatabricksAdapter(BaseAdapter):
         """
 
         FLOAT = "DOUBLE"
+        BOOLEAN = "BOOLEAN"
         TIMESTAMP = "TIMESTAMP"
         STRING = "STRING"
         MAP = "MAP<STRING, DOUBLE>"
@@ -188,6 +189,7 @@ class DatabricksAdapter(BaseAdapter):
         mapping = {
             DBVarType.INT: cls.DataType.FLOAT,
             DBVarType.FLOAT: cls.DataType.FLOAT,
+            DBVarType.BOOL: cls.DataType.BOOLEAN,
             DBVarType.VARCHAR: cls.DataType.STRING,
             DBVarType.OBJECT: cls.DataType.MAP,
             DBVarType.TIMESTAMP: cls.DataType.TIMESTAMP,

--- a/featurebyte/query_graph/sql/adapter/snowflake.py
+++ b/featurebyte/query_graph/sql/adapter/snowflake.py
@@ -41,6 +41,7 @@ class SnowflakeAdapter(BaseAdapter):
         """
 
         FLOAT = "FLOAT"
+        BOOLEAN = "BOOLEAN"
         OBJECT = "OBJECT"
         TIMESTAMP_NTZ = "TIMESTAMP_NTZ"
         TIMESTAMP_TZ = "TIMESTAMP_TZ"
@@ -125,6 +126,7 @@ class SnowflakeAdapter(BaseAdapter):
             DBVarType.INT: cls.SnowflakeDataType.FLOAT,
             DBVarType.FLOAT: cls.SnowflakeDataType.FLOAT,
             DBVarType.VARCHAR: cls.SnowflakeDataType.VARCHAR,
+            DBVarType.BOOL: cls.SnowflakeDataType.BOOLEAN,
             DBVarType.TIMESTAMP: cls.SnowflakeDataType.TIMESTAMP_NTZ,
             DBVarType.TIMESTAMP_TZ: cls.SnowflakeDataType.TIMESTAMP_TZ,
             DBVarType.ARRAY: cls.SnowflakeDataType.ARRAY,

--- a/tests/unit/query_graph/sql/adapter/base_adapter_test.py
+++ b/tests/unit/query_graph/sql/adapter/base_adapter_test.py
@@ -26,6 +26,7 @@ class BaseAdapterTest:
     """
 
     adapter: BaseAdapter
+    expected_physical_type_from_dtype_mapping: dict[str, str] = {}
 
     @classmethod
     def get_group_by_expected_result(cls) -> str:
@@ -158,3 +159,13 @@ class BaseAdapterTest:
         lon_node_2_expr = get_qualified_column_identifier("lon2", "TABLE")
         expr = adapter.haversine(lat_node_1_expr, lon_node_1_expr, lat_node_2_expr, lon_node_2_expr)
         assert expr.sql(pretty=True) == self.get_expected_haversine_sql()
+
+    def test_get_physical_type_from_dtype(self):
+        """
+        Test get_physical_type_from_dtype
+        """
+        adapter = self.adapter
+        mapping = {}
+        for dtype in DBVarType:
+            mapping[dtype.value] = str(adapter.get_physical_type_from_dtype(dtype))
+        assert mapping == self.expected_physical_type_from_dtype_mapping

--- a/tests/unit/query_graph/sql/adapter/test_bigquery.py
+++ b/tests/unit/query_graph/sql/adapter/test_bigquery.py
@@ -2,12 +2,65 @@
 Tests for BigQueryAdapter
 """
 
+import textwrap
+
 from sqlglot.expressions import select
 
 from featurebyte.enum import SourceType
 from featurebyte.query_graph.sql.adapter import BigQueryAdapter
 from featurebyte.query_graph.sql.common import sql_to_string
-from tests.util.helper import assert_equal_with_expected_fixture
+from tests.unit.query_graph.sql.adapter.base_adapter_test import BaseAdapterTest
+from tests.util.helper import assert_equal_with_expected_fixture, get_sql_adapter_from_source_type
+
+
+class TestBigQueryAdapter(BaseAdapterTest):
+    """
+    Test bigquery adapter class
+    """
+
+    adapter = get_sql_adapter_from_source_type(SourceType.BIGQUERY)
+    expected_physical_type_from_dtype_mapping = {
+        "BOOL": "BOOLEAN",
+        "CHAR": "STRING",
+        "DATE": "STRING",
+        "FLOAT": "FLOAT64",
+        "INT": "FLOAT64",
+        "TIME": "STRING",
+        "TIMESTAMP": "TIMESTAMP",
+        "TIMESTAMP_TZ": "TIMESTAMP",
+        "VARCHAR": "STRING",
+        "ARRAY": "ARRAY<FLOAT64>",
+        "DICT": "JSON",
+        "TIMEDELTA": "STRING",
+        "EMBEDDING": "ARRAY<FLOAT64>",
+        "FLAT_DICT": "JSON",
+        "OBJECT": "JSON",
+        "TIMESTAMP_TZ_TUPLE": "STRING",
+        "UNKNOWN": "STRING",
+        "BINARY": "STRING",
+        "VOID": "STRING",
+        "MAP": "JSON",
+        "STRUCT": "JSON",
+    }
+
+    @classmethod
+    def get_expected_haversine_sql(cls) -> str:
+        """
+        Get expected haversine SQL string
+        """
+        return textwrap.dedent(
+            """
+            2 * ASIN(
+              SQRT(
+                POWER(SIN((
+                  ACOS(-1) * TABLE."lat1" / 180 - ACOS(-1) * TABLE."lat2" / 180
+                ) / 2), 2) + COS(ACOS(-1) * TABLE."lat1" / 180) * COS(ACOS(-1) * TABLE."lat2" / 180) * POWER(SIN((
+                  ACOS(-1) * TABLE."lon1" / 180 - ACOS(-1) * TABLE."lon2" / 180
+                ) / 2), 2)
+              )
+            ) * 6371
+        """
+        ).strip()
 
 
 def test_random_sample(update_fixtures):

--- a/tests/unit/query_graph/sql/adapter/test_databricks_unity.py
+++ b/tests/unit/query_graph/sql/adapter/test_databricks_unity.py
@@ -8,7 +8,39 @@ from featurebyte.enum import SourceType
 from featurebyte.query_graph.sql.adapter import DatabricksUnityAdapter
 from featurebyte.query_graph.sql.common import quoted_identifier, sql_to_string
 from featurebyte.query_graph.sql.source_info import SourceInfo
-from tests.util.helper import assert_equal_with_expected_fixture
+from tests.unit.query_graph.sql.adapter.base_adapter_test import BaseAdapterTest
+from tests.util.helper import assert_equal_with_expected_fixture, get_sql_adapter_from_source_type
+
+
+class TestDatabricksUnityAdapter(BaseAdapterTest):
+    """
+    Test databricks unity adapter class
+    """
+
+    adapter = get_sql_adapter_from_source_type(SourceType.DATABRICKS_UNITY)
+    expected_physical_type_from_dtype_mapping = {
+        "BOOL": "BOOLEAN",
+        "CHAR": "STRING",
+        "DATE": "STRING",
+        "FLOAT": "DOUBLE",
+        "INT": "DOUBLE",
+        "TIME": "STRING",
+        "TIMESTAMP": "TIMESTAMP",
+        "TIMESTAMP_TZ": "STRING",
+        "VARCHAR": "STRING",
+        "ARRAY": "ARRAY<STRING>",
+        "DICT": "STRING",
+        "TIMEDELTA": "STRING",
+        "EMBEDDING": "ARRAY<DOUBLE>",
+        "FLAT_DICT": "STRING",
+        "OBJECT": "MAP<STRING, DOUBLE>",
+        "TIMESTAMP_TZ_TUPLE": "STRING",
+        "UNKNOWN": "STRING",
+        "BINARY": "STRING",
+        "VOID": "STRING",
+        "MAP": "STRING",
+        "STRUCT": "STRING",
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/query_graph/sql/adapter/test_snowflake.py
+++ b/tests/unit/query_graph/sql/adapter/test_snowflake.py
@@ -19,6 +19,29 @@ class TestSnowflakeAdapter(BaseAdapterTest):
     """
 
     adapter = get_sql_adapter_from_source_type(SourceType.SNOWFLAKE)
+    expected_physical_type_from_dtype_mapping = {
+        "BOOL": "BOOLEAN",
+        "CHAR": "VARIANT",
+        "DATE": "VARIANT",
+        "FLOAT": "FLOAT",
+        "INT": "FLOAT",
+        "TIME": "VARIANT",
+        "TIMESTAMP": "TIMESTAMP_NTZ",
+        "TIMESTAMP_TZ": "TIMESTAMP_TZ",
+        "VARCHAR": "VARCHAR",
+        "ARRAY": "ARRAY",
+        "DICT": "OBJECT",
+        "TIMEDELTA": "VARIANT",
+        "EMBEDDING": "ARRAY",
+        "FLAT_DICT": "OBJECT",
+        "OBJECT": "OBJECT",
+        "TIMESTAMP_TZ_TUPLE": "VARIANT",
+        "UNKNOWN": "VARIANT",
+        "BINARY": "VARIANT",
+        "VOID": "VARIANT",
+        "MAP": "OBJECT",
+        "STRUCT": "OBJECT",
+    }
 
     @classmethod
     def get_group_by_expected_result(cls) -> str:

--- a/tests/unit/query_graph/sql/adapter/test_spark.py
+++ b/tests/unit/query_graph/sql/adapter/test_spark.py
@@ -17,6 +17,29 @@ class TestSparkAdapter(BaseAdapterTest):
     """
 
     adapter = get_sql_adapter_from_source_type(SourceType.SPARK)
+    expected_physical_type_from_dtype_mapping = {
+        "BOOL": "BOOLEAN",
+        "CHAR": "STRING",
+        "DATE": "STRING",
+        "FLOAT": "DOUBLE",
+        "INT": "DOUBLE",
+        "TIME": "STRING",
+        "TIMESTAMP": "TIMESTAMP",
+        "TIMESTAMP_TZ": "STRING",
+        "VARCHAR": "STRING",
+        "ARRAY": "ARRAY<STRING>",
+        "DICT": "STRING",
+        "TIMEDELTA": "STRING",
+        "EMBEDDING": "ARRAY<DOUBLE>",
+        "FLAT_DICT": "STRING",
+        "OBJECT": "MAP<STRING, DOUBLE>",
+        "TIMESTAMP_TZ_TUPLE": "STRING",
+        "UNKNOWN": "STRING",
+        "BINARY": "STRING",
+        "VOID": "STRING",
+        "MAP": "STRING",
+        "STRUCT": "STRING",
+    }
 
     def test_dateadd_seconds(self):
         """


### PR DESCRIPTION
## Description

This fixes a bug where features / targets with boolean dtype are materialized as string type in the data warehouse.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
