### PR TITLE
[DEV-4139] Validate blind spot is multiple of time interval for SnapshotsTable

### DIFF
--- a/featurebyte/enum.py
+++ b/featurebyte/enum.py
@@ -129,6 +129,15 @@ class TimeIntervalUnit(OrderedStrEnum):
     QUARTER = "QUARTER"
     YEAR = "YEAR"
 
+    @classmethod
+    def fixed_size_units(cls) -> list[TimeIntervalUnit]:
+        return [
+            TimeIntervalUnit.MINUTE,
+            TimeIntervalUnit.HOUR,
+            TimeIntervalUnit.DAY,
+            TimeIntervalUnit.WEEK,
+        ]
+
 
 class DBVarType(StrEnum):
     """

--- a/featurebyte/models/snapshots_table.py
+++ b/featurebyte/models/snapshots_table.py
@@ -73,6 +73,16 @@ class SnapshotsTableModel(SnapshotsTableData, TableModel):
     def _validate_blind_spot_time_interval(self) -> "SnapshotsTableModel":
         """
         Validate that blind_spot in default_feature_job_setting is a multiple of time_interval
+
+        Returns
+        -------
+        SnapshotsTableModel
+            The validated model instance
+
+        Raises
+        ------
+        ValueError
+            If blind_spot and time_interval are not compatible
         """
         if self.default_feature_job_setting is not None:
             blind_spot_window = self.default_feature_job_setting.get_blind_spot_calendar_window()

--- a/featurebyte/query_graph/model/window.py
+++ b/featurebyte/query_graph/model/window.py
@@ -32,11 +32,7 @@ class CalendarWindow(FeatureByteBaseModel):
         return f"{self.size}_{self.unit}"
 
     def is_fixed_size(self) -> bool:
-        return self.unit not in {
-            TimeIntervalUnit.MONTH,
-            TimeIntervalUnit.QUARTER,
-            TimeIntervalUnit.YEAR,
-        }
+        return self.unit in TimeIntervalUnit.fixed_size_units()
 
     def to_seconds(self) -> int:
         """

