### PR TITLE
[DEV-4100] Update partition column filters to include only primary table

### DIFF
--- a/featurebyte/service/preview.py
+++ b/featurebyte/service/preview.py
@@ -19,10 +19,9 @@ from featurebyte.enum import DBVarType, InternalName
 from featurebyte.exception import DescribeQueryExecutionError
 from featurebyte.logging import get_logger, truncate_query
 from featurebyte.models.feature_store import FeatureStoreModel
-from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.query_graph.model.graph import QueryGraphModel
-from featurebyte.query_graph.node.input import InputNode, InputNodeParameters
+from featurebyte.query_graph.node.input import InputNode
 from featurebyte.query_graph.node.metadata.operation import OperationStructure
 from featurebyte.query_graph.node.schema import TableDetails
 from featurebyte.query_graph.sql.common import (
@@ -955,16 +954,13 @@ class PreviewService:
     ) -> Optional[PartitionColumnFilters]:
         if from_timestamp is None and to_timestamp is None:
             return None
-        node = query_graph.get_node_by_name(node_name)
+        primary_table_node = query_graph.get_sample_table_node(node_name=node_name)
         mapping = {}
-        for input_node in query_graph.iterate_nodes(node, NodeType.INPUT):
-            input_node_parameters = cast(InputNodeParameters, input_node.parameters)
-            table_id = input_node_parameters.id
-            if table_id is not None:
-                mapping[table_id] = PartitionColumnFilter(
-                    from_timestamp=from_timestamp,
-                    to_timestamp=to_timestamp,
-                )
+        if primary_table_node.parameters.id is not None:
+            mapping[primary_table_node.parameters.id] = PartitionColumnFilter(
+                from_timestamp=from_timestamp,
+                to_timestamp=to_timestamp,
+            )
         return PartitionColumnFilters(mapping=mapping)
 
 

