### PR TITLE
[chore] Fix feature store table cleanup task drop_table calls

### DIFF
--- a/featurebyte/service/feature_store_table_cleanup.py
+++ b/featurebyte/service/feature_store_table_cleanup.py
@@ -237,7 +237,7 @@ class FeatureStoreTableCleanupService:
                 await self.warehouse_table_service.drop_table_with_session(
                     session=db_session,
                     warehouse_table=warehouse_table,
-                    exists=True,
+                    if_exists=True,
                 )
                 cleanup_count += 1
                 logger.info(

--- a/tests/unit/service/test_feature_store_table_cleanup.py
+++ b/tests/unit/service/test_feature_store_table_cleanup.py
@@ -139,11 +139,11 @@ async def test_run_cleanup_with_drop_failure_increments_counter(
         # Run cleanup - should not raise exception even though drop fails
         await service.run_cleanup(feature_store_id=feature_store.id)
 
-        # Verify drop_table_with_session was called with correct parameters including exists=True
+        # Verify drop_table_with_session was called with correct parameters including if_exists=True
         mock_drop.assert_called_once_with(
             session=mock_session_manager,
             warehouse_table=expired_warehouse_table,
-            exists=True,
+            if_exists=True,
         )
 
         # After cleanup - document should still exist with incremented failure counter
@@ -191,11 +191,11 @@ async def test_run_cleanup_force_delete_after_max_failures(
         # Run cleanup - this should force delete the document
         await service.run_cleanup(feature_store_id=feature_store.id)
 
-        # Verify drop_table_with_session was called with correct parameters including exists=True
+        # Verify drop_table_with_session was called with correct parameters including if_exists=True
         mock_drop.assert_called_once_with(
             session=mock_session_manager,
             warehouse_table=warehouse_table,
-            exists=True,
+            if_exists=True,
         )
 
         # After cleanup - document should be force deleted


### PR DESCRIPTION
## Description

Fix error in feature store cleanup task by correcting parameter name when calling `drop_table`: use `if_exists` instead of invalid `exists`.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
