### PR TITLE
[chore] Fix use case default eda table auto tagging logic

### DIFF
--- a/featurebyte/worker/task/observation_table.py
+++ b/featurebyte/worker/task/observation_table.py
@@ -244,10 +244,11 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask[ObservationTableTaskPayl
                 use_case = await self.use_case_service.get_document(document_id=payload.use_case_id)
                 if use_case.default_eda_table_id is None:
                     # use case does not have default EDA table set, set it to this table
-                    await self.use_case_service.update_use_case(
-                        document_id=use_case.id,
-                        data=UseCaseUpdate(default_eda_table_id=observation_table.id),
-                    )
+                    if payload.target_namespace_id == use_case.target_namespace_id:
+                        await self.use_case_service.update_use_case(
+                            document_id=use_case.id,
+                            data=UseCaseUpdate(default_eda_table_id=observation_table.id),
+                        )
 
             if payload.target_namespace_id:
                 # update the target namespace with the unique target values if applicable

--- a/featurebyte/worker/task/target_table.py
+++ b/featurebyte/worker/task/target_table.py
@@ -244,8 +244,12 @@ class TargetTableTask(DataWarehouseMixin, BaseTask[TargetTableTaskPayload]):
             )
 
             purpose: Optional[Purpose] = None
+            context_id = payload.context_id
             if isinstance(observation_set, ObservationTableModel):
+                # inherit purpose and context_id from observation set if available
                 purpose = observation_set.purpose
+                if context_id is None:
+                    context_id = observation_set.context_id
                 use_case_ids = observation_set.use_case_ids
             else:
                 use_case_ids = []
@@ -255,7 +259,7 @@ class TargetTableTask(DataWarehouseMixin, BaseTask[TargetTableTaskPayload]):
                 user_id=payload.user_id,
                 name=payload.name,
                 location=location,
-                context_id=payload.context_id,
+                context_id=context_id,
                 use_case_ids=use_case_ids,
                 request_input=TargetInput(
                     target_id=target_id,

--- a/tests/unit/routes/test_observation_table.py
+++ b/tests/unit/routes/test_observation_table.py
@@ -3,6 +3,7 @@ Tests for ObservationTable routes
 """
 
 import copy
+import json
 import os
 import tempfile
 import textwrap
@@ -963,6 +964,30 @@ class TestObservationTableApi(BaseMaterializedTableTestSuite):
         assert response_dict["context_id"] == "646f6c1c0ed28a5271fb02d5"
         assert response_dict["use_case_ids"] == ["64dc9461ad86dba795606745"]
         assert response_dict["purpose"] == "eda"
+
+        # check that use case default eda table is not set
+        response = test_api_client.get("/use_case/64dc9461ad86dba795606745")
+        response_dict = response.json()
+        assert response.status_code == HTTPStatus.OK, response_dict
+        assert response_dict["default_eda_table_id"] is None
+
+        # create target table
+        target_table_payload = BaseMaterializedTableTestSuite.load_payload(
+            "tests/fixtures/request_payloads/target_table.json"
+        )
+        response = test_api_client.post(
+            "/target_table", data={"payload": json.dumps(target_table_payload)}
+        )
+        response_dict = response.json()
+        assert response.status_code == HTTPStatus.CREATED, response_dict
+        response = self.wait_for_results(test_api_client, response)
+        response_dict = response.json()
+        assert response_dict["status"] == "SUCCESS", response_dict["traceback"]
+
+        observation_table_id = response_dict["payload"]["output_document_id"]
+        response = test_api_client.get(f"{self.base_route}/{observation_table_id}")
+        response_dict = response.json()
+        assert response.status_code == HTTPStatus.OK, response_dict
 
         # check that use case default eda table is set
         response = test_api_client.get("/use_case/64dc9461ad86dba795606745")

--- a/tests/unit/routes/test_observation_table.py
+++ b/tests/unit/routes/test_observation_table.py
@@ -988,6 +988,9 @@ class TestObservationTableApi(BaseMaterializedTableTestSuite):
         response = test_api_client.get(f"{self.base_route}/{observation_table_id}")
         response_dict = response.json()
         assert response.status_code == HTTPStatus.OK, response_dict
+        assert response_dict["context_id"] == "646f6c1c0ed28a5271fb02d5"
+        assert response_dict["use_case_ids"] == ["64dc9461ad86dba795606745"]
+        assert response_dict["purpose"] == "eda"
 
         # check that use case default eda table is set
         response = test_api_client.get("/use_case/64dc9461ad86dba795606745")


### PR DESCRIPTION
## Description

- Add missing default eda table tagging logic to target table
- Observation table must have matching target namespace

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
