### PR TITLE
Allow empty list of development tables and more update to schemas

### DIFF
--- a/featurebyte/models/development_dataset.py
+++ b/featurebyte/models/development_dataset.py
@@ -36,6 +36,21 @@ class DevelopmentDatasetStatus(StrEnum):
     ACTIVE = "Active", "Development tables mapped to source tables."
 
 
+class DevelopmentDatasetSourceType(StrEnum):
+    """
+    Development Dataset Source Type
+    """
+
+    SOURCE_TABLES = (
+        "Source Tables",
+        "Development Tables origin from Source Tables.",
+    )
+    OBSERVATION_TABLE = (
+        "Observation Table",
+        "Development Tables are samples of Registered Tables using an observation table to extract relevant entities.",
+    )
+
+
 class DevelopmentTable(FeatureByteBaseModel):
     """
     Development source table for a table
@@ -55,8 +70,12 @@ class DevelopmentDatasetModel(FeatureByteCatalogBaseDocumentModel):
     sample_from_timestamp: datetime
     sample_to_timestamp: datetime
     development_tables: List[DevelopmentTable] = Field(default_factory=list)
-    development_plan_id: Optional[PydanticObjectId] = None
     status: DevelopmentDatasetStatus = Field(default=DevelopmentDatasetStatus.ACTIVE)
+    source_type: DevelopmentDatasetSourceType = Field(
+        default=DevelopmentDatasetSourceType.SOURCE_TABLES
+    )
+    development_plan_id: Optional[PydanticObjectId] = None
+    observation_table_id: Optional[PydanticObjectId] = None
 
     class Settings(FeatureByteCatalogBaseDocumentModel.Settings):
         """
@@ -105,8 +124,6 @@ class DevelopmentDatasetModel(FeatureByteCatalogBaseDocumentModel):
         ValueError
             If no development source tables are provided or if there are duplicate table IDs.
         """
-        if not value:
-            raise ValueError("At least one development source table is required")
 
         table_ids = [dev_table.table_id for dev_table in value]
         if len(set(table_ids)) != len(table_ids):

--- a/featurebyte/routes/development_dataset/controller.py
+++ b/featurebyte/routes/development_dataset/controller.py
@@ -132,7 +132,11 @@ class DevelopmentDatasetController(
         Task
         """
         # check if document exists
