### PR TITLE
[chore] Fix last_updated_by_scheduled_task_at for grouped tile queries

### DIFF
--- a/featurebyte/service/feature.py
+++ b/featurebyte/service/feature.py
@@ -352,20 +352,20 @@ class FeatureService(BaseFeatureService[FeatureModel, FeatureServiceCreate]):
         )
 
     async def update_last_updated_by_scheduled_task_at(
-        self, aggregation_id: str, last_updated_by_scheduled_task_at: datetime
+        self, aggregation_ids: list[str], last_updated_by_scheduled_task_at: datetime
     ) -> None:
         """
-        Update last updated date for features with the given aggregation id
+        Update last updated date for features with the given aggregation ids
 
         Parameters
         ----------
-        aggregation_id: str
-            aggregation id
+        aggregation_ids: list[str]
+            aggregation ids to filter features
         last_updated_by_scheduled_task_at: datetime
             last updated date
         """
         await self.update_documents(
-            query_filter={"aggregation_ids": aggregation_id},
+            query_filter={"aggregation_ids": {"$in": aggregation_ids}},
             update={
                 "$set": {"last_updated_by_scheduled_task_at": last_updated_by_scheduled_task_at}
             },

--- a/featurebyte/service/feature_manager.py
+++ b/featurebyte/service/feature_manager.py
@@ -347,6 +347,10 @@ class FeatureManagerService:
                 document_id=deployed_tile_table.id,
                 backfill_start_date=start_ts,
             )
+        await self.feature_service.update_last_updated_by_scheduled_task_at(
+            aggregation_ids=deployed_tile_table.aggregation_ids,
+            last_updated_by_scheduled_task_at=datetime.utcnow(),
+        )
 
     async def online_disable(self, session: Optional[BaseSession], feature: FeatureModel) -> None:
         """

--- a/featurebyte/service/tile/tile_task_executor.py
+++ b/featurebyte/service/tile/tile_task_executor.py
@@ -180,10 +180,12 @@ class TileTaskExecutor:
         # Use deployed tile table as the tile table name if it is provided. Not strictly needed as
         # the tile_id of the params should have been set to the same value.
         if params.deployed_tile_table_id is not None:
-            tile_table_name = (
-                await self.deployed_tile_table_service.get_document(params.deployed_tile_table_id)
-            ).table_name
+            deployed_tile_table_model = await self.deployed_tile_table_service.get_document(
+                params.deployed_tile_table_id
+            )
+            tile_table_name = deployed_tile_table_model.table_name
         else:
+            deployed_tile_table_model = None
             tile_table_name = tile_id
 
         tile_generate_ins = TileGenerate(
@@ -244,8 +246,12 @@ class TileTaskExecutor:
             await _add_log_entry(success_code, "", duration=duration)
 
         logger.debug("Start updating feature last updated date")
+        if deployed_tile_table_model is None:
+            aggregation_ids = [params.aggregation_id]
+        else:
+            aggregation_ids = deployed_tile_table_model.aggregation_ids
         await self.feature_service.update_last_updated_by_scheduled_task_at(
-            aggregation_id=params.aggregation_id,
+            aggregation_ids=aggregation_ids,
             last_updated_by_scheduled_task_at=datetime.utcnow(),
         )
         await self.system_metrics_service.create_metrics(

--- a/tests/unit/service/test_feature.py
+++ b/tests/unit/service/test_feature.py
@@ -196,7 +196,7 @@ async def test_update_last_updated_date(feature_service, feature):
     last_updated_date = datetime.utcnow()
     aggregation_ids = updated_feature.aggregation_ids
     await feature_service.update_last_updated_by_scheduled_task_at(
-        aggregation_id=aggregation_ids[0], last_updated_by_scheduled_task_at=last_updated_date
+        aggregation_ids=[aggregation_ids[0]], last_updated_by_scheduled_task_at=last_updated_date
     )
 
     new_updated_feature = await feature_service.get_document(document_id=feature.id)


### PR DESCRIPTION
## Description

Changes:

* Fix `last_updated_by_scheduled_task_at` for grouped tile queries in scheduled tile task
* Update `last_updated_by_scheduled_task_at` when enabling deployment

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
