### PR TITLE
[chore] Skip deriving deprecated attributes in FeatureModel

### DIFF
--- a/featurebyte/models/feature.py
+++ b/featurebyte/models/feature.py
@@ -44,9 +44,6 @@ from featurebyte.query_graph.node.metadata.operation import GroupOperationStruct
 from featurebyte.query_graph.node.nested import AggregationNodeInfo
 from featurebyte.query_graph.node.request import RequestColumnNode
 from featurebyte.query_graph.sql.interpreter import GraphInterpreter
-from featurebyte.query_graph.sql.online_store_compute_query import (
-    get_online_store_precompute_queries,
-)
 from featurebyte.query_graph.sql.source_info import SourceInfo
 from featurebyte.query_graph.transform.definition import (
     DefinitionHashExtractor,
@@ -554,8 +551,8 @@ class FeatureModel(BaseFeatureModel):
     feature_list_ids: List[PydanticObjectId] = Field(default_factory=list)
     deployed_feature_list_ids: List[PydanticObjectId] = Field(default_factory=list)
     aggregation_ids: List[str] = Field(default_factory=list)
-    aggregation_result_names: List[str] = Field(default_factory=list)
-    online_store_table_names: List[str] = Field(default_factory=list)
+    aggregation_result_names: List[str] = Field(default_factory=list)  # deprecated
+    online_store_table_names: List[str] = Field(default_factory=list)  # deprecated
     agg_result_name_include_serving_names: bool = Field(default=False)  # backward compatibility
     last_updated_by_scheduled_task_at: Optional[datetime] = Field(frozen=True, default=None)
 
@@ -596,17 +593,6 @@ class FeatureModel(BaseFeatureModel):
         # assign to __dict__ to avoid infinite recursion due to model_validator(mode="after") call with
         # validate_assign=True in model_config.
         self.__dict__["aggregation_ids"] = aggregation_ids
-        self.__dict__["aggregation_result_names"] = []
-        online_store_table_names = set()
-        for query in get_online_store_precompute_queries(
-            graph,
-            graph.get_node_by_name(node_name),
-            source_info,
-            self.agg_result_name_include_serving_names,
-        ):
-            self.__dict__["aggregation_result_names"].append(query.result_name)
-            online_store_table_names.add(query.table_name)
-        self.__dict__["online_store_table_names"] = sorted(online_store_table_names)
 
         return self
 

--- a/tests/unit/api/test_deployment.py
+++ b/tests/unit/api/test_deployment.py
@@ -324,12 +324,8 @@ def test_deployment_with_unbounded_window(
     assert feat_latest_model.online_store_table_names == []
 
     # Check latest with window has associated aggregation result names
-    assert feat_latest_combined_model.aggregation_result_names == [
-        "_fb_internal_cust_id_window_w604800_latest_ac7aa941d28f489e56c9ab50a583a8c6c88eebe5"
-    ]
-    assert feat_latest_combined_model.online_store_table_names == [
-        "ONLINE_STORE_377553E5920DD2DB8B17F21DDD52F8B1194A780C"
-    ]
+    assert feat_latest_combined_model.aggregation_result_names == []
+    assert feat_latest_combined_model.online_store_table_names == []
 
     offline_store_info = feat_latest.cached_model.offline_store_info
     assert offline_store_info.metadata.has_ttl is False

--- a/tests/unit/feature_manager/test_unit_snowflake_feature.py
+++ b/tests/unit/feature_manager/test_unit_snowflake_feature.py
@@ -19,6 +19,9 @@ def mock_snowflake_feature_fixture(mock_snowflake_feature):
     """
     mock_snowflake_feature.save()
     feature_model = mock_snowflake_feature.cached_model
+    # This is to test that legacy features which have aggregation_result_names are disabled properly
+    # (in test_online_disable)
+    feature_model.__dict__["aggregation_result_names"] = ["some_result_name"]
     return ExtendedFeatureModel(
         **feature_model.model_dump(exclude={"version": True}, by_alias=True),
         version=get_version(),

--- a/tests/unit/models/test_feature.py
+++ b/tests/unit/models/test_feature.py
@@ -127,15 +127,11 @@ def test_feature_model(feature_model_dict, api_object_to_id):
         "user_defined_function_ids": [],
         "block_modification_by": [],
         "aggregation_ids": ["sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295"],
-        "aggregation_result_names": [
-            "_fb_internal_window_w1800_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295",
-            "_fb_internal_window_w7200_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295",
-            "_fb_internal_window_w86400_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295",
-        ],
+        "aggregation_result_names": [],
         "agg_result_name_include_serving_names": False,
         "description": None,
         "definition_hash": None,
-        "online_store_table_names": ["ONLINE_STORE_377553E5920DD2DB8B17F21DDD52F8B1194A780C"],
+        "online_store_table_names": [],
         "last_updated_by_scheduled_task_at": None,
         "is_deleted": False,
     }

--- a/tests/unit/routes/test_feature.py
+++ b/tests/unit/routes/test_feature.py
@@ -982,18 +982,6 @@ class TestFeatureApi(BaseCatalogApiTestSuite):
         response = test_api_client.get(f"{self.base_route}/{feature_create2.id}")
         assert response.status_code == HTTPStatus.OK
 
-    def test_aggregation_result_names_based_on_pruned_graph(self, create_success_response):
-        """
-        Test that aggregation_result_names are derived based on pruned graph.
-
-        The feature_sum_30m.json fixture's groupby node has unpruned parameters. If the
-        aggregation_result_names is derived from the graph directly without pruning, there will be
-        multiple items in aggregation_result_names which is wrong for this feature.
-        """
-        assert create_success_response.json()["aggregation_result_names"] == [
-            "_fb_internal_cust_id_window_w1800_sum_e8c51d7d1ec78e1f35195fc0cf61221b3f830295"
-        ]
-
     def test_request_sample_entity_serving_names(
         self,
         test_api_client_persistent,


### PR DESCRIPTION
## Description

The attributes `aggregation_result_names` and `online_store_table_names` are related to internal online stores that are deprecated and don't need to be derived for new features.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
