### PR TITLE
[chore] Use PydanticObjectId in route definitions

### DIFF
--- a/featurebyte/routes/base_materialized_table_router.py
+++ b/featurebyte/routes/base_materialized_table_router.py
@@ -6,7 +6,7 @@ from typing import Generic, Type, TypeVar
 
 from fastapi import APIRouter, Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.materialized_table import MaterializedTableModel
 from featurebyte.routes.base_router import BaseRouter
 
@@ -34,7 +34,9 @@ class BaseMaterializedTableRouter(Generic[MaterializedTableModelT], BaseRouter):
             response_model=self.table_model,
         )
 
-    async def get_table(self, request: Request, table_id: PyObjectId) -> MaterializedTableModelT:
+    async def get_table(
+        self, request: Request, table_id: PydanticObjectId
+    ) -> MaterializedTableModelT:
         """
         Get table
         """

--- a/featurebyte/routes/base_router.py
+++ b/featurebyte/routes/base_router.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Request
 from fastapi.routing import APIRoute
 from starlette.routing import BaseRoute
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.common.base import BaseDocumentController
@@ -147,7 +147,7 @@ class BaseApiRouter(
         app_container: LazyAppContainer = request.state.app_container
         return cast(ControllerT, app_container.get(cls.controller))
 
-    async def get_object(self, request: Request, object_id: PyObjectId) -> ObjectModelT:
+    async def get_object(self, request: Request, object_id: PydanticObjectId) -> ObjectModelT:
         """
         Get table
         """
@@ -188,7 +188,7 @@ class BaseApiRouter(
             ),
         )
 
-    async def delete_object(self, request: Request, object_id: PyObjectId) -> DeleteResponse:
+    async def delete_object(self, request: Request, object_id: PydanticObjectId) -> DeleteResponse:
         """
         Delete object
         """
