### PR TITLE
[DEV-4080] Add catalog setting to disable populating offline feature tables

### DIFF
--- a/featurebyte/models/catalog.py
+++ b/featurebyte/models/catalog.py
@@ -56,6 +56,10 @@ class CatalogModel(FeatureByteBaseDocumentModel):
         default=None,
         description="Online store ID that is associated with the catalog.",
     )
+    populate_offline_feature_tables: Optional[bool] = Field(
+        default=False,
+        description="Whether to populate offline feature tables when there is no associated online store.",
+    )
 
     # pydantic validators
     _sort_ids_validator = field_validator("default_feature_store_ids")(construct_sort_validator())

--- a/featurebyte/schema/catalog.py
+++ b/featurebyte/schema/catalog.py
@@ -53,6 +53,7 @@ class CatalogOnlineStoreUpdate(BaseDocumentServiceUpdateSchema):
     """
 
     online_store_id: Optional[PydanticObjectId] = Field(default=None)
+    populate_offline_feature_tables: Optional[bool] = Field(default=None)
 
 
 class CatalogServiceUpdate(BaseDocumentServiceUpdateSchema):

--- a/featurebyte/schema/worker/task/online_store_initialize.py
+++ b/featurebyte/schema/worker/task/online_store_initialize.py
@@ -24,3 +24,4 @@ class CatalogOnlineStoreInitializeTaskPayload(BaseTaskPayload):
     # instance variables
     task_type: TaskType = Field(default=TaskType.CPU_TASK)
     online_store_id: Optional[PydanticObjectId]
+    populate_offline_feature_tables: Optional[bool] = Field(default=None)

--- a/featurebyte/service/catalog.py
+++ b/featurebyte/service/catalog.py
@@ -85,7 +85,10 @@ class CatalogService(BaseDocumentService[CatalogModel, CatalogCreate, CatalogSer
         # or populate_offline_feature_tables is being set or unset)
         if data.online_store_id != document.online_store_id:
             return payload
-        if data.populate_offline_feature_tables != document.populate_offline_feature_tables:
+        if (
+            data.populate_offline_feature_tables is not None
+            and data.populate_offline_feature_tables != document.populate_offline_feature_tables
+        ):
             return payload
         return None
 

--- a/featurebyte/service/offline_store_feature_table.py
+++ b/featurebyte/service/offline_store_feature_table.py
@@ -332,6 +332,20 @@ class OfflineStoreFeatureTableService(
         ):
             yield doc
 
+    async def list_source_feature_tables(self) -> AsyncIterator[OfflineStoreFeatureTableModel]:
+        """
+        Retrieve list of source feature tables in the catalog
+
+        Yields
+        -------
+        AsyncIterator[OfflineStoreFeatureTableModel]
+            List query output
+        """
+        async for doc in self.list_documents_iterator(
+            query_filter={"precomputed_lookup_feature_table_info": {"$eq": None}}
+        ):
+            yield doc
+
     async def list_precomputed_lookup_feature_tables_from_source(
         self,
         source_feature_table_id: ObjectId,

--- a/tests/fixtures/feature_materialize/initialize_features_no_entity_databricks_unity.sql
+++ b/tests/fixtures/feature_materialize/initialize_features_no_entity_databricks_unity.sql
@@ -10,7 +10,8 @@ TBLPROPERTIES (
   'delta.minWriterVersion'='5'
 ) AS
 SELECT
-  1 AS `dummy_entity`;
+  1 AS `dummy_entity`
+LIMIT 0;
 
 CREATE OR REPLACE TABLE `sf_db`.`sf_schema`.`TEMP_REQUEST_TABLE_000000000000000000000000`
 USING DELTA

--- a/tests/integration/feature_store_integration/test_update_online_store.py
+++ b/tests/integration/feature_store_integration/test_update_online_store.py
@@ -98,7 +98,9 @@ async def test_catalog_update_online_store(
     Ordered to run later than other feature store integration test to reduce coupling.
     """
     # Enable online store after deployment is made
