### PR TITLE
[chore] Fix mutable default value for dataclass

### DIFF
--- a/featurebyte/query_graph/sql/partition_filter_helper.py
+++ b/featurebyte/query_graph/sql/partition_filter_helper.py
@@ -4,7 +4,7 @@ Helpers to derive partition filers from query graph
 
 import math
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Literal, Optional
 
@@ -105,8 +105,8 @@ class DataRequirements:
         The maximum range of data required after the maximum point in time.
     """
 
-    before_min: RangeType = RelativeDeltaRange.zero()
-    after_max: RangeType = RelativeDeltaRange.zero()
+    before_min: RangeType = field(default_factory=RelativeDeltaRange.zero)
+    after_max: RangeType = field(default_factory=RelativeDeltaRange.zero)
 
     def merge(self, other: "DataRequirements") -> None:
         """


### PR DESCRIPTION
## Description

Failing on main: https://github.com/featurebyte/featurebyte/actions/runs/17729966055/job/50379168129

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/featurebyte/__init__.py", line 16, in <module>
    from featurebyte.api.batch_feature_table import BatchFeatureTable
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/featurebyte/api/batch_feature_table.py", line 13, in <module>
    from featurebyte.api.api_object import ApiObject
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/featurebyte/api/api_object.py", line 18, in <module>
    from featurebyte.api.api_handler.base import ListHandler
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/featurebyte/api/api_handler/base.py", line 24, in <module>
    from featurebyte.models.base import FeatureByteBaseDocumentModel
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/featurebyte/models/__init__.py", line 8, in <module>
    from featurebyte.models.feature import FeatureModel
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/featurebyte/models/feature.py", line 46, in <module>
    from featurebyte.query_graph.sql.interpreter import GraphInterpreter
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/featurebyte/query_graph/sql/interpreter/__init__.py", line 5, in <module>
    from featurebyte.query_graph.sql.interpreter.preview import PreviewMixin
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/featurebyte/query_graph/sql/interpreter/preview.py", line 20, in <module>
    from featurebyte.query_graph.sql.builder import SQLOperationGraph
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/featurebyte/query_graph/sql/builder.py", line 107, in <module>
    NODE_REGISTRY = NodeRegistry()
                    ^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/featurebyte/query_graph/sql/builder.py", line 42, in __init__
    for _, cls in self.iterate_sql_nodes():
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/featurebyte/query_graph/sql/builder.py", line 101, in iterate_sql_nodes
    for _, mod in import_submodules("featurebyte.query_graph.sql.ast").items():
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/featurebyte/common/path_util.py", line 39, in import_submodules
    return {
           ^
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/featurebyte/common/path_util.py", line 40, in <dictcomp>
    name: importlib.import_module(package_name + "." + name)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/featurebyte/query_graph/sql/ast/input.py", line 28, in <module>
    from featurebyte.query_graph.sql.entity_filter import get_table_filtered_by_entity
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/featurebyte/query_graph/sql/entity_filter.py", line 21, in <module>
    from featurebyte.query_graph.sql.partition_filter_helper import (
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/featurebyte/query_graph/sql/partition_filter_helper.py", line 94, in <module>
    @dataclass
     ^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/dataclasses.py", line 1232, in dataclass
    return wrap(cls)
           ^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/dataclasses.py", line 1222, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/dataclasses.py", line 958, in _process_class
    cls_fields.append(_get_field(cls, name, type, kw_only))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/dataclasses.py", line 815, in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
ValueError: mutable default <class 'featurebyte.query_graph.sql.partition_filter_helper.RelativeDeltaRange'> for field before_min is not allowed: use default_factory
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
