### PR TITLE
[chore] Populate managed views column info in service

### DIFF
--- a/featurebyte/query_graph/model/common_table.py
+++ b/featurebyte/query_graph/model/common_table.py
@@ -55,6 +55,7 @@ class BaseTableData(FeatureByteBaseModel):
 
     columns_info: List[ColumnInfo]
     tabular_source: TabularSource
+    managed_view_id: Optional[PydanticObjectId] = Field(default=None)
 
     # pydantic validators
     _validator = field_validator("columns_info")(columns_info_validator)

--- a/featurebyte/routes/managed_view/controller.py
+++ b/featurebyte/routes/managed_view/controller.py
@@ -160,7 +160,7 @@ class ManagedViewController(
         return [
             (
                 self.table_service,
-                {"tabular_source": document.tabular_source.model_dump(by_alias=True)},
+                {"managed_view_id": document.id},
             )
         ]
 

--- a/featurebyte/schema/managed_view.py
+++ b/featurebyte/schema/managed_view.py
@@ -28,7 +28,6 @@ class ManagedViewCreateBase(FeatureByteBaseModel):
     name: NameStr
     description: Optional[StrictStr] = Field(default=None)
     sql: StrictStr
-    columns_info: List[ColumnInfo]
 
 
 class ManagedViewCreate(ManagedViewCreateBase):
@@ -47,6 +46,7 @@ class ManagedViewServiceCreate(ManagedViewCreateBase):
 
     catalog_id: Optional[PydanticObjectId] = Field(default=None)
     tabular_source: TabularSource
+    columns_info: Optional[List[ColumnInfo]] = Field(default=None)
 
 
 class ManagedViewList(PaginationMixin):

--- a/featurebyte/schema/table.py
+++ b/featurebyte/schema/table.py
@@ -31,6 +31,7 @@ class TableCreate(FeatureByteBaseModel):
     columns_info: List[ColumnSpecWithDescription]
     record_creation_timestamp_column: Optional[StrictStr] = Field(default=None)
     description: Optional[StrictStr] = Field(default=None)
+    managed_view_id: Optional[PydanticObjectId] = Field(default=None)
 
     # pydantic validators
     _columns_info_validator = field_validator("columns_info")(columns_info_validator)

--- a/featurebyte/service/managed_view.py
+++ b/featurebyte/service/managed_view.py
@@ -28,6 +28,7 @@ from featurebyte.service.catalog import CatalogService
 from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.service.feature_store_warehouse import FeatureStoreWarehouseService
 from featurebyte.service.session_manager import SessionManagerService
+from featurebyte.session.base import INTERACTIVE_SESSION_TIMEOUT_SECONDS
 from featurebyte.storage import Storage
 
 
@@ -170,6 +171,7 @@ class ManagedViewService(
                 database_name=table_details.database_name or source_info.database_name,
                 schema_name=table_details.schema_name or source_info.schema_name,
                 table_name=table_details.table_name,
+                timeout=INTERACTIVE_SESSION_TIMEOUT_SECONDS,
             )
         except Exception as exc:
             raise InvalidViewSQL(f"Failed to drop managed view: {exc}") from exc

--- a/featurebyte/service/managed_view.py
+++ b/featurebyte/service/managed_view.py
@@ -17,6 +17,7 @@ from featurebyte.exception import (
 from featurebyte.models.managed_view import ManagedViewModel
 from featurebyte.models.persistent import QueryFilter
 from featurebyte.persistent import Persistent
+from featurebyte.query_graph.model.column_info import ColumnInfo
 from featurebyte.query_graph.sql.common import sql_to_string
 from featurebyte.routes.block_modification_handler import BlockModificationHandler
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema
@@ -25,6 +26,7 @@ from featurebyte.schema.managed_view import ManagedViewServiceCreate
 from featurebyte.service.base_document import BaseDocumentService
 from featurebyte.service.catalog import CatalogService
 from featurebyte.service.feature_store import FeatureStoreService
+from featurebyte.service.feature_store_warehouse import FeatureStoreWarehouseService
 from featurebyte.service.session_manager import SessionManagerService
 from featurebyte.storage import Storage
 
@@ -47,6 +49,7 @@ class ManagedViewService(
         catalog_id: Optional[ObjectId],
         catalog_service: CatalogService,
         feature_store_service: FeatureStoreService,
+        feature_store_warehouse_service: FeatureStoreWarehouseService,
         session_manager_service: SessionManagerService,
         block_modification_handler: BlockModificationHandler,
         storage: Storage,
@@ -62,6 +65,7 @@ class ManagedViewService(
         )
         self.catalog_service = catalog_service
         self.feature_store_service = feature_store_service
+        self.feature_store_warehouse_service = feature_store_warehouse_service
         self.session_manager_service = session_manager_service
 
     async def construct_get_query_filter(
@@ -129,6 +133,18 @@ class ManagedViewService(
             select_expr=sql_to_string(select_expr, source_type=session.source_type),
             kind="VIEW",
         )
+
+        # populate columns info of the created view
+        source_info = feature_store.get_source_info()
+        table_details = data.tabular_source.table_details
+        column_specs = await self.feature_store_warehouse_service.list_columns(
+            feature_store=feature_store,
+            database_name=table_details.database_name or source_info.database_name,
+            schema_name=table_details.schema_name or source_info.schema_name,
+            table_name=table_details.table_name,
+        )
+        columns_info = [ColumnInfo(**dict(col)) for col in column_specs]
+        data.columns_info = columns_info
 
         return await super().create_document(data=data)
 

--- a/tests/fixtures/request_payloads/dimension_table.json
+++ b/tests/fixtures/request_payloads/dimension_table.json
@@ -81,6 +81,7 @@
     ],
     "description": "test dimension table",
     "dimension_id_column": "col_int",
+    "managed_view_id": null,
     "name": "sf_dimension_table",
     "record_creation_timestamp_column": "created_at",
     "tabular_source": {

--- a/tests/fixtures/request_payloads/event_table.json
+++ b/tests/fixtures/request_payloads/event_table.json
@@ -91,6 +91,7 @@
     "event_timestamp_schema": null,
     "event_timestamp_timezone_offset": null,
     "event_timestamp_timezone_offset_column": null,
+    "managed_view_id": null,
     "name": "sf_event_table",
     "record_creation_timestamp_column": "created_at",
     "tabular_source": {

--- a/tests/fixtures/request_payloads/item_table.json
+++ b/tests/fixtures/request_payloads/item_table.json
@@ -59,6 +59,7 @@
     "event_id_column": "event_id_col",
     "event_table_id": "6337f9651050ee7d5980660d",
     "item_id_column": "item_id_col",
+    "managed_view_id": null,
     "name": "sf_item_table",
     "record_creation_timestamp_column": null,
     "tabular_source": {

--- a/tests/fixtures/request_payloads/managed_view.json
+++ b/tests/fixtures/request_payloads/managed_view.json
@@ -5,17 +5,6 @@
         "Run `pytest --update-fixtures` to update it."
     ],
     "_id": "646f6c190ed28a5271fb02e9",
-    "columns_info": [
-        {
-            "critical_data_info": null,
-            "description": null,
-            "dtype": "FLOAT",
-            "dtype_metadata": null,
-            "entity_id": null,
-            "name": "col1",
-            "semantic_id": null
-        }
-    ],
     "description": "This is a managed view",
     "feature_store_id": "646f6c190ed28a5271fb02a1",
     "is_global": false,

--- a/tests/fixtures/request_payloads/scd_table.json
+++ b/tests/fixtures/request_payloads/scd_table.json
@@ -102,6 +102,7 @@
     "effective_timestamp_schema": null,
     "end_timestamp_column": "end_timestamp",
     "end_timestamp_schema": null,
+    "managed_view_id": null,
     "name": "sf_scd_table",
     "natural_key_column": "col_text",
     "record_creation_timestamp_column": null,

--- a/tests/fixtures/request_payloads/time_series_table.json
+++ b/tests/fixtures/request_payloads/time_series_table.json
@@ -76,6 +76,7 @@
     ],
     "default_feature_job_setting": null,
     "description": "test time series table",
+    "managed_view_id": null,
     "name": "sf_time_series_table",
     "record_creation_timestamp_column": "created_at",
     "reference_datetime_column": "date",

--- a/tests/unit/api/test_event_table.py
+++ b/tests/unit/api/test_event_table.py
@@ -977,6 +977,7 @@ def test_default_feature_job_setting_history(saved_event_table):
         "event_timestamp_schema",
         "block_modification_by",
         "is_deleted",
+        "managed_view_id",
         "validation",
     }
 

--- a/tests/unit/api/test_time_series_table.py
+++ b/tests/unit/api/test_time_series_table.py
@@ -976,6 +976,7 @@ def test_default_feature_job_setting_history(saved_time_series_table):
         "catalog_id",
         "block_modification_by",
         "is_deleted",
+        "managed_view_id",
         "validation",
         "reference_datetime_schema.is_utc_time",
         "reference_datetime_schema.format_string",

--- a/tests/unit/models/test_dimension_table.py
+++ b/tests/unit/models/test_dimension_table.py
@@ -94,6 +94,7 @@ def get_base_expected_dimension_table_model(dimension_table_model, dimension_col
         "block_modification_by": [],
         "description": None,
         "is_deleted": False,
+        "managed_view_id": None,
         "validation": None,
     }
 

--- a/tests/unit/models/test_event_table.py
+++ b/tests/unit/models/test_event_table.py
@@ -110,6 +110,7 @@ def test_event_table_model(snowflake_feature_store, feature_job_setting):
         "block_modification_by": [],
         "description": None,
         "is_deleted": False,
+        "managed_view_id": None,
         "validation": None,
     }
     assert event_table.model_dump() == expected_event_table_dict

--- a/tests/unit/models/test_scd_table.py
+++ b/tests/unit/models/test_scd_table.py
@@ -139,6 +139,7 @@ def get_base_expected_scd_table_model(scd_table_model, scd_columns_info):
         "block_modification_by": [],
         "description": None,
         "is_deleted": False,
+        "managed_view_id": None,
         "validation": None,
         "effective_timestamp_schema": None,
         "end_timestamp_schema": None,

--- a/tests/unit/models/test_time_series_table.py
+++ b/tests/unit/models/test_time_series_table.py
@@ -127,6 +127,7 @@ def test_time_series_table_model(snowflake_feature_store, feature_job_setting):
         "block_modification_by": [],
         "description": None,
         "is_deleted": False,
+        "managed_view_id": None,
         "validation": None,
     }
     assert time_series_table.model_dump() == expected_time_series_table_dict

--- a/tests/unit/routes/test_managed_view.py
+++ b/tests/unit/routes/test_managed_view.py
@@ -210,7 +210,7 @@ class TestManagedViewApi(BaseCatalogApiTestSuite):
         response_dict = create_success_response.json()
         view_name = response_dict["tabular_source"]["table_details"]["table_name"]
 
-        assert snowflake_execute_query.call_args[1] == {
+        assert snowflake_execute_query.call_args_list[-2][1] == {
             "query": (
                 f'CREATE VIEW "sf_database"."sf_schema"."{view_name}" AS\n'
                 "SELECT * FROM (SELECT\n  *\nFROM my_table)"
@@ -262,17 +262,7 @@ class TestManagedViewApi(BaseCatalogApiTestSuite):
                     "table_name": "MANAGED_VIEW_646f6c190ed28a5271fb02e9",
                 },
             },
-            "columns_info": [
-                {
-                    "name": "col1",
-                    "dtype": "FLOAT",
-                    "dtype_metadata": None,
-                    "description": None,
-                    "entity_id": None,
-                    "semantic_id": None,
-                    "critical_data_info": None,
-                }
-            ],
+            "columns_info": [],
         }
 
     def test_create_global_managed_view(self, test_api_client_persistent, create_success_response):

--- a/tests/unit/routes/test_managed_view.py
+++ b/tests/unit/routes/test_managed_view.py
@@ -126,7 +126,7 @@ class TestManagedViewApi(BaseCatalogApiTestSuite):
 
         # check delete view used by registered table
         payload = self.load_payload("tests/fixtures/request_payloads/event_table.json")
-        payload["tabular_source"] = response_dict["tabular_source"]
+        payload["managed_view_id"] = response_dict["_id"]
         response = test_api_client.post("/event_table", json=payload)
         assert response.status_code == HTTPStatus.CREATED
 


### PR DESCRIPTION
## Description

Populate managed views column info in service since it will not be available before the view is created

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
