### PR TITLE
[chore] Refine progress tracking in historical feature table creation

### DIFF
--- a/featurebyte/service/target_helper/base_feature_or_target_computer.py
+++ b/featurebyte/service/target_helper/base_feature_or_target_computer.py
@@ -166,6 +166,9 @@ class Computer(Generic[ComputeRequestT, ExecutorParamsT]):
         observation_set: Union[pd.DataFrame, ObservationTableModel],
         compute_request: ComputeRequestT,
         output_table_details: TableDetails,
+        progress_callback: Optional[
+            Callable[[int, Optional[str]], Coroutine[Any, Any, None]]
+        ] = None,
     ) -> ExecutionResult:
         """
         Compute targets or features
@@ -178,6 +181,8 @@ class Computer(Generic[ComputeRequestT, ExecutorParamsT]):
             Compute request
         output_table_details: TableDetails
             Table details to write the results to
+        progress_callback: Optional[Callable[[int, Optional[str]], Coroutine[Any, Any, None]]]
+            Optional progress callback to override the default task progress updater
 
         Returns
         -------
@@ -208,7 +213,7 @@ class Computer(Generic[ComputeRequestT, ExecutorParamsT]):
                 session=db_session,
                 output_table_details=output_table_details,
                 parent_serving_preparation=parent_serving_preparation,
-                progress_callback=self.task_progress_updater.update_progress,
+                progress_callback=progress_callback or self.task_progress_updater.update_progress,
                 observation_set=observation_set,
             ),
             validation_parameters=validation_parameters,


### PR DESCRIPTION
## Description

Fixes premature 100% progress updates in historical feature table creation. Progress now reaches 100% only when all operations are actually complete.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
