### PR TITLE
[chore] Refactor PydanticObjectId to fix openapi specs schema

### DIFF
--- a/featurebyte/routes/base_materialized_table_router.py
+++ b/featurebyte/routes/base_materialized_table_router.py
@@ -6,9 +6,9 @@ from typing import Generic, Type, TypeVar
 
 from fastapi import APIRouter, Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.materialized_table import MaterializedTableModel
 from featurebyte.routes.base_router import BaseRouter
-from featurebyte.routes.common.schema import PyObjectId
 
 MaterializedTableModelT = TypeVar("MaterializedTableModelT", bound=MaterializedTableModel)
 

--- a/featurebyte/routes/base_router.py
+++ b/featurebyte/routes/base_router.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Request
 from fastapi.routing import APIRoute
 from starlette.routing import BaseRoute
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.common.base import BaseDocumentController
@@ -18,7 +19,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/batch_feature_table/api.py
+++ b/featurebyte/routes/batch_feature_table/api.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional, cast
 from fastapi import APIRouter, Query, Request
 from starlette.responses import StreamingResponse
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.batch_feature_table import BatchFeatureTableModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -21,7 +22,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/batch_request_table/api.py
+++ b/featurebyte/routes/batch_request_table/api.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional, cast
 from fastapi import APIRouter, Query, Request
 from starlette.responses import StreamingResponse
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.batch_request_table import BatchRequestTableModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -21,7 +22,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/catalog/api.py
+++ b/featurebyte/routes/catalog/api.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 from bson import ObjectId
 from fastapi import Query, Request, Response
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.catalog import CatalogModel, CatalogNameHistoryEntry
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -19,7 +20,6 @@ from featurebyte.routes.common.schema import (
     AuditLogSortByQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortDirQuery,
     VerboseQuery,

--- a/featurebyte/routes/common/schema.py
+++ b/featurebyte/routes/common/schema.py
@@ -2,11 +2,7 @@
 Common classes mixin for API payload schema
 """
 
-from typing import Any
-
-from bson import ObjectId
 from fastapi import Query
-from pydantic_core import core_schema
 
 # route query parameters
 COLUMN_STR_MAX_LENGTH = 255
@@ -32,44 +28,3 @@ AuditLogSortByQuery = Query(
     default="_id", min_length=COLUMN_STR_MIN_LENGTH, max_length=COLUMN_STR_MAX_LENGTH
 )
 VerboseQuery = Query(default=False)
-
-
-class PyObjectId(str):
-    """
-    Pydantic ObjectId type for API route path parameter
-    """
-
-    @classmethod
-    def __get_pydantic_core_schema__(
-        cls, _source_type: Any, _handler: Any
-    ) -> core_schema.CoreSchema:
-        return core_schema.json_or_python_schema(
-            json_schema=core_schema.str_schema(),
-            python_schema=core_schema.union_schema([
-                core_schema.is_instance_schema(ObjectId),
-                core_schema.chain_schema([
-                    core_schema.str_schema(),
-                    core_schema.no_info_plain_validator_function(cls.validate),
-                ]),
-            ]),
-            serialization=core_schema.plain_serializer_function_ser_schema(str),
-        )
-
-    @classmethod
-    def validate(cls, value: Any) -> ObjectId:
-        """
-        Validate ObjectId
-
-        Parameters
-        ----------
-        value: Any
-            value to validate
-
-        Returns
-        -------
-        ObjectId
-            ObjectId value
-        """
-        if not ObjectId.is_valid(value):
-            raise ValueError("Invalid ObjectId")
-        return ObjectId(value)

--- a/featurebyte/routes/context/api.py
+++ b/featurebyte/routes/context/api.py
@@ -10,6 +10,7 @@ from typing import Optional
 from bson import ObjectId
 from fastapi import Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.context import ContextModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -18,7 +19,6 @@ from featurebyte.routes.common.schema import (
     AuditLogSortByQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortDirQuery,
 )

--- a/featurebyte/routes/credential/api.py
+++ b/featurebyte/routes/credential/api.py
@@ -10,6 +10,7 @@ from typing import Optional
 from bson import ObjectId
 from fastapi import Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseApiRouter
@@ -18,7 +19,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/credential/controller.py
+++ b/featurebyte/routes/credential/controller.py
@@ -9,9 +9,9 @@ from fastapi import Request
 
 from featurebyte.exception import DocumentDeletionError
 from featurebyte.models import FeatureStoreModel
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.credential import CredentialModel
 from featurebyte.routes.common.base import BaseDocumentController
-from featurebyte.routes.common.schema import PyObjectId
 from featurebyte.schema.credential import (
     CredentialCreate,
     CredentialList,

--- a/featurebyte/routes/deployment/api.py
+++ b/featurebyte/routes/deployment/api.py
@@ -9,6 +9,7 @@ from bson import ObjectId
 from fastapi import APIRouter, Query, Request, Response
 from fastapi.responses import ORJSONResponse
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.deployment import DeploymentModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -18,7 +19,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/dimension_table/api.py
+++ b/featurebyte/routes/dimension_table/api.py
@@ -10,6 +10,7 @@ from typing import Optional
 from bson import ObjectId
 from fastapi import APIRouter, Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.dimension_table import DimensionTableModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -18,7 +19,6 @@ from featurebyte.routes.common.schema import (
     AuditLogSortByQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortDirQuery,
     VerboseQuery,

--- a/featurebyte/routes/entity/api.py
+++ b/featurebyte/routes/entity/api.py
@@ -9,6 +9,7 @@ from typing import List, Optional, cast
 
 from fastapi import APIRouter, Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.entity import EntityModel, EntityNameHistoryEntry
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -18,7 +19,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/event_table/api.py
+++ b/featurebyte/routes/event_table/api.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 from bson import ObjectId
 from fastapi import APIRouter, Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.event_table import EventTableModel, FeatureJobSettingHistoryEntry
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -18,7 +19,6 @@ from featurebyte.routes.common.schema import (
     AuditLogSortByQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortDirQuery,
     VerboseQuery,

--- a/featurebyte/routes/feature/api.py
+++ b/featurebyte/routes/feature/api.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Optional, Union, cast
 
 from fastapi import APIRouter, Query, Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseRouter
@@ -17,7 +18,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/feature_job_setting_analysis/api.py
+++ b/featurebyte/routes/feature_job_setting_analysis/api.py
@@ -10,6 +10,7 @@ from typing import Optional, cast
 from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.feature_job_setting_analysis import FeatureJobSettingAnalysisModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -19,7 +20,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/feature_list/api.py
+++ b/featurebyte/routes/feature_list/api.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional, Union, cast
 
 from fastapi import APIRouter, File, Form, Query, Request, Response, UploadFile
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseRouter
@@ -18,7 +19,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/feature_list_namespace/api.py
+++ b/featurebyte/routes/feature_list_namespace/api.py
@@ -8,6 +8,7 @@ from typing import Optional, cast
 
 from fastapi import APIRouter, Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseRouter
@@ -16,7 +17,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/feature_namespace/api.py
+++ b/featurebyte/routes/feature_namespace/api.py
@@ -8,6 +8,7 @@ from typing import Optional, cast
 
 from fastapi import APIRouter, Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseRouter
@@ -16,7 +17,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/feature_store/api.py
+++ b/featurebyte/routes/feature_store/api.py
@@ -12,6 +12,7 @@ from fastapi import Query, Request
 
 from featurebyte.common import DEFAULT_CATALOG_ID
 from featurebyte.exception import DocumentNotFoundError
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -26,7 +27,6 @@ from featurebyte.routes.common.schema import (
     AuditLogSortByQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortDirQuery,
     VerboseQuery,

--- a/featurebyte/routes/historical_feature_table/api.py
+++ b/featurebyte/routes/historical_feature_table/api.py
@@ -12,6 +12,7 @@ from bson import ObjectId
 from fastapi import APIRouter, Form, Query, Request, UploadFile
 from starlette.responses import StreamingResponse
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.historical_feature_table import HistoricalFeatureTableModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -23,7 +24,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/item_table/api.py
+++ b/featurebyte/routes/item_table/api.py
@@ -10,6 +10,7 @@ from typing import Optional
 from bson import ObjectId
 from fastapi import APIRouter, Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.item_table import ItemTableModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -18,7 +19,6 @@ from featurebyte.routes.common.schema import (
     AuditLogSortByQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortDirQuery,
     VerboseQuery,

--- a/featurebyte/routes/managed_view/api.py
+++ b/featurebyte/routes/managed_view/api.py
@@ -9,6 +9,7 @@ from typing import Optional, cast
 from bson import ObjectId
 from fastapi import Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseApiRouter
@@ -17,7 +18,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/managed_view/controller.py
+++ b/featurebyte/routes/managed_view/controller.py
@@ -10,13 +10,13 @@ from bson import ObjectId
 
 from featurebyte.enum import ViewNamePrefix
 from featurebyte.logging import get_logger
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.managed_view import ManagedViewModel
 from featurebyte.models.persistent import QueryFilter
 from featurebyte.persistent.base import SortDir
 from featurebyte.query_graph.model.common_table import TabularSource
 from featurebyte.query_graph.node.schema import TableDetails
 from featurebyte.routes.common.base import BaseDocumentController
-from featurebyte.routes.common.schema import PyObjectId
 from featurebyte.schema.managed_view import (
     ManagedViewCreate,
     ManagedViewInfo,

--- a/featurebyte/routes/observation_table/api.py
+++ b/featurebyte/routes/observation_table/api.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Optional, cast
 from fastapi import APIRouter, Form, Query, Request, UploadFile
 from starlette.responses import StreamingResponse
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.observation_table import ObservationTableModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -22,7 +23,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/online_store/api.py
+++ b/featurebyte/routes/online_store/api.py
@@ -9,6 +9,7 @@ from typing import Optional, cast
 from bson import ObjectId
 from fastapi import Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseApiRouter
@@ -16,7 +17,6 @@ from featurebyte.routes.common.schema import (
     AuditLogSortByQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortDirQuery,
     VerboseQuery,

--- a/featurebyte/routes/periodic_tasks/api.py
+++ b/featurebyte/routes/periodic_tasks/api.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.periodic_task import PeriodicTask
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseRouter
@@ -15,7 +16,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/relationship_info/api.py
+++ b/featurebyte/routes/relationship_info/api.py
@@ -9,6 +9,7 @@ from typing import Optional
 from bson import ObjectId
 from fastapi import APIRouter, Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.models.relationship import RelationshipInfoModel
 from featurebyte.persistent.base import SortDir
@@ -18,7 +19,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/scd_table/api.py
+++ b/featurebyte/routes/scd_table/api.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 from bson import ObjectId
 from fastapi import APIRouter, Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.event_table import FeatureJobSettingHistoryEntry
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.models.scd_table import SCDTableModel
@@ -19,7 +20,6 @@ from featurebyte.routes.common.schema import (
     AuditLogSortByQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortDirQuery,
     VerboseQuery,

--- a/featurebyte/routes/semantic/api.py
+++ b/featurebyte/routes/semantic/api.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from fastapi import Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.models.relationship import Parent
 from featurebyte.models.semantic import SemanticModel
@@ -18,7 +19,6 @@ from featurebyte.routes.common.schema import (
     AuditLogSortByQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortDirQuery,
 )

--- a/featurebyte/routes/static_source_table/api.py
+++ b/featurebyte/routes/static_source_table/api.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional, cast
 from fastapi import APIRouter, Query, Request
 from starlette.responses import StreamingResponse
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.models.static_source_table import StaticSourceTableModel
 from featurebyte.persistent.base import SortDir
@@ -21,7 +22,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/system_metrics/api.py
+++ b/featurebyte/routes/system_metrics/api.py
@@ -8,12 +8,12 @@ from typing import Any, Optional
 
 from fastapi import APIRouter, Query, Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseRouter
 from featurebyte.routes.common.schema import (
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SortByQuery,
     SortDirQuery,
 )

--- a/featurebyte/routes/table/api.py
+++ b/featurebyte/routes/table/api.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.proxy_table import TableModel
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseRouter
@@ -15,7 +16,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/target/api.py
+++ b/featurebyte/routes/target/api.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 from bson import ObjectId
 from fastapi import APIRouter, Query, Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.models.target import TargetModel
 from featurebyte.persistent.base import SortDir
@@ -19,7 +20,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/target_namespace/api.py
+++ b/featurebyte/routes/target_namespace/api.py
@@ -9,6 +9,7 @@ from typing import Optional, cast
 
 from fastapi import APIRouter, Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.models.target_namespace import TargetNamespaceModel
 from featurebyte.persistent.base import SortDir
@@ -18,7 +19,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/target_table/api.py
+++ b/featurebyte/routes/target_table/api.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Optional, cast
 from fastapi import Form, Query, Request, UploadFile
 from starlette.responses import StreamingResponse
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.models.target_table import TargetTableModel
 from featurebyte.persistent.base import SortDir
@@ -22,7 +23,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/time_series_table/api.py
+++ b/featurebyte/routes/time_series_table/api.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 from bson import ObjectId
 from fastapi import APIRouter, Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.models.time_series_table import (
     CronFeatureJobSettingHistoryEntry,
@@ -21,7 +22,6 @@ from featurebyte.routes.common.schema import (
     AuditLogSortByQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortDirQuery,
     VerboseQuery,

--- a/featurebyte/routes/use_case/api.py
+++ b/featurebyte/routes/use_case/api.py
@@ -7,6 +7,7 @@ from typing import Optional, cast
 
 from fastapi import APIRouter, Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.models.use_case import UseCaseModel
 from featurebyte.persistent.base import SortDir
@@ -16,7 +17,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/use_case/controller.py
+++ b/featurebyte/routes/use_case/controller.py
@@ -12,11 +12,11 @@ from featurebyte.exception import (
     DocumentUpdateError,
     ObservationTableInvalidUseCaseError,
 )
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.persistent import QueryFilter
 from featurebyte.models.use_case import UseCaseModel
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.common.base import BaseDocumentController
-from featurebyte.routes.common.schema import PyObjectId
 from featurebyte.schema.info import EntityBriefInfo, EntityBriefInfoList, UseCaseInfo
 from featurebyte.schema.observation_table import ObservationTableServiceUpdate
 from featurebyte.schema.use_case import UseCaseCreate, UseCaseList, UseCaseUpdate

--- a/featurebyte/routes/user_defined_function/api.py
+++ b/featurebyte/routes/user_defined_function/api.py
@@ -7,6 +7,7 @@ from typing import Optional, cast
 
 from fastapi import APIRouter, Request
 
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseRouter
@@ -15,7 +16,6 @@ from featurebyte.routes.common.schema import (
     NameQuery,
     PageQuery,
     PageSizeQuery,
-    PyObjectId,
     SearchQuery,
     SortByQuery,
     SortDirQuery,

--- a/featurebyte/routes/user_defined_function/controller.py
+++ b/featurebyte/routes/user_defined_function/controller.py
@@ -9,12 +9,12 @@ from typing import Any, Dict, List, Tuple, cast
 from bson import ObjectId
 
 from featurebyte.exception import DocumentCreationError, DocumentUpdateError
+from featurebyte.models.base import PyObjectId
 from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.models.persistent import QueryFilter
 from featurebyte.models.user_defined_function import UserDefinedFunctionModel
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.common.base import BaseDocumentController
-from featurebyte.routes.common.schema import PyObjectId
 from featurebyte.schema.info import UserDefinedFunctionFeatureInfo, UserDefinedFunctionInfo
 from featurebyte.schema.user_defined_function import (
     UserDefinedFunctionCreate,

--- a/featurebyte/schema/batch_feature_table.py
+++ b/featurebyte/schema/batch_feature_table.py
@@ -87,7 +87,7 @@ class BatchFeatureTableListRecord(BaseMaterializedTableListRecord):
     """
 
     feature_store_id: PydanticObjectId
-    batch_request_table_id: PydanticObjectId
+    batch_request_table_id: Optional[PydanticObjectId]
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/unit/routes/base.py
+++ b/tests/unit/routes/base.py
@@ -1105,7 +1105,7 @@ class BaseTableApiTestSuite(BaseCatalogApiTestSuite):
             {
                 "ctx": {"error": {}},
                 "input": "abc",
-                "loc": ["path", self.id_field_name, "chain[str,function-plain[validate()]]"],
+                "loc": ["path", self.id_field_name, "function-after[validate(), str]"],
                 "msg": "Value error, Invalid ObjectId",
                 "type": "value_error",
             },

--- a/tests/unit/routes/test_catalog.py
+++ b/tests/unit/routes/test_catalog.py
@@ -337,7 +337,7 @@ class TestCatalogApi(BaseApiTestSuite):
             {
                 "ctx": {"error": {}},
                 "input": "abc",
-                "loc": ["path", "catalog_id", "chain[str,function-plain[validate()]]"],
+                "loc": ["path", "catalog_id", "function-after[validate(), str]"],
                 "msg": "Value error, Invalid ObjectId",
                 "type": "value_error",
             },

--- a/tests/unit/routes/test_credential.py
+++ b/tests/unit/routes/test_credential.py
@@ -220,7 +220,7 @@ class TestCredentialApi(BaseApiTestSuite):
             {
                 "ctx": {"error": {}},
                 "input": "abc",
-                "loc": ["path", self.id_field_name, "chain[str,function-plain[validate()]]"],
+                "loc": ["path", self.id_field_name, "function-after[validate(), str]"],
                 "msg": "Value error, Invalid ObjectId",
                 "type": "value_error",
             },

--- a/tests/unit/routes/test_entity.py
+++ b/tests/unit/routes/test_entity.py
@@ -194,7 +194,7 @@ class TestEntityApi(BaseCatalogApiTestSuite):
             {
                 "ctx": {"error": {}},
                 "input": "abc",
-                "loc": ["path", "entity_id", "chain[str,function-plain[validate()]]"],
+                "loc": ["path", "entity_id", "function-after[validate(), str]"],
                 "msg": "Value error, Invalid ObjectId",
                 "type": "value_error",
             },

--- a/tests/unit/routes/test_use_case.py
+++ b/tests/unit/routes/test_use_case.py
@@ -41,8 +41,8 @@ class TestUseCaseApi(BaseCatalogApiTestSuite):
                 {
                     "ctx": {"error": {}},
                     "input": "test_id",
-                    "loc": ["body", "context_id", "function-plain[validate_from_str()]"],
-                    "msg": "Value error, Invalid ObjectId: test_id",
+                    "loc": ["body", "context_id", "chain[str,function-plain[validate()]]"],
+                    "msg": "Value error, Invalid ObjectId",
                     "type": "value_error",
                 },
             ],

