### PR TITLE
[DEV-4087] Exclude dtype metadata check from column specs compatibility check

### DIFF
--- a/featurebyte/query_graph/node/schema.py
+++ b/featurebyte/query_graph/node/schema.py
@@ -516,6 +516,4 @@ class ColumnSpec(FeatureByteBaseModel):
             return False
         if not DBVarType.are_compatible_types(self.dtype, other.dtype):
             return False
-        if self.dtype_metadata != other.dtype_metadata:
-            return False
         return True


### PR DESCRIPTION
## Description

Exclude dtype metadata check from column specs compatibility check since it should not be a requirement for current usage.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
