### PR TITLE
[chore] Fix default preview table auto tagging logic during observation table creation

### DIFF
--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -298,7 +298,7 @@ class ObservationTableService(
                         document_id=context.id,
                         data=ContextUpdate(default_eda_table_id=observation_table.id),
                     )
-            if observation_table.purpose in [Purpose.PREVIEW, Purpose.EDA]:
+            if observation_table.purpose == Purpose.PREVIEW:
                 if context.default_preview_table_id is None:
                     # context does not have default preview table set, set it to this table
                     await self.context_service.update_document(
@@ -317,7 +317,7 @@ class ObservationTableService(
                             document_id=use_case_id,
                             data=UseCaseUpdate(default_eda_table_id=observation_table.id),
                         )
-        if observation_table.purpose in [Purpose.PREVIEW, Purpose.EDA]:
+        if observation_table.purpose == Purpose.PREVIEW:
             for use_case_id in observation_table.use_case_ids:
                 use_case = await self.use_case_service.get_document(document_id=use_case_id)
                 if use_case.default_preview_table_id is None:


### PR DESCRIPTION
## Description

Auto tag default preview table for context and use case only if observation table purpose is tagged as "preview"

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
