### PR TITLE
Dev Dataset: If status is set to ACTIVE but there are no tables, force EMPTY

### DIFF
--- a/featurebyte/models/development_dataset.py
+++ b/featurebyte/models/development_dataset.py
@@ -122,7 +122,7 @@ class DevelopmentDatasetModel(FeatureByteCatalogBaseDocumentModel):
 
     @model_validator(mode="after")
     def _normalize_status(self) -> "DevelopmentDatasetModel":
-        """If status is set to ACTIVE but there are no tables, force EMPTY"""
+        # If status is set to ACTIVE but there are no tables, force EMPTY
         if self.status == DevelopmentDatasetStatus.ACTIVE and not self.development_tables:
             self.status = DevelopmentDatasetStatus.EMPTY
         return self

--- a/featurebyte/models/development_dataset.py
+++ b/featurebyte/models/development_dataset.py
@@ -34,6 +34,7 @@ class DevelopmentDatasetStatus(StrEnum):
         "Sampling tables and statistics generated; development tables not yet created.",
     )
     ACTIVE = "Active", "Development tables mapped to source tables."
+    EMPTY = "Empty", "No development table mapped to source tables."
 
 
 class DevelopmentDatasetSourceType(StrEnum):
@@ -117,6 +118,13 @@ class DevelopmentDatasetModel(FeatureByteCatalogBaseDocumentModel):
                     "Both development_plan_id and observation_table_id should be null "
                     "when source_type is SOURCE_TABLES."
                 )
+        return self
+
+    @model_validator(mode="after")
+    def _normalize_status(self) -> "DevelopmentDatasetModel":
+        """If status is set to ACTIVE but there are no tables, force EMPTY"""
+        if self.status == DevelopmentDatasetStatus.ACTIVE and not self.development_tables:
+            self.status = DevelopmentDatasetStatus.EMPTY
         return self
 
     @field_validator("development_tables", mode="after")

--- a/tests/unit/models/test_development_dataset.py
+++ b/tests/unit/models/test_development_dataset.py
@@ -9,9 +9,24 @@ from pydantic import ValidationError
 from featurebyte.models.development_dataset import (
     DevelopmentDatasetModel,
     DevelopmentDatasetSourceType,
+    DevelopmentDatasetStatus,
     DevelopmentTable,
 )
 from featurebyte.query_graph.model.common_table import TabularSource
+
+
+def test_empty_development_tables():
+    """
+    Test that an empty development dataset can't have an active status
+    """
+
+    empty_dev = DevelopmentDatasetModel(
+        name="test_dataset",
+        sample_from_timestamp="2023-01-01T00:00:00Z",
+        sample_to_timestamp="2023-01-02T00:00:00Z",
+        development_tables=[],
+    )
+    assert empty_dev.status == DevelopmentDatasetStatus.EMPTY
 
 
 def test_duplicate_table_ids_development_tables():


### PR DESCRIPTION
## Description

@kchua78 A small PR for dev dataset to force EMPTY status If status is set to ACTIVE but there are no tables.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
