### PR TITLE
[chore] Use snapshot date as last primary key for external feature table

### DIFF
--- a/featurebyte/service/batch_external_feature_table.py
+++ b/featurebyte/service/batch_external_feature_table.py
@@ -236,7 +236,7 @@ class BatchExternalFeatureTableService:
                     f"ALTER TABLE {output_feature_table_name} ALTER COLUMN {quoted_col} SET NOT NULL"
                 )
             primary_key_args = ", ".join(
-                [f"{quoted_timestamp_column} TIMESERIES"] + quoted_primary_key_columns
+                quoted_primary_key_columns + [f"{quoted_timestamp_column} TIMESERIES"]
             )
             await db_session.execute_query_long_running(
                 textwrap.dedent(

--- a/tests/fixtures/batch_feature_table_task/expected_batch_external_feature_table_new_databricks_table_queries.sql
+++ b/tests/fixtures/batch_feature_table_task/expected_batch_external_feature_table_new_databricks_table_queries.sql
@@ -144,4 +144,4 @@ ALTER TABLE `db`.`schema`.`new_batch_prediction_table` ALTER COLUMN `snapshot_da
 ALTER TABLE `db`.`schema`.`new_batch_prediction_table` ALTER COLUMN `cust_id` SET NOT NULL;
 
 ALTER TABLE `db`.`schema`.`new_batch_prediction_table` ADD CONSTRAINT `pk_new_batch_prediction_table`
-PRIMARY KEY(`snapshot_date` TIMESERIES, `cust_id`);
+PRIMARY KEY(`cust_id`, `snapshot_date` TIMESERIES);


### PR DESCRIPTION
## Description

Use snapshot date as last primary key for external feature table

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
