### PR TITLE
[DEV-4170] Fix dtype derivation for `count_dict.get_value`

### DIFF
--- a/.changelog/DEV-4170.yaml
+++ b/.changelog/DEV-4170.yaml
@@ -1,0 +1,34 @@
+# This template file is used to generate changelog entries on release
+# Check the generated entry in your PR with the task command
+
+# To view the generated changelog, run the following command:
+# task changelog-pr
+
+# --- TEMPLATE --- #
+# One of 'breaking', 'deprecation', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+# (e.g. gh-actions, docs, middleware, worker)
+component: service
+
+# (Optional) One or more tracking issues or pull requests related to the change
+issues: []
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix dtype derivation for count_dict.get_value when the parent aggregation yields an OBJECT dictionary column by normalizing to FLOAT to prevent incorrect dtype propagation."
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# SAMPLE
+#subtext: |
+#  + note this will make everything better
+#  + major performance improvement
+#  + time reduction for test suite from 10 minutes to 2 minutes
+#  ```
+#   Code sample
+#   goes here
+#  ```

--- a/tests/unit/api/test_feature.py
+++ b/tests/unit/api/test_feature.py
@@ -2091,3 +2091,85 @@ def test_feature_generated_from_item_view(snowflake_item_table, saved_event_tabl
         feature_name="order_size",
     )
     feat.save()
+
+
+def test_feature_count_dict_get_value_dtype(
+    snowflake_item_table,
+    saved_event_table,
+    snowflake_dimension_table,
+    cust_id_entity,
+    transaction_entity,
+    feature_group_feature_job_setting,
+):
+    """Test feature created from count_dict operations with get_value has FLOAT dtype"""
+    # Create additional entities to match debug_dtype.py structure
+    # item entity for item table (like GROCERYINVOICEITEMGUID)
+    item_entity = Entity(name="item", serving_names=["item_id_col"])
+    item_entity.save()
+
+    # product entity for dimension table (like GROCERYPRODUCTGUID)
+    product_entity = Entity(name="product", serving_names=["item_type"])
+    product_entity.save()
+
+    # invoice entity (like GROCERYINVOICEGUID)
+    invoice_entity = Entity(name="invoice", serving_names=["invoice_id"])
+    invoice_entity.save()
+
+    # Set up entity relationships matching debug_dtype.py:
+    # - item_table: item_entity (item_id_col), invoice_entity (event_id_col), product_entity (item_type)
+    # - dimension_table: product_entity (col_text as product type/category key)
+    # - event_table: invoice_entity (col_int as event_id), cust_id_entity (cust_id)
+
+    snowflake_item_table.item_id_col.as_entity(item_entity.name)
+    snowflake_item_table.event_id_col.as_entity(invoice_entity.name)
+    snowflake_item_table.item_type.as_entity(product_entity.name)
+
+    snowflake_dimension_table.col_text.as_entity(product_entity.name)
+
+    saved_event_table.col_int.as_entity(invoice_entity.name)
+    saved_event_table.cust_id.as_entity(cust_id_entity.name)
+
+    # Get views
+    item_view = snowflake_item_table.get_view()
+    event_view = saved_event_table.get_view()
+    dim_view = snowflake_dimension_table.get_view()
+
+    # Join item_view with dim_view on product type (like INVOICEITEMS join GROCERYPRODUCT)
+    item_view = item_view.join(dim_view, on="item_type", rsuffix="_product")
+
+    # Create a groupby with category parameter (similar to ProductGroup in debug_dtype.py)
+    # Group by event_id_col (invoice), category is col_boolean from product dimension (with rsuffix)
+    item_view_by_invoice = item_view.groupby("event_id_col", category="col_boolean_product")
+
+    # Aggregate with sum to create a count_dict feature
+    invoice_items_sum_by_category = item_view_by_invoice.aggregate(
+        "item_amount",
+        method="sum",
+        feature_name="invoice_items_sum_by_product_category",
+    )
+
+    # Add feature to event view (like adding to GROCERYINVOICE)
+    event_view = event_view.add_feature(
+        "invoice_items_sum_by_product_category",
+        invoice_items_sum_by_category,
+    )
+
+    # Create aggregate_over with latest method
+    event_view_by_customer = event_view.groupby(["cust_id"])
+    customer_latest_invoice_items_sum_by_category = event_view_by_customer.aggregate_over(
+        "invoice_items_sum_by_product_category",
+        method="latest",
+        feature_names=["customer_latest_invoice_items_sum_by_category_13w"],
+        windows=["13w"],
+        feature_job_setting=feature_group_feature_job_setting,
+    )["customer_latest_invoice_items_sum_by_category_13w"]
+
+    # Get value from count_dict using cd accessor
+    feature_with_get_value = customer_latest_invoice_items_sum_by_category.cd.get_value("test_key")
+
+    # Set name and save
+    feature_with_get_value.name = "customer_latest_invoice_items_sum_by_category_test_key"
+    feature_with_get_value.save()
+
+    # Assert the dtype is FLOAT
+    assert feature_with_get_value.dtype == DBVarType.FLOAT


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
Fix dtype derivation for count_dict.get_value when the parent aggregation yields an OBJECT dictionary column by normalizing to FLOAT to prevent incorrect dtype propagation.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
