### PR TITLE
[chore] Increase default query cache duration to 21 days

### DIFF
--- a/featurebyte/service/query_cache.py
+++ b/featurebyte/service/query_cache.py
@@ -13,7 +13,7 @@ from featurebyte.models.query_cache import QueryCacheModel
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema
 from featurebyte.service.base_document import BaseDocumentService
 
-STALE_THRESHOLD_SECONDS = 86400 * 7
+STALE_THRESHOLD_SECONDS = 86400 * 21
 STALE_CLEANUP_BUFFER_SECONDS = 3600 * 3
 
 

--- a/featurebyte/service/query_cache.py
+++ b/featurebyte/service/query_cache.py
@@ -4,6 +4,7 @@ QueryCacheService class
 
 from __future__ import annotations
 
+import os
 from datetime import datetime, timedelta
 from typing import Any, AsyncIterator, Dict
 
@@ -13,7 +14,8 @@ from featurebyte.models.query_cache import QueryCacheModel
 from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema
 from featurebyte.service.base_document import BaseDocumentService
 
-STALE_THRESHOLD_SECONDS = 86400 * 21
+STALE_THRESHOLD_DAYS = int(os.getenv("FEATUREBYTE_QUERY_CACHE_THRESHOLD_DAYS", "21"))
+STALE_THRESHOLD_SECONDS = 86400 * STALE_THRESHOLD_DAYS
 STALE_CLEANUP_BUFFER_SECONDS = 3600 * 3
 
 

--- a/tests/unit/service/test_query_cache_manager.py
+++ b/tests/unit/service/test_query_cache_manager.py
@@ -320,14 +320,14 @@ async def test_cleanup_service(
         assert mock_snowflake_session.drop_table.call_args_list == []
 
     # Cleanup before stale (first document already not retrievable but not yet ready for cleanup)
-    with freeze_time("2024-01-08 03:00:00"):
+    with freeze_time("2024-01-22 03:00:00"):
         await cleanup_service.run_cleanup(feature_store_id)
         tasks = await get_all_periodic_tasks(periodic_task_service)
         assert len(tasks) == 1
         assert mock_snowflake_session.drop_table.call_args_list == []
 
     # Cleanup after the first query was stale and ready for cleanup
-    with freeze_time("2024-01-08 03:00:01"):
+    with freeze_time("2024-01-22 03:00:01"):
         await cleanup_service.run_cleanup(feature_store_id)
         tasks = await get_all_periodic_tasks(periodic_task_service)
         assert len(tasks) == 1
@@ -337,7 +337,7 @@ async def test_cleanup_service(
 
     # Cleanup after all the remaining query was stale
     mock_snowflake_session.drop_table.reset_mock()
-    with freeze_time("2024-01-10"):
+    with freeze_time("2024-01-24"):
         await cleanup_service.run_cleanup(feature_store_id)
         tasks = await get_all_periodic_tasks(periodic_task_service)
         assert len(tasks) == 0
@@ -377,7 +377,7 @@ async def test_cleanup_service_dataframes(
     storage_path = docs["data"][0]["cached_object"]["storage_path"]
     await app_container.storage.get_bytes(storage_path)
 
-    with freeze_time("2024-01-09"):
+    with freeze_time("2024-01-23"):
         await cleanup_service.run_cleanup(feature_store_id)
         tasks = await get_all_periodic_tasks(periodic_task_service)
         assert len(tasks) == 0
@@ -419,7 +419,7 @@ async def test_cleanup_service_error_handling(
 
     # Simulate error when cleaning up a query
     mock_snowflake_session.drop_table.reset_mock()
-    with freeze_time("2024-01-10"):
+    with freeze_time("2024-01-24"):
         mock_snowflake_session.drop_table.side_effect = _mock_drop_table
         await cleanup_service.run_cleanup(feature_store_id)
         # Check attempts to drop tables
@@ -435,7 +435,7 @@ async def test_cleanup_service_error_handling(
         assert stale_docs[0]["cached_object"]["table_name"] == "created_table_2"
 
     # Retry cleanup should work
-    with freeze_time("2024-01-11"):
+    with freeze_time("2024-01-25"):
         mock_snowflake_session.drop_table.reset_mock()
         mock_snowflake_session.drop_table.side_effect = None
         await cleanup_service.run_cleanup(feature_store_id)


### PR DESCRIPTION
## Description

Increase default query cache duration to 21 days and make it configurable via an environment variable.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