-        _ = await self.service.get_document(document_id=document_id)
+        development_dataset = await self.service.get_document(document_id=document_id)
+
+        # check if a plan exists
+        if development_dataset.development_plan_id:
+            raise ValueError("Use the route to delete the development plan.")
 
         # check if document is used by any other documents
         await self.verify_operation_by_checking_reference(

--- a/featurebyte/schema/development_dataset.py
+++ b/featurebyte/schema/development_dataset.py
@@ -9,7 +9,11 @@ from bson import ObjectId
 from pydantic import Field, StrictStr
 
 from featurebyte.models.base import FeatureByteBaseModel, NameStr, PydanticObjectId
-from featurebyte.models.development_dataset import DevelopmentDatasetStatus, DevelopmentTable
+from featurebyte.models.development_dataset import (
+    DevelopmentDatasetSourceType,
+    DevelopmentDatasetStatus,
+    DevelopmentTable,
+)
 from featurebyte.query_graph.model.common_table import TabularSource
 from featurebyte.query_graph.node.schema import TableDetails
 from featurebyte.schema.common.base import (
@@ -28,8 +32,12 @@ class DevelopmentDatasetBase(FeatureByteBaseModel):
     description: Optional[StrictStr] = Field(default=None)
     sample_from_timestamp: datetime
     sample_to_timestamp: datetime
-    development_plan_id: Optional[PydanticObjectId] = None
     status: DevelopmentDatasetStatus = Field(default=DevelopmentDatasetStatus.ACTIVE)
+    source_type: DevelopmentDatasetSourceType = Field(
+        default=DevelopmentDatasetSourceType.SOURCE_TABLES
+    )
+    development_plan_id: Optional[PydanticObjectId] = None
+    observation_table_id: Optional[PydanticObjectId] = None
 
 
 class DevelopmentTableCreate(FeatureByteBaseModel):
@@ -91,6 +99,7 @@ class DevelopmentDatasetServiceUpdate(BaseDocumentServiceUpdateSchema):
 
     name: Optional[NameStr] = Field(default=None)
     development_tables: Optional[List[DevelopmentTable]] = Field(default=None)
+    status: Optional[DevelopmentDatasetStatus] = Field(default=None)
 
 
 class DevelopmentTableInfo(FeatureByteBaseModel):
@@ -113,5 +122,9 @@ class DevelopmentDatasetInfo(BaseInfo):
     sample_from_timestamp: datetime
     sample_to_timestamp: datetime
     development_tables: List[DevelopmentTableInfo]
-    development_plan_id: Optional[PydanticObjectId] = None
     status: DevelopmentDatasetStatus = Field(default=DevelopmentDatasetStatus.ACTIVE)
+    source_type: DevelopmentDatasetSourceType = Field(
+        default=DevelopmentDatasetSourceType.SOURCE_TABLES
+    )
+    development_plan_id: Optional[PydanticObjectId] = None
+    observation_table_id: Optional[PydanticObjectId] = None

--- a/tests/unit/models/test_development_dataset.py
+++ b/tests/unit/models/test_development_dataset.py
@@ -10,21 +10,6 @@ from featurebyte.models.development_dataset import DevelopmentDatasetModel, Deve
 from featurebyte.query_graph.model.common_table import TabularSource
 
 
-def test_empty_development_tables():
-    """
-    Test that an empty development dataset raises a validation error
-    """
-
-    with pytest.raises(ValidationError) as exc_info:
-        DevelopmentDatasetModel(
-            name="test_dataset",
-            sample_from_timestamp="2023-01-01T00:00:00Z",
-            sample_to_timestamp="2023-01-02T00:00:00Z",
-            development_tables=[],
-        )
-    assert "At least one development source table is required" in str(exc_info.value)
-
-
 def test_duplicate_table_ids_development_tables():
     """
     Test that an duplicate table ids indevelopment dataset raises a validation error

--- a/tests/unit/routes/test_development_dataset.py
+++ b/tests/unit/routes/test_development_dataset.py
@@ -431,7 +431,9 @@ class TestDevelopmentDatasetApi(BaseAsyncApiTestSuite):
             "sample_from_timestamp": "2022-01-01T00:00:00",
             "sample_to_timestamp": "2024-12-31T00:00:00",
             "development_plan_id": None,
+            "observation_table_id": None,
             "status": "Active",
+            "source_type": "Source Tables",
         }
 
     def test_get_schema(self, test_api_client_persistent, create_success_response):
@@ -455,7 +457,9 @@ class TestDevelopmentDatasetApi(BaseAsyncApiTestSuite):
             "sample_from_timestamp": "2022-01-01T00:00:00",
             "sample_to_timestamp": "2024-12-31T00:00:00",
             "development_plan_id": None,
+            "observation_table_id": None,
             "status": "Active",
+            "source_type": "Source Tables",
             "development_tables": [
                 {
                     "location": {
@@ -606,5 +610,7 @@ class TestDevelopmentDatasetApi(BaseAsyncApiTestSuite):
             "sample_from_timestamp": "2022-01-01T00:00:00",
             "sample_to_timestamp": "2024-12-31T00:00:00",
             "development_plan_id": None,
+            "observation_table_id": None,
             "status": "Active",
+            "source_type": "Source Tables",
         }


### PR DESCRIPTION
## Description

PR to:
- allow empty list of development tables
- support update of status
- add source_type and observation_table_id parameters to development dataset schemas
- block the deletion if a development plan is associated with the dataset. The dataset will be deleted together with the plan using the plan routes

## Related Issue

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