-    catalog.update_online_store(online_store.name)
+    with patch("featurebyte.service.feature_materialize.datetime", autospec=True) as mock_datetime:
+        mock_datetime.utcnow.return_value = datetime(2001, 1, 2, 12)
+        catalog.update_online_store(online_store.name)
 
     # Check get_online_features() produces correct result
     client = config.get_client()

--- a/tests/unit/api/test_catalog.py
+++ b/tests/unit/api/test_catalog.py
@@ -525,6 +525,7 @@ def test_catalog_update_name(new_catalog, user_id):
             ("INSERT", 'insert: "grocery"', "is_deleted", np.nan, False),
             ("INSERT", 'insert: "grocery"', "name", np.nan, "grocery"),
             ("INSERT", 'insert: "grocery"', "online_store_id", np.nan, None),
+            ("INSERT", 'insert: "grocery"', "populate_offline_feature_tables", np.nan, False),
             ("INSERT", 'insert: "grocery"', "updated_at", np.nan, None),
             ("INSERT", 'insert: "grocery"', "user_id", np.nan, str(user_id)),
         ],

--- a/tests/unit/service/conftest.py
+++ b/tests/unit/service/conftest.py
@@ -1091,6 +1091,14 @@ def is_online_store_registered_for_catalog_fixture():
     return True
 
 
+@pytest.fixture(name="populate_offline_feature_tables_for_catalog")
+def populate_offline_feature_tables_for_catalog_fixture():
+    """
+    Fixture to determine if offline feature tables should be populated for catalog
+    """
+    return True
+
+
 @pytest_asyncio.fixture(name="deployed_feature_list_requiring_parent_serving")
 async def deployed_feature_list_requiring_parent_serving_fixture(
     app_container,
@@ -1179,6 +1187,9 @@ async def deployed_feature_list_requiring_parent_serving_ttl_fixture(
     fl_requiring_parent_serving_deployment_id,
     mock_offline_store_feature_manager_dependencies,
     mock_update_data_warehouse,
+    is_online_store_registered_for_catalog,
+    populate_offline_feature_tables_for_catalog,
+    online_store,
 ):
     """
     Fixture a deployed feature list that require serving parent features with ttl
@@ -1199,6 +1210,18 @@ async def deployed_feature_list_requiring_parent_serving_ttl_fixture(
     new_feature = float_feature + non_time_based_feature
     new_feature.name = "feature_requiring_parent_serving_ttl"
     new_feature.save()
+
+    if is_online_store_registered_for_catalog:
+        catalog_update = CatalogOnlineStoreUpdate(online_store_id=online_store.id)
+        await app_container.catalog_service.update_document(
+            document_id=app_container.catalog_id, data=catalog_update
+        )
+
+    if populate_offline_feature_tables_for_catalog:
+        catalog_update = CatalogOnlineStoreUpdate(populate_offline_feature_tables=True)
+        await app_container.catalog_service.update_document(
+            document_id=app_container.catalog_id, data=catalog_update
+        )
 
     feature_list = await deploy_feature_ids(
         app_container,
@@ -1239,6 +1262,7 @@ async def deployed_feature_list_requiring_parent_serving_composite_entity_fixtur
     mock_offline_store_feature_manager_dependencies,
     mock_update_data_warehouse,
     is_online_store_registered_for_catalog,
+    populate_offline_feature_tables_for_catalog,
     online_store,
 ):
     """
@@ -1264,6 +1288,12 @@ async def deployed_feature_list_requiring_parent_serving_composite_entity_fixtur
 
     if is_online_store_registered_for_catalog:
         catalog_update = CatalogOnlineStoreUpdate(online_store_id=online_store.id)
+        await app_container.catalog_service.update_document(
+            document_id=app_container.catalog_id, data=catalog_update
+        )
+
+    if populate_offline_feature_tables_for_catalog:
+        catalog_update = CatalogOnlineStoreUpdate(populate_offline_feature_tables=True)
         await app_container.catalog_service.update_document(
             document_id=app_container.catalog_id, data=catalog_update
         )


### PR DESCRIPTION
## Description

This adds a catalog setting `populate_offline_feature_tables` to determine whether to populate offline feature tables in deployments when there is no associated online store.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
