### PR TITLE
[chore] Use sample instead of limit for subsetting table for feature preview

### DIFF
--- a/tests/unit/routes/test_feature_list.py
+++ b/tests/unit/routes/test_feature_list.py
@@ -1325,10 +1325,26 @@ class TestFeatureListApi(BaseCatalogApiTestSuite):
             mock_session.execute_query.call_args_list[0][0][0]
             == textwrap.dedent(
                 """
-            SELECT
-              *
-            FROM "sf_database"."sf_schema"."OBSERVATION_TABLE_000000000000000000000000"
-            LIMIT 50
+                SELECT
+                  "POINT_IN_TIME",
+                  "cust_id"
+                FROM (
+                  SELECT
+                    CAST(BITAND(RANDOM(1234), 2147483647) AS DOUBLE) / 2147483647.0 AS "prob",
+                    "POINT_IN_TIME",
+                    "cust_id"
+                  FROM (
+                    SELECT
+                      "POINT_IN_TIME",
+                      "cust_id"
+                    FROM "sf_database"."sf_schema"."OBSERVATION_TABLE_000000000000000000000000"
+                  )
+                )
+                WHERE
+                  "prob" <= 0.75
+                ORDER BY
+                  "prob"
+                LIMIT 50
             """
             ).strip()
         )


### PR DESCRIPTION
## Description

Use sample instead of limit for subsetting table to keep within the preview size limit for feature preview.
This will use a uniform sample instead of the first n rows if the observation table is too large.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
