### PR TITLE
[DEV-4106] Use string timestamp filtering for event tables tile computation

### DIFF
--- a/featurebyte/query_graph/sql/ast/input.py
+++ b/featurebyte/query_graph/sql/ast/input.py
@@ -10,10 +10,9 @@ from typing import Any
 from sqlglot import expressions
 from sqlglot.expressions import Expression, Select
 
-from featurebyte.enum import DBVarType, InternalName, TableDataType, TimeIntervalUnit
+from featurebyte.enum import DBVarType, InternalName, TableDataType
 from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.model.dtype import DBVarTypeMetadata
-from featurebyte.query_graph.model.time_series_table import TimeInterval
 from featurebyte.query_graph.model.timestamp_schema import (
     TimestampSchema,
 )
@@ -28,7 +27,9 @@ from featurebyte.query_graph.sql.common import (
 )
 from featurebyte.query_graph.sql.entity_filter import get_table_filtered_by_entity
 from featurebyte.query_graph.sql.partition_filter import get_partition_filter
-from featurebyte.query_graph.sql.partition_filter_helper import DEFAULT_BUFFER_NUM_DAYS
+from featurebyte.query_graph.sql.partition_filter_helper import (
+    get_default_partition_column_filter_buffer,
+)
 from featurebyte.query_graph.sql.timestamp_helper import convert_timestamp_to_utc
 
 
