### PR TITLE
[chore] Handle empty dtype metadata in get_tile_compute_spec

### DIFF
--- a/featurebyte/query_graph/sql/ast/tile.py
+++ b/featurebyte/query_graph/sql/ast/tile.py
@@ -87,16 +87,18 @@ class BuildTileNode(TableNode):
         timestamp_column = TileTableInputColumn(
             name=self.timestamp, expr=self.input_node.columns_map[self.timestamp]
         )
-        if self.timestamp_metadata is None:
-            timestamp_expr = self.context.adapter.convert_to_utc_timestamp(
-                quoted_identifier(self.timestamp)
-            )
-        else:
-            assert self.timestamp_metadata.timestamp_schema is not None
+        if (
+            self.timestamp_metadata is not None
+            and self.timestamp_metadata.timestamp_schema is not None
+        ):
             timestamp_expr = convert_timestamp_to_utc(
                 quoted_identifier(self.timestamp),
                 self.timestamp_metadata.timestamp_schema,
                 self.adapter,
+            )
+        else:
+            timestamp_expr = self.context.adapter.convert_to_utc_timestamp(
+                quoted_identifier(self.timestamp)
             )
         tile_index_expr = alias_(
             self.adapter.call_udf(


### PR DESCRIPTION
## Description

Handle the case where `dtype_metadata` is set but all fields are empty (currently can occur for datetime partition column).

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