--- a/tests/unit/routes/test_use_case.py
+++ b/tests/unit/routes/test_use_case.py
@@ -41,7 +41,7 @@ class TestUseCaseApi(BaseCatalogApiTestSuite):
                 {
                     "ctx": {"error": {}},
                     "input": "test_id",
-                    "loc": ["body", "context_id", "chain[str,function-plain[validate()]]"],
+                    "loc": ["body", "context_id", "function-after[validate(), str]"],
                     "msg": "Value error, Invalid ObjectId",
                     "type": "value_error",
                 },

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -55,10 +55,10 @@ def test_open_api_schema():
     assert "info" in schema
     assert "paths" in schema
     assert "components" in schema
-    assert schema["components"]["schemas"]["FeatureListNamespaceModelResponse"]["properties"][
-        "feature_namespace_ids"
+    assert schema["components"]["schemas"]["CatalogCreate"]["properties"][
+        "default_feature_store_ids"
     ] == {
         "type": "array",
         "items": {"type": "string"},
-        "title": "Feature Namespace Ids",
+        "title": "Default Feature Store Ids",
     }

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -44,3 +44,21 @@ def test_get_status():
     response = Configurations().get_client().get("/status")
     assert response.status_code == HTTPStatus.OK
     assert response.json() == {"sdk_version": get_version()}
+
+
+def test_open_api_schema():
+    """Test app openapi schema"""
+    response = Configurations().get_client().get("/openapi.json")
+    assert response.status_code == HTTPStatus.OK
+    schema = response.json()
+    assert "openapi" in schema
+    assert "info" in schema
+    assert "paths" in schema
+    assert "components" in schema
+    assert schema["components"]["schemas"]["FeatureListNamespaceModelResponse"]["properties"][
+        "feature_namespace_ids"
+    ] == {
+        "type": "array",
+        "items": {"type": "string"},
+        "title": "Feature Namespace Ids",
+    }


### PR DESCRIPTION
## Description

Refactor pydantic id to fix openapi specs schema.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
