### PR TITLE
fix: Validate date format string on more rows during table validation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -453,7 +453,7 @@ jobs:
     needs:
       - build-jar
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/featurebyte/service/base_table_validation.py
+++ b/featurebyte/service/base_table_validation.py
@@ -4,6 +4,7 @@ BaseTableValidationService class
 
 from __future__ import annotations
 
+import os
 from typing import Generic
 
 from bson import ObjectId
@@ -38,6 +39,10 @@ from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.service.mixin import Document
 from featurebyte.service.session_manager import SessionManagerService
 from featurebyte.session.base import BaseSession
+
+FORMAT_STRING_VALIDATION_NUM_RECORDS = int(
+    os.getenv("FEATUREBYTE_FORMAT_STRING_VALIDATION_NUM_RECORDS", "50000")
+)
 
 
 class BaseTableValidationService(Generic[Document, DocumentCreate, DocumentUpdate]):
@@ -130,7 +135,6 @@ class BaseTableValidationService(Generic[Document, DocumentCreate, DocumentUpdat
         timestamp_schema: TimestampSchema,
         session: BaseSession,
         table_model: TableModel,
-        num_records: int,
     ) -> None:
         adapter = session.adapter
         assert timestamp_schema.format_string is not None
@@ -138,7 +142,7 @@ class BaseTableValidationService(Generic[Document, DocumentCreate, DocumentUpdat
         source_table_expr = get_fully_qualified_table_name(
             table_model.tabular_source.table_details.model_dump()
         )
-        query_expr = (
+        converted_expr = (
             select(
                 expressions.alias_(
                     adapter.to_timestamp_from_string(
@@ -151,8 +155,13 @@ class BaseTableValidationService(Generic[Document, DocumentCreate, DocumentUpdat
             )
             .from_(source_table_expr)
             .where(columns_not_null([column_name]))
-            .limit(num_records)
+            .limit(FORMAT_STRING_VALIDATION_NUM_RECORDS)
         )
+        query_expr = select(
+            expressions.alias_(
+                expressions.Max(this=quoted_identifier(column_name)), alias="RESULT", quoted=True
+            )
+        ).from_(converted_expr.subquery())
         query = sql_to_string(query_expr, source_type=adapter.source_type)
         # check that the format string is valid for the first num_records
         try:
@@ -174,12 +183,19 @@ class BaseTableValidationService(Generic[Document, DocumentCreate, DocumentUpdat
                     timestamp_schema.format_string,
                 ),
             )
-            query_expr = (
+            converted_expr = (
                 select(column_expr)
                 .from_(source_table_expr)
                 .where(columns_not_null([column_name]))
-                .limit(num_records)
+                .limit(FORMAT_STRING_VALIDATION_NUM_RECORDS)
             )
+            query_expr = select(
+                expressions.alias_(
+                    expressions.Max(this=quoted_identifier(column_name)),
+                    alias="RESULT",
+                    quoted=True,
+                )
+            ).from_(converted_expr.subquery())
             query = sql_to_string(query_expr, source_type=adapter.source_type)
             # check that the offset is valid for the first num_records
             try:
@@ -221,7 +237,6 @@ class BaseTableValidationService(Generic[Document, DocumentCreate, DocumentUpdat
                     timestamp_schema=col_info.dtype_metadata.timestamp_schema,
                     session=session,
                     table_model=table_model,
-                    num_records=num_records,
                 )
 
             if col_info.critical_data_info:
@@ -233,7 +248,6 @@ class BaseTableValidationService(Generic[Document, DocumentCreate, DocumentUpdat
                             timestamp_schema=clean_op.timestamp_schema,
                             session=session,
                             table_model=table_model,
-                            num_records=num_records,
                         )
 
         await self._validate_table(

--- a/tests/fixtures/time_series_table_validation_service/validate_and_update.sql
+++ b/tests/fixtures/time_series_table_validation_service/validate_and_update.sql
@@ -1,9 +1,13 @@
 SELECT
-  TO_TIMESTAMP("snapshot_date", '%Y-%m-%d') AS "snapshot_date"
-FROM "my_db"."my_schema"."my_table"
-WHERE
-  "snapshot_date" IS NOT NULL
-LIMIT 10;
+  MAX("snapshot_date") AS "RESULT"
+FROM (
+  SELECT
+    TO_TIMESTAMP("snapshot_date", '%Y-%m-%d') AS "snapshot_date"
+  FROM "my_db"."my_schema"."my_table"
+  WHERE
+    "snapshot_date" IS NOT NULL
+  LIMIT 50000
+);
 
 SELECT
   COUNT(DISTINCT "snapshot_date") AS "snapshot_date"


### PR DESCRIPTION
## Description

This updates date format string validation during table validation to use more rows (previously only 10).

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