@@ -111,10 +112,7 @@ class InputNode(TableNode):
             partition_column_filter = PartitionColumnFilter(
                 from_timestamp=_maybe_cast(start_date_placeholder),
                 to_timestamp=_maybe_cast(end_date_placeholder),
-                buffer=TimeInterval(
-                    unit=TimeIntervalUnit.DAY,
-                    value=DEFAULT_BUFFER_NUM_DAYS,
-                ),
+                buffer=get_default_partition_column_filter_buffer(),
             )
             select_expr = self._apply_partition_column_filter(
                 select_expr=select_expr,

--- a/featurebyte/query_graph/sql/common.py
+++ b/featurebyte/query_graph/sql/common.py
@@ -14,6 +14,7 @@ from sqlglot import expressions
 from sqlglot.expressions import Expression, select
 
 from featurebyte.enum import SourceType
+from featurebyte.query_graph.model.time_series_table import TimeInterval
 from featurebyte.query_graph.model.timestamp_schema import TimestampSchema
 from featurebyte.query_graph.sql.dialects import get_dialect_from_source_type
 
@@ -348,6 +349,7 @@ class PartitionColumnFilter:
 
     from_timestamp: Optional[datetime | Expression] = None
     to_timestamp: Optional[datetime | Expression] = None
+    buffer: Optional[TimeInterval] = None
 
 
 @dataclass

--- a/featurebyte/query_graph/sql/entity_filter.py
+++ b/featurebyte/query_graph/sql/entity_filter.py
@@ -126,7 +126,9 @@ def get_table_filtered_by_entity(
                 buffer=get_default_partition_column_filter_buffer(),
             )
             timestamp_condition = get_partition_filter(
-                partition_column=normalized_timestamp_column,
+                partition_column=(
+                    timestamp_expr if format_string is not None else normalized_timestamp_column
+                ),
                 partition_column_filter=partition_column_filter,
                 format_string=format_string,
                 adapter=adapter,

--- a/featurebyte/query_graph/sql/entity_filter.py
+++ b/featurebyte/query_graph/sql/entity_filter.py
@@ -9,10 +9,12 @@ from typing import Optional
 from sqlglot import expressions
 from sqlglot.expressions import Expression, Select, select
 
-from featurebyte.enum import InternalName
+from featurebyte.enum import InternalName, TimeIntervalUnit
 from featurebyte.query_graph.model.dtype import DBVarTypeMetadata
 from featurebyte.query_graph.sql.adapter import BaseAdapter
+from featurebyte.query_graph.sql.ast.literal import make_literal_value
 from featurebyte.query_graph.sql.common import get_qualified_column_identifier, quoted_identifier
+from featurebyte.query_graph.sql.partition_filter import get_partition_filter
 from featurebyte.query_graph.sql.timestamp_helper import convert_timestamp_to_utc
 
 
@@ -74,41 +76,62 @@ def get_table_filtered_by_entity(
         )
         join_conditions.append(condition)
 
-    # Only filter by timestamp if no transform has to be applied to the timestamp column
     if timestamp_column is not None:
+        # Check if the timestamp can be used for filtering directly.
         original_timestamp_expr = get_qualified_column_identifier(timestamp_column, "R")
+        format_string = None
         if timestamp_metadata is not None and timestamp_metadata.timestamp_schema is not None:
+            format_string = timestamp_metadata.timestamp_schema.format_string
             timestamp_for_filtering_expr = convert_timestamp_to_utc(
                 original_timestamp_expr,
                 timestamp_metadata.timestamp_schema,
                 adapter,
             )
-            should_filter_by_timestamp = timestamp_for_filtering_expr == original_timestamp_expr
+            filter_on_exact_timestamp = timestamp_for_filtering_expr == original_timestamp_expr
         else:
-            should_filter_by_timestamp = True
-    else:
-        should_filter_by_timestamp = False
+            filter_on_exact_timestamp = True
 
-    if should_filter_by_timestamp:
-        assert timestamp_column is not None
         timestamp_expr = get_qualified_column_identifier(timestamp_column, "R")
         normalized_timestamp_column = adapter.normalize_timestamp_before_comparison(timestamp_expr)
-        join_conditions.append(
-            expressions.GTE(
-                this=normalized_timestamp_column,
-                expression=get_qualified_column_identifier(
-                    start_date, entity_table, quote_column=False
-                ),
-            )
+        start_date_expr = get_qualified_column_identifier(
+            start_date, entity_table, quote_column=False
         )
-        join_conditions.append(
-            expressions.LT(
-                this=normalized_timestamp_column,
-                expression=get_qualified_column_identifier(
-                    end_date, entity_table, quote_column=False
-                ),
+        end_date_expr = get_qualified_column_identifier(end_date, entity_table, quote_column=False)
+        if filter_on_exact_timestamp:
+            join_conditions.append(
+                expressions.GTE(
+                    this=normalized_timestamp_column,
+                    expression=start_date_expr,
+                )
             )
-        )
+            join_conditions.append(
+                expressions.LT(
+                    this=normalized_timestamp_column,
+                    expression=end_date_expr,
+                )
+            )
+        else:
+            # Use a date range with buffer to account for timezone / format string without having to
+            # transform the source timestamp column. This works for historical features since the
+            # extra data doesn't have unintended side effects.
+            start_date_expr = adapter.dateadd_time_interval(
+                quantity_expr=make_literal_value(-7),
+                unit=TimeIntervalUnit.DAY,
+                timestamp_expr=start_date_expr,
+            )
+            end_date_expr = adapter.dateadd_time_interval(
+                quantity_expr=make_literal_value(7),
+                unit=TimeIntervalUnit.DAY,
+                timestamp_expr=end_date_expr,
+            )
+            timestamp_condition = get_partition_filter(
+                partition_column=normalized_timestamp_column,
+                from_timestamp=start_date_expr,
+                to_timestamp=end_date_expr,
+                format_string=format_string,
+                adapter=adapter,
+            )
+            join_conditions.append(timestamp_condition)
 
     join_conditions_expr = expressions.and_(*join_conditions)
 

--- a/featurebyte/query_graph/sql/entity_filter.py
+++ b/featurebyte/query_graph/sql/entity_filter.py
@@ -9,9 +9,8 @@ from typing import Optional
 from sqlglot import expressions
 from sqlglot.expressions import Expression, Select, select
 
-from featurebyte.enum import InternalName, TimeIntervalUnit
+from featurebyte.enum import InternalName
 from featurebyte.query_graph.model.dtype import DBVarTypeMetadata
-from featurebyte.query_graph.model.time_series_table import TimeInterval
 from featurebyte.query_graph.sql.adapter import BaseAdapter
 from featurebyte.query_graph.sql.common import (
     PartitionColumnFilter,
@@ -19,7 +18,9 @@ from featurebyte.query_graph.sql.common import (
     quoted_identifier,
 )
 from featurebyte.query_graph.sql.partition_filter import get_partition_filter
-from featurebyte.query_graph.sql.partition_filter_helper import DEFAULT_BUFFER_NUM_DAYS
+from featurebyte.query_graph.sql.partition_filter_helper import (
+    get_default_partition_column_filter_buffer,
+)
 from featurebyte.query_graph.sql.timestamp_helper import convert_timestamp_to_utc
 
 
@@ -122,10 +123,7 @@ def get_table_filtered_by_entity(
             partition_column_filter = PartitionColumnFilter(
                 from_timestamp=start_date_expr,
                 to_timestamp=end_date_expr,
-                buffer=TimeInterval(
-                    unit=TimeIntervalUnit.DAY,
-                    value=DEFAULT_BUFFER_NUM_DAYS,
-                ),
+                buffer=get_default_partition_column_filter_buffer(),
             )
             timestamp_condition = get_partition_filter(
                 partition_column=normalized_timestamp_column,

--- a/featurebyte/query_graph/sql/partition_filter.py
+++ b/featurebyte/query_graph/sql/partition_filter.py
@@ -5,18 +5,53 @@ Module to handle partition filters in SQL queries
 from datetime import datetime
 from typing import Optional
 
+from dateutil.relativedelta import relativedelta
 from sqlglot import expressions
 from sqlglot.expressions import Expression
 
+from featurebyte.enum import TimeIntervalUnit
+from featurebyte.query_graph.model.time_series_table import TimeInterval
 from featurebyte.query_graph.sql.adapter import BaseAdapter
 from featurebyte.query_graph.sql.ast.literal import make_literal_value
-from featurebyte.query_graph.sql.common import quoted_identifier
+from featurebyte.query_graph.sql.common import PartitionColumnFilter, quoted_identifier
+
+
+def convert_time_interval_to_relativedelta(
+    time_interval: TimeInterval, backward: bool
+) -> relativedelta:
+    """
+    Convert a TimeInterval to a relativedelta object.
+
+    Parameters
+    ----------
+    time_interval: TimeInterval
+        The time interval to convert.
+    backward: bool
+        If True, the relativedelta will be negative (i.e., it represents a backward interval).
+
+    Returns
+    -------
+    relativedelta
+        The corresponding relativedelta object.
+    """
+    # Map TimeInterval units to relativedelta arguments. We only use this internally, so we
+    # only support the required units for now.
+    assert time_interval.unit in [
+        TimeIntervalUnit.DAY,
+        TimeIntervalUnit.MONTH,
+    ], f"Unsupported time interval unit: {time_interval.unit}"
+    if backward:
+        value = -time_interval.value
+    else:
+        value = time_interval.value
+    if time_interval.unit == TimeIntervalUnit.DAY:
+        return relativedelta(days=value)
+    return relativedelta(months=value)
 
 
 def get_partition_filter(
     partition_column: str | Expression,
-    from_timestamp: Optional[datetime | Expression],
-    to_timestamp: Optional[datetime | Expression],
+    partition_column_filter: PartitionColumnFilter,
     format_string: Optional[str],
     adapter: BaseAdapter,
 ) -> Expression:
@@ -27,10 +62,8 @@ def get_partition_filter(
     ----------
     partition_column: str | Expression
         The name of the partition column.
-    from_timestamp: Optional[datetime | Expression]
-        The start timestamp for the filter.
-    to_timestamp: Optional[datetime | Expression]
-        The end timestamp for the filter.
+    partition_column_filter: PartitionColumnFilter
+        The partition column filter containing the from and to timestamps
     format_string: Optional[str]
         Format string for the timestamp, if applicable.
     adapter: BaseAdapter
@@ -42,7 +75,54 @@ def get_partition_filter(
         The SQL expression representing the partition filter.
     """
 
-    def _get_boundary_value_expr(value: datetime | Expression) -> Optional[Expression]:
+    def _get_adjusted_boundary_value(
+        value: datetime | Expression, backward: bool
+    ) -> datetime | Expression:
+        """
+        Adjust the boundary value based on the buffer defined in the partition column filter.
+
+        Parameters
+        ----------
+        value: datetime | Expression
+            The boundary value to adjust.
+        backward: bool
+            Whether this is the backward adjustment (i.e., subtracting the buffer).
+
+        Returns
+        -------
+        datetime | Expression
+            The adjusted boundary value.
+        """
+        buffer = partition_column_filter.buffer
+        if not buffer:
+            return value
+        adjusted_value: datetime | Expression
+        if isinstance(value, datetime):
+            adjusted_value = value + convert_time_interval_to_relativedelta(buffer, backward)
+        else:
+            adjusted_value = adapter.dateadd_time_interval(
+                quantity_expr=make_literal_value(
+                    buffer.value if not backward else -buffer.value,
+                ),
+                unit=buffer.unit,
+                timestamp_expr=value,
+            )
+        return adjusted_value
+
+    def _get_boundary_value_expr(value: datetime | Expression) -> Expression:
+        """
+        Get the SQL expression for the boundary value, accounting for any format string.
+
+        Parameters
+        ----------
+        value: datetime | Expression
+            The boundary value to convert into an SQL expression.
+
+        Returns
+        -------
+        Expression
+            The SQL expression representing the boundary value, formatted if necessary.
+        """
         if isinstance(value, Expression):
             # E.g. a placeholder in scheduled tile sql
             expr = value
@@ -53,6 +133,8 @@ def get_partition_filter(
             expr = adapter.format_timestamp(expr, format_string)
         return expr
 
+    from_timestamp = partition_column_filter.from_timestamp
+    to_timestamp = partition_column_filter.to_timestamp
     assert (
         from_timestamp is not None or to_timestamp is not None
     ), "At least one of from_timestamp or to_timestamp must be provided"
@@ -66,14 +148,18 @@ def get_partition_filter(
         conditions.append(
             expressions.GTE(
                 this=partition_column_expr,
-                expression=_get_boundary_value_expr(from_timestamp),
+                expression=_get_boundary_value_expr(
+                    _get_adjusted_boundary_value(from_timestamp, backward=True)
+                ),
             )
         )
     if to_timestamp is not None:
         conditions.append(
             expressions.LTE(
                 this=partition_column_expr,
-                expression=_get_boundary_value_expr(to_timestamp),
+                expression=_get_boundary_value_expr(
+                    _get_adjusted_boundary_value(to_timestamp, backward=False)
+                ),
             )
         )
     return expressions.and_(*conditions)

--- a/featurebyte/query_graph/sql/partition_filter.py
+++ b/featurebyte/query_graph/sql/partition_filter.py
@@ -14,7 +14,7 @@ from featurebyte.query_graph.sql.common import quoted_identifier
 
 
 def get_partition_filter(
-    partition_column: str,
+    partition_column: str | Expression,
     from_timestamp: Optional[datetime | Expression],
     to_timestamp: Optional[datetime | Expression],
     format_string: Optional[str],
@@ -25,7 +25,7 @@ def get_partition_filter(
 
     Parameters
     ----------
-    partition_column: str
+    partition_column: str | Expression
         The name of the partition column.
     from_timestamp: Optional[datetime | Expression]
         The start timestamp for the filter.
@@ -57,7 +57,10 @@ def get_partition_filter(
         from_timestamp is not None or to_timestamp is not None
     ), "At least one of from_timestamp or to_timestamp must be provided"
 
-    partition_column_expr = quoted_identifier(partition_column)
+    if isinstance(partition_column, str):
+        partition_column_expr = quoted_identifier(partition_column)
+    else:
+        partition_column_expr = partition_column
     conditions: list[Expression] = []
     if from_timestamp is not None:
         conditions.append(

--- a/featurebyte/query_graph/sql/partition_filter_helper.py
+++ b/featurebyte/query_graph/sql/partition_filter_helper.py
@@ -21,7 +21,16 @@ from featurebyte.query_graph.node.generic import (
 from featurebyte.query_graph.node.input import SCDTableInputNodeParameters
 from featurebyte.query_graph.sql.common import PartitionColumnFilter, PartitionColumnFilters
 
-DEFAULT_BUFFER_NUM_DAYS = 7
+
+def get_default_partition_column_filter_buffer() -> TimeInterval:
+    """
+    Get the default buffer for partition filters when a conservative filtering is required
+
+    Returns
+    -------
+    TimeInterval
+    """
+    return TimeInterval(unit=TimeIntervalUnit.DAY, value=7)
 
 
 def get_relativedeltas_from_window_aggregate_params(

--- a/tests/fixtures/expected_tile_sql_on_demand_event_timestamp_schema.sql
+++ b/tests/fixtures/expected_tile_sql_on_demand_event_timestamp_schema.sql
@@ -12,6 +12,10 @@ WITH __FB_ENTITY_TABLE_NAME AS (
     FROM "sf_database"."sf_schema"."sf_table_no_tz"
   ) AS R
     ON R."cust_id" = __FB_ENTITY_TABLE_NAME."cust_id"
+    AND (
+      R."event_timestamp" >= DATEADD(DAY, -7, __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_START_DATE)
+      AND R."event_timestamp" <= DATEADD(DAY, 7, __FB_ENTITY_TABLE_NAME.__FB_ENTITY_TABLE_END_DATE)
+    )
 )
 SELECT
   index,

--- a/tests/fixtures/query_graph/test_partition_filter/varchar_2d_bigquery.sql
+++ b/tests/fixtures/query_graph/test_partition_filter/varchar_2d_bigquery.sql
@@ -1,0 +1,2 @@
+`partition_col` >= FORMAT_DATETIME('yyyy-MM-dd', CAST('2023-01-30 00:00:00' AS DATETIME))
+AND `partition_col` <= FORMAT_DATETIME('yyyy-MM-dd', CAST('2023-05-03 00:00:00' AS DATETIME))

--- a/tests/fixtures/query_graph/test_partition_filter/varchar_2d_databricks_unity.sql
+++ b/tests/fixtures/query_graph/test_partition_filter/varchar_2d_databricks_unity.sql
@@ -1,0 +1,2 @@
+`partition_col` >= DATE_FORMAT(CAST('2023-01-30 00:00:00' AS TIMESTAMP), 'yyyy-MM-dd')
+AND `partition_col` <= DATE_FORMAT(CAST('2023-05-03 00:00:00' AS TIMESTAMP), 'yyyy-MM-dd')

--- a/tests/fixtures/query_graph/test_partition_filter/varchar_2d_snowflake.sql
+++ b/tests/fixtures/query_graph/test_partition_filter/varchar_2d_snowflake.sql
@@ -1,0 +1,2 @@
+"partition_col" >= TO_CHAR(CAST('2023-01-30 00:00:00' AS TIMESTAMP), 'yyyy-MM-dd')
+AND "partition_col" <= TO_CHAR(CAST('2023-05-03 00:00:00' AS TIMESTAMP), 'yyyy-MM-dd')

--- a/tests/fixtures/query_graph/test_partition_filter/varchar_2m_bigquery.sql
+++ b/tests/fixtures/query_graph/test_partition_filter/varchar_2m_bigquery.sql
@@ -1,0 +1,2 @@
+`partition_col` >= FORMAT_DATETIME('yyyy-MM-dd', CAST('2022-12-01 00:00:00' AS DATETIME))
+AND `partition_col` <= FORMAT_DATETIME('yyyy-MM-dd', CAST('2023-07-01 00:00:00' AS DATETIME))

--- a/tests/fixtures/query_graph/test_partition_filter/varchar_2m_databricks_unity.sql
+++ b/tests/fixtures/query_graph/test_partition_filter/varchar_2m_databricks_unity.sql
@@ -1,0 +1,2 @@
+`partition_col` >= DATE_FORMAT(CAST('2022-12-01 00:00:00' AS TIMESTAMP), 'yyyy-MM-dd')
+AND `partition_col` <= DATE_FORMAT(CAST('2023-07-01 00:00:00' AS TIMESTAMP), 'yyyy-MM-dd')

--- a/tests/fixtures/query_graph/test_partition_filter/varchar_2m_snowflake.sql
+++ b/tests/fixtures/query_graph/test_partition_filter/varchar_2m_snowflake.sql
@@ -1,0 +1,2 @@
+"partition_col" >= TO_CHAR(CAST('2022-12-01 00:00:00' AS TIMESTAMP), 'yyyy-MM-dd')
+AND "partition_col" <= TO_CHAR(CAST('2023-07-01 00:00:00' AS TIMESTAMP), 'yyyy-MM-dd')

--- a/tests/unit/query_graph/sql/test_partition_filter_helper.py
+++ b/tests/unit/query_graph/sql/test_partition_filter_helper.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 import pytest
 
+from featurebyte import TimeInterval
 from featurebyte.query_graph.sql.common import PartitionColumnFilter, PartitionColumnFilters
 from featurebyte.query_graph.sql.partition_filter_helper import get_partition_filters_from_graph
 
@@ -48,8 +49,9 @@ def test_tile_based_window_aggregate(
     assert partition_column_filters == PartitionColumnFilters(
         mapping={
             event_table_id: PartitionColumnFilter(
-                from_timestamp=datetime(2022, 7, 3, 0, 0, 0),
-                to_timestamp=datetime(2023, 9, 1, 0, 0, 0),
+                from_timestamp=datetime(2022, 10, 3, 0, 0, 0),
+                to_timestamp=datetime(2023, 6, 1, 0, 0, 0),
+                buffer=TimeInterval(unit="MONTH", value=3),
             )
         }
     )
@@ -73,8 +75,9 @@ def test_tile_based_window_aggregate_with_offset(
     assert partition_column_filters == PartitionColumnFilters(
         mapping={
             event_table_id: PartitionColumnFilter(
-                from_timestamp=datetime(2022, 9, 30, 16, 0),
-                to_timestamp=datetime(2023, 9, 1, 0, 0),
+                from_timestamp=datetime(2022, 12, 30, 16, 0),
+                to_timestamp=datetime(2023, 6, 1, 0, 0),
+                buffer=TimeInterval(unit="MONTH", value=3),
             )
         }
     )
@@ -98,8 +101,9 @@ def test_time_series_window_aggregate(
     assert partition_column_filters == PartitionColumnFilters(
         mapping={
             time_series_table_input_node.parameters.id: PartitionColumnFilter(
-                from_timestamp=datetime(2022, 9, 25, 0, 0, 0),
-                to_timestamp=datetime(2023, 9, 1, 0, 0, 0),
+                from_timestamp=datetime(2022, 12, 25, 0, 0, 0),
+                to_timestamp=datetime(2023, 6, 1, 0, 0, 0),
+                buffer=TimeInterval(unit="MONTH", value=3),
             )
         }
     )
@@ -123,8 +127,9 @@ def test_time_series_window_aggregate_with_offset(
     assert partition_column_filters == PartitionColumnFilters(
         mapping={
             time_series_table_input_node.parameters.id: PartitionColumnFilter(
-                from_timestamp=datetime(2022, 9, 22, 0, 0, 0),
-                to_timestamp=datetime(2023, 9, 1, 0, 0, 0),
+                from_timestamp=datetime(2022, 12, 22, 0, 0, 0),
+                to_timestamp=datetime(2023, 6, 1, 0, 0, 0),
+                buffer=TimeInterval(unit="MONTH", value=3),
             )
         }
     )
@@ -180,12 +185,14 @@ def test_mixed_features(
     assert partition_column_filters == PartitionColumnFilters(
         mapping={
             event_table_input_node_with_id.parameters.id: PartitionColumnFilter(
-                from_timestamp=datetime(2022, 7, 3, 0, 0, 0),
-                to_timestamp=datetime(2023, 9, 1, 0, 0, 0),
+                from_timestamp=datetime(2022, 10, 3, 0, 0, 0),
+                to_timestamp=datetime(2023, 6, 1, 0, 0, 0),
+                buffer=TimeInterval(unit="MONTH", value=3),
             ),
             time_series_table_input_node.parameters.id: PartitionColumnFilter(
-                from_timestamp=datetime(2022, 9, 22, 0, 0, 0),
-                to_timestamp=datetime(2023, 9, 1, 0, 0, 0),
+                from_timestamp=datetime(2022, 12, 22, 0, 0, 0),
+                to_timestamp=datetime(2023, 6, 1, 0, 0, 0),
+                buffer=TimeInterval(unit="MONTH", value=3),
             ),
         }
     )


### PR DESCRIPTION
## Description

Changes:

* Use string timestamp filtering for event tables tile computation when timestamp conversion is required 
* Refactor and move handling of buffer periods to `get_partition_filter` for more convenient usage

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