--- a/tests/fixtures/preview_service/expected_scd_join_with_partition_column_filters.sql
+++ b/tests/fixtures/preview_service/expected_scd_join_with_partition_column_filters.sql
@@ -1,0 +1,154 @@
+SELECT
+  COUNT(*) AS "count"
+FROM (
+  SELECT
+    CAST("event_partition_col" AS VARCHAR) AS "event_partition_col",
+    "ts" AS "ts",
+    "cust_id" AS "cust_id",
+    "event_id" AS "event_id"
+  FROM "sf_database"."sf_schema"."EVENT"
+  WHERE
+    (
+      "event_partition_col" >= TO_CHAR(CAST('2023-01-01 00:00:00' AS TIMESTAMP), '%Y-%m-%d')
+      AND "event_partition_col" <= TO_CHAR(CAST('2025-01-01 00:00:00' AS TIMESTAMP), '%Y-%m-%d')
+    )
+    AND (
+      "ts" >= CAST('2023-01-01T00:00:00' AS TIMESTAMP)
+      AND "ts" < CAST('2025-01-01T00:00:00' AS TIMESTAMP)
+    )
+);
+
+CREATE TABLE "__FB_TEMPORARY_TABLE_000000000000000000000000" AS
+SELECT
+  "event_partition_col",
+  "ts",
+  "cust_id",
+  "event_id"
+FROM (
+  SELECT
+    CAST(BITAND(RANDOM(1234), 2147483647) AS DOUBLE) / 2147483647.0 AS "prob",
+    "event_partition_col",
+    "ts",
+    "cust_id",
+    "event_id"
+  FROM (
+    SELECT
+      CAST("event_partition_col" AS VARCHAR) AS "event_partition_col",
+      "ts" AS "ts",
+      "cust_id" AS "cust_id",
+      "event_id" AS "event_id"
+    FROM "sf_database"."sf_schema"."EVENT"
+    WHERE
+      (
+        "event_partition_col" >= TO_CHAR(CAST('2023-01-01 00:00:00' AS TIMESTAMP), '%Y-%m-%d')
+        AND "event_partition_col" <= TO_CHAR(CAST('2025-01-01 00:00:00' AS TIMESTAMP), '%Y-%m-%d')
+      )
+      AND (
+        "ts" >= CAST('2023-01-01T00:00:00' AS TIMESTAMP)
+        AND "ts" < CAST('2025-01-01T00:00:00' AS TIMESTAMP)
+      )
+  )
+)
+WHERE
+  "prob" <= 0.15000000000000002
+ORDER BY
+  "prob"
+LIMIT 10;
+
+SELECT
+  IFF(
+    CAST(L."ts" AS TIMESTAMP) < CAST('1900-01-01' AS TIMESTAMP)
+    OR CAST(L."ts" AS TIMESTAMP) > CAST('2200-01-01' AS TIMESTAMP),
+    NULL,
+    L."ts"
+  ) AS "ts",
+  L."cust_id" AS "cust_id",
+  L."event_id" AS "event_id",
+  R."scd_value" AS "scd_value_latest"
+FROM (
+  SELECT
+    "__FB_KEY_COL_0",
+    "__FB_LAST_TS",
+    "__FB_TS_COL",
+    "ts",
+    "cust_id",
+    "event_id"
+  FROM (
+    SELECT
+      "__FB_KEY_COL_0",
+      LAG("__FB_EFFECTIVE_TS_COL") IGNORE NULLS OVER (PARTITION BY "__FB_KEY_COL_0" ORDER BY "__FB_TS_COL" NULLS FIRST, "__FB_TS_TIE_BREAKER_COL") AS "__FB_LAST_TS",
+      "__FB_TS_COL",
+      "ts",
+      "cust_id",
+      "event_id",
+      "__FB_EFFECTIVE_TS_COL"
+    FROM (
+      SELECT
+        CAST(CONVERT_TIMEZONE('UTC', "ts") AS TIMESTAMP) AS "__FB_TS_COL",
+        "cust_id" AS "__FB_KEY_COL_0",
+        NULL AS "__FB_EFFECTIVE_TS_COL",
+        2 AS "__FB_TS_TIE_BREAKER_COL",
+        "ts" AS "ts",
+        "cust_id" AS "cust_id",
+        "event_id" AS "event_id"
+      FROM (
+        SELECT
+          "ts" AS "ts",
+          "cust_id" AS "cust_id",
+          "event_id" AS "event_id"
+        FROM "__FB_TEMPORARY_TABLE_000000000000000000000000"
+      )
+      UNION ALL
+      SELECT
+        CAST(CONVERT_TIMEZONE('UTC', "effective_ts") AS TIMESTAMP) AS "__FB_TS_COL",
+        "scd_cust_id" AS "__FB_KEY_COL_0",
+        "effective_ts" AS "__FB_EFFECTIVE_TS_COL",
+        1 AS "__FB_TS_TIE_BREAKER_COL",
+        NULL AS "ts",
+        NULL AS "cust_id",
+        NULL AS "event_id"
+      FROM (
+        SELECT
+          "effective_ts" AS "effective_ts",
+          "end_ts" AS "end_ts",
+          "scd_cust_id" AS "scd_cust_id",
+          "scd_value" AS "scd_value"
+        FROM "sf_database"."sf_schema"."SCD"
+        WHERE
+          "effective_ts" IS NOT NULL
+      )
+    )
+  )
+  WHERE
+    "__FB_EFFECTIVE_TS_COL" IS NULL
+) AS L
+LEFT JOIN (
+  SELECT
+    "effective_ts",
+    ANY_VALUE("end_ts") AS "end_ts",
+    "scd_cust_id",
+    ANY_VALUE("scd_value") AS "scd_value"
+  FROM (
+    SELECT
+      "effective_ts" AS "effective_ts",
+      "end_ts" AS "end_ts",
+      "scd_cust_id" AS "scd_cust_id",
+      "scd_value" AS "scd_value"
+    FROM "sf_database"."sf_schema"."SCD"
+    WHERE
+      "effective_ts" IS NOT NULL
+  )
+  GROUP BY
+    "effective_ts",
+    "scd_cust_id"
+) AS R
+  ON L."__FB_LAST_TS" = R."effective_ts"
+  AND L."__FB_KEY_COL_0" = R."scd_cust_id"
+  AND (
+    L."__FB_TS_COL" < TO_TIMESTAMP(R."end_ts", 'YYYY|MM|DD|HH24:MI:SS')
+    OR R."end_ts" IS NULL
+  )
+WHERE
+  "ts" >= CAST('2023-01-01T00:00:00' AS TIMESTAMP)
+  AND "ts" < CAST('2025-01-01T00:00:00' AS TIMESTAMP)
+LIMIT 10;

--- a/tests/unit/service/test_preview.py
+++ b/tests/unit/service/test_preview.py
@@ -143,6 +143,242 @@ def feature_store_sample_with_time_range_fixture(feature_store_sample):
     )
 
 
