### PR TITLE
[chore] Relax entity dtype validation except for bigquery (cherry-pick)

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -219,7 +219,7 @@ tasks:
       REDIS_URI: redis://localhost:36379
     cmds:
       - task: test-setup
-      - poetry run pytest --timeout=900 --junitxml=pytest.xml.5 --cov=featurebyte tests/integration --source-types bigquery --splits={{.PYTEST_SPLITS}} --group={{.PYTEST_GROUP}} --store-durations --clean-durations
+      - poetry run pytest --timeout=1800 --junitxml=pytest.xml.5 --cov=featurebyte tests/integration --source-types bigquery --splits={{.PYTEST_SPLITS}} --group={{.PYTEST_GROUP}} --store-durations --clean-durations
       - task: test-teardown
 
   test-docs:

--- a/tests/integration/api/test_entity_tagging.py
+++ b/tests/integration/api/test_entity_tagging.py
@@ -1,0 +1,95 @@
+"""
+Integration tests related to entity tagging
+"""
+
+from datetime import datetime
+
+import pandas as pd
+import pytest
+
+import featurebyte as fb
+from tests.source_types import SNOWFLAKE_SPARK_DATABRICKS_UNITY
+from tests.util.deployment import deploy_and_get_online_features
+from tests.util.helper import fb_assert_frame_equal
+
+
+@pytest.mark.parametrize("source_type", SNOWFLAKE_SPARK_DATABRICKS_UNITY, indirect=True)
+@pytest.mark.asyncio
+async def test_entity_different_dtypes(session_without_datasets, data_source, config):
+    """
+    Test registering an entity with different dtypes
+    """
+
+    def _unique_serving_name(serving_name: str) -> str:
+        return "test_entity_different_dtypes__" + serving_name
+
+    session = session_without_datasets
+    df_scd = pd.DataFrame({
+        "effective_ts": pd.to_datetime([
+            "2022-04-12 10:00:00",
+            "2022-04-12 10:00:00",
+            "2022-04-20 10:00:00",
+            "2022-04-20 10:00:00",
+        ]),
+        "cust_id": [1000, 1001, 1000, 1001],
+        "value": [1, 1, 2, 2],
+    })
+    df_dimension = pd.DataFrame({
+        "cust_id": ["1000", "1001"],
+        "dimension_value": ["A", "B"],
+    })
+    await session.register_table("test_entity_different_dtypes__scd", df_scd)
+    await session.register_table("test_entity_different_dtypes__dimension", df_dimension)
+    scd_table = data_source.get_source_table(
+        database_name=session.database_name,
+        schema_name=session.schema_name,
+        table_name="test_entity_different_dtypes__scd",
+    ).create_scd_table(
+        name="test_entity_different_dtypes__scd_table",
+        effective_timestamp_column="effective_ts",
+        natural_key_column="cust_id",
+    )
+    dimension_table = data_source.get_source_table(
+        database_name=session.database_name,
+        schema_name=session.schema_name,
+        table_name="test_entity_different_dtypes__dimension",
+    ).create_dimension_table(
+        name="test_entity_different_dtypes__dimension_table",
+        dimension_id_column="cust_id",
+    )
+
+    # Tagging entities with different dtypes
+    entity = fb.Entity.create(
+        "test_entity_different_dtypes_entity", [_unique_serving_name("cust_id")]
+    )
+    scd_table["cust_id"].as_entity(entity.name)
+    dimension_table["cust_id"].as_entity(entity.name)
+
+    # Feature with cust_id entity
+    view = scd_table.get_view()
+    view = view.join(dimension_table.get_view())
+    feature = view["dimension_value"].as_feature("my_feature")
+
+    # Test preview
+    preview_params = pd.DataFrame({
+        "POINT_IN_TIME": pd.to_datetime(["2022-05-01", "2022-05-01"]),
+        _unique_serving_name("cust_id"): ["1000", "1001"],
+    })
+    df_preview = feature.preview(preview_params)
+    df_expected = pd.DataFrame({
+        "POINT_IN_TIME": pd.to_datetime(["2022-05-01", "2022-05-01"]),
+        _unique_serving_name("cust_id"): ["1000", "1001"],
+        "my_feature": ["A", "B"],
+    })
+    fb_assert_frame_equal(df_preview, df_expected)
+
+    # Test online serving
+    request_data = preview_params[[_unique_serving_name("cust_id")]].to_dict(orient="records")
+    df_online_features = deploy_and_get_online_features(
+        client=config.get_client(),
+        feature_list=fb.FeatureList([feature], "test_entity_different_dtypes"),
+        deploy_at=datetime(2022, 5, 1, 12, 0, 0),
+        request_data=request_data,
+    )
+    df_expected = df_expected[[_unique_serving_name("cust_id"), "my_feature"]]
+    fb_assert_frame_equal(df_online_features, df_expected)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -290,14 +290,6 @@ def always_patch_app_get_storage_fixture(storage):
         yield
 
 
