### PR TITLE
[DEV-4083] perf: Skip timestamp filtering in entity table when conversion is required

### DIFF
--- a/tests/fixtures/expected_tile_sql_on_demand_event_timestamp_schema.sql
+++ b/tests/fixtures/expected_tile_sql_on_demand_event_timestamp_schema.sql
@@ -1,0 +1,36 @@
+WITH __FB_ENTITY_TABLE_NAME AS (
+  __FB_ENTITY_TABLE_SQL_PLACEHOLDER
+), __FB_TILE_COMPUTE_INPUT_TABLE_NAME AS (
+  SELECT
+    R.*
+  FROM __FB_ENTITY_TABLE_NAME
+  INNER JOIN (
+    SELECT
+      "event_timestamp" AS "event_timestamp",
+      "cust_id" AS "cust_id",
+      "col_int" AS "input_col_sum_fefdc3e84902d2f76f04cc746b8bba9256212347"
+    FROM "sf_database"."sf_schema"."sf_table_no_tz"
+  ) AS R
+    ON R."cust_id" = __FB_ENTITY_TABLE_NAME."cust_id"
+)
+SELECT
+  index,
+  "cust_id",
+  SUM("input_col_sum_fefdc3e84902d2f76f04cc746b8bba9256212347") AS value_sum_fefdc3e84902d2f76f04cc746b8bba9256212347
+FROM (
+  SELECT
+    *,
+    F_TIMESTAMP_TO_INDEX(
+      CAST(CONVERT_TIMEZONE(
+        'UTC',
+        TO_TIMESTAMP_TZ(CONCAT(TO_CHAR("event_timestamp", 'YYYY-MM-DD HH24:MI:SS'), ' ', "tz_offset"))
+      ) AS TIMESTAMP),
+      300,
+      600,
+      30
+    ) AS index
+  FROM __FB_TILE_COMPUTE_INPUT_TABLE_NAME
+)
+GROUP BY
+  index,
+  "cust_id"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2212,6 +2212,28 @@ def non_time_based_feature_with_event_timestamp_schema(
     return feature
 
 
+@pytest.fixture(name="float_feature_with_event_timestamp_schema")
+def float_feature_with_event_timestamp_schema_fixture(
+    snowflake_event_table_with_timestamp_schema, cust_id_entity, feature_group_feature_job_setting
+):
+    """
+    Get a non-time-based feature with event timestamp schema
+    """
+    snowflake_event_table_with_timestamp_schema.cust_id.as_entity(cust_id_entity.name)
+    event_view = snowflake_event_table_with_timestamp_schema.get_view()
+    feature = event_view.groupby("cust_id").aggregate_over(
+        value_column="col_int",
+        method="sum",
+        windows=["30m"],
+        feature_job_setting=feature_group_feature_job_setting,
+        feature_names=["sum_30m"],
+    )["sum_30m"]
+    feature = feature.astype(float)
+    feature.name = "sum_30m"
+    feature.save()
+    return feature
+
+
 @pytest.fixture(name="float_feature")
 def float_feature_fixture(feature_group):
     """


### PR DESCRIPTION
## Description

Filtering by timestamp when the conditions require conversion such as timestamp parsing can be expensive. This updates the filtering to exclude timestamp from filtering conditions in such cases. This affects historical features computation for tile based features.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