+@pytest.fixture(name="scd_join_sample_with_time_range")
+def scd_join_sample_with_time_range_fixture(feature_store):
+    """
+    Fixture for an SCD join sample with a time range
+    """
+    graph_dict = {
+        "edges": [
+            {"source": "input_1", "target": "graph_1"},
+            {"source": "input_2", "target": "graph_2"},
+            {"source": "graph_1", "target": "join_1"},
+            {"source": "graph_2", "target": "join_1"},
+        ],
+        "nodes": [
+            {
+                "name": "input_1",
+                "type": "input",
+                "output_type": "frame",
+                "parameters": {
+                    "columns": [
+                        {
+                            "name": "event_partition_col",
+                            "dtype": "VARCHAR",
+                            "partition_metadata": {"is_partition_key": True},
+                            "dtype_metadata": {
+                                "timestamp_schema": {"format_string": "%Y-%m-%d"},
+                            },
+                        },
+                        {
+                            "name": "ts",
+                            "dtype": "TIMESTAMP",
+                            "dtype_metadata": None,
+                            "partition_metadata": None,
+                        },
+                        {
+                            "name": "cust_id",
+                            "dtype": "INT",
+                            "dtype_metadata": None,
+                            "partition_metadata": None,
+                        },
+                        {
+                            "name": "event_id",
+                            "dtype": "INT",
+                            "dtype_metadata": None,
+                            "partition_metadata": None,
+                        },
+                    ],
+                    "table_details": {
+                        "database_name": "sf_database",
+                        "schema_name": "sf_schema",
+                        "table_name": "EVENT",
+                    },
+                    "feature_store_details": {"type": "snowflake", "details": None},
+                    "type": "event_table",
+                    "id": "6867f9d7b6058fa2167035d0",
+                    "timestamp_column": "ts",
+                    "id_column": "event_id",
+                    "event_timestamp_timezone_offset": None,
+                    "event_timestamp_timezone_offset_column": None,
+                    "event_timestamp_schema": None,
+                },
+            },
+            {
+                "name": "graph_1",
+                "type": "graph",
+                "output_type": "frame",
+                "parameters": {
+                    "graph": {
+                        "edges": [{"source": "proxy_input_1", "target": "project_1"}],
+                        "nodes": [
+                            {
+                                "name": "proxy_input_1",
+                                "type": "proxy_input",
+                                "output_type": "frame",
+                                "parameters": {"input_order": 0},
+                            },
+                            {
+                                "name": "project_1",
+                                "type": "project",
+                                "output_type": "frame",
+                                "parameters": {"columns": ["ts", "cust_id", "event_id"]},
+                            },
+                        ],
+                    },
+                    "output_node_name": "project_1",
+                    "type": "event_view",
+                    "metadata": {
+                        "view_mode": "auto",
+                        "drop_column_names": [],
+                        "column_cleaning_operations": [],
+                        "table_id": "6867f9d7b6058fa2167035d0",
+                    },
+                },
+            },
+            {
+                "name": "input_2",
+                "type": "input",
+                "output_type": "frame",
+                "parameters": {
+                    "columns": [
+                        {
+                            "name": "scd_partition_col",
+                            "dtype": "VARCHAR",
+                            "partition_metadata": {"is_partition_key": True},
+                            "dtype_metadata": {
+                                "timestamp_schema": {"format_string": "%Y-%m-%d"},
+                            },
+                        },
+                        {
+                            "name": "effective_ts",
+                            "dtype": "TIMESTAMP",
+                            "dtype_metadata": None,
+                            "partition_metadata": None,
+                        },
+                        {
+                            "name": "end_ts",
+                            "dtype": "VARCHAR",
+                            "dtype_metadata": {
+                                "timestamp_schema": {
+                                    "format_string": "YYYY|MM|DD|HH24:MI:SS",
+                                    "is_utc_time": True,
+                                    "timezone": None,
+                                },
+                                "timestamp_tuple_schema": None,
+                            },
+                            "partition_metadata": None,
+                        },
+                        {
+                            "name": "scd_cust_id",
+                            "dtype": "INT",
+                            "dtype_metadata": None,
+                            "partition_metadata": None,
+                        },
+                        {
+                            "name": "scd_value",
+                            "dtype": "INT",
+                            "dtype_metadata": None,
+                            "partition_metadata": None,
+                        },
+                    ],
+                    "table_details": {
+                        "database_name": "sf_database",
+                        "schema_name": "sf_schema",
+                        "table_name": "SCD",
+                    },
+                    "feature_store_details": {"type": "snowflake", "details": None},
+                    "type": "scd_table",
+                    "id": "6867f9d9b6058fa2167035dc",
+                    "natural_key_column": "scd_cust_id",
+                    "effective_timestamp_column": "effective_ts",
+                    "surrogate_key_column": None,
+                    "end_timestamp_column": "end_ts",
+                    "current_flag_column": None,
+                },
+            },
+            {
+                "name": "graph_2",
+                "type": "graph",
+                "output_type": "frame",
+                "parameters": {
+                    "graph": {
+                        "edges": [{"source": "proxy_input_1", "target": "project_1"}],
+                        "nodes": [
+                            {
+                                "name": "proxy_input_1",
+                                "type": "proxy_input",
+                                "output_type": "frame",
+                                "parameters": {"input_order": 0},
+                            },
+                            {
+                                "name": "project_1",
+                                "type": "project",
+                                "output_type": "frame",
+                                "parameters": {
+                                    "columns": [
+                                        "effective_ts",
+                                        "end_ts",
+                                        "scd_cust_id",
+                                        "scd_value",
+                                    ]
+                                },
+                            },
+                        ],
+                    },
+                    "output_node_name": "project_1",
+                    "type": "scd_view",
+                    "metadata": {
+                        "view_mode": "auto",
+                        "drop_column_names": [],
+                        "column_cleaning_operations": [],
+                        "table_id": "6867f9d9b6058fa2167035dc",
+                    },
+                },
+            },
+            {
+                "name": "join_1",
+                "type": "join",
+                "output_type": "frame",
+                "parameters": {
+                    "left_on": "cust_id",
+                    "right_on": "scd_cust_id",
+                    "left_input_columns": ["ts", "cust_id", "event_id"],
+                    "left_output_columns": ["ts", "cust_id", "event_id"],
+                    "right_input_columns": ["scd_value"],
+                    "right_output_columns": ["scd_value_latest"],
+                    "join_type": "left",
+                    "scd_parameters": {
+                        "effective_timestamp_column": "effective_ts",
+                        "natural_key_column": "scd_cust_id",
+                        "current_flag_column": None,
+                        "end_timestamp_column": "end_ts",
+                        "effective_timestamp_metadata": None,
+                        "end_timestamp_metadata": {
+                            "timestamp_schema": {
+                                "format_string": "YYYY|MM|DD|HH24:MI:SS",
+                                "is_utc_time": True,
+                                "timezone": None,
+                            },
+                            "timestamp_tuple_schema": None,
+                        },
+                        "left_timestamp_column": "ts",
+                        "left_timestamp_metadata": None,
+                    },
+                    "metadata": {"type": "join", "rsuffix": "_latest", "rprefix": ""},
+                },
+            },
+        ],
+    }
+    return FeatureStoreSample(
+        graph=graph_dict,
+        node_name="join_1",
+        from_timestamp=datetime(2023, 1, 1),
+        to_timestamp=datetime(2025, 1, 1),
+        timestamp_column="ts",
+    )
+
+
 @pytest.mark.asyncio
 async def test_preview_feature__time_based_feature_without_point_in_time_errors(
     feature_preview_service, float_feature
@@ -294,7 +530,7 @@ async def mock_execute_query(query):
     result_column_names = [
         col.alias_or_name for col in parse_one(query, read="snowflake").expressions
     ]
-    # Make %missing stats null in all columns
+    # Make %missing stats None in all columns
     data = {col: ["some_value"] if "%missing" not in col else [None] for col in result_column_names}
     return pd.DataFrame(data)
 
@@ -843,5 +1079,27 @@ async def test_value_counts_with_partition_column_filters(
     queries = extract_session_executed_queries(mock_snowflake_session)
     fixture_filename = (
         "tests/fixtures/preview_service/expected_value_counts_with_partition_column_filters.sql"
+    )
+    assert_equal_with_expected_fixture(queries, fixture_filename, update_fixtures)
+
+
+@pytest.mark.asyncio
+async def test_scd_join_with_partition_column_filters(
+    preview_service, scd_join_sample_with_time_range, mock_snowflake_session, update_fixtures
+):
+    """Test partition column filtering is applied only on primary table"""
+    mock_snowflake_session.execute_query.side_effect = mock_execute_query
+    mock_snowflake_session.execute_query_long_running.side_effect = mock_execute_query
+    seed = 1234
+
+    await preview_service.sample(
+        scd_join_sample_with_time_range,
+        size=10,
+        seed=seed,
+        sample_on_primary_table=True,
+    )
+    queries = extract_session_executed_queries(mock_snowflake_session)
+    fixture_filename = (
+        "tests/fixtures/preview_service/expected_scd_join_with_partition_column_filters.sql"
     )
     assert_equal_with_expected_fixture(queries, fixture_filename, update_fixtures)

--- a/tests/unit/service/test_preview.py
+++ b/tests/unit/service/test_preview.py
@@ -530,7 +530,7 @@ async def mock_execute_query(query):
     result_column_names = [
         col.alias_or_name for col in parse_one(query, read="snowflake").expressions
     ]
-    # Make %missing stats None in all columns
+    # Make %missing stats null in all columns
     data = {col: ["some_value"] if "%missing" not in col else [None] for col in result_column_names}
     return pd.DataFrame(data)
 


### PR DESCRIPTION
## Description

Follow up to #3033: make sure partition columns filtering is applied only on the primary table. This was already the case due to `sample_on_primary_table`, but this PR updates `_get_partition_column_filters` to do so explicitly.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
