### PR TITLE
[chore] Fix progress messages when enabling deployments

### DIFF
--- a/featurebyte/service/deploy.py
+++ b/featurebyte/service/deploy.py
@@ -784,7 +784,7 @@ class DeployService:
 
             await feature_update_progress(
                 int(i / len(feature_list.feature_ids) * 100),
-                f"Enabling feature online ({feature.name}) ...",
+                f"Deploying feature: {feature.name}",
             )
 
         tic = time.time()
@@ -934,7 +934,7 @@ class DeployService:
                 features.append(updated_feature)
                 await feature_update_progress(
                     int(len(features) / len(feature_list.feature_ids) * 100),
-                    f"Disabling features online ({feature.name}) ...",
+                    f"Undeploying feature: {feature.name}",
                 )
 
             # update offline feature table deployment reference

--- a/featurebyte/service/offline_store_feature_table_manager.py
+++ b/featurebyte/service/offline_store_feature_table_manager.py
@@ -263,7 +263,7 @@ class OfflineStoreFeatureTableManagerService:
 
             if update_progress:
                 message = (
-                    f"Materializing features to online store for table {offline_store_table_name} "
+                    f"Processing feature table: {offline_store_table_name} "
                     f"({idx + 1} / {offline_table_count} tables)"
                 )
                 await update_progress(int((idx + 1) / offline_table_count * 90), message)
@@ -383,7 +383,7 @@ class OfflineStoreFeatureTableManagerService:
 
             if update_progress:
                 message = (
-                    f"Updating offline store feature table {feature_table_dict['name']} for online disabling features "
+                    f"Updating feature table {feature_table_dict['name']} for deployment removal "
                     f"({idx + 1} / {offline_table_count} tables)"
                 )
                 await update_progress(int((idx + 1) / offline_table_count * 90), message)


### PR DESCRIPTION
## Description

This updates progress messages when enabling deployments to be less confusing:

* Avoid the terminology "online enabling"
* `Materializing features to online store for table` was misleading: the step was about processing a feature table (creating, updating, and conditionally moving features to online store but not always)

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