-@pytest.fixture(autouse=True)
-def always_patch_initialize_entity_dtype_service(patch_initialize_entity_dtype):
-    """
-    Patch the initialize entity dtype service for all tests in this module
-    """
-    yield patch_initialize_entity_dtype
-
-
 @pytest.fixture(name="config", scope="session")
 def config_fixture(storage):
     """

--- a/tests/unit/api/test_event_table.py
+++ b/tests/unit/api/test_event_table.py
@@ -20,7 +20,7 @@ from typeguard import TypeCheckError
 from featurebyte import Configurations, TimestampSchema, TimeZoneColumn
 from featurebyte.api.entity import Entity
 from featurebyte.api.event_table import EventTable
-from featurebyte.enum import DBVarType, TableDataType
+from featurebyte.enum import DBVarType, SourceType, TableDataType
 from featurebyte.exception import (
     DuplicatedRecordException,
     ObjectHasBeenSavedError,
@@ -1302,7 +1302,11 @@ def test_associate_conflicting_dtype_to_different_tables(
     # check exception raised when associating conflicting dtype to different tables
     assert saved_scd_table.col_text.info.dtype == DBVarType.VARCHAR
     with pytest.raises(RecordUpdateException) as exc:
-        saved_scd_table.col_text.as_entity(cust_id_entity.name)
+        with patch(
+            "featurebyte.service.table_columns_info.TableColumnsInfoService._get_source_type",
+            return_value=SourceType.BIGQUERY,
+        ):
+            saved_scd_table.col_text.as_entity(cust_id_entity.name)
     expected_msg = (
         f"Column col_text (Table ID: {saved_scd_table.id}, Name: sf_scd_table) has dtype VARCHAR which does not "
         f"match the entity dtype INT."

--- a/tests/unit/service/test_table_columns_info.py
+++ b/tests/unit/service/test_table_columns_info.py
@@ -10,7 +10,7 @@ import pytest_asyncio
 from bson import ObjectId
 
 from featurebyte import Relationship
-from featurebyte.enum import DBVarType
+from featurebyte.enum import DBVarType, SourceType
 from featurebyte.exception import DocumentUpdateError
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.entity import ParentEntity
@@ -23,6 +23,18 @@ from featurebyte.schema.item_table import ItemTableServiceUpdate
 from featurebyte.schema.relationship_info import RelationshipInfoCreate
 from featurebyte.schema.scd_table import SCDTableServiceUpdate
 from tests.util.helper import compare_pydantic_obj
+
+
+@pytest.fixture(autouse=True)
+def patch_source_type_as_bigquery():
+    """
+    Patch the source type to BigQuery for all tests in this module.
+    """
+    with patch(
+        "featurebyte.service.table_columns_info.TableColumnsInfoService._get_source_type",
+        return_value=SourceType.BIGQUERY,
+    ):
+        yield
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Cherry pick: #2993 

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
