### PR TITLE
[chore] Test disabling entity dtype patches in integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -291,14 +291,6 @@ def always_patch_app_get_storage_fixture(storage):
         yield
 
 
-@pytest.fixture(autouse=True)
-def always_patch_initialize_entity_dtype_service(patch_initialize_entity_dtype):
-    """
-    Patch the initialize entity dtype service for all tests in this module
-    """
-    yield patch_initialize_entity_dtype
-
-
 @pytest.fixture(name="config", scope="session")
 def config_fixture(storage):
     """


### PR DESCRIPTION
## Description

Checking the impact of these patches in integration tests: https://github.com/featurebyte/featurebyte/blob/829efdc7e6643005c71a37868ee55b99f475e4c0/tests/conftest.py#L121-L142

Update: the tests passed so these patches are not necessary. Will merge this as part of https://github.com/featurebyte/featurebyte/pull/2993.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
