### PR TITLE
[DEV-4136] Apply partition column filters only when dtype_metadata exists

### DIFF
--- a/tests/fixtures/query_graph/test_input/partition_column_filters_no_dtype_metadata.sql
+++ b/tests/fixtures/query_graph/test_input/partition_column_filters_no_dtype_metadata.sql
@@ -1,0 +1,6 @@
+SELECT
+  `partition_col` AS `partition_col`,
+  `ts` AS `ts`,
+  `cust_id` AS `cust_id`,
+  `a` AS `a`
+FROM `db`.`public`.`event_table`

--- a/tests/unit/query_graph/sql/ast/test_input.py
+++ b/tests/unit/query_graph/sql/ast/test_input.py
@@ -197,6 +197,56 @@ def test_partition_column_filters_with_on_demand_entity_filters(
     assert_equal_with_expected_fixture(actual, fixture_filename, update_fixtures)
 
 
+def test_partition_column_filters_no_dtype_metadata(global_graph, input_details, update_fixtures):
+    """
+    Test that partition column filters are not applied if dtype_metadata is not provided
+    """
+    source_type = SourceType.DATABRICKS_UNITY
+    node_params = {
+        "id": ObjectId(),
+        "type": "event_table",
+        "columns": [
+            {
+                "name": "partition_col",
+                "dtype": DBVarType.VARCHAR,
+                "partition_metadata": {"is_partition_key": True},
+            },
+            {"name": "ts", "dtype": DBVarType.TIMESTAMP},
+            {"name": "cust_id", "dtype": DBVarType.INT},
+            {"name": "a", "dtype": DBVarType.FLOAT},
+        ],
+    }
+    node_params.update(input_details)
+    input_node = global_graph.add_operation(
+        node_type=NodeType.INPUT,
+        node_params=node_params,
+        node_output_type=NodeOutputType.FRAME,
+        input_nodes=[],
+    )
+    source_info = SourceInfo(
+        database_name="my_db", schema_name="my_schema", source_type=source_type
+    )
+    partition_column_filters = PartitionColumnFilters(
+        mapping={
+            node_params["id"]: PartitionColumnFilter(
+                from_timestamp=make_literal_value(datetime(2023, 1, 1), cast_as_timestamp=True),
+                to_timestamp=make_literal_value(datetime(2023, 6, 1), cast_as_timestamp=True),
+            )
+        }
+    )
+    sql_graph = SQLOperationGraph(
+        global_graph,
+        sql_type=SQLType.MATERIALIZE,
+        partition_column_filters=partition_column_filters,
+        source_info=source_info,
+    )
+    actual = sql_to_string(sql_graph.build(input_node).sql, source_type)
+    fixture_filename = (
+        "tests/fixtures/query_graph/test_input/partition_column_filters_no_dtype_metadata.sql"
+    )
+    assert_equal_with_expected_fixture(actual, fixture_filename, update_fixtures)
+
+
 def test_development_datasets(global_graph, input_details, update_fixtures):
     """
     Test that development datasets are used correctly in the SQL AST for input nodes


### PR DESCRIPTION
## Description

This updates the partition column filtering logic to only apply the filtering when `dtype_metadata` is set. The reason is that currently `partition_metadata` can be set even if the column is not specified as a partition column during table registration. In this case, we should not be applying the partition column filters. 

On the other hand, a column specified explicitly as a partition column filter will also have `dtype_metadata` set.

To resolve this issue without having to reregister tables, we will use `dtype_metadata` as an additional condition when determining whether to apply partition column filters.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
