### PR TITLE
[chore][release] yanking 3.1.1 releasing 3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v3.1.0 (2025-07-14)
+## v3.1.2 (2025-07-14)
 
 ### 💡 Enhancements
 
@@ -10,6 +10,10 @@
 ### 🐛 Bug Fixes
 
 + `service` Fix inconsistent request timestamp causing missing values in time series batch features
+
+## v3.1.1 (2025-07-14) YANKED
+
+Publishing error
 
 ## v3.1.0 (2025-06-28)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ license = "Elastic License 2.0"
 name = "featurebyte"
 readme = "README.md"
 repository = "https://github.com/featurebyte/featurebyte"
-version = "3.1.1"
+version = "3.1.2"
 
 [tool.poetry.dependencies]
 aiofiles = "^24.1.0"


### PR DESCRIPTION
## Description

Release error on 3.1.1.
Publishing 3.1.2 instead

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
