### PR TITLE
[DEV-4067] Serialize timestamp tz tuple as json string in all source types

### DIFF
--- a/featurebyte/query_graph/sql/adapter/snowflake.py
+++ b/featurebyte/query_graph/sql/adapter/snowflake.py
@@ -129,6 +129,7 @@ class SnowflakeAdapter(BaseAdapter):
             DBVarType.BOOL: cls.SnowflakeDataType.BOOLEAN,
             DBVarType.TIMESTAMP: cls.SnowflakeDataType.TIMESTAMP_NTZ,
             DBVarType.TIMESTAMP_TZ: cls.SnowflakeDataType.TIMESTAMP_TZ,
+            DBVarType.TIMESTAMP_TZ_TUPLE: cls.SnowflakeDataType.VARCHAR,
             DBVarType.ARRAY: cls.SnowflakeDataType.ARRAY,
             DBVarType.EMBEDDING: cls.SnowflakeDataType.ARRAY,
         }
@@ -608,7 +609,7 @@ class SnowflakeAdapter(BaseAdapter):
     def zip_timestamp_string_and_timezone(
         cls, timestamp_str_expr: Expression, timezone_expr: Expression
     ) -> Expression:
-        return expressions.Anonymous(
+        object_expr = expressions.Anonymous(
             this="OBJECT_CONSTRUCT",
             expressions=[
                 make_literal_value(cls.ZIPPED_TIMESTAMP_FIELD),
@@ -617,11 +618,13 @@ class SnowflakeAdapter(BaseAdapter):
                 timezone_expr,
             ],
         )
+        return expressions.Anonymous(this="TO_JSON", expressions=[object_expr])
 
     @classmethod
     def unzip_timestamp_string_and_timezone(
         cls, zipped_expr: Expression
     ) -> Tuple[Expression, Expression]:
+        zipped_expr = expressions.Anonymous(this="PARSE_JSON", expressions=[zipped_expr])
         timestamp_str_expr = cls.cast_to_string(
             expressions.Anonymous(
                 this="GET",

--- a/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_bigquery.sql
+++ b/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_bigquery.sql
@@ -1,7 +1,7 @@
 (
   TIMESTAMP_DIFF(
-    CAST(CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', zipped_column_1.`timestamp`) AS DATETIME) AS DATETIME),
-    CAST(CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', zipped_column_2.`timestamp`) AS DATETIME) AS DATETIME),
+    CAST(CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', JSON_VALUE(zipped_column_1, '$.timestamp')) AS DATETIME) AS DATETIME),
+    CAST(CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', JSON_VALUE(zipped_column_2, '$.timestamp')) AS DATETIME) AS DATETIME),
     MICROSECOND
   ) * CAST(1 AS INT64) / CAST(1000000 AS INT64)
 )

--- a/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_databricks_unity.sql
+++ b/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_databricks_unity.sql
@@ -1,7 +1,7 @@
 (
   DATEDIFF(
     MICROSECOND,
-    TO_TIMESTAMP(zipped_column_2.timestamp, 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''),
-    TO_TIMESTAMP(zipped_column_1.timestamp, 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\'')
+    TO_TIMESTAMP(GET_JSON_OBJECT(zipped_column_2, '$.timestamp'), 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''),
+    TO_TIMESTAMP(GET_JSON_OBJECT(zipped_column_1, '$.timestamp'), 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\'')
   ) * CAST(1 AS BIGINT) / CAST(1000000 AS BIGINT)
 )

--- a/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_snowflake.sql
+++ b/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_snowflake.sql
@@ -1,7 +1,13 @@
 (
   DATEDIFF(
     MICROSECOND,
-    TO_TIMESTAMP(CAST(GET(zipped_column_2, 'timestamp') AS VARCHAR), 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
-    TO_TIMESTAMP(CAST(GET(zipped_column_1, 'timestamp') AS VARCHAR), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+    TO_TIMESTAMP(
+      CAST(GET(PARSE_JSON(zipped_column_2), 'timestamp') AS VARCHAR),
+      'YYYY-MM-DD"T"HH24:MI:SS"Z"'
+    ),
+    TO_TIMESTAMP(
+      CAST(GET(PARSE_JSON(zipped_column_1), 'timestamp') AS VARCHAR),
+      'YYYY-MM-DD"T"HH24:MI:SS"Z"'
+    )
   ) * CAST(1 AS BIGINT) / CAST(1000000 AS BIGINT)
 )

--- a/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_spark.sql
+++ b/tests/fixtures/query_graph/test_datetime_diff/timestamp_tuple_schema_spark.sql
@@ -1,5 +1,5 @@
 (
   (
-    CAST(CAST(TO_TIMESTAMP(zipped_column_1.timestamp, 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\'') AS TIMESTAMP) AS DOUBLE) * 1000000.0 - CAST(CAST(TO_TIMESTAMP(zipped_column_2.timestamp, 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\'') AS TIMESTAMP) AS DOUBLE) * 1000000.0
+    CAST(CAST(TO_TIMESTAMP(GET_JSON_OBJECT(zipped_column_1, '$.timestamp'), 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\'') AS TIMESTAMP) AS DOUBLE) * 1000000.0 - CAST(CAST(TO_TIMESTAMP(GET_JSON_OBJECT(zipped_column_2, '$.timestamp'), 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\'') AS TIMESTAMP) AS DOUBLE) * 1000000.0
   ) * CAST(1 AS BIGINT) / CAST(1000000 AS BIGINT)
 )

--- a/tests/fixtures/query_graph/test_datetime_extract/timestamp_tuple_schema_bigquery.sql
+++ b/tests/fixtures/query_graph/test_datetime_extract/timestamp_tuple_schema_bigquery.sql
@@ -3,7 +3,7 @@ SELECT
   `cust_id` AS `cust_id`,
   `a` AS `a`,
   EXTRACT(hour FROM DATETIME(
-    CAST(CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', `ts`.`timestamp`) AS DATETIME) AS TIMESTAMP),
-    `ts`.`timezone`
+    CAST(CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', JSON_VALUE(`ts`, '$.timestamp')) AS DATETIME) AS TIMESTAMP),
+    JSON_VALUE(`ts`, '$.timezone')
   )) AS `hour`
 FROM `db`.`public`.`event_table`

--- a/tests/fixtures/query_graph/test_datetime_extract/timestamp_tuple_schema_databricks_unity.sql
+++ b/tests/fixtures/query_graph/test_datetime_extract/timestamp_tuple_schema_databricks_unity.sql
@@ -2,5 +2,8 @@ SELECT
   `ts` AS `ts`,
   `cust_id` AS `cust_id`,
   `a` AS `a`,
-  EXTRACT(hour FROM FROM_UTC_TIMESTAMP(TO_TIMESTAMP(`ts`.timestamp, 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''), `ts`.timezone)) AS `hour`
+  EXTRACT(hour FROM FROM_UTC_TIMESTAMP(
+    TO_TIMESTAMP(GET_JSON_OBJECT(`ts`, '$.timestamp'), 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''),
+    GET_JSON_OBJECT(`ts`, '$.timezone')
+  )) AS `hour`
 FROM `db`.`public`.`event_table`

--- a/tests/fixtures/query_graph/test_datetime_extract/timestamp_tuple_schema_snowflake.sql
+++ b/tests/fixtures/query_graph/test_datetime_extract/timestamp_tuple_schema_snowflake.sql
@@ -6,8 +6,8 @@ SELECT
     hour,
     CONVERT_TIMEZONE(
       'UTC',
-      CAST(GET("ts", 'timezone') AS VARCHAR),
-      TO_TIMESTAMP(CAST(GET("ts", 'timestamp') AS VARCHAR), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+      CAST(GET(PARSE_JSON("ts"), 'timezone') AS VARCHAR),
+      TO_TIMESTAMP(CAST(GET(PARSE_JSON("ts"), 'timestamp') AS VARCHAR), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
     )
   ) AS "hour"
 FROM "db"."public"."event_table"

--- a/tests/fixtures/query_graph/test_datetime_extract/timestamp_tuple_schema_spark.sql
+++ b/tests/fixtures/query_graph/test_datetime_extract/timestamp_tuple_schema_spark.sql
@@ -2,5 +2,8 @@ SELECT
   `ts` AS `ts`,
   `cust_id` AS `cust_id`,
   `a` AS `a`,
-  EXTRACT(hour FROM FROM_UTC_TIMESTAMP(TO_TIMESTAMP(`ts`.timestamp, 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''), `ts`.timezone)) AS `hour`
+  EXTRACT(hour FROM FROM_UTC_TIMESTAMP(
+    TO_TIMESTAMP(GET_JSON_OBJECT(`ts`, '$.timestamp'), 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''),
+    GET_JSON_OBJECT(`ts`, '$.timezone')
+  )) AS `hour`
 FROM `db`.`public`.`event_table`

--- a/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/local/varchar_tz_column_offset_bigquery.sql
+++ b/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/local/varchar_tz_column_offset_bigquery.sql
@@ -1,4 +1,4 @@
 DATETIME(
-  CAST(CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', `zipped_timestamp_tuple`.`timestamp`) AS DATETIME) AS TIMESTAMP),
-  `zipped_timestamp_tuple`.`timezone`
+  CAST(CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', JSON_VALUE(`zipped_timestamp_tuple`, '$.timestamp')) AS DATETIME) AS TIMESTAMP),
+  JSON_VALUE(`zipped_timestamp_tuple`, '$.timezone')
 )

--- a/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/local/varchar_tz_column_offset_databricks_unity.sql
+++ b/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/local/varchar_tz_column_offset_databricks_unity.sql
@@ -1,4 +1,7 @@
 FROM_UTC_TIMESTAMP(
-  TO_TIMESTAMP(`zipped_timestamp_tuple`.timestamp, 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''),
-  `zipped_timestamp_tuple`.timezone
+  TO_TIMESTAMP(
+    GET_JSON_OBJECT(`zipped_timestamp_tuple`, '$.timestamp'),
+    'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''
+  ),
+  GET_JSON_OBJECT(`zipped_timestamp_tuple`, '$.timezone')
 )

--- a/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/local/varchar_tz_column_offset_snowflake.sql
+++ b/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/local/varchar_tz_column_offset_snowflake.sql
@@ -1,8 +1,8 @@
 DATEADD(
   SECOND,
-  F_TIMEZONE_OFFSET_TO_SECOND(CAST(GET("zipped_timestamp_tuple", 'timezone') AS VARCHAR)),
+  F_TIMEZONE_OFFSET_TO_SECOND(CAST(GET(PARSE_JSON("zipped_timestamp_tuple"), 'timezone') AS VARCHAR)),
   TO_TIMESTAMP(
-    CAST(GET("zipped_timestamp_tuple", 'timestamp') AS VARCHAR),
+    CAST(GET(PARSE_JSON("zipped_timestamp_tuple"), 'timestamp') AS VARCHAR),
     'YYYY-MM-DD"T"HH24:MI:SS"Z"'
   )
 )

--- a/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/local/varchar_tz_column_offset_spark.sql
+++ b/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/local/varchar_tz_column_offset_spark.sql
@@ -1,4 +1,7 @@
 FROM_UTC_TIMESTAMP(
-  TO_TIMESTAMP(`zipped_timestamp_tuple`.timestamp, 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''),
-  `zipped_timestamp_tuple`.timezone
+  TO_TIMESTAMP(
+    GET_JSON_OBJECT(`zipped_timestamp_tuple`, '$.timestamp'),
+    'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''
+  ),
+  GET_JSON_OBJECT(`zipped_timestamp_tuple`, '$.timezone')
 )

--- a/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/local/varchar_tz_column_timezone_bigquery.sql
+++ b/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/local/varchar_tz_column_timezone_bigquery.sql
@@ -1,4 +1,4 @@
 DATETIME(
-  CAST(CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', `zipped_timestamp_tuple`.`timestamp`) AS DATETIME) AS TIMESTAMP),
-  `zipped_timestamp_tuple`.`timezone`
+  CAST(CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', JSON_VALUE(`zipped_timestamp_tuple`, '$.timestamp')) AS DATETIME) AS TIMESTAMP),
+  JSON_VALUE(`zipped_timestamp_tuple`, '$.timezone')
 )

--- a/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/local/varchar_tz_column_timezone_databricks_unity.sql
+++ b/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/local/varchar_tz_column_timezone_databricks_unity.sql
@@ -1,4 +1,7 @@
 FROM_UTC_TIMESTAMP(
-  TO_TIMESTAMP(`zipped_timestamp_tuple`.timestamp, 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''),
-  `zipped_timestamp_tuple`.timezone
+  TO_TIMESTAMP(
+    GET_JSON_OBJECT(`zipped_timestamp_tuple`, '$.timestamp'),
+    'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''
+  ),
+  GET_JSON_OBJECT(`zipped_timestamp_tuple`, '$.timezone')
 )

--- a/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/local/varchar_tz_column_timezone_snowflake.sql
+++ b/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/local/varchar_tz_column_timezone_snowflake.sql
@@ -1,8 +1,8 @@
 CONVERT_TIMEZONE(
   'UTC',
-  CAST(GET("zipped_timestamp_tuple", 'timezone') AS VARCHAR),
+  CAST(GET(PARSE_JSON("zipped_timestamp_tuple"), 'timezone') AS VARCHAR),
   TO_TIMESTAMP(
-    CAST(GET("zipped_timestamp_tuple", 'timestamp') AS VARCHAR),
+    CAST(GET(PARSE_JSON("zipped_timestamp_tuple"), 'timestamp') AS VARCHAR),
     'YYYY-MM-DD"T"HH24:MI:SS"Z"'
   )
 )

--- a/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/local/varchar_tz_column_timezone_spark.sql
+++ b/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/local/varchar_tz_column_timezone_spark.sql
@@ -1,4 +1,7 @@
 FROM_UTC_TIMESTAMP(
-  TO_TIMESTAMP(`zipped_timestamp_tuple`.timestamp, 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''),
-  `zipped_timestamp_tuple`.timezone
+  TO_TIMESTAMP(
+    GET_JSON_OBJECT(`zipped_timestamp_tuple`, '$.timestamp'),
+    'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''
+  ),
+  GET_JSON_OBJECT(`zipped_timestamp_tuple`, '$.timezone')
 )

--- a/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/utc/varchar_tz_column_offset_bigquery.sql
+++ b/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/utc/varchar_tz_column_offset_bigquery.sql
@@ -1,1 +1,1 @@
-CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', `zipped_timestamp_tuple`.`timestamp`) AS DATETIME)
+CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', JSON_VALUE(`zipped_timestamp_tuple`, '$.timestamp')) AS DATETIME)

--- a/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/utc/varchar_tz_column_offset_databricks_unity.sql
+++ b/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/utc/varchar_tz_column_offset_databricks_unity.sql
@@ -1,1 +1,4 @@
-TO_TIMESTAMP(`zipped_timestamp_tuple`.timestamp, 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\'')
+TO_TIMESTAMP(
+  GET_JSON_OBJECT(`zipped_timestamp_tuple`, '$.timestamp'),
+  'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''
+)

--- a/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/utc/varchar_tz_column_offset_snowflake.sql
+++ b/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/utc/varchar_tz_column_offset_snowflake.sql
@@ -1,4 +1,4 @@
 TO_TIMESTAMP(
-  CAST(GET("zipped_timestamp_tuple", 'timestamp') AS VARCHAR),
+  CAST(GET(PARSE_JSON("zipped_timestamp_tuple"), 'timestamp') AS VARCHAR),
   'YYYY-MM-DD"T"HH24:MI:SS"Z"'
 )

--- a/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/utc/varchar_tz_column_offset_spark.sql
+++ b/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/utc/varchar_tz_column_offset_spark.sql
@@ -1,1 +1,4 @@
-TO_TIMESTAMP(`zipped_timestamp_tuple`.timestamp, 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\'')
+TO_TIMESTAMP(
+  GET_JSON_OBJECT(`zipped_timestamp_tuple`, '$.timestamp'),
+  'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''
+)

--- a/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/utc/varchar_tz_column_timezone_bigquery.sql
+++ b/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/utc/varchar_tz_column_timezone_bigquery.sql
@@ -1,1 +1,1 @@
-CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', `zipped_timestamp_tuple`.`timestamp`) AS DATETIME)
+CAST(PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', JSON_VALUE(`zipped_timestamp_tuple`, '$.timestamp')) AS DATETIME)

--- a/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/utc/varchar_tz_column_timezone_databricks_unity.sql
+++ b/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/utc/varchar_tz_column_timezone_databricks_unity.sql
@@ -1,1 +1,4 @@
-TO_TIMESTAMP(`zipped_timestamp_tuple`.timestamp, 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\'')
+TO_TIMESTAMP(
+  GET_JSON_OBJECT(`zipped_timestamp_tuple`, '$.timestamp'),
+  'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''
+)

--- a/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/utc/varchar_tz_column_timezone_snowflake.sql
+++ b/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/utc/varchar_tz_column_timezone_snowflake.sql
@@ -1,4 +1,4 @@
 TO_TIMESTAMP(
-  CAST(GET("zipped_timestamp_tuple", 'timestamp') AS VARCHAR),
+  CAST(GET(PARSE_JSON("zipped_timestamp_tuple"), 'timestamp') AS VARCHAR),
   'YYYY-MM-DD"T"HH24:MI:SS"Z"'
 )

--- a/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/utc/varchar_tz_column_timezone_spark.sql
+++ b/tests/fixtures/query_graph/test_timestamp_handler/convert_timestamp_timezone_tuple/utc/varchar_tz_column_timezone_spark.sql
@@ -1,1 +1,4 @@
-TO_TIMESTAMP(`zipped_timestamp_tuple`.timestamp, 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\'')
+TO_TIMESTAMP(
+  GET_JSON_OBJECT(`zipped_timestamp_tuple`, '$.timestamp'),
+  'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''
+)

--- a/tests/fixtures/query_graph/test_zip_timestamp/zip_timestamp_bigquery.sql
+++ b/tests/fixtures/query_graph/test_zip_timestamp/zip_timestamp_bigquery.sql
@@ -1,7 +1,9 @@
-STRUCT(
-  FORMAT_DATETIME(
-    '%Y-%m-%dT%H:%M:%SZ',
-    CAST(TIMESTAMP(CAST(`timestamp_col` AS DATETIME), `tz_col`) AS DATETIME)
-  ) AS `timestamp`,
-  `tz_col` AS `timezone`
+TO_JSON_STRING(
+  STRUCT(
+    FORMAT_DATETIME(
+      '%Y-%m-%dT%H:%M:%SZ',
+      CAST(TIMESTAMP(CAST(`timestamp_col` AS DATETIME), `tz_col`) AS DATETIME)
+    ) AS `timestamp`,
+    `tz_col` AS `timezone`
+  )
 )

--- a/tests/fixtures/query_graph/test_zip_timestamp/zip_timestamp_databricks_unity.sql
+++ b/tests/fixtures/query_graph/test_zip_timestamp/zip_timestamp_databricks_unity.sql
@@ -1,6 +1,8 @@
-NAMED_STRUCT(
-  'timestamp',
-  DATE_FORMAT(TO_UTC_TIMESTAMP(`timestamp_col`, `tz_col`), 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''),
-  'timezone',
-  `tz_col`
+TO_JSON(
+  NAMED_STRUCT(
+    'timestamp',
+    DATE_FORMAT(TO_UTC_TIMESTAMP(`timestamp_col`, `tz_col`), 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''),
+    'timezone',
+    `tz_col`
+  )
 )

--- a/tests/fixtures/query_graph/test_zip_timestamp/zip_timestamp_snowflake.sql
+++ b/tests/fixtures/query_graph/test_zip_timestamp/zip_timestamp_snowflake.sql
@@ -1,6 +1,8 @@
-OBJECT_CONSTRUCT(
-  'timestamp',
-  TO_CHAR(CONVERT_TIMEZONE("tz_col", 'UTC', "timestamp_col"), 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
-  'timezone',
-  "tz_col"
+TO_JSON(
+  OBJECT_CONSTRUCT(
+    'timestamp',
+    TO_CHAR(CONVERT_TIMEZONE("tz_col", 'UTC', "timestamp_col"), 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+    'timezone',
+    "tz_col"
+  )
 )

--- a/tests/fixtures/query_graph/test_zip_timestamp/zip_timestamp_spark.sql
+++ b/tests/fixtures/query_graph/test_zip_timestamp/zip_timestamp_spark.sql
@@ -1,6 +1,8 @@
-NAMED_STRUCT(
-  'timestamp',
-  DATE_FORMAT(TO_UTC_TIMESTAMP(`timestamp_col`, `tz_col`), 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''),
-  'timezone',
-  `tz_col`
+TO_JSON(
+  NAMED_STRUCT(
+    'timestamp',
+    DATE_FORMAT(TO_UTC_TIMESTAMP(`timestamp_col`, `tz_col`), 'yyyy-MM-dd\'T\'HH:mm:ss\'Z\''),
+    'timezone',
+    `tz_col`
+  )
 )

--- a/tests/unit/query_graph/sql/adapter/test_snowflake.py
+++ b/tests/unit/query_graph/sql/adapter/test_snowflake.py
@@ -35,7 +35,7 @@ class TestSnowflakeAdapter(BaseAdapterTest):
         "EMBEDDING": "ARRAY",
         "FLAT_DICT": "OBJECT",
         "OBJECT": "OBJECT",
-        "TIMESTAMP_TZ_TUPLE": "VARIANT",
+        "TIMESTAMP_TZ_TUPLE": "VARCHAR",
         "UNKNOWN": "VARIANT",
         "BINARY": "VARIANT",
         "VOID": "VARIANT",


### PR DESCRIPTION
## Description

This unifies the serialization format of the `TIMESTAMP_TZ_TUPLE` dtype so that it can be consumed more easily by on-demand functions or externally.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
