### PR TITLE
[chore] Auto tag use case default eda table during eda obs table creation

### DIFF
--- a/featurebyte/worker/task/observation_table.py
+++ b/featurebyte/worker/task/observation_table.py
@@ -11,13 +11,14 @@ from dateutil import tz
 
 from featurebyte.enum import SpecialColumnName
 from featurebyte.logging import get_logger
-from featurebyte.models.observation_table import ObservationTableModel, TargetInput
+from featurebyte.models.observation_table import ObservationTableModel, Purpose, TargetInput
 from featurebyte.query_graph.node.schema import TableDetails
 from featurebyte.query_graph.sql.common import sql_to_string
 from featurebyte.query_graph.sql.feature_historical import (
     HISTORICAL_REQUESTS_POINT_IN_TIME_RECENCY_HOUR,
 )
 from featurebyte.query_graph.sql.materialisation import get_source_count_expr
+from featurebyte.schema.use_case import UseCaseUpdate
 from featurebyte.schema.worker.task.observation_table import ObservationTableTaskPayload
 from featurebyte.service.entity import EntityService
 from featurebyte.service.feature_store import FeatureStoreService
@@ -25,6 +26,7 @@ from featurebyte.service.observation_table import ObservationTableService
 from featurebyte.service.session_manager import SessionManagerService
 from featurebyte.service.target_namespace import TargetNamespaceService
 from featurebyte.service.task_manager import TaskManager
+from featurebyte.service.use_case import UseCaseService
 from featurebyte.session.base import BaseSession
 from featurebyte.worker.task.base import BaseTask
 from featurebyte.worker.task.mixin import DataWarehouseMixin
@@ -47,6 +49,7 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask[ObservationTableTaskPayl
         observation_table_service: ObservationTableService,
         target_namespace_service: TargetNamespaceService,
         entity_service: EntityService,
+        use_case_service: UseCaseService,
     ):
         super().__init__(task_manager=task_manager)
         self.feature_store_service = feature_store_service
@@ -54,6 +57,7 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask[ObservationTableTaskPayl
         self.observation_table_service = observation_table_service
         self.target_namespace_service = target_namespace_service
         self.entity_service = entity_service
+        self.use_case_service = use_case_service
 
     async def get_task_description(self, payload: ObservationTableTaskPayload) -> str:
         return f'Save observation table "{payload.name}" from source table.'
@@ -233,6 +237,18 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask[ObservationTableTaskPayl
             observation_table = await self.observation_table_service.create_document(
                 observation_table
             )
+
+            # if use case is linked and purpose of the observation table is EDA,
+            # check if the use case has default EDA table set
+            if payload.use_case_id is not None and payload.purpose == Purpose.EDA:
+                use_case = await self.use_case_service.get_document(document_id=payload.use_case_id)
+                if use_case.default_eda_table_id is None:
+                    # use case does not have default EDA table set, set it to this table
+                    await self.use_case_service.update_use_case(
+                        document_id=use_case.id,
+                        data=UseCaseUpdate(default_eda_table_id=observation_table.id),
+                    )
+
             if payload.target_namespace_id:
                 # update the target namespace with the unique target values if applicable
                 await self.target_namespace_service.update_target_namespace_classification_metadata(

--- a/tests/unit/routes/test_observation_table.py
+++ b/tests/unit/routes/test_observation_table.py
@@ -951,6 +951,7 @@ class TestObservationTableApi(BaseMaterializedTableTestSuite):
         payload["primary_entity_ids"] = None
         payload["context_id"] = None
         payload["use_case_id"] = "64dc9461ad86dba795606745"
+        payload["purpose"] = "eda"
         response = self.post(test_api_client, payload)
         response_dict = response.json()
         assert response.status_code == HTTPStatus.CREATED, response_dict
@@ -961,6 +962,13 @@ class TestObservationTableApi(BaseMaterializedTableTestSuite):
         assert response.status_code == HTTPStatus.OK, response_dict
         assert response_dict["context_id"] == "646f6c1c0ed28a5271fb02d5"
         assert response_dict["use_case_ids"] == ["64dc9461ad86dba795606745"]
+        assert response_dict["purpose"] == "eda"
+
+        # check that use case default eda table is set
+        response = test_api_client.get("/use_case/64dc9461ad86dba795606745")
+        response_dict = response.json()
+        assert response.status_code == HTTPStatus.OK, response_dict
+        assert response_dict["default_eda_table_id"] == observation_table_id
 
     def test_upload_with_use_case_201(self, test_api_client_persistent):
         """


### PR DESCRIPTION
## Description

Automatically tag use case default EDA table during obs table creation if:
- Default EDA table is not set for the use case
- Observation table is tagged with the use case and EDA as purpose

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