@@ -199,7 +199,7 @@ class BaseApiRouter(
     async def list_audit_logs(
         self,
         request: Request,
-        object_id: PyObjectId,
+        object_id: PydanticObjectId,
         page: int = PageQuery,
         page_size: int = PageSizeQuery,
         sort_by: Optional[str] = AuditLogSortByQuery,
@@ -220,7 +220,7 @@ class BaseApiRouter(
         return audit_doc_list
 
     async def update_description(
-        self, request: Request, object_id: PyObjectId, data: DescriptionUpdate
+        self, request: Request, object_id: PydanticObjectId, data: DescriptionUpdate
     ) -> ObjectModelT:
         """
         Update description

--- a/featurebyte/routes/batch_feature_table/api.py
+++ b/featurebyte/routes/batch_feature_table/api.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Optional, cast
 from fastapi import APIRouter, Query, Request
 from starlette.responses import StreamingResponse
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.batch_feature_table import BatchFeatureTableModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -164,7 +164,7 @@ class BatchFeatureTableRouter(BaseRouter):
         return task_submit
 
     async def get_batch_feature_table(
-        self, request: Request, batch_feature_table_id: PyObjectId
+        self, request: Request, batch_feature_table_id: PydanticObjectId
     ) -> BatchFeatureTableModel:
         """
         Get BatchFeatureTable
@@ -176,7 +176,7 @@ class BatchFeatureTableRouter(BaseRouter):
         return batch_feature_table
 
     async def delete_batch_feature_table(
-        self, request: Request, batch_feature_table_id: PyObjectId
+        self, request: Request, batch_feature_table_id: PydanticObjectId
     ) -> Task:
         """
         Delete BatchFeatureTable
@@ -211,7 +211,7 @@ class BatchFeatureTableRouter(BaseRouter):
     async def list_batch_feature_table_audit_logs(
         self,
         request: Request,
-        batch_feature_table_id: PyObjectId,
+        batch_feature_table_id: PydanticObjectId,
         page: int = PageQuery,
         page_size: int = PageSizeQuery,
         sort_by: Optional[str] = AuditLogSortByQuery,
@@ -232,7 +232,10 @@ class BatchFeatureTableRouter(BaseRouter):
         return audit_doc_list
 
     async def get_batch_feature_table_info(
-        self, request: Request, batch_feature_table_id: PyObjectId, verbose: bool = VerboseQuery
+        self,
+        request: Request,
+        batch_feature_table_id: PydanticObjectId,
+        verbose: bool = VerboseQuery,
     ) -> BatchFeatureTableInfo:
         """
         Get BatchFeatureTable info
@@ -242,7 +245,7 @@ class BatchFeatureTableRouter(BaseRouter):
         return cast(BatchFeatureTableInfo, info)
 
     async def download_table_as_pyarrow_table(
-        self, request: Request, batch_feature_table_id: PyObjectId
+        self, request: Request, batch_feature_table_id: PydanticObjectId
     ) -> StreamingResponse:
         """
         Download BatchFeatureTable as pyarrow table
@@ -254,7 +257,7 @@ class BatchFeatureTableRouter(BaseRouter):
         return result
 
     async def download_table_as_parquet(
-        self, request: Request, batch_feature_table_id: PyObjectId
+        self, request: Request, batch_feature_table_id: PydanticObjectId
     ) -> StreamingResponse:
         """
         Download BatchFeatureTable as parquet file
@@ -268,7 +271,7 @@ class BatchFeatureTableRouter(BaseRouter):
     async def update_batch_feature_table_description(
         self,
         request: Request,
-        batch_feature_table_id: PyObjectId,
+        batch_feature_table_id: PydanticObjectId,
         data: DescriptionUpdate,
     ) -> BatchFeatureTableModel:
         """
@@ -284,7 +287,7 @@ class BatchFeatureTableRouter(BaseRouter):
     async def preview_batch_feature_table(
         self,
         request: Request,
-        batch_feature_table_id: PyObjectId,
+        batch_feature_table_id: PydanticObjectId,
         limit: int = Query(default=PREVIEW_DEFAULT, gt=0, le=PREVIEW_LIMIT),
     ) -> Dict[str, Any]:
         """
@@ -300,7 +303,7 @@ class BatchFeatureTableRouter(BaseRouter):
     async def recreate_batch_feature_table(
         self,
         request: Request,
-        batch_feature_table_id: PyObjectId,
+        batch_feature_table_id: PydanticObjectId,
     ) -> Task:
         """
         Recreate a BatchFeatureTable from an existing one

--- a/featurebyte/routes/batch_request_table/api.py
+++ b/featurebyte/routes/batch_request_table/api.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Optional, cast
 from fastapi import APIRouter, Query, Request
 from starlette.responses import StreamingResponse
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.batch_request_table import BatchRequestTableModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -61,7 +61,7 @@ async def create_batch_request_table(
 
 @router.get("/{batch_request_table_id}", response_model=BatchRequestTableModel)
 async def get_batch_request_table(
-    request: Request, batch_request_table_id: PyObjectId
+    request: Request, batch_request_table_id: PydanticObjectId
 ) -> BatchRequestTableModel:
     """
     Get BatchRequestTable
@@ -74,7 +74,9 @@ async def get_batch_request_table(
 
 
 @router.delete("/{batch_request_table_id}", response_model=Task, status_code=HTTPStatus.ACCEPTED)
-async def delete_batch_request_table(request: Request, batch_request_table_id: PyObjectId) -> Task:
+async def delete_batch_request_table(
+    request: Request, batch_request_table_id: PydanticObjectId
+) -> Task:
     """
     Delete BatchRequestTable
     """
@@ -112,7 +114,7 @@ async def list_batch_request_tables(
 @router.get("/audit/{batch_request_table_id}", response_model=AuditDocumentList)
 async def list_batch_request_table_audit_logs(
     request: Request,
-    batch_request_table_id: PyObjectId,
+    batch_request_table_id: PydanticObjectId,
     page: int = PageQuery,
     page_size: int = PageSizeQuery,
     sort_by: Optional[str] = AuditLogSortByQuery,
@@ -135,7 +137,7 @@ async def list_batch_request_table_audit_logs(
 
 @router.get("/{batch_request_table_id}/info", response_model=BatchRequestTableInfo)
 async def get_batch_request_table_info(
-    request: Request, batch_request_table_id: PyObjectId, verbose: bool = VerboseQuery
+    request: Request, batch_request_table_id: PydanticObjectId, verbose: bool = VerboseQuery
 ) -> BatchRequestTableInfo:
     """
     Get BatchRequestTable info
@@ -147,7 +149,7 @@ async def get_batch_request_table_info(
 
 @router.get("/pyarrow_table/{batch_request_table_id}")
 async def download_table_as_pyarrow_table(
-    request: Request, batch_request_table_id: PyObjectId
+    request: Request, batch_request_table_id: PydanticObjectId
 ) -> StreamingResponse:
     """
     Download BatchRequestTable as pyarrow table
@@ -161,7 +163,7 @@ async def download_table_as_pyarrow_table(
 
 @router.get("/parquet/{batch_request_table_id}")
 async def download_table_as_parquet(
-    request: Request, batch_request_table_id: PyObjectId
+    request: Request, batch_request_table_id: PydanticObjectId
 ) -> StreamingResponse:
     """
     Download BatchRequestTable as parquet file
@@ -176,7 +178,7 @@ async def download_table_as_parquet(
 @router.patch("/{batch_request_table_id}/description", response_model=BatchRequestTableModel)
 async def update_batch_request_table_description(
     request: Request,
-    batch_request_table_id: PyObjectId,
+    batch_request_table_id: PydanticObjectId,
     data: DescriptionUpdate,
 ) -> BatchRequestTableModel:
     """
@@ -193,7 +195,7 @@ async def update_batch_request_table_description(
 @router.post("/{batch_request_table_id}/preview", response_model=Dict[str, Any])
 async def preview_batch_request_table(
     request: Request,
-    batch_request_table_id: PyObjectId,
+    batch_request_table_id: PydanticObjectId,
     limit: int = Query(default=PREVIEW_DEFAULT, gt=0, le=PREVIEW_LIMIT),
 ) -> Dict[str, Any]:
     """

--- a/featurebyte/routes/catalog/api.py
+++ b/featurebyte/routes/catalog/api.py
@@ -10,7 +10,7 @@ from typing import List, Optional
 from bson import ObjectId
 from fastapi import Query, Request, Response
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.catalog import CatalogModel, CatalogNameHistoryEntry
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -99,13 +99,13 @@ class CatalogRouter(BaseApiRouter[CatalogModel, CatalogList, CatalogCreate, Cata
             response_model=List[CatalogNameHistoryEntry],
         )
 
-    async def get_object(self, request: Request, catalog_id: PyObjectId) -> CatalogModel:
+    async def get_object(self, request: Request, catalog_id: PydanticObjectId) -> CatalogModel:
         return await super().get_object(request, catalog_id)
 
     async def list_audit_logs(
         self,
         request: Request,
-        catalog_id: PyObjectId,
+        catalog_id: PydanticObjectId,
         page: int = PageQuery,
         page_size: int = PageSizeQuery,
         sort_by: Optional[str] = AuditLogSortByQuery,
@@ -117,7 +117,7 @@ class CatalogRouter(BaseApiRouter[CatalogModel, CatalogList, CatalogCreate, Cata
         )
 
     async def update_description(
-        self, request: Request, catalog_id: PyObjectId, data: DescriptionUpdate
+        self, request: Request, catalog_id: PydanticObjectId, data: DescriptionUpdate
     ) -> CatalogModel:
         return await super().update_description(request, catalog_id, data)
 
@@ -134,7 +134,7 @@ class CatalogRouter(BaseApiRouter[CatalogModel, CatalogList, CatalogCreate, Cata
     async def get_catalog_info(
         self,
         request: Request,
-        catalog_id: PyObjectId,
+        catalog_id: PydanticObjectId,
         verbose: bool = VerboseQuery,
     ) -> CatalogInfo:
         """
@@ -150,7 +150,7 @@ class CatalogRouter(BaseApiRouter[CatalogModel, CatalogList, CatalogCreate, Cata
     async def update_catalog(
         self,
         request: Request,
-        catalog_id: PyObjectId,
+        catalog_id: PydanticObjectId,
         data: CatalogUpdate,
     ) -> CatalogModel:
         """
@@ -166,7 +166,7 @@ class CatalogRouter(BaseApiRouter[CatalogModel, CatalogList, CatalogCreate, Cata
     async def update_catalog_online_store(
         self,
         request: Request,
-        catalog_id: PyObjectId,
+        catalog_id: PydanticObjectId,
         data: CatalogOnlineStoreUpdate,
     ) -> CatalogModel:
         """
@@ -182,7 +182,7 @@ class CatalogRouter(BaseApiRouter[CatalogModel, CatalogList, CatalogCreate, Cata
     async def update_catalog_online_store_async(
         self,
         request: Request,
-        catalog_id: PyObjectId,
+        catalog_id: PydanticObjectId,
         data: CatalogOnlineStoreUpdate,
         response: Response,
     ) -> Optional[Task]:
@@ -203,7 +203,7 @@ class CatalogRouter(BaseApiRouter[CatalogModel, CatalogList, CatalogCreate, Cata
     async def delete_catalog(
         self,
         request: Request,
-        catalog_id: PyObjectId,
+        catalog_id: PydanticObjectId,
         soft_delete: bool = Query(default=True),
     ) -> None:
         """
@@ -213,7 +213,7 @@ class CatalogRouter(BaseApiRouter[CatalogModel, CatalogList, CatalogCreate, Cata
         ----------
         request: Request
             Request
-        catalog_id: PyObjectId
+        catalog_id: PydanticObjectId
             Catalog ID
         soft_delete: Optional[str]
             Soft delete
@@ -227,7 +227,7 @@ class CatalogRouter(BaseApiRouter[CatalogModel, CatalogList, CatalogCreate, Cata
     async def list_name_history(
         self,
         request: Request,
-        catalog_id: PyObjectId,
+        catalog_id: PydanticObjectId,
     ) -> List[CatalogNameHistoryEntry]:
         """
         List catalog name history

--- a/featurebyte/routes/context/api.py
+++ b/featurebyte/routes/context/api.py
@@ -10,7 +10,7 @@ from typing import Optional
 from bson import ObjectId
 from fastapi import Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.context import ContextModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -67,13 +67,13 @@ class ContextRouter(BaseApiRouter[ContextModel, ContextList, ContextCreate, Cont
             response_model=ContextInfo,
         )
 
-    async def get_object(self, request: Request, context_id: PyObjectId) -> ContextModel:
+    async def get_object(self, request: Request, context_id: PydanticObjectId) -> ContextModel:
         return await super().get_object(request, context_id)
 
     async def list_audit_logs(
         self,
         request: Request,
-        context_id: PyObjectId,
+        context_id: PydanticObjectId,
         page: int = PageQuery,
         page_size: int = PageSizeQuery,
         sort_by: Optional[str] = AuditLogSortByQuery,
@@ -85,7 +85,7 @@ class ContextRouter(BaseApiRouter[ContextModel, ContextList, ContextCreate, Cont
         )
 
     async def update_description(
-        self, request: Request, context_id: PyObjectId, data: DescriptionUpdate
+        self, request: Request, context_id: PydanticObjectId, data: DescriptionUpdate
     ) -> ContextModel:
         return await super().update_description(request, context_id, data)
 
@@ -101,7 +101,7 @@ class ContextRouter(BaseApiRouter[ContextModel, ContextList, ContextCreate, Cont
         result: ContextModel = await controller.create_context(data=data)
         return result
 
-    async def delete_object(self, request: Request, context_id: PyObjectId) -> DeleteResponse:
+    async def delete_object(self, request: Request, context_id: PydanticObjectId) -> DeleteResponse:
         """
         Delete Context
         """
@@ -110,7 +110,7 @@ class ContextRouter(BaseApiRouter[ContextModel, ContextList, ContextCreate, Cont
         return DeleteResponse()
 
     async def update_context(
-        self, request: Request, context_id: PyObjectId, data: ContextUpdate
+        self, request: Request, context_id: PydanticObjectId, data: ContextUpdate
     ) -> ContextModel:
         """
         Update Context
@@ -124,7 +124,7 @@ class ContextRouter(BaseApiRouter[ContextModel, ContextList, ContextCreate, Cont
     @staticmethod
     async def list_context_observation_tables(
         request: Request,
-        context_id: PyObjectId,
+        context_id: PydanticObjectId,
         page: int = PageQuery,
         page_size: int = PageSizeQuery,
     ) -> ObservationTableList:
@@ -139,7 +139,7 @@ class ContextRouter(BaseApiRouter[ContextModel, ContextList, ContextCreate, Cont
         )
         return observation_table_list
 
-    async def context_info(self, request: Request, context_id: PyObjectId) -> ContextInfo:
+    async def context_info(self, request: Request, context_id: PydanticObjectId) -> ContextInfo:
         """
         Get Context Info
         """

--- a/featurebyte/routes/credential/api.py
+++ b/featurebyte/routes/credential/api.py
@@ -10,7 +10,7 @@ from typing import Optional
 from bson import ObjectId
 from fastapi import Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseApiRouter
@@ -67,11 +67,13 @@ class CredentialRouter(
             response_model=CredentialInfo,
         )
 
-    async def get_object(self, request: Request, credential_id: PyObjectId) -> CredentialRead:
+    async def get_object(self, request: Request, credential_id: PydanticObjectId) -> CredentialRead:
         credential = await super().get_object(request, credential_id)
         return CredentialRead(**credential.model_dump(by_alias=True))
 
-    async def delete_object(self, request: Request, credential_id: PyObjectId) -> DeleteResponse:
+    async def delete_object(
+        self, request: Request, credential_id: PydanticObjectId
+    ) -> DeleteResponse:
         controller = self.get_controller_for_request(request)
         await controller.delete_credential(credential_id)
         return DeleteResponse()
@@ -79,7 +81,7 @@ class CredentialRouter(
     async def list_audit_logs(
         self,
         request: Request,
-        credential_id: PyObjectId,
+        credential_id: PydanticObjectId,
         page: int = PageQuery,
         page_size: int = PageSizeQuery,
         sort_by: Optional[str] = AuditLogSortByQuery,
@@ -97,7 +99,7 @@ class CredentialRouter(
         )
 
     async def update_description(
-        self, request: Request, credential_id: PyObjectId, data: DescriptionUpdate
+        self, request: Request, credential_id: PydanticObjectId, data: DescriptionUpdate
     ) -> CredentialRead:
         credentials = await super().update_description(request, credential_id, data)
         return CredentialRead(**credentials.model_dump(by_alias=True))
@@ -111,7 +113,7 @@ class CredentialRouter(
         sort_dir: Optional[SortDir] = SortDirQuery,
         search: Optional[str] = SearchQuery,
         name: Optional[str] = NameQuery,
-        feature_store_id: Optional[PyObjectId] = None,
+        feature_store_id: Optional[PydanticObjectId] = None,
     ) -> CredentialList:
         """
         List credentials
@@ -141,7 +143,7 @@ class CredentialRouter(
     async def update_credential(
         self,
         request: Request,
-        credential_id: PyObjectId,
+        credential_id: PydanticObjectId,
         data: CredentialUpdate,
     ) -> CredentialRead:
         """
@@ -154,7 +156,7 @@ class CredentialRouter(
     async def get_credential_info(
         self,
         request: Request,
-        credential_id: PyObjectId,
+        credential_id: PydanticObjectId,
         verbose: bool = VerboseQuery,
     ) -> CredentialInfo:
         """

--- a/featurebyte/routes/credential/controller.py
+++ b/featurebyte/routes/credential/controller.py
@@ -9,7 +9,7 @@ from fastapi import Request
 
 from featurebyte.exception import DocumentDeletionError
 from featurebyte.models import FeatureStoreModel
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.credential import CredentialModel
 from featurebyte.routes.common.base import BaseDocumentController
 from featurebyte.schema.credential import (
@@ -96,14 +96,14 @@ class CredentialController(
         return CredentialRead(**saved_credentials.model_dump(by_alias=True))
 
     async def update_credential(
-        self, credential_id: PyObjectId, data: CredentialUpdate
+        self, credential_id: PydanticObjectId, data: CredentialUpdate
     ) -> CredentialRead:
         """
         Update credential
 
         Parameters
         ----------
-        credential_id: PyObjectId
+        credential_id: PydanticObjectId
             credential id
         data: CredentialUpdate
             CredentialUpdate object
@@ -133,13 +133,13 @@ class CredentialController(
         assert document is not None
         return CredentialRead(**document.model_dump(by_alias=True))
 
-    async def delete_credential(self, credential_id: PyObjectId) -> None:
+    async def delete_credential(self, credential_id: PydanticObjectId) -> None:
         """
         Delete credential
 
         Parameters
         ----------
-        credential_id: PyObjectId
+        credential_id: PydanticObjectId
             Credential ID
 
         Raises

--- a/featurebyte/routes/deployment/api.py
+++ b/featurebyte/routes/deployment/api.py
@@ -9,7 +9,7 @@ from bson import ObjectId
 from fastapi import APIRouter, Query, Request, Response
 from fastapi.responses import ORJSONResponse
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.deployment import DeploymentModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -61,7 +61,7 @@ async def create_deployment(request: Request, data: DeploymentCreate) -> Task:
 
 
 @router.get("/{deployment_id}", response_model=DeploymentModel)
-async def get_deployment(request: Request, deployment_id: PyObjectId) -> DeploymentModel:
+async def get_deployment(request: Request, deployment_id: PydanticObjectId) -> DeploymentModel:
     """
     Get Deployment
     """
@@ -72,7 +72,7 @@ async def get_deployment(request: Request, deployment_id: PyObjectId) -> Deploym
 
 @router.patch("/{deployment_id}")
 async def update_deployment(
-    request: Request, deployment_id: PyObjectId, data: DeploymentUpdate, response: Response
+    request: Request, deployment_id: PydanticObjectId, data: DeploymentUpdate, response: Response
 ) -> Optional[Task]:
     """
     Update Deployment
@@ -94,7 +94,7 @@ async def list_deployments(
     sort_dir: Optional[SortDir] = SortDirQuery,
     search: Optional[str] = SearchQuery,
     name: Optional[str] = NameQuery,
-    feature_list_id: Optional[PyObjectId] = None,
+    feature_list_id: Optional[PydanticObjectId] = None,
 ) -> DeploymentList:
     """
     List Deployments
@@ -115,7 +115,7 @@ async def list_deployments(
 
 
 @router.delete("/{deployment_id}")
-async def delete_deployment(request: Request, deployment_id: PyObjectId) -> None:
+async def delete_deployment(request: Request, deployment_id: PydanticObjectId) -> None:
     """
     Delete Deployment
     """
@@ -126,7 +126,7 @@ async def delete_deployment(request: Request, deployment_id: PyObjectId) -> None
 @router.get("/audit/{deployment_id}", response_model=AuditDocumentList)
 async def list_deployment_audit_logs(
     request: Request,
-    deployment_id: PyObjectId,
+    deployment_id: PydanticObjectId,
     page: int = PageQuery,
     page_size: int = PageSizeQuery,
     sort_by: Optional[str] = AuditLogSortByQuery,
@@ -150,7 +150,7 @@ async def list_deployment_audit_logs(
 @router.get("/{deployment_id}/info", response_model=DeploymentInfo)
 async def get_deployment_info(
     request: Request,
-    deployment_id: PyObjectId,
+    deployment_id: PydanticObjectId,
     verbose: bool = False,
 ) -> DeploymentInfo:
     """
@@ -170,7 +170,7 @@ async def get_deployment_info(
 )
 async def compute_online_features(
     request: Request,
-    deployment_id: PyObjectId,
+    deployment_id: PydanticObjectId,
     data: OnlineFeaturesRequestPayload,
 ) -> OnlineFeaturesResponseModel:
     """
@@ -190,7 +190,7 @@ async def compute_online_features(
 )
 async def get_deployment_job_history(
     request: Request,
-    deployment_id: PyObjectId,
+    deployment_id: PydanticObjectId,
     num_runs: int = Query(default=5),
 ) -> DeploymentJobHistory:
     """
@@ -237,7 +237,7 @@ async def get_deployment_summary(
 @router.patch("/{deployment_id}/description", response_model=DeploymentModel)
 async def update_deployment_description(
     request: Request,
-    deployment_id: PyObjectId,
+    deployment_id: PydanticObjectId,
     data: DescriptionUpdate,
 ) -> DeploymentModel:
     """
@@ -254,7 +254,7 @@ async def update_deployment_description(
 @router.get("/{deployment_id}/request_code_template", response_model=DeploymentRequestCodeTemplate)
 async def get_deployment_request_code_template(
     request: Request,
-    deployment_id: PyObjectId,
+    deployment_id: PydanticObjectId,
     language: Literal["python", "sh"] = Query(default="python"),
 ) -> DeploymentRequestCodeTemplate:
     """
@@ -274,7 +274,7 @@ async def get_deployment_request_code_template(
 )
 async def get_deployment_sample_entity_serving_names(
     request: Request,
-    deployment_id: PyObjectId,
+    deployment_id: PydanticObjectId,
     count: int = Query(default=1, gt=0, le=10),
 ) -> SampleEntityServingNames:
     """

--- a/featurebyte/routes/development_dataset/api.py
+++ b/featurebyte/routes/development_dataset/api.py
@@ -10,7 +10,7 @@ from typing import Optional, cast
 from bson import ObjectId
 from fastapi import Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.development_dataset import DevelopmentDatasetModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -105,14 +105,14 @@ class DevelopmentDatasetRouter(
         return task_submit
 
     async def get_object(
-        self, request: Request, development_dataset_id: PyObjectId
+        self, request: Request, development_dataset_id: PydanticObjectId
     ) -> DevelopmentDatasetModel:
         return await super().get_object(request, development_dataset_id)
 
     async def list_audit_logs(
         self,
         request: Request,
-        development_dataset_id: PyObjectId,
+        development_dataset_id: PydanticObjectId,
         page: int = PageQuery,
         page_size: int = PageSizeQuery,
         sort_by: Optional[str] = AuditLogSortByQuery,
@@ -131,7 +131,7 @@ class DevelopmentDatasetRouter(
 
     @staticmethod
     async def update_development_dataset(
-        request: Request, development_dataset_id: PyObjectId, data: DevelopmentDatasetUpdate
+        request: Request, development_dataset_id: PydanticObjectId, data: DevelopmentDatasetUpdate
     ) -> DevelopmentDatasetModel:
         """
         Update online store
@@ -143,14 +143,14 @@ class DevelopmentDatasetRouter(
         return result
 
     async def update_description(
-        self, request: Request, development_dataset_id: PyObjectId, data: DescriptionUpdate
+        self, request: Request, development_dataset_id: PydanticObjectId, data: DescriptionUpdate
     ) -> DevelopmentDatasetModel:
         return await super().update_description(request, development_dataset_id, data)
 
     @staticmethod
     async def get_development_dataset_info(
         request: Request,
-        development_dataset_id: PyObjectId,
+        development_dataset_id: PydanticObjectId,
         verbose: bool = VerboseQuery,
     ) -> DevelopmentDatasetInfo:
         """
@@ -164,7 +164,7 @@ class DevelopmentDatasetRouter(
         return cast(DevelopmentDatasetInfo, info)
 
     async def delete_development_dataset(
-        self, request: Request, development_dataset_id: PyObjectId
+        self, request: Request, development_dataset_id: PydanticObjectId
     ) -> Task:
         controller = self.get_controller_for_request(request)
         task_submit: Task = await controller.delete_development_dataset(
@@ -175,7 +175,7 @@ class DevelopmentDatasetRouter(
     async def add_development_tables(
         self,
         request: Request,
-        development_dataset_id: PyObjectId,
+        development_dataset_id: PydanticObjectId,
         data: DevelopmentDatasetAddTables,
     ) -> Task:
         """

--- a/featurebyte/routes/dimension_table/api.py
+++ b/featurebyte/routes/dimension_table/api.py
@@ -10,7 +10,7 @@ from typing import Optional
 from bson import ObjectId
 from fastapi import APIRouter, Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.dimension_table import DimensionTableModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -102,14 +102,14 @@ class DimensionTableRouter(
         )
 
     async def get_object(
-        self, request: Request, dimension_table_id: PyObjectId
+        self, request: Request, dimension_table_id: PydanticObjectId
     ) -> DimensionTableModel:
         return await super().get_object(request, dimension_table_id)
 
     async def list_audit_logs(
         self,
         request: Request,
-        dimension_table_id: PyObjectId,
+        dimension_table_id: PydanticObjectId,
         page: int = PageQuery,
         page_size: int = PageSizeQuery,
         sort_by: Optional[str] = AuditLogSortByQuery,
@@ -127,7 +127,7 @@ class DimensionTableRouter(
         )
 
     async def update_description(
-        self, request: Request, dimension_table_id: PyObjectId, data: DescriptionUpdate
+        self, request: Request, dimension_table_id: PydanticObjectId, data: DescriptionUpdate
     ) -> DimensionTableModel:
         return await super().update_description(request, dimension_table_id, data)
 
@@ -138,7 +138,7 @@ class DimensionTableRouter(
         return await controller.create_table(data=data)
 
     async def get_dimension_table_info(
-        self, request: Request, dimension_table_id: PyObjectId, verbose: bool = VerboseQuery
+        self, request: Request, dimension_table_id: PydanticObjectId, verbose: bool = VerboseQuery
     ) -> DimensionTableInfo:
         """
         Retrieve dimension table info
@@ -151,7 +151,7 @@ class DimensionTableRouter(
         return info
 
     async def update_dimension_table(
-        self, request: Request, dimension_table_id: PyObjectId, data: DimensionTableUpdate
+        self, request: Request, dimension_table_id: PydanticObjectId, data: DimensionTableUpdate
     ) -> DimensionTableModel:
         """
         Update dimension table
@@ -164,7 +164,7 @@ class DimensionTableRouter(
         return dimension_table
 
     async def update_column_entity(
-        self, request: Request, dimension_table_id: PyObjectId, data: ColumnEntityUpdate
+        self, request: Request, dimension_table_id: PydanticObjectId, data: ColumnEntityUpdate
     ) -> DimensionTableModel:
         """
         Update column entity
@@ -180,7 +180,7 @@ class DimensionTableRouter(
     async def update_column_critical_data_info(
         self,
         request: Request,
-        dimension_table_id: PyObjectId,
+        dimension_table_id: PydanticObjectId,
         data: ColumnCriticalDataInfoUpdate,
     ) -> DimensionTableModel:
         """
@@ -197,7 +197,7 @@ class DimensionTableRouter(
     async def update_column_description(
         self,
         request: Request,
-        dimension_table_id: PyObjectId,
+        dimension_table_id: PydanticObjectId,
         data: ColumnDescriptionUpdate,
     ) -> DimensionTableModel:
         """
@@ -212,7 +212,7 @@ class DimensionTableRouter(
         return dimension_table
 
     async def delete_object(
-        self, request: Request, dimension_table_id: PyObjectId
+        self, request: Request, dimension_table_id: PydanticObjectId
     ) -> DeleteResponse:
         controller = self.get_controller_for_request(request)
         await controller.delete(document_id=ObjectId(dimension_table_id))

--- a/featurebyte/routes/entity/api.py
+++ b/featurebyte/routes/entity/api.py
@@ -9,7 +9,7 @@ from typing import List, Optional, cast
 
 from fastapi import APIRouter, Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.entity import EntityModel, EntityNameHistoryEntry
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -51,7 +51,7 @@ async def create_entity(request: Request, data: EntityCreate) -> EntityModel:
 
 
 @router.get("/{entity_id}", response_model=EntityModel)
-async def get_entity(request: Request, entity_id: PyObjectId) -> EntityModel:
+async def get_entity(request: Request, entity_id: PydanticObjectId) -> EntityModel:
     """
     Get Entity
     """
@@ -87,7 +87,7 @@ async def list_entities(
 @router.patch("/{entity_id}", response_model=EntityModel)
 async def update_entity(
     request: Request,
-    entity_id: PyObjectId,
+    entity_id: PydanticObjectId,
     data: EntityUpdate,
 ) -> EntityModel:
     """
@@ -104,7 +104,7 @@ async def update_entity(
 @router.get("/audit/{entity_id}", response_model=AuditDocumentList)
 async def list_entity_audit_logs(
     request: Request,
-    entity_id: PyObjectId,
+    entity_id: PydanticObjectId,
     page: int = PageQuery,
     page_size: int = PageSizeQuery,
     sort_by: Optional[str] = AuditLogSortByQuery,
@@ -131,7 +131,7 @@ async def list_entity_audit_logs(
 )
 async def list_name_history(
     request: Request,
-    entity_id: PyObjectId,
+    entity_id: PydanticObjectId,
 ) -> List[EntityNameHistoryEntry]:
     """
     List Entity name history
@@ -154,7 +154,7 @@ async def list_name_history(
 @router.get("/{entity_id}/info", response_model=EntityInfo)
 async def get_entity_info(
     request: Request,
-    entity_id: PyObjectId,
+    entity_id: PydanticObjectId,
     verbose: bool = VerboseQuery,
 ) -> EntityInfo:
     """
@@ -171,7 +171,7 @@ async def get_entity_info(
 @router.patch("/{entity_id}/description", response_model=EntityModel)
 async def update_entity_description(
     request: Request,
-    entity_id: PyObjectId,
+    entity_id: PydanticObjectId,
     data: DescriptionUpdate,
 ) -> EntityModel:
     """
@@ -186,7 +186,7 @@ async def update_entity_description(
 
 
 @router.delete("/{entity_id}")
-async def delete_entity(request: Request, entity_id: PyObjectId) -> None:
+async def delete_entity(request: Request, entity_id: PydanticObjectId) -> None:
     """
     Delete Entity
     """

--- a/featurebyte/routes/event_table/api.py
+++ b/featurebyte/routes/event_table/api.py
@@ -10,7 +10,7 @@ from typing import List, Optional
 from bson import ObjectId
 from fastapi import APIRouter, Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.event_table import EventTableModel, FeatureJobSettingHistoryEntry
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -103,13 +103,15 @@ class EventTableRouter(
             response_model=List[FeatureJobSettingHistoryEntry],
         )
 
-    async def get_object(self, request: Request, event_table_id: PyObjectId) -> EventTableModel:
+    async def get_object(
+        self, request: Request, event_table_id: PydanticObjectId
+    ) -> EventTableModel:
         return await super().get_object(request, event_table_id)
 
     async def list_audit_logs(
         self,
         request: Request,
-        event_table_id: PyObjectId,
+        event_table_id: PydanticObjectId,
         page: int = PageQuery,
         page_size: int = PageSizeQuery,
         sort_by: Optional[str] = AuditLogSortByQuery,
@@ -127,7 +129,7 @@ class EventTableRouter(
         )
 
     async def update_description(
-        self, request: Request, event_table_id: PyObjectId, data: DescriptionUpdate
+        self, request: Request, event_table_id: PydanticObjectId, data: DescriptionUpdate
     ) -> EventTableModel:
         return await super().update_description(request, event_table_id, data)
 
@@ -136,7 +138,7 @@ class EventTableRouter(
         return await controller.create_table(data=data)
 
     async def get_event_table_info(
-        self, request: Request, event_table_id: PyObjectId, verbose: bool = VerboseQuery
+        self, request: Request, event_table_id: PydanticObjectId, verbose: bool = VerboseQuery
     ) -> EventTableInfo:
         """
         Retrieve event table info
@@ -149,7 +151,7 @@ class EventTableRouter(
         return info
 
     async def update_event_table(
-        self, request: Request, event_table_id: PyObjectId, data: EventTableUpdate
+        self, request: Request, event_table_id: PydanticObjectId, data: EventTableUpdate
     ) -> EventTableModel:
         """
         Update event table
@@ -162,7 +164,7 @@ class EventTableRouter(
         return event_table
 
     async def update_column_entity(
-        self, request: Request, event_table_id: PyObjectId, data: ColumnEntityUpdate
+        self, request: Request, event_table_id: PydanticObjectId, data: ColumnEntityUpdate
     ) -> EventTableModel:
         """
         Update column entity
@@ -178,7 +180,7 @@ class EventTableRouter(
     async def update_column_critical_data_info(
         self,
         request: Request,
-        event_table_id: PyObjectId,
+        event_table_id: PydanticObjectId,
         data: ColumnCriticalDataInfoUpdate,
     ) -> EventTableModel:
         """
@@ -195,7 +197,7 @@ class EventTableRouter(
     async def update_column_description(
         self,
         request: Request,
-        event_table_id: PyObjectId,
+        event_table_id: PydanticObjectId,
         data: ColumnDescriptionUpdate,
     ) -> EventTableModel:
         """
@@ -212,7 +214,7 @@ class EventTableRouter(
     async def list_default_feature_job_setting_history(
         self,
         request: Request,
-        event_table_id: PyObjectId,
+        event_table_id: PydanticObjectId,
     ) -> List[FeatureJobSettingHistoryEntry]:
         """
         List EventTable default feature job settings history
@@ -231,7 +233,9 @@ class EventTableRouter(
             for record in history_values
         ]
 
-    async def delete_object(self, request: Request, event_table_id: PyObjectId) -> DeleteResponse:
+    async def delete_object(
+        self, request: Request, event_table_id: PydanticObjectId
+    ) -> DeleteResponse:
         controller = self.get_controller_for_request(request)
         await controller.delete(document_id=ObjectId(event_table_id))
         return DeleteResponse()

--- a/featurebyte/routes/feature/api.py
+++ b/featurebyte/routes/feature/api.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Optional, Union, cast
 
 from fastapi import APIRouter, Query, Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseRouter
@@ -74,7 +74,7 @@ async def submit_batch_feature_create_task(request: Request, data: BatchFeatureC
 
 
 @router.get("/{feature_id}", response_model=FeatureModelResponse)
-async def get_feature(request: Request, feature_id: PyObjectId) -> FeatureModelResponse:
+async def get_feature(request: Request, feature_id: PydanticObjectId) -> FeatureModelResponse:
     """
     Get Feature
     """
@@ -85,7 +85,7 @@ async def get_feature(request: Request, feature_id: PyObjectId) -> FeatureModelR
 
 @router.patch("/{feature_id}", response_model=FeatureModelResponse)
 async def update_feature(
-    request: Request, feature_id: PyObjectId, data: FeatureUpdate
+    request: Request, feature_id: PydanticObjectId, data: FeatureUpdate
 ) -> FeatureModelResponse:
     """
     Update Feature
@@ -99,7 +99,7 @@ async def update_feature(
 
 
 @router.delete("/{feature_id}", status_code=HTTPStatus.OK)
-async def delete_feature(request: Request, feature_id: PyObjectId) -> DeleteResponse:
+async def delete_feature(request: Request, feature_id: PydanticObjectId) -> DeleteResponse:
     """
     Delete Feature
     """
@@ -118,8 +118,8 @@ async def list_features(
     search: Optional[str] = SearchQuery,
     name: Optional[str] = NameQuery,
     version: Optional[str] = VersionQuery,
-    feature_list_id: Optional[PyObjectId] = None,
-    feature_namespace_id: Optional[PyObjectId] = None,
+    feature_list_id: Optional[PydanticObjectId] = None,
+    feature_namespace_id: Optional[PydanticObjectId] = None,
 ) -> FeaturePaginatedList:
     """
     List Features
@@ -141,7 +141,7 @@ async def list_features(
 @router.get("/audit/{feature_id}", response_model=AuditDocumentList)
 async def list_feature_audit_logs(
     request: Request,
-    feature_id: PyObjectId,
+    feature_id: PydanticObjectId,
     page: int = PageQuery,
     page_size: int = PageSizeQuery,
     sort_by: Optional[str] = AuditLogSortByQuery,
@@ -165,7 +165,7 @@ async def list_feature_audit_logs(
 @router.get("/{feature_id}/info", response_model=FeatureInfo)
 async def get_feature_info(
     request: Request,
-    feature_id: PyObjectId,
+    feature_id: PydanticObjectId,
     verbose: bool = VerboseQuery,
 ) -> FeatureInfo:
     """
@@ -212,7 +212,7 @@ async def get_feature_sql(
 @router.get("/{feature_id}/feature_job_logs", response_model=Dict[str, Any])
 async def get_feature_job_logs(
     request: Request,
-    feature_id: PyObjectId,
+    feature_id: PydanticObjectId,
     hour_limit: int = Query(default=24, gt=0, le=2400),
 ) -> Dict[str, Any]:
     """
@@ -229,7 +229,7 @@ async def get_feature_job_logs(
 @router.patch("/{feature_id}/description", response_model=FeatureModelResponse)
 async def update_feature_description(
     request: Request,
-    feature_id: PyObjectId,
+    feature_id: PydanticObjectId,
     data: DescriptionUpdate,
 ) -> FeatureModelResponse:
     """
@@ -249,7 +249,7 @@ async def update_feature_description(
 )
 async def get_feature_sample_entity_serving_names(
     request: Request,
-    feature_id: PyObjectId,
+    feature_id: PydanticObjectId,
     count: int = Query(default=1, gt=0, le=10),
 ) -> SampleEntityServingNames:
     """

--- a/featurebyte/routes/feature_job_setting_analysis/api.py
+++ b/featurebyte/routes/feature_job_setting_analysis/api.py
@@ -10,7 +10,7 @@ from typing import Optional, cast
 from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.feature_job_setting_analysis import FeatureJobSettingAnalysisModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -70,7 +70,7 @@ async def list_feature_job_setting_analysis(
     sort_dir: Optional[SortDir] = SortDirQuery,
     search: Optional[str] = SearchQuery,
     name: Optional[str] = NameQuery,
-    event_table_id: Optional[PyObjectId] = None,
+    event_table_id: Optional[PydanticObjectId] = None,
 ) -> FeatureJobSettingAnalysisList:
     """
     List Feature Job Setting Analysis
@@ -94,7 +94,7 @@ async def list_feature_job_setting_analysis(
 @router.get("/{feature_job_setting_analysis_id}", response_model=FeatureJobSettingAnalysisModel)
 async def get_feature_job_setting_analysis(
     request: Request,
-    feature_job_setting_analysis_id: PyObjectId,
+    feature_job_setting_analysis_id: PydanticObjectId,
 ) -> FeatureJobSettingAnalysisModel:
     """
     Retrieve Feature Job Setting Analysis
@@ -109,7 +109,7 @@ async def get_feature_job_setting_analysis(
 @router.get("/{feature_job_setting_analysis_id}/info", response_model=FeatureJobSettingAnalysisInfo)
 async def get_feature_job_setting_analysis_info(
     request: Request,
-    feature_job_setting_analysis_id: PyObjectId,
+    feature_job_setting_analysis_id: PydanticObjectId,
     verbose: bool = VerboseQuery,
 ) -> FeatureJobSettingAnalysisInfo:
     """
@@ -125,7 +125,7 @@ async def get_feature_job_setting_analysis_info(
 
 @router.get("/{feature_job_setting_analysis_id}/report")
 async def get_feature_job_setting_analysis_report(
-    request: Request, feature_job_setting_analysis_id: PyObjectId
+    request: Request, feature_job_setting_analysis_id: PydanticObjectId
 ) -> StreamingResponse:
     """
     Retrieve FeatureJobSettingAnalysis pdf report
@@ -142,7 +142,7 @@ async def get_feature_job_setting_analysis_report(
 @router.get("/audit/{feature_job_setting_analysis_id}", response_model=AuditDocumentList)
 async def list_feature_job_setting_analysis_audit_logs(
     request: Request,
-    feature_job_setting_analysis_id: PyObjectId,
+    feature_job_setting_analysis_id: PydanticObjectId,
     page: int = PageQuery,
     page_size: int = PageSizeQuery,
     sort_by: Optional[str] = AuditLogSortByQuery,
@@ -188,7 +188,7 @@ async def run_backtest(
 )
 async def update_feature_job_setting_analysis_description(
     request: Request,
-    feature_job_setting_analysis_id: PyObjectId,
+    feature_job_setting_analysis_id: PydanticObjectId,
     data: DescriptionUpdate,
 ) -> FeatureJobSettingAnalysisModel:
     """
@@ -206,7 +206,7 @@ async def update_feature_job_setting_analysis_description(
 
 @router.delete("/{feature_job_setting_analysis_id}")
 async def delete_feature_job_setting_analysis(
-    request: Request, feature_job_setting_analysis_id: PyObjectId
+    request: Request, feature_job_setting_analysis_id: PydanticObjectId
 ) -> None:
     """
     Delete Feature Job Setting Analysis

--- a/featurebyte/routes/feature_list/api.py
+++ b/featurebyte/routes/feature_list/api.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Optional, Union, cast
 
 from fastapi import APIRouter, File, Form, Query, Request, Response, UploadFile
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseRouter
@@ -94,7 +94,7 @@ async def submit_feature_list_creation_job(request: Request, data: FeatureListCr
 
 @router.get("/{feature_list_id}", response_model=FeatureListModelResponse)
 async def get_feature_list(
-    request: Request, feature_list_id: PyObjectId
+    request: Request, feature_list_id: PydanticObjectId
 ) -> FeatureListModelResponse:
     """
     Get FeatureList
@@ -106,7 +106,7 @@ async def get_feature_list(
 
 @router.patch("/{feature_list_id}", response_model=Union[FeatureListModelResponse, Task])
 async def update_feature_list(
-    request: Request, feature_list_id: PyObjectId, data: FeatureListUpdate, response: Response
+    request: Request, feature_list_id: PydanticObjectId, data: FeatureListUpdate, response: Response
 ) -> Union[FeatureListModelResponse, Task]:
     """
     Update FeatureList
@@ -123,7 +123,9 @@ async def update_feature_list(
 
 
 @router.delete("/{feature_list_id}", status_code=HTTPStatus.OK)
-async def delete_feature_list(request: Request, feature_list_id: PyObjectId) -> DeleteResponse:
+async def delete_feature_list(
+    request: Request, feature_list_id: PydanticObjectId
+) -> DeleteResponse:
     """
     Delete FeatureList
     """
@@ -142,7 +144,7 @@ async def list_feature_list(
     search: Optional[str] = SearchQuery,
     name: Optional[str] = NameQuery,
     version: Optional[str] = VersionQuery,
-    feature_list_namespace_id: Optional[PyObjectId] = None,
+    feature_list_namespace_id: Optional[PydanticObjectId] = None,
 ) -> FeatureListPaginatedList:
     """
     List FeatureLists
@@ -163,7 +165,7 @@ async def list_feature_list(
 @router.get("/audit/{feature_list_id}", response_model=AuditDocumentList)
 async def list_feature_list_audit_logs(
     request: Request,
-    feature_list_id: PyObjectId,
+    feature_list_id: PydanticObjectId,
     page: int = PageQuery,
     page_size: int = PageSizeQuery,
     sort_by: Optional[str] = AuditLogSortByQuery,
@@ -187,7 +189,7 @@ async def list_feature_list_audit_logs(
 @router.get("/{feature_list_id}/info", response_model=FeatureListInfo)
 async def get_feature_list_info(
     request: Request,
-    feature_list_id: PyObjectId,
+    feature_list_id: PydanticObjectId,
     verbose: bool = VerboseQuery,
 ) -> FeatureListInfo:
     """
@@ -254,7 +256,7 @@ async def get_historical_features_sql(
 @router.get("/{feature_list_id}/feature_job_logs", response_model=Dict[str, Any])
 async def get_feature_job_logs(
     request: Request,
-    feature_list_id: PyObjectId,
+    feature_list_id: PydanticObjectId,
     hour_limit: int = Query(default=24, gt=0, le=2400),
 ) -> Dict[str, Any]:
     """
@@ -271,7 +273,7 @@ async def get_feature_job_logs(
 @router.patch("/{feature_list_id}/description", response_model=FeatureListModelResponse)
 async def update_feature_list_description(
     request: Request,
-    feature_list_id: PyObjectId,
+    feature_list_id: PydanticObjectId,
     data: DescriptionUpdate,
 ) -> FeatureListModelResponse:
     """
@@ -291,7 +293,7 @@ async def update_feature_list_description(
 )
 async def get_feature_list_sample_entity_serving_names(
     request: Request,
-    feature_list_id: PyObjectId,
+    feature_list_id: PydanticObjectId,
     count: int = Query(default=1, gt=0, le=10),
 ) -> SampleEntityServingNames:
     """

--- a/featurebyte/routes/feature_list_namespace/api.py
+++ b/featurebyte/routes/feature_list_namespace/api.py
@@ -8,7 +8,7 @@ from typing import Optional, cast
 
 from fastapi import APIRouter, Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseRouter
@@ -44,7 +44,7 @@ class FeatureListNamespaceRouter(BaseRouter):
 
 @router.get("/{feature_list_namespace_id}", response_model=FeatureListNamespaceModelResponse)
 async def get_feature_list_namespace(
-    request: Request, feature_list_namespace_id: PyObjectId
+    request: Request, feature_list_namespace_id: PydanticObjectId
 ) -> FeatureListNamespaceModelResponse:
     """
     Get FeatureListNamespace
@@ -62,7 +62,7 @@ async def get_feature_list_namespace(
 
 @router.patch("/{feature_list_namespace_id}", response_model=FeatureListNamespaceModelResponse)
 async def update_feature_list_namespace(
-    request: Request, feature_list_namespace_id: PyObjectId, data: FeatureListNamespaceUpdate
+    request: Request, feature_list_namespace_id: PydanticObjectId, data: FeatureListNamespaceUpdate
 ) -> FeatureListNamespaceModelResponse:
     """
     Update FeatureListNamespace
@@ -104,7 +104,7 @@ async def list_feature_list_namespace(
 @router.get("/audit/{feature_list_namespace_id}", response_model=AuditDocumentList)
 async def list_feature_list_namespace_audit_logs(
     request: Request,
-    feature_list_namespace_id: PyObjectId,
+    feature_list_namespace_id: PydanticObjectId,
     page: int = PageQuery,
     page_size: int = PageSizeQuery,
     sort_by: Optional[str] = AuditLogSortByQuery,
@@ -128,7 +128,7 @@ async def list_feature_list_namespace_audit_logs(
 @router.get("/{feature_list_namespace_id}/info", response_model=FeatureListNamespaceInfo)
 async def get_feature_list_namespace_info(
     request: Request,
-    feature_list_namespace_id: PyObjectId,
+    feature_list_namespace_id: PydanticObjectId,
     verbose: bool = VerboseQuery,
 ) -> FeatureListNamespaceInfo:
     """
@@ -147,7 +147,7 @@ async def get_feature_list_namespace_info(
 )
 async def update_feature_list_namespace_description(
     request: Request,
-    feature_list_namespace_id: PyObjectId,
+    feature_list_namespace_id: PydanticObjectId,
     data: DescriptionUpdate,
 ) -> FeatureListNamespaceModelResponse:
     """

--- a/featurebyte/routes/feature_namespace/api.py
+++ b/featurebyte/routes/feature_namespace/api.py
@@ -8,7 +8,7 @@ from typing import Optional, cast
 
 from fastapi import APIRouter, Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseRouter
@@ -44,7 +44,7 @@ class FeatureNamespaceRouter(BaseRouter):
 
 @router.get("/{feature_namespace_id}", response_model=FeatureNamespaceModelResponse)
 async def get_feature_namespace(
-    request: Request, feature_namespace_id: PyObjectId
+    request: Request, feature_namespace_id: PydanticObjectId
 ) -> FeatureNamespaceModelResponse:
     """
     Retrieve Feature Namespace
@@ -61,7 +61,7 @@ async def get_feature_namespace(
 
 @router.patch("/{feature_namespace_id}", response_model=FeatureNamespaceModelResponse)
 async def update_feature(
-    request: Request, feature_namespace_id: PyObjectId, data: FeatureNamespaceUpdate
+    request: Request, feature_namespace_id: PydanticObjectId, data: FeatureNamespaceUpdate
 ) -> FeatureNamespaceModelResponse:
     """
     Update FeatureNamespace
@@ -101,7 +101,7 @@ async def list_feature_namespaces(
 @router.get("/audit/{feature_namespace_id}", response_model=AuditDocumentList)
 async def list_feature_namespace_audit_logs(
     request: Request,
-    feature_namespace_id: PyObjectId,
+    feature_namespace_id: PydanticObjectId,
     page: int = PageQuery,
     page_size: int = PageSizeQuery,
     sort_by: Optional[str] = AuditLogSortByQuery,
@@ -125,7 +125,7 @@ async def list_feature_namespace_audit_logs(
 @router.get("/{feature_namespace_id}/info", response_model=FeatureNamespaceInfo)
 async def get_feature_namespace_info(
     request: Request,
-    feature_namespace_id: PyObjectId,
+    feature_namespace_id: PydanticObjectId,
     verbose: bool = VerboseQuery,
 ) -> FeatureNamespaceInfo:
     """
@@ -142,7 +142,7 @@ async def get_feature_namespace_info(
 @router.patch("/{feature_namespace_id}/description", response_model=FeatureNamespaceModelResponse)
 async def update_feature_namespace_description(
     request: Request,
-    feature_namespace_id: PyObjectId,
+    feature_namespace_id: PydanticObjectId,
     data: DescriptionUpdate,
 ) -> FeatureNamespaceModelResponse:
     """

--- a/featurebyte/routes/feature_store/api.py
+++ b/featurebyte/routes/feature_store/api.py
@@ -12,7 +12,7 @@ from fastapi import Query, Request
 
 from featurebyte.common import DEFAULT_CATALOG_ID
 from featurebyte.exception import DocumentNotFoundError
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -164,13 +164,15 @@ class FeatureStoreRouter(
         controller: FeatureStoreController = request.state.app_container.feature_store_controller
         return await controller.create_feature_store(data=data)
 
-    async def get_object(self, request: Request, feature_store_id: PyObjectId) -> FeatureStoreModel:
+    async def get_object(
+        self, request: Request, feature_store_id: PydanticObjectId
+    ) -> FeatureStoreModel:
         return await super().get_object(request, feature_store_id)
 
     async def list_audit_logs(
         self,
         request: Request,
-        feature_store_id: PyObjectId,
+        feature_store_id: PydanticObjectId,
         page: int = PageQuery,
         page_size: int = PageSizeQuery,
         sort_by: Optional[str] = AuditLogSortByQuery,
@@ -188,14 +190,14 @@ class FeatureStoreRouter(
         )
 
     async def update_description(
-        self, request: Request, feature_store_id: PyObjectId, data: DescriptionUpdate
+        self, request: Request, feature_store_id: PydanticObjectId, data: DescriptionUpdate
     ) -> FeatureStoreModel:
         return await super().update_description(request, feature_store_id, data)
 
     @staticmethod
     async def get_feature_store_info(
         request: Request,
-        feature_store_id: PyObjectId,
+        feature_store_id: PydanticObjectId,
         verbose: bool = VerboseQuery,
     ) -> FeatureStoreInfo:
         """
@@ -389,7 +391,7 @@ class FeatureStoreRouter(
         sample: FeatureStoreSample,
         size: int = Query(default=0, gte=0, le=DESCRIPTION_SIZE_LIMIT),
         seed: int = Query(default=PREVIEW_SEED),
-        catalog_id: PyObjectId = Query(default=None),
+        catalog_id: Optional[PydanticObjectId] = Query(default=None),
     ) -> Task:
         """
         Submit data description task for query graph node
@@ -401,13 +403,15 @@ class FeatureStoreRouter(
         )
         return task_submit
 
-    async def delete_object(self, request: Request, feature_store_id: PyObjectId) -> DeleteResponse:
+    async def delete_object(
+        self, request: Request, feature_store_id: PydanticObjectId
+    ) -> DeleteResponse:
         controller: FeatureStoreController = self.get_controller_for_request(request)
         await controller.delete(document_id=ObjectId(feature_store_id))
         return DeleteResponse()
 
     async def update_details(
-        self, request: Request, feature_store_id: PyObjectId, data: DatabaseDetailsUpdate
+        self, request: Request, feature_store_id: PydanticObjectId, data: DatabaseDetailsUpdate
     ) -> FeatureStoreModel:
         """Update details"""
         controller: FeatureStoreController = self.get_controller_for_request(request)
@@ -418,7 +422,7 @@ class FeatureStoreRouter(
     async def update(
         self,
         request: Request,
-        feature_store_id: PyObjectId,
+        feature_store_id: PydanticObjectId,
         data: FeatureStoreUpdate,
     ) -> FeatureStoreModel:
         """Update max_query_concurrency"""

--- a/featurebyte/routes/historical_feature_table/api.py
+++ b/featurebyte/routes/historical_feature_table/api.py
@@ -12,7 +12,7 @@ from bson import ObjectId
 from fastapi import APIRouter, Form, Query, Request, UploadFile
 from starlette.responses import StreamingResponse
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.historical_feature_table import HistoricalFeatureTableModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -72,7 +72,7 @@ async def create_historical_feature_table(
 
 @router.get("/{historical_feature_table_id}", response_model=HistoricalFeatureTableModel)
 async def get_historical_feature_table(
-    request: Request, historical_feature_table_id: PyObjectId
+    request: Request, historical_feature_table_id: PydanticObjectId
 ) -> HistoricalFeatureTableModel:
     """
     Get HistoricalFeatureTable
@@ -87,7 +87,7 @@ async def get_historical_feature_table(
     "/{historical_feature_table_id}", response_model=Task, status_code=HTTPStatus.ACCEPTED
 )
 async def delete_historical_feature_table(
-    request: Request, historical_feature_table_id: PyObjectId
+    request: Request, historical_feature_table_id: PydanticObjectId
 ) -> Task:
     """
     Delete HistoricalFeatureTable
@@ -127,7 +127,7 @@ async def list_historical_feature_tables(
 @router.get("/audit/{historical_feature_table_id}", response_model=AuditDocumentList)
 async def list_historical_feature_table_audit_logs(
     request: Request,
-    historical_feature_table_id: PyObjectId,
+    historical_feature_table_id: PydanticObjectId,
     page: int = PageQuery,
     page_size: int = PageSizeQuery,
     sort_by: Optional[str] = AuditLogSortByQuery,
@@ -150,7 +150,7 @@ async def list_historical_feature_table_audit_logs(
 
 @router.get("/{historical_feature_table_id}/info", response_model=HistoricalFeatureTableInfo)
 async def get_historical_feature_table_info(
-    request: Request, historical_feature_table_id: PyObjectId, verbose: bool = VerboseQuery
+    request: Request, historical_feature_table_id: PydanticObjectId, verbose: bool = VerboseQuery
 ) -> HistoricalFeatureTableInfo:
     """
     Get HistoricalFeatureTable info
@@ -165,7 +165,7 @@ async def get_historical_feature_table_info(
 
 @router.get("/pyarrow_table/{historical_feature_table_id}")
 async def download_table_as_pyarrow_table(
-    request: Request, historical_feature_table_id: PyObjectId
+    request: Request, historical_feature_table_id: PydanticObjectId
 ) -> StreamingResponse:
     """
     Download HistoricalFeatureTable as pyarrow table
@@ -180,7 +180,7 @@ async def download_table_as_pyarrow_table(
 
 @router.get("/parquet/{historical_feature_table_id}")
 async def download_table_as_parquet(
-    request: Request, historical_feature_table_id: PyObjectId
+    request: Request, historical_feature_table_id: PydanticObjectId
 ) -> StreamingResponse:
     """
     Download HistoricalFeatureTable as parquet file
@@ -198,7 +198,7 @@ async def download_table_as_parquet(
 )
 async def update_historical_feature_table_description(
     request: Request,
-    historical_feature_table_id: PyObjectId,
+    historical_feature_table_id: PydanticObjectId,
     data: DescriptionUpdate,
 ) -> HistoricalFeatureTableModel:
     """
@@ -216,7 +216,7 @@ async def update_historical_feature_table_description(
 @router.patch("/{historical_feature_table_id}", response_model=HistoricalFeatureTableModel)
 async def update_historical_feature_table(
     request: Request,
-    historical_feature_table_id: PyObjectId,
+    historical_feature_table_id: PydanticObjectId,
     data: HistoricalFeatureTableUpdate,
 ) -> HistoricalFeatureTableModel:
     """
@@ -235,7 +235,7 @@ async def update_historical_feature_table(
 @router.post("/{historical_feature_table_id}/preview", response_model=Dict[str, Any])
 async def preview_historical_feature_table(
     request: Request,
-    historical_feature_table_id: PyObjectId,
+    historical_feature_table_id: PydanticObjectId,
     limit: int = Query(default=PREVIEW_DEFAULT, gt=0, le=PREVIEW_LIMIT),
 ) -> Dict[str, Any]:
     """
@@ -254,8 +254,8 @@ async def preview_historical_feature_table(
 )
 async def preview_historical_feature_table_feature(
     request: Request,
-    historical_feature_table_id: PyObjectId,
-    feature_id: PyObjectId,
+    historical_feature_table_id: PydanticObjectId,
+    feature_id: PydanticObjectId,
     limit: int = Query(default=PREVIEW_DEFAULT, gt=0, le=PREVIEW_LIMIT),
 ) -> Dict[str, Any]:
     """

--- a/featurebyte/routes/item_table/api.py
+++ b/featurebyte/routes/item_table/api.py
@@ -10,7 +10,7 @@ from typing import Optional
 from bson import ObjectId
 from fastapi import APIRouter, Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.item_table import ItemTableModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -95,13 +95,13 @@ class ItemTableRouter(
             status_code=HTTPStatus.OK,
         )
 
-    async def get_object(self, request: Request, item_table_id: PyObjectId) -> ItemTableModel:
+    async def get_object(self, request: Request, item_table_id: PydanticObjectId) -> ItemTableModel:
         return await super().get_object(request, item_table_id)
 
     async def list_audit_logs(
         self,
         request: Request,
-        item_table_id: PyObjectId,
+        item_table_id: PydanticObjectId,
         page: int = PageQuery,
         page_size: int = PageSizeQuery,
         sort_by: Optional[str] = AuditLogSortByQuery,
@@ -119,7 +119,7 @@ class ItemTableRouter(
         )
 
     async def update_description(
-        self, request: Request, item_table_id: PyObjectId, data: DescriptionUpdate
+        self, request: Request, item_table_id: PydanticObjectId, data: DescriptionUpdate
     ) -> ItemTableModel:
         return await super().update_description(request, item_table_id, data)
 
@@ -128,7 +128,7 @@ class ItemTableRouter(
         return await controller.create_table(data=data)
 
     async def get_item_table_info(
-        self, request: Request, item_table_id: PyObjectId, verbose: bool = VerboseQuery
+        self, request: Request, item_table_id: PydanticObjectId, verbose: bool = VerboseQuery
     ) -> ItemTableInfo:
         """
         Retrieve item table info
@@ -141,7 +141,7 @@ class ItemTableRouter(
         return info
 
     async def update_item_table(
-        self, request: Request, item_table_id: PyObjectId, data: ItemTableUpdate
+        self, request: Request, item_table_id: PydanticObjectId, data: ItemTableUpdate
     ) -> ItemTableModel:
         """
         Update item table
@@ -154,7 +154,7 @@ class ItemTableRouter(
         return item_table
 
     async def update_column_entity(
-        self, request: Request, item_table_id: PyObjectId, data: ColumnEntityUpdate
+        self, request: Request, item_table_id: PydanticObjectId, data: ColumnEntityUpdate
     ) -> ItemTableModel:
         """
         Update column entity
@@ -170,7 +170,7 @@ class ItemTableRouter(
     async def update_column_critical_data_info(
         self,
         request: Request,
-        item_table_id: PyObjectId,
+        item_table_id: PydanticObjectId,
         data: ColumnCriticalDataInfoUpdate,
     ) -> ItemTableModel:
         """
@@ -187,7 +187,7 @@ class ItemTableRouter(
     async def update_column_description(
         self,
         request: Request,
-        item_table_id: PyObjectId,
+        item_table_id: PydanticObjectId,
         data: ColumnDescriptionUpdate,
     ) -> ItemTableModel:
         """
@@ -201,7 +201,9 @@ class ItemTableRouter(
         )
         return item_table
 
-    async def delete_object(self, request: Request, item_table_id: PyObjectId) -> DeleteResponse:
+    async def delete_object(
+        self, request: Request, item_table_id: PydanticObjectId
+    ) -> DeleteResponse:
         controller = self.get_controller_for_request(request)
         await controller.delete(document_id=ObjectId(item_table_id))
         return DeleteResponse()

--- a/featurebyte/routes/managed_view/api.py
+++ b/featurebyte/routes/managed_view/api.py
@@ -9,7 +9,7 @@ from typing import Optional, cast
 from bson import ObjectId
 from fastapi import Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseApiRouter
@@ -74,7 +74,9 @@ class ManagedViewRouter(
         managed_view = await controller.create_managed_view(data=data)
         return ManagedViewRead(**managed_view.model_dump(by_alias=True))
 
-    async def get_object(self, request: Request, managed_view_id: PyObjectId) -> ManagedViewRead:
+    async def get_object(
+        self, request: Request, managed_view_id: PydanticObjectId
+    ) -> ManagedViewRead:
         managed_view = await super().get_object(request, managed_view_id)
         return ManagedViewRead(**managed_view.model_dump(by_alias=True))
 
@@ -87,7 +89,7 @@ class ManagedViewRouter(
         sort_dir: Optional[SortDir] = SortDirQuery,
         search: Optional[str] = SearchQuery,
         name: Optional[str] = NameQuery,
-        feature_store_id: Optional[PyObjectId] = None,
+        feature_store_id: Optional[PydanticObjectId] = None,
     ) -> ManagedViewList:
         """
         List objects
@@ -105,7 +107,7 @@ class ManagedViewRouter(
     async def list_audit_logs(
         self,
         request: Request,
-        managed_view_id: PyObjectId,
+        managed_view_id: PydanticObjectId,
         page: int = PageQuery,
         page_size: int = PageSizeQuery,
         sort_by: Optional[str] = AuditLogSortByQuery,
@@ -124,7 +126,7 @@ class ManagedViewRouter(
 
     @staticmethod
     async def update_managed_view(
-        request: Request, managed_view_id: PyObjectId, data: ManagedViewUpdate
+        request: Request, managed_view_id: PydanticObjectId, data: ManagedViewUpdate
     ) -> ManagedViewRead:
         """
         Update online store
@@ -134,7 +136,7 @@ class ManagedViewRouter(
         return ManagedViewRead(**document.model_dump(by_alias=True))
 
     async def update_description(
-        self, request: Request, managed_view_id: PyObjectId, data: DescriptionUpdate
+        self, request: Request, managed_view_id: PydanticObjectId, data: DescriptionUpdate
     ) -> ManagedViewRead:
         managed_view = await super().update_description(request, managed_view_id, data)
         return ManagedViewRead(**managed_view.model_dump(by_alias=True))
@@ -142,7 +144,7 @@ class ManagedViewRouter(
     @staticmethod
     async def get_managed_view_info(
         request: Request,
-        managed_view_id: PyObjectId,
+        managed_view_id: PydanticObjectId,
         verbose: bool = VerboseQuery,
     ) -> ManagedViewInfo:
         """
@@ -155,7 +157,9 @@ class ManagedViewRouter(
         )
         return cast(ManagedViewInfo, info)
 
-    async def delete_object(self, request: Request, managed_view_id: PyObjectId) -> DeleteResponse:
+    async def delete_object(
+        self, request: Request, managed_view_id: PydanticObjectId
+    ) -> DeleteResponse:
         controller = self.get_controller_for_request(request)
         await controller.delete(document_id=ObjectId(managed_view_id))
         return DeleteResponse()

--- a/featurebyte/routes/managed_view/controller.py
+++ b/featurebyte/routes/managed_view/controller.py
@@ -10,7 +10,7 @@ from bson import ObjectId
 
 from featurebyte.enum import ViewNamePrefix
 from featurebyte.logging import get_logger
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.managed_view import ManagedViewModel
 from featurebyte.models.persistent import QueryFilter
 from featurebyte.persistent.base import SortDir
@@ -66,7 +66,7 @@ class ManagedViewController(
         sort_by: list[tuple[str, SortDir]] | None = None,
         search: str | None = None,
         name: str | None = None,
-        feature_store_id: PyObjectId | None = None,
+        feature_store_id: PydanticObjectId | None = None,
     ) -> ManagedViewList:
         """
         List ManagedView stored in persistent
@@ -83,7 +83,7 @@ class ManagedViewController(
             Search token to be used in filtering
         name: str | None
             Feature name to be used in filtering
-        feature_store_id: PyObjectId | None
+        feature_store_id: PydanticObjectId | None
             FeatureStore id to be used in filtering
 
         Returns

--- a/featurebyte/routes/observation_table/api.py
+++ b/featurebyte/routes/observation_table/api.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Optional, cast
 from fastapi import APIRouter, Form, Query, Request, UploadFile
 from starlette.responses import StreamingResponse
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.observation_table import ObservationTableModel
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
@@ -86,7 +86,7 @@ async def upload_observation_table(
 
 @router.get("/{observation_table_id}", response_model=ObservationTableModelResponse)
 async def get_observation_table(
-    request: Request, observation_table_id: PyObjectId
+    request: Request, observation_table_id: PydanticObjectId
 ) -> ObservationTableModelResponse:
     """
     Get ObservationTable
@@ -99,7 +99,9 @@ async def get_observation_table(
 
 
 @router.delete("/{observation_table_id}", response_model=Task, status_code=HTTPStatus.ACCEPTED)
-async def delete_observation_table(request: Request, observation_table_id: PyObjectId) -> Task:
+async def delete_observation_table(
+    request: Request, observation_table_id: PydanticObjectId
+) -> Task:
     """
     Delete ObservationTable by submitting a deletion task
     """
@@ -135,7 +137,7 @@ async def list_observation_tables(
 @router.get("/audit/{observation_table_id}", response_model=AuditDocumentList)
 async def list_observation_table_audit_logs(
     request: Request,
-    observation_table_id: PyObjectId,
+    observation_table_id: PydanticObjectId,
     page: int = PageQuery,
     page_size: int = PageSizeQuery,
     sort_by: Optional[str] = AuditLogSortByQuery,
@@ -158,7 +160,7 @@ async def list_observation_table_audit_logs(
 
 @router.get("/{observation_table_id}/info", response_model=ObservationTableInfo)
 async def get_observation_table_info(
-    request: Request, observation_table_id: PyObjectId, verbose: bool = VerboseQuery
+    request: Request, observation_table_id: PydanticObjectId, verbose: bool = VerboseQuery
 ) -> ObservationTableInfo:
     """
     Get ObservationTable info
@@ -170,7 +172,7 @@ async def get_observation_table_info(
 
 @router.get("/pyarrow_table/{observation_table_id}")
 async def download_table_as_pyarrow_table(
-    request: Request, observation_table_id: PyObjectId
+    request: Request, observation_table_id: PydanticObjectId
 ) -> StreamingResponse:
     """
     Download ObservationTable as pyarrow table
@@ -184,7 +186,7 @@ async def download_table_as_pyarrow_table(
 
 @router.get("/parquet/{observation_table_id}")
 async def download_table_as_parquet(
-    request: Request, observation_table_id: PyObjectId
+    request: Request, observation_table_id: PydanticObjectId
 ) -> StreamingResponse:
     """
     Download ObservationTable as parquet file
@@ -199,7 +201,7 @@ async def download_table_as_parquet(
 @router.patch("/{observation_table_id}/description", response_model=ObservationTableModel)
 async def update_observation_table_description(
     request: Request,
-    observation_table_id: PyObjectId,
+    observation_table_id: PydanticObjectId,
     data: DescriptionUpdate,
 ) -> ObservationTableModel:
     """
@@ -216,7 +218,7 @@ async def update_observation_table_description(
 @router.patch("/{observation_table_id}", response_model=ObservationTableModel)
 async def update_observation_table(
     request: Request,
-    observation_table_id: PyObjectId,
+    observation_table_id: PydanticObjectId,
     data: ObservationTableUpdate,
 ) -> ObservationTableModel:
     """
@@ -232,7 +234,7 @@ async def update_observation_table(
 @router.post("/{observation_table_id}/preview", response_model=Dict[str, Any])
 async def preview_observation_table(
     request: Request,
-    observation_table_id: PyObjectId,
+    observation_table_id: PydanticObjectId,
     limit: int = Query(default=PREVIEW_DEFAULT, gt=0, le=PREVIEW_LIMIT),
 ) -> Dict[str, Any]:
     """

--- a/featurebyte/routes/online_store/api.py
+++ b/featurebyte/routes/online_store/api.py
@@ -9,7 +9,7 @@ from typing import Optional, cast
 from bson import ObjectId
 from fastapi import Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseApiRouter
@@ -72,14 +72,16 @@ class OnlineStoreRouter(
         online_store = await controller.create_online_store(data=data)
         return OnlineStoreRead(**online_store.model_dump(by_alias=True))
 
-    async def get_object(self, request: Request, online_store_id: PyObjectId) -> OnlineStoreRead:
+    async def get_object(
+        self, request: Request, online_store_id: PydanticObjectId
+    ) -> OnlineStoreRead:
         online_store = await super().get_object(request, online_store_id)
         return OnlineStoreRead(**online_store.model_dump(by_alias=True))
 
     async def list_audit_logs(
         self,
         request: Request,
-        online_store_id: PyObjectId,
+        online_store_id: PydanticObjectId,
         page: int = PageQuery,
         page_size: int = PageSizeQuery,
         sort_by: Optional[str] = AuditLogSortByQuery,
@@ -98,7 +100,7 @@ class OnlineStoreRouter(
 
     @staticmethod
     async def update_online_store(
-        request: Request, online_store_id: PyObjectId, data: OnlineStoreUpdate
+        request: Request, online_store_id: PydanticObjectId, data: OnlineStoreUpdate
     ) -> OnlineStoreRead:
         """
         Update online store
@@ -108,7 +110,7 @@ class OnlineStoreRouter(
         return OnlineStoreRead(**document.model_dump(by_alias=True))
 
     async def update_description(
-        self, request: Request, online_store_id: PyObjectId, data: DescriptionUpdate
+        self, request: Request, online_store_id: PydanticObjectId, data: DescriptionUpdate
     ) -> OnlineStoreRead:
         online_store = await super().update_description(request, online_store_id, data)
         return OnlineStoreRead(**online_store.model_dump(by_alias=True))
@@ -116,7 +118,7 @@ class OnlineStoreRouter(
     @staticmethod
     async def get_online_store_info(
         request: Request,
-        online_store_id: PyObjectId,
+        online_store_id: PydanticObjectId,
         verbose: bool = VerboseQuery,
     ) -> OnlineStoreInfo:
         """
@@ -129,7 +131,9 @@ class OnlineStoreRouter(
         )
         return cast(OnlineStoreInfo, info)
 
-    async def delete_object(self, request: Request, online_store_id: PyObjectId) -> DeleteResponse:
+    async def delete_object(
+        self, request: Request, online_store_id: PydanticObjectId
+    ) -> DeleteResponse:
         controller = self.get_controller_for_request(request)
         await controller.delete(document_id=ObjectId(online_store_id))
         return DeleteResponse()

--- a/featurebyte/routes/periodic_tasks/api.py
+++ b/featurebyte/routes/periodic_tasks/api.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.periodic_task import PeriodicTask
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseRouter
@@ -51,7 +51,9 @@ class PeriodicTaskRouter(BaseRouter):
         )
 
     @staticmethod
-    async def get_periodic_task(request: Request, periodic_task_id: PyObjectId) -> PeriodicTask:
+    async def get_periodic_task(
+        request: Request, periodic_task_id: PydanticObjectId
+    ) -> PeriodicTask:
         """
         Get Periodic Task
         """
@@ -85,7 +87,7 @@ class PeriodicTaskRouter(BaseRouter):
     @staticmethod
     async def update_periodic_task_description(
         request: Request,
-        periodic_task_id: PyObjectId,
+        periodic_task_id: PydanticObjectId,
         data: DescriptionUpdate,
     ) -> PeriodicTask:
         """

--- a/featurebyte/routes/relationship_info/api.py
+++ b/featurebyte/routes/relationship_info/api.py
@@ -9,7 +9,7 @@ from typing import Optional
 from bson import ObjectId
 from fastapi import APIRouter, Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.models.relationship import RelationshipInfoModel
 from featurebyte.persistent.base import SortDir
@@ -71,7 +71,7 @@ async def list_relationship_info(
 
 @router.get("/{relationship_info_id}", response_model=RelationshipInfoModel)
 async def get_relationship_info(
-    request: Request, relationship_info_id: PyObjectId
+    request: Request, relationship_info_id: PydanticObjectId
 ) -> RelationshipInfoModel:
     """
     Retrieve relationship info
@@ -88,7 +88,7 @@ async def get_relationship_info(
 @router.patch("/{relationship_info_id}")
 async def update_relationship_info(
     request: Request,
-    relationship_info_id: PyObjectId,
+    relationship_info_id: PydanticObjectId,
     data: RelationshipInfoUpdate,
 ) -> RelationshipInfoModel:
     """
@@ -107,7 +107,7 @@ async def update_relationship_info(
 @router.get("/{relationship_info_id}/info", response_model=RelationshipInfoInfo)
 async def get_relationship_info_info(
     request: Request,
-    relationship_info_id: PyObjectId,
+    relationship_info_id: PydanticObjectId,
 ) -> RelationshipInfoInfo:
     """
     Retrieve RelationshipInfo info
@@ -124,7 +124,7 @@ async def get_relationship_info_info(
 @router.get("/audit/{relationship_info_id}", response_model=AuditDocumentList)
 async def list_relationship_info_audit_logs(
     request: Request,
-    relationship_info_id: PyObjectId,
+    relationship_info_id: PydanticObjectId,
     page: int = PageQuery,
     page_size: int = PageSizeQuery,
     sort_by: Optional[str] = AuditLogSortByQuery,
@@ -150,7 +150,7 @@ async def list_relationship_info_audit_logs(
 @router.patch("/{relationship_info_id}/description", response_model=RelationshipInfoModel)
 async def update_relationship_info_description(
     request: Request,
-    relationship_info_id: PyObjectId,
+    relationship_info_id: PydanticObjectId,
     data: DescriptionUpdate,
 ) -> RelationshipInfoModel:
     """

--- a/featurebyte/routes/scd_table/api.py
+++ b/featurebyte/routes/scd_table/api.py
@@ -10,7 +10,7 @@ from typing import List, Optional
 from bson import ObjectId
 from fastapi import APIRouter, Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.event_table import FeatureJobSettingHistoryEntry
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.models.scd_table import SCDTableModel
@@ -104,13 +104,13 @@ class SCDTableRouter(
             response_model=List[FeatureJobSettingHistoryEntry],
         )
 
-    async def get_object(self, request: Request, scd_table_id: PyObjectId) -> SCDTableModel:
+    async def get_object(self, request: Request, scd_table_id: PydanticObjectId) -> SCDTableModel:
         return await super().get_object(request, scd_table_id)
 
     async def list_audit_logs(
         self,
         request: Request,
-        scd_table_id: PyObjectId,
+        scd_table_id: PydanticObjectId,
         page: int = PageQuery,
         page_size: int = PageSizeQuery,
         sort_by: Optional[str] = AuditLogSortByQuery,
@@ -128,7 +128,7 @@ class SCDTableRouter(
         )
 
     async def update_description(
-        self, request: Request, scd_table_id: PyObjectId, data: DescriptionUpdate
+        self, request: Request, scd_table_id: PydanticObjectId, data: DescriptionUpdate
     ) -> SCDTableModel:
         return await super().update_description(request, scd_table_id, data)
 
@@ -137,7 +137,7 @@ class SCDTableRouter(
         return await controller.create_table(data=data)
 
     async def get_scd_table_info(
-        self, request: Request, scd_table_id: PyObjectId, verbose: bool = VerboseQuery
+        self, request: Request, scd_table_id: PydanticObjectId, verbose: bool = VerboseQuery
     ) -> SCDTableInfo:
         """
         Retrieve scd table info
@@ -150,7 +150,7 @@ class SCDTableRouter(
         return info
 
     async def update_scd_table(
-        self, request: Request, scd_table_id: PyObjectId, data: SCDTableUpdate
+        self, request: Request, scd_table_id: PydanticObjectId, data: SCDTableUpdate
     ) -> SCDTableModel:
         """
         Update scd table
@@ -163,7 +163,7 @@ class SCDTableRouter(
         return scd_table
 
     async def update_column_entity(
-        self, request: Request, scd_table_id: PyObjectId, data: ColumnEntityUpdate
+        self, request: Request, scd_table_id: PydanticObjectId, data: ColumnEntityUpdate
     ) -> SCDTableModel:
         """
         Update column entity
@@ -179,7 +179,7 @@ class SCDTableRouter(
     async def update_column_critical_data_info(
         self,
         request: Request,
-        scd_table_id: PyObjectId,
+        scd_table_id: PydanticObjectId,
         data: ColumnCriticalDataInfoUpdate,
     ) -> SCDTableModel:
         """
@@ -196,7 +196,7 @@ class SCDTableRouter(
     async def update_column_description(
         self,
         request: Request,
-        scd_table_id: PyObjectId,
+        scd_table_id: PydanticObjectId,
         data: ColumnDescriptionUpdate,
     ) -> SCDTableModel:
         """
@@ -213,7 +213,7 @@ class SCDTableRouter(
     async def list_default_feature_job_setting_history(
         self,
         request: Request,
-        scd_table_id: PyObjectId,
+        scd_table_id: PydanticObjectId,
     ) -> List[FeatureJobSettingHistoryEntry]:
         """
         List SCDTable default feature job settings history
@@ -232,7 +232,9 @@ class SCDTableRouter(
             for record in history_values
         ]
 
-    async def delete_object(self, request: Request, scd_table_id: PyObjectId) -> DeleteResponse:
+    async def delete_object(
+        self, request: Request, scd_table_id: PydanticObjectId
+    ) -> DeleteResponse:
         controller = self.get_controller_for_request(request)
         await controller.delete(document_id=ObjectId(scd_table_id))
         return DeleteResponse()

--- a/featurebyte/routes/semantic/api.py
+++ b/featurebyte/routes/semantic/api.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 from fastapi import Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.models.relationship import Parent
 from featurebyte.models.semantic import SemanticModel
@@ -56,7 +56,9 @@ class SemanticRouter(
         )
 
     @staticmethod
-    async def add_parent(request: Request, semantic_id: PyObjectId, data: Parent) -> SemanticModel:
+    async def add_parent(
+        request: Request, semantic_id: PydanticObjectId, data: Parent
+    ) -> SemanticModel:
         """
         Create semantic relationship
         """
@@ -68,7 +70,7 @@ class SemanticRouter(
 
     @staticmethod
     async def remove_parent(
-        request: Request, semantic_id: PyObjectId, parent_semantic_id: PyObjectId
+        request: Request, semantic_id: PydanticObjectId, parent_semantic_id: PydanticObjectId
     ) -> SemanticModel:
         """
         Remove semantic relationship
@@ -82,13 +84,13 @@ class SemanticRouter(
     async def create_object(self, request: Request, data: SemanticCreate) -> SemanticModel:
         return await super().create_object(request=request, data=data)
 
-    async def get_object(self, request: Request, semantic_id: PyObjectId) -> SemanticModel:
+    async def get_object(self, request: Request, semantic_id: PydanticObjectId) -> SemanticModel:
         return await super().get_object(request=request, object_id=semantic_id)
 
     async def list_audit_logs(
         self,
         request: Request,
-        semantic_id: PyObjectId,
+        semantic_id: PydanticObjectId,
         page: int = PageQuery,
         page_size: int = PageSizeQuery,
         sort_by: Optional[str] = AuditLogSortByQuery,
@@ -106,9 +108,11 @@ class SemanticRouter(
         )
 
     async def update_description(
-        self, request: Request, semantic_id: PyObjectId, data: DescriptionUpdate
+        self, request: Request, semantic_id: PydanticObjectId, data: DescriptionUpdate
     ) -> SemanticModel:
         return await super().update_description(request, semantic_id, data)
 
-    async def delete_object(self, request: Request, semantic_id: PyObjectId) -> DeleteResponse:
+    async def delete_object(
+        self, request: Request, semantic_id: PydanticObjectId
+    ) -> DeleteResponse:
         return await super().delete_object(request, semantic_id)

--- a/featurebyte/routes/static_source_table/api.py
+++ b/featurebyte/routes/static_source_table/api.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Optional, cast
 from fastapi import APIRouter, Query, Request
 from starlette.responses import StreamingResponse
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.models.static_source_table import StaticSourceTableModel
 from featurebyte.persistent.base import SortDir
@@ -48,7 +48,7 @@ class StaticSourceTableRouter(BaseMaterializedTableRouter[StaticSourceTableModel
         self.add_router(router)
 
     async def get_table(
-        self, request: Request, static_source_table_id: PyObjectId
+        self, request: Request, static_source_table_id: PydanticObjectId
     ) -> StaticSourceTableModel:
         return await super().get_table(request, static_source_table_id)
 
@@ -69,7 +69,9 @@ async def create_static_source_table(
 
 
 @router.delete("/{static_source_table_id}", response_model=Task, status_code=HTTPStatus.ACCEPTED)
-async def delete_static_source_table(request: Request, static_source_table_id: PyObjectId) -> Task:
+async def delete_static_source_table(
+    request: Request, static_source_table_id: PydanticObjectId
+) -> Task:
     """
     Delete StaticSourceTable by submitting a deletion task
     """
@@ -105,7 +107,7 @@ async def list_static_source_tables(
 @router.get("/audit/{static_source_table_id}", response_model=AuditDocumentList)
 async def list_static_source_table_audit_logs(
     request: Request,
-    static_source_table_id: PyObjectId,
+    static_source_table_id: PydanticObjectId,
     page: int = PageQuery,
     page_size: int = PageSizeQuery,
     sort_by: Optional[str] = AuditLogSortByQuery,
@@ -128,7 +130,7 @@ async def list_static_source_table_audit_logs(
 
 @router.get("/{static_source_table_id}/info", response_model=StaticSourceTableInfo)
 async def get_static_source_table_info(
-    request: Request, static_source_table_id: PyObjectId, verbose: bool = VerboseQuery
+    request: Request, static_source_table_id: PydanticObjectId, verbose: bool = VerboseQuery
 ) -> StaticSourceTableInfo:
     """
     Get StaticSourceTable info
@@ -140,7 +142,7 @@ async def get_static_source_table_info(
 
 @router.get("/pyarrow_table/{static_source_table_id}")
 async def download_table_as_pyarrow_table(
-    request: Request, static_source_table_id: PyObjectId
+    request: Request, static_source_table_id: PydanticObjectId
 ) -> StreamingResponse:
     """
     Download StaticSourceTable as pyarrow table
@@ -154,7 +156,7 @@ async def download_table_as_pyarrow_table(
 
 @router.get("/parquet/{static_source_table_id}")
 async def download_table_as_parquet(
-    request: Request, static_source_table_id: PyObjectId
+    request: Request, static_source_table_id: PydanticObjectId
 ) -> StreamingResponse:
     """
     Download StaticSourceTable as parquet file
@@ -169,7 +171,7 @@ async def download_table_as_parquet(
 @router.patch("/{static_source_table_id}/description", response_model=StaticSourceTableModel)
 async def update_static_source_table_description(
     request: Request,
-    static_source_table_id: PyObjectId,
+    static_source_table_id: PydanticObjectId,
     data: DescriptionUpdate,
 ) -> StaticSourceTableModel:
     """
@@ -186,7 +188,7 @@ async def update_static_source_table_description(
 @router.post("/{static_source_table_id}/preview", response_model=Dict[str, Any])
 async def preview_static_source_table(
     request: Request,
-    static_source_table_id: PyObjectId,
+    static_source_table_id: PydanticObjectId,
     limit: int = Query(default=PREVIEW_DEFAULT, gt=0, le=PREVIEW_LIMIT),
 ) -> Dict[str, Any]:
     """

--- a/featurebyte/routes/system_metrics/api.py
+++ b/featurebyte/routes/system_metrics/api.py
@@ -8,7 +8,7 @@ from typing import Any, Optional
 
 from fastapi import APIRouter, Query, Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseRouter
 from featurebyte.routes.common.schema import (
@@ -40,12 +40,12 @@ async def list_metrics(
     sort_by: Optional[str] = SortByQuery,
     sort_dir: Optional[SortDir] = SortDirQuery,
     metrics_type: Optional[str] = Query(default=None),
-    historical_feature_table_id: Optional[PyObjectId] = Query(default=None),
+    historical_feature_table_id: Optional[PydanticObjectId] = Query(default=None),
     tile_table_id: Optional[str] = Query(default=None),
-    offline_store_feature_table_id: Optional[PyObjectId] = Query(default=None),
-    deployment_id: Optional[PyObjectId] = Query(default=None),
-    observation_table_id: Optional[PyObjectId] = Query(default=None),
-    batch_feature_table_id: Optional[PyObjectId] = Query(default=None),
+    offline_store_feature_table_id: Optional[PydanticObjectId] = Query(default=None),
+    deployment_id: Optional[PydanticObjectId] = Query(default=None),
+    observation_table_id: Optional[PydanticObjectId] = Query(default=None),
+    batch_feature_table_id: Optional[PydanticObjectId] = Query(default=None),
 ) -> SystemMetricsList:
     """
     List system metrics

--- a/featurebyte/routes/table/api.py
+++ b/featurebyte/routes/table/api.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.proxy_table import TableModel
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseRouter
@@ -59,7 +59,7 @@ async def list_table(
 
 
 @router.get("/{table_id}", response_model=TableModel)
-async def get_table(request: Request, table_id: PyObjectId) -> TableModel:
+async def get_table(request: Request, table_id: PydanticObjectId) -> TableModel:
     """
     Retrieve Table
     """

--- a/featurebyte/routes/target/api.py
+++ b/featurebyte/routes/target/api.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Optional
 from bson import ObjectId
 from fastapi import APIRouter, Query, Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.models.target import TargetModel
 from featurebyte.persistent.base import SortDir
@@ -78,7 +78,7 @@ async def list_target(
 
 
 @router.get("/{target_id}", response_model=TargetModel)
-async def get_target(request: Request, target_id: PyObjectId) -> TargetModel:
+async def get_target(request: Request, target_id: PydanticObjectId) -> TargetModel:
     """
     Retrieve Target
     """
@@ -89,7 +89,7 @@ async def get_target(request: Request, target_id: PyObjectId) -> TargetModel:
 @router.get("/{target_id}/info", response_model=TargetInfo)
 async def get_target_info(
     request: Request,
-    target_id: PyObjectId,
+    target_id: PydanticObjectId,
     verbose: bool = VerboseQuery,
 ) -> TargetInfo:
     """
@@ -105,7 +105,7 @@ async def get_target_info(
 @router.get("/audit/{target_id}", response_model=AuditDocumentList)
 async def list_target_audit_logs(
     request: Request,
-    target_id: PyObjectId,
+    target_id: PydanticObjectId,
     page: int = PageQuery,
     page_size: int = PageSizeQuery,
     sort_by: Optional[str] = AuditLogSortByQuery,
@@ -141,7 +141,7 @@ async def get_target_preview(
 @router.patch("/{target_id}/description", response_model=TargetModel)
 async def update_target_description(
     request: Request,
-    target_id: PyObjectId,
+    target_id: PydanticObjectId,
     data: DescriptionUpdate,
 ) -> TargetModel:
     """
@@ -160,7 +160,7 @@ async def update_target_description(
 )
 async def get_feature_sample_entity_serving_names(
     request: Request,
-    target_id: PyObjectId,
+    target_id: PydanticObjectId,
     count: int = Query(default=1, gt=0, le=10),
 ) -> SampleEntityServingNames:
     """
@@ -173,7 +173,7 @@ async def get_feature_sample_entity_serving_names(
 
 
 @router.delete("/{target_id}")
-async def delete_target(request: Request, target_id: PyObjectId) -> None:
+async def delete_target(request: Request, target_id: PydanticObjectId) -> None:
     """
     Delete Target
     """

--- a/featurebyte/routes/target_namespace/api.py
+++ b/featurebyte/routes/target_namespace/api.py
@@ -9,7 +9,7 @@ from typing import Optional, cast
 
 from fastapi import APIRouter, Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.models.target_namespace import TargetNamespaceModel
 from featurebyte.persistent.base import SortDir
@@ -58,7 +58,7 @@ async def create_target_namespace(
 
 @router.get("/{target_namespace_id}", response_model=TargetNamespaceModel)
 async def get_target_namespace(
-    request: Request, target_namespace_id: PyObjectId
+    request: Request, target_namespace_id: PydanticObjectId
 ) -> TargetNamespaceModel:
     """
     Retrieve Target Namespace
@@ -75,7 +75,7 @@ async def get_target_namespace(
 
 @router.patch("/{target_namespace_id}", response_model=TargetNamespaceModel)
 async def update_target_namespace(
-    request: Request, target_namespace_id: PyObjectId, data: TargetNamespaceUpdate
+    request: Request, target_namespace_id: PydanticObjectId, data: TargetNamespaceUpdate
 ) -> TargetNamespaceModel:
     """
     Update TargetNamespace
@@ -114,7 +114,7 @@ async def list_target_namespaces(
 @router.get("/audit/{target_namespace_id}", response_model=AuditDocumentList)
 async def list_target_namespace_audit_logs(
     request: Request,
-    target_namespace_id: PyObjectId,
+    target_namespace_id: PydanticObjectId,
     page: int = PageQuery,
     page_size: int = PageSizeQuery,
     sort_by: Optional[str] = AuditLogSortByQuery,
@@ -138,7 +138,7 @@ async def list_target_namespace_audit_logs(
 @router.get("/{target_namespace_id}/info", response_model=TargetNamespaceInfo)
 async def get_target_namespace_info(
     request: Request,
-    target_namespace_id: PyObjectId,
+    target_namespace_id: PydanticObjectId,
     verbose: bool = VerboseQuery,
 ) -> TargetNamespaceInfo:
     """
@@ -155,7 +155,7 @@ async def get_target_namespace_info(
 @router.patch("/{target_namespace_id}/description", response_model=TargetNamespaceModel)
 async def update_target_namespace_description(
     request: Request,
-    target_namespace_id: PyObjectId,
+    target_namespace_id: PydanticObjectId,
     data: DescriptionUpdate,
 ) -> TargetNamespaceModel:
     """
@@ -172,7 +172,7 @@ async def update_target_namespace_description(
 @router.delete("/{target_namespace_id}")
 async def delete_target_namespace(
     request: Request,
-    target_namespace_id: PyObjectId,
+    target_namespace_id: PydanticObjectId,
 ) -> None:
     """
     Delete TargetNamespace

--- a/featurebyte/routes/target_table/api.py
+++ b/featurebyte/routes/target_table/api.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Optional, cast
 from fastapi import Form, Query, Request, UploadFile
 from starlette.responses import StreamingResponse
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.models.target_table import TargetTableModel
 from featurebyte.persistent.base import SortDir
@@ -98,7 +98,9 @@ class TargetTableRouter(BaseMaterializedTableRouter[TargetTableModel]):
             methods=["POST"],
         )
 
-    async def get_table(self, request: Request, target_table_id: PyObjectId) -> TargetTableModel:
+    async def get_table(
+        self, request: Request, target_table_id: PydanticObjectId
+    ) -> TargetTableModel:
         """
         Test random string
         """
@@ -128,7 +130,7 @@ class TargetTableRouter(BaseMaterializedTableRouter[TargetTableModel]):
         return task_submit
 
     @staticmethod
-    async def delete_target_table(request: Request, target_table_id: PyObjectId) -> Task:
+    async def delete_target_table(request: Request, target_table_id: PydanticObjectId) -> Task:
         """
         Delete TargetTable
         """
@@ -162,7 +164,7 @@ class TargetTableRouter(BaseMaterializedTableRouter[TargetTableModel]):
     @staticmethod
     async def list_target_table_audit_logs(
         request: Request,
-        target_table_id: PyObjectId,
+        target_table_id: PydanticObjectId,
         page: int = PageQuery,
         page_size: int = PageSizeQuery,
         sort_by: Optional[str] = AuditLogSortByQuery,
@@ -184,7 +186,7 @@ class TargetTableRouter(BaseMaterializedTableRouter[TargetTableModel]):
 
     @staticmethod
     async def get_target_table_info(
-        request: Request, target_table_id: PyObjectId, verbose: bool = VerboseQuery
+        request: Request, target_table_id: PydanticObjectId, verbose: bool = VerboseQuery
     ) -> TargetTableInfo:
         """
         Get TargetTable info
@@ -195,7 +197,7 @@ class TargetTableRouter(BaseMaterializedTableRouter[TargetTableModel]):
 
     @staticmethod
     async def download_table_as_pyarrow_table(
-        request: Request, target_table_id: PyObjectId
+        request: Request, target_table_id: PydanticObjectId
     ) -> StreamingResponse:
         """
         Download TargetTable as pyarrow table
@@ -208,7 +210,7 @@ class TargetTableRouter(BaseMaterializedTableRouter[TargetTableModel]):
 
     @staticmethod
     async def download_table_as_parquet(
-        request: Request, target_table_id: PyObjectId
+        request: Request, target_table_id: PydanticObjectId
     ) -> StreamingResponse:
         """
         Download TargetTable as parquet file
@@ -222,7 +224,7 @@ class TargetTableRouter(BaseMaterializedTableRouter[TargetTableModel]):
     @staticmethod
     async def update_target_table_description(
         request: Request,
-        target_table_id: PyObjectId,
+        target_table_id: PydanticObjectId,
         data: DescriptionUpdate,
     ) -> TargetTableModel:
         """
@@ -238,7 +240,7 @@ class TargetTableRouter(BaseMaterializedTableRouter[TargetTableModel]):
     @staticmethod
     async def preview_target_table(
         request: Request,
-        target_table_id: PyObjectId,
+        target_table_id: PydanticObjectId,
         limit: int = Query(default=PREVIEW_DEFAULT, gt=0, le=PREVIEW_LIMIT),
     ) -> Dict[str, Any]:
         """

--- a/featurebyte/routes/time_series_table/api.py
+++ b/featurebyte/routes/time_series_table/api.py
@@ -10,7 +10,7 @@ from typing import List, Optional
 from bson import ObjectId
 from fastapi import APIRouter, Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.models.time_series_table import (
     CronFeatureJobSettingHistoryEntry,
@@ -113,14 +113,14 @@ class TimeSeriesTableRouter(
         )
 
     async def get_object(
-        self, request: Request, time_series_table_id: PyObjectId
+        self, request: Request, time_series_table_id: PydanticObjectId
     ) -> TimeSeriesTableModel:
         return await super().get_object(request, time_series_table_id)
 
     async def list_audit_logs(
         self,
         request: Request,
-        time_series_table_id: PyObjectId,
+        time_series_table_id: PydanticObjectId,
         page: int = PageQuery,
         page_size: int = PageSizeQuery,
         sort_by: Optional[str] = AuditLogSortByQuery,
@@ -138,7 +138,7 @@ class TimeSeriesTableRouter(
         )
 
     async def update_description(
-        self, request: Request, time_series_table_id: PyObjectId, data: DescriptionUpdate
+        self, request: Request, time_series_table_id: PydanticObjectId, data: DescriptionUpdate
     ) -> TimeSeriesTableModel:
         return await super().update_description(request, time_series_table_id, data)
 
@@ -149,7 +149,7 @@ class TimeSeriesTableRouter(
         return await controller.create_table(data=data)
 
     async def get_time_series_table_info(
-        self, request: Request, time_series_table_id: PyObjectId, verbose: bool = VerboseQuery
+        self, request: Request, time_series_table_id: PydanticObjectId, verbose: bool = VerboseQuery
     ) -> TimeSeriesTableInfo:
         """
         Retrieve time series table info
@@ -162,7 +162,7 @@ class TimeSeriesTableRouter(
         return info
 
     async def update_time_series_table(
-        self, request: Request, time_series_table_id: PyObjectId, data: TimeSeriesTableUpdate
+        self, request: Request, time_series_table_id: PydanticObjectId, data: TimeSeriesTableUpdate
     ) -> TimeSeriesTableModel:
         """
         Update time series table
@@ -175,7 +175,7 @@ class TimeSeriesTableRouter(
         return time_series_table
 
     async def update_column_entity(
-        self, request: Request, time_series_table_id: PyObjectId, data: ColumnEntityUpdate
+        self, request: Request, time_series_table_id: PydanticObjectId, data: ColumnEntityUpdate
     ) -> TimeSeriesTableModel:
         """
         Update column entity
@@ -191,7 +191,7 @@ class TimeSeriesTableRouter(
     async def update_column_critical_data_info(
         self,
         request: Request,
-        time_series_table_id: PyObjectId,
+        time_series_table_id: PydanticObjectId,
         data: ColumnCriticalDataInfoUpdate,
     ) -> TimeSeriesTableModel:
         """
@@ -208,7 +208,7 @@ class TimeSeriesTableRouter(
     async def update_column_description(
         self,
         request: Request,
-        time_series_table_id: PyObjectId,
+        time_series_table_id: PydanticObjectId,
         data: ColumnDescriptionUpdate,
     ) -> TimeSeriesTableModel:
         """
@@ -225,7 +225,7 @@ class TimeSeriesTableRouter(
     async def list_default_feature_job_setting_history(
         self,
         request: Request,
-        time_series_table_id: PyObjectId,
+        time_series_table_id: PydanticObjectId,
     ) -> List[CronFeatureJobSettingHistoryEntry]:
         """
         List TimeSeriesTable default feature job settings history
@@ -245,7 +245,7 @@ class TimeSeriesTableRouter(
         ]
 
     async def delete_object(
-        self, request: Request, time_series_table_id: PyObjectId
+        self, request: Request, time_series_table_id: PydanticObjectId
     ) -> DeleteResponse:
         controller = self.get_controller_for_request(request)
         await controller.delete(document_id=ObjectId(time_series_table_id))

--- a/featurebyte/routes/use_case/api.py
+++ b/featurebyte/routes/use_case/api.py
@@ -7,7 +7,7 @@ from typing import Optional, cast
 
 from fastapi import APIRouter, Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.models.use_case import UseCaseModel
 from featurebyte.persistent.base import SortDir
@@ -56,7 +56,7 @@ async def create_use_case(
 
 
 @router.get("/{use_case_id}", response_model=UseCaseModel)
-async def get_use_case(request: Request, use_case_id: PyObjectId) -> UseCaseModel:
+async def get_use_case(request: Request, use_case_id: PydanticObjectId) -> UseCaseModel:
     """
     Get Use Case
     """
@@ -68,7 +68,7 @@ async def get_use_case(request: Request, use_case_id: PyObjectId) -> UseCaseMode
 @router.get("/{use_case_id}/observation_tables", response_model=ObservationTableList)
 async def list_use_case_observation_tables(
     request: Request,
-    use_case_id: PyObjectId,
+    use_case_id: PydanticObjectId,
     page: int = PageQuery,
     page_size: int = PageSizeQuery,
 ) -> ObservationTableList:
@@ -93,7 +93,7 @@ async def list_use_case_observation_tables(
 @router.get("/{use_case_id}/feature_tables", response_model=HistoricalFeatureTableList)
 async def list_use_case_feature_tables(
     request: Request,
-    use_case_id: PyObjectId,
+    use_case_id: PydanticObjectId,
     page: int = PageQuery,
     page_size: int = PageSizeQuery,
 ) -> HistoricalFeatureTableList:
@@ -111,7 +111,7 @@ async def list_use_case_feature_tables(
 @router.get("/{use_case_id}/deployments", response_model=DeploymentList)
 async def list_use_case_deployments(
     request: Request,
-    use_case_id: PyObjectId,
+    use_case_id: PydanticObjectId,
     page: int = PageQuery,
     page_size: int = PageSizeQuery,
 ) -> DeploymentList:
@@ -132,7 +132,7 @@ async def list_use_case_deployments(
 
 @router.patch("/{use_case_id}", response_model=UseCaseModel)
 async def update_use_case(
-    request: Request, use_case_id: PyObjectId, data: UseCaseUpdate
+    request: Request, use_case_id: PydanticObjectId, data: UseCaseUpdate
 ) -> UseCaseModel:
     """
     Update Use Case
@@ -143,7 +143,7 @@ async def update_use_case(
 
 
 @router.delete("/{use_case_id}", status_code=HTTPStatus.OK)
-async def delete_use_case(request: Request, use_case_id: PyObjectId) -> None:
+async def delete_use_case(request: Request, use_case_id: PydanticObjectId) -> None:
     """
     Update Use Case
     """
@@ -152,7 +152,7 @@ async def delete_use_case(request: Request, use_case_id: PyObjectId) -> None:
 
 
 @router.get("/{use_case_id}/info", response_model=UseCaseInfo, status_code=HTTPStatus.OK)
-async def use_case_info(request: Request, use_case_id: PyObjectId) -> UseCaseInfo:
+async def use_case_info(request: Request, use_case_id: PydanticObjectId) -> UseCaseInfo:
     """
     Get Use Case Info
     """
@@ -169,7 +169,7 @@ async def list_use_cases(
     sort_dir: Optional[SortDir] = SortDirQuery,
     search: Optional[str] = SearchQuery,
     name: Optional[str] = NameQuery,
-    feature_list_id: Optional[PyObjectId] = None,
+    feature_list_id: Optional[PydanticObjectId] = None,
 ) -> UseCaseList:
     """
     List Use Case
@@ -189,7 +189,7 @@ async def list_use_cases(
 @router.get("/audit/{use_case_id}", response_model=AuditDocumentList)
 async def list_use_case_audit_logs(
     request: Request,
-    use_case_id: PyObjectId,
+    use_case_id: PydanticObjectId,
     page: int = PageQuery,
     page_size: int = PageSizeQuery,
     sort_by: Optional[str] = AuditLogSortByQuery,
@@ -213,7 +213,7 @@ async def list_use_case_audit_logs(
 @router.patch("/{use_case_id}/description", response_model=UseCaseModel)
 async def update_use_case_description(
     request: Request,
-    use_case_id: PyObjectId,
+    use_case_id: PydanticObjectId,
     data: DescriptionUpdate,
 ) -> UseCaseModel:
     """

--- a/featurebyte/routes/use_case/controller.py
+++ b/featurebyte/routes/use_case/controller.py
@@ -12,7 +12,7 @@ from featurebyte.exception import (
     DocumentUpdateError,
     ObservationTableInvalidUseCaseError,
 )
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import QueryFilter
 from featurebyte.models.use_case import UseCaseModel
 from featurebyte.persistent.base import SortDir
@@ -287,7 +287,7 @@ class UseCaseController(BaseDocumentController[UseCaseModel, UseCaseService, Use
         sort_by: Optional[List[Tuple[str, SortDir]]] = None,
         search: Optional[str] = None,
         name: Optional[str] = None,
-        feature_list_id: Optional[PyObjectId] = None,
+        feature_list_id: Optional[PydanticObjectId] = None,
     ) -> UseCaseList:
         """
         List UseCases
@@ -304,7 +304,7 @@ class UseCaseController(BaseDocumentController[UseCaseModel, UseCaseService, Use
             Search string
         name: Optional[str]
             UseCase name
-        feature_list_id: Optional[PyObjectId]
+        feature_list_id: Optional[PydanticObjectId]
             FeatureList id
 
         Returns

--- a/featurebyte/routes/user_defined_function/api.py
+++ b/featurebyte/routes/user_defined_function/api.py
@@ -7,7 +7,7 @@ from typing import Optional, cast
 
 from fastapi import APIRouter, Request
 
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.persistent import AuditDocumentList
 from featurebyte.persistent.base import SortDir
 from featurebyte.routes.base_router import BaseRouter
@@ -56,7 +56,7 @@ async def create_user_defined_function(
 
 @router.get("/{user_defined_function_id}", response_model=UserDefinedFunctionResponse)
 async def get_user_defined_function(
-    request: Request, user_defined_function_id: PyObjectId
+    request: Request, user_defined_function_id: PydanticObjectId
 ) -> UserDefinedFunctionResponse:
     """
     Get UserDefinedFunction
@@ -68,7 +68,7 @@ async def get_user_defined_function(
 
 @router.patch("/{user_defined_function_id}", response_model=UserDefinedFunctionResponse)
 async def update_user_defined_function(
-    request: Request, user_defined_function_id: PyObjectId, data: UserDefinedFunctionUpdate
+    request: Request, user_defined_function_id: PydanticObjectId, data: UserDefinedFunctionUpdate
 ) -> UserDefinedFunctionResponse:
     """
     Update UserDefinedFunction
@@ -82,7 +82,7 @@ async def update_user_defined_function(
 
 @router.delete("/{user_defined_function_id}", response_model=DeleteResponse)
 async def delete_user_defined_function(
-    request: Request, user_defined_function_id: PyObjectId
+    request: Request, user_defined_function_id: PydanticObjectId
 ) -> DeleteResponse:
     """
     Delete UserDefinedFunction
@@ -101,7 +101,7 @@ async def list_user_defined_functions(
     sort_dir: Optional[SortDir] = SortDirQuery,
     search: Optional[str] = SearchQuery,
     name: Optional[str] = NameQuery,
-    feature_store_id: Optional[PyObjectId] = None,
+    feature_store_id: Optional[PydanticObjectId] = None,
 ) -> UserDefinedFunctionList:
     """
     List UserDefinedFunctions
@@ -121,7 +121,7 @@ async def list_user_defined_functions(
 @router.get("/audit/{user_defined_function_id}", response_model=AuditDocumentList)
 async def get_user_defined_function_audit_log(
     request: Request,
-    user_defined_function_id: PyObjectId,
+    user_defined_function_id: PydanticObjectId,
     page: int = PageQuery,
     page_size: int = PageSizeQuery,
     sort_by: Optional[str] = AuditLogSortByQuery,
@@ -144,7 +144,7 @@ async def get_user_defined_function_audit_log(
 
 @router.get("/{user_defined_function_id}/info", response_model=UserDefinedFunctionInfo)
 async def get_user_defined_function_info(
-    request: Request, user_defined_function_id: PyObjectId, verbose: bool = VerboseQuery
+    request: Request, user_defined_function_id: PydanticObjectId, verbose: bool = VerboseQuery
 ) -> UserDefinedFunctionInfo:
     """
     Get UserDefinedFunction info
@@ -157,7 +157,7 @@ async def get_user_defined_function_info(
 @router.patch("/{user_defined_function_id}/description", response_model=UserDefinedFunctionResponse)
 async def update_user_defined_function_description(
     request: Request,
-    user_defined_function_id: PyObjectId,
+    user_defined_function_id: PydanticObjectId,
     data: DescriptionUpdate,
 ) -> UserDefinedFunctionResponse:
     """

--- a/featurebyte/routes/user_defined_function/controller.py
+++ b/featurebyte/routes/user_defined_function/controller.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Tuple, cast
 from bson import ObjectId
 
 from featurebyte.exception import DocumentCreationError, DocumentUpdateError
-from featurebyte.models.base import PyObjectId
+from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.feature_store import FeatureStoreModel
 from featurebyte.models.persistent import QueryFilter
 from featurebyte.models.user_defined_function import UserDefinedFunctionModel
@@ -129,7 +129,7 @@ class UserDefinedFunctionController(
 
     async def update_user_defined_function(
         self,
-        document_id: PyObjectId,
+        document_id: PydanticObjectId,
         data: UserDefinedFunctionUpdate,
     ) -> UserDefinedFunctionModel:
         """
@@ -137,7 +137,7 @@ class UserDefinedFunctionController(
 
         Parameters
         ----------
-        document_id: PyObjectId
+        document_id: PydanticObjectId
             UserDefinedFunction id
         data: UserDefinedFunctionUpdate
             UserDefinedFunction update payload
@@ -203,7 +203,7 @@ class UserDefinedFunctionController(
         sort_by: list[tuple[str, SortDir]] | None = None,
         search: str | None = None,
         name: str | None = None,
-        feature_store_id: PyObjectId | None = None,
+        feature_store_id: PydanticObjectId | None = None,
     ) -> UserDefinedFunctionList:
         """
         List UserDefinedFunction stored in persistent
@@ -220,7 +220,7 @@ class UserDefinedFunctionController(
             Search token to be used in filtering
         name: str | None
             Feature name to be used in filtering
-        feature_store_id: PyObjectId | None
+        feature_store_id: PydanticObjectId | None
             FeatureStore id to be used in filtering
 
         Returns


### PR DESCRIPTION
## Description

Use PydanticObjectId instead of PyObjectId in schema defintions

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