--- a/tests/unit/api/test_snapshots_table.py
+++ b/tests/unit/api/test_snapshots_table.py
@@ -1272,15 +1272,8 @@ def test_validate_blind_spot_time_interval(
     _ = catalog
 
     # Create snapshots table with specified time interval
-    test_name = f"sf_snapshots_table_{time_interval_value}_{time_interval_unit}"
-    if blind_spot is not None:
-        blind_spot_str = str(blind_spot).replace(" ", "_").replace("=", "_")
-        test_name += f"_{blind_spot_str}"
-    else:
-        test_name += "_none"
-
     snapshots_table = snowflake_database_snapshots_table.create_snapshots_table(
-        name=test_name,
+        name="test_snapshots_table",
         snapshot_id_column="col_int",
         snapshot_datetime_column="date",
         snapshot_datetime_schema=TimestampSchema(

--- a/tests/unit/api/test_snapshots_table.py
+++ b/tests/unit/api/test_snapshots_table.py
@@ -1248,15 +1248,15 @@ def test_update_critical_data_info_with_none_value(saved_snapshots_table):
 @pytest.mark.parametrize(
     "time_interval_value,time_interval_unit,blind_spot,expected_error",
     [
-        # Valid case - fixed size unit with valid string blind_spot
+        # Valid case: fixed size unit with valid string blind_spot
         (1, "HOUR", "7200s", None),  # 2 hours in seconds
-        # Valid case - non-fixed size unit with CalendarWindow blind_spot
+        # Valid case: non-fixed size unit with CalendarWindow blind_spot
         (1, "MONTH", CalendarWindow(unit=TimeIntervalUnit.MONTH, size=3), None),
-        # Valid case - no blind spot
+        # Valid case: no blind spot
         (1, "HOUR", None, None),
-        # Invalid case - not multiple (string blind_spot)
+        # Invalid case: not multiple (string blind_spot)
         (1, "HOUR", "5400s", "has to be a multiple of time_interval"),  # 90 minutes
-        # Invalid case - incompatible types
+        # Invalid case: incompatible types
         (1, "MONTH", "3600s", "are not compatible"),  # string vs non-fixed
     ],
 )

--- a/tests/unit/api/test_snapshots_table.py
+++ b/tests/unit/api/test_snapshots_table.py
@@ -17,7 +17,7 @@ from typeguard import TypeCheckError
 
 from featurebyte import SnapshotsTable
 from featurebyte.api.entity import Entity
-from featurebyte.enum import TableDataType
+from featurebyte.enum import TableDataType, TimeIntervalUnit
 from featurebyte.exception import (
     DuplicatedRecordException,
     ObjectHasBeenSavedError,
@@ -36,6 +36,7 @@ from featurebyte.query_graph.model.timestamp_schema import (
     TimestampSchema,
     TimeZoneColumn,
 )
+from featurebyte.query_graph.model.window import CalendarWindow
 from featurebyte.query_graph.node.cleaning_operation import (
     DisguisedValueImputation,
     MissingValueImputation,
@@ -1242,3 +1243,80 @@ def test_update_critical_data_info_with_none_value(saved_snapshots_table):
         saved_snapshots_table.col_int.info.critical_data_info.cleaning_operations
         == cleaning_operations
     )
+
+
+@pytest.mark.parametrize(
+    "time_interval_value,time_interval_unit,blind_spot,expected_error",
+    [
+        # Valid case - fixed size unit with valid string blind_spot
+        (1, "HOUR", "7200s", None),  # 2 hours in seconds
+        # Valid case - non-fixed size unit with CalendarWindow blind_spot
+        (1, "MONTH", CalendarWindow(unit=TimeIntervalUnit.MONTH, size=3), None),
+        # Valid case - no blind spot
+        (1, "HOUR", None, None),
+        # Invalid case - not multiple (string blind_spot)
+        (1, "HOUR", "5400s", "has to be a multiple of time_interval"),  # 90 minutes
+        # Invalid case - incompatible types
+        (1, "MONTH", "3600s", "are not compatible"),  # string vs non-fixed
+    ],
+)
+def test_validate_blind_spot_time_interval(
+    snowflake_database_snapshots_table,
+    catalog,
+    time_interval_value,
+    time_interval_unit,
+    blind_spot,
+    expected_error,
+):
+    """Test _validate_blind_spot_time_interval with various combinations"""
+    _ = catalog
+
+    # Create snapshots table with specified time interval
+    test_name = f"sf_snapshots_table_{time_interval_value}_{time_interval_unit}"
+    if blind_spot is not None:
+        blind_spot_str = str(blind_spot).replace(" ", "_").replace("=", "_")
+        test_name += f"_{blind_spot_str}"
+    else:
+        test_name += "_none"
+
+    snapshots_table = snowflake_database_snapshots_table.create_snapshots_table(
+        name=test_name,
+        snapshot_id_column="col_int",
+        snapshot_datetime_column="date",
+        snapshot_datetime_schema=TimestampSchema(
+            format_string="YYYY-MM-DD HH24:MI:SS", timezone="Etc/UTC"
+        ),
+        time_interval=TimeInterval(value=time_interval_value, unit=time_interval_unit),
+        record_creation_timestamp_column="created_at",
+    )
+
+    # Create feature job setting with optional blind spot
+    feature_job_setting_kwargs = {
+        "crontab": Crontab(
+            minute=0,
+            hour="*" if time_interval_unit in ["HOUR", "MINUTE"] else 0,
+            day_of_week="*",
+            day_of_month="*" if time_interval_unit not in ["MONTH", "QUARTER"] else "1",
+            month_of_year="*",
+        ),
+        "timezone": "Etc/UTC",
+    }
+    if blind_spot is not None:
+        feature_job_setting_kwargs["blind_spot"] = blind_spot
+
+    if expected_error is None:
+        # Should not raise error
+        snapshots_table.update_default_feature_job_setting(
+            feature_job_setting=CronFeatureJobSetting(**feature_job_setting_kwargs)
+        )
+        if blind_spot is not None:
+            assert snapshots_table.default_feature_job_setting.blind_spot == blind_spot
+        else:
+            assert snapshots_table.default_feature_job_setting.blind_spot is None
+    else:
+        # Should raise exception with expected message
+        with pytest.raises(RecordUpdateException) as exc:
+            snapshots_table.update_default_feature_job_setting(
+                feature_job_setting=CronFeatureJobSetting(**feature_job_setting_kwargs)
+            )
+        assert expected_error in str(exc.value)


### PR DESCRIPTION
## Description

This adds validation for SnapshotsTable's blind spot: it has to be a multiple of the table's time interval.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
