### PR TITLE
[chore] fixing missing index creation

### DIFF
--- a/featurebyte/models/feature_store_cache.py
+++ b/featurebyte/models/feature_store_cache.py
@@ -63,7 +63,14 @@ class FeatureStoreCacheModel(FeatureByteBaseDocumentModel):
 
         collection_name = "feature_store_cache"
         unique_constraints = []
-        indexes = FeatureByteBaseDocumentModel.Settings.indexes + [
+
+        # Remove created_at index if it already exists to avoid duplication error
+        indexes = list(
+            filter(
+                lambda x: "created_at" not in x.document["key"],
+                FeatureByteBaseDocumentModel.Settings.indexes,
+            )
+        ) + [
             pymongo.operations.IndexModel("feature_store_id"),
             pymongo.operations.IndexModel("database_name"),
             pymongo.operations.IndexModel("schema_name"),


### PR DESCRIPTION
## Description

Mongodb error on index creation
```
{"collection": "feature_store_cache", "exc": "An equivalent index already exists with the same name but different options. Requested index: { v: 2, key: { created_at: 1 }, name: \"created_at_1\", expireAfterSecond │
│ s: 3600 }, existing index: { v: 2, key: { created_at: 1 }, name: \"created_at_1\" }
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
