### PR TITLE
fix: DatabricksUnitySession _list_schemas fallback infinite recursion

### DIFF
--- a/featurebyte/session/databricks_unity.py
+++ b/featurebyte/session/databricks_unity.py
@@ -126,7 +126,7 @@ class DatabricksUnitySession(DatabricksSession):
             )
         except self._no_schema_error:
             # fallback to using show statements if catalog does not have information schema
-            return await super().list_schemas(database_name=database_name)
+            return await super()._list_schemas(database_name=database_name)
         output = []
         if schemas is not None:
             output.extend(schemas["SCHEMA_NAME"].tolist())


### PR DESCRIPTION
## Description

Since none of `DatabricksSession` nor `BaseSparkSession` implements `list_schemas()`, the fallback `list_schema` call triggers the same method and leads to infinite recursion.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
