### PR TITLE
Add support for user-provided observation weights

### DIFF
--- a/featurebyte/api/observation_table.py
+++ b/featurebyte/api/observation_table.py
@@ -53,6 +53,12 @@ DOCSTRING_FORMAT_PARAMS = {"class_name": "ObservationTable"}
 class ObservationTable(PrimaryEntityMixin, MaterializedTableMixin):
     """
     ObservationTable class
+
+    An ObservationTable can optionally include an OBSERVATION_WEIGHT column to provide custom
+    per-row weights. This is configured at the target level: when a TargetNamespace has
+    has_observation_weight enabled, any observation table added to a related use case must
+    contain an OBSERVATION_WEIGHT column. During materialization, this column is automatically
+    converted into the internal weight column used by downstream operations such as model training.
     """
 
     # class variables
@@ -472,6 +478,11 @@ class ObservationTable(PrimaryEntityMixin, MaterializedTableMixin):
     ) -> ObservationTable:
         """
         Upload a file to create an observation table. This file can either be a CSV or Parquet file.
+
+        The file may optionally include a column named "OBSERVATION_WEIGHT" containing per-row
+        weights. This column is required when the associated target namespace has
+        has_observation_weight enabled. During materialization it is converted into the internal
+        weight column used by downstream operations.
 
         Parameters
         ----------

--- a/featurebyte/api/source_table.py
+++ b/featurebyte/api/source_table.py
@@ -1713,6 +1713,10 @@ class SourceTable(AbstractTableData):
 
         - column(s) containing entity values with an accepted serving name.
         - a column containing historical points-in-time in UTC. The column name must be "POINT_IN_TIME".
+        - optionally, a column named "OBSERVATION_WEIGHT" containing per-row weights. This column is
+          required when the associated target namespace has has_observation_weight enabled. During
+          materialization it is converted into the internal weight column used by downstream operations.
+          You can use columns_rename_mapping to rename an existing column to "OBSERVATION_WEIGHT".
 
         Parameters
         ----------

--- a/featurebyte/api/target_namespace.py
+++ b/featurebyte/api/target_namespace.py
@@ -62,6 +62,7 @@ class TargetNamespace(FeatureOrTargetNamespaceMixin, DeletableApiObject, Savable
         window: Optional[str] = None,
         target_type: Optional[TargetType] = None,
         positive_label: Optional[PositiveLabelType] = None,
+        has_observation_weight: bool = False,
     ) -> TargetNamespace:
         """
         Create a new TargetNamespace.
@@ -82,6 +83,8 @@ class TargetNamespace(FeatureOrTargetNamespaceMixin, DeletableApiObject, Savable
             Positive label value for classification targets. Only applicable when target_type is
             CLASSIFICATION. The value type must match the dtype (str for VARCHAR/CHAR, int for INT,
             bool for BOOL).
+        has_observation_weight: bool
+            Whether observation tables for this target should include an OBSERVATION_WEIGHT column
 
         Returns
         -------
@@ -114,6 +117,7 @@ class TargetNamespace(FeatureOrTargetNamespaceMixin, DeletableApiObject, Savable
             window=window,
             target_type=target_type,
             positive_label=positive_label,
+            has_observation_weight=has_observation_weight,
         )
         target_namespace.save()
         return target_namespace
@@ -272,6 +276,49 @@ class TargetNamespace(FeatureOrTargetNamespaceMixin, DeletableApiObject, Savable
             url=f"{self._route}/{self.id}",
             skip_update_schema_check=True,
         )
+
+    @typechecked
+    def update_has_observation_weight(self, has_observation_weight: bool) -> None:
+        """
+        Update whether observation tables for this target should include an OBSERVATION_WEIGHT column.
+
+        When enabled, any observation table added to a use case associated with this target must
+        contain an OBSERVATION_WEIGHT column. This allows users to provide custom weights for each
+        observation row.
+
+        Parameters
+        ----------
+        has_observation_weight: bool
+            Whether the target requires an OBSERVATION_WEIGHT column in observation tables
+
+        Examples
+        --------
+        >>> target_namespace = fb.TargetNamespace.create(  # doctest: +SKIP
+        ...     name="amount_7d_target",
+        ...     window="7d",
+        ...     dtype=DBVarType.FLOAT,
+        ...     primary_entity=["customer"],
+        ...     target_type=fb.TargetType.REGRESSION,
+        ... )
+        >>> target_namespace.update_has_observation_weight(True)  # doctest: +SKIP
+        """
+        self.update(
+            update_payload={"has_observation_weight": has_observation_weight},
+            allow_update_local=False,
+            url=f"{self._route}/{self.id}",
+            skip_update_schema_check=True,
+        )
+
+    @property
+    def has_observation_weight(self) -> bool:
+        """
+        Whether observation tables for this target should include an OBSERVATION_WEIGHT column.
+
+        Returns
+        -------
+        bool
+        """
+        return self.cached_model.has_observation_weight
 
     def delete(self) -> None:
         """

--- a/featurebyte/api/view.py
+++ b/featurebyte/api/view.py
@@ -1901,6 +1901,10 @@ class View(ProtectedColumnsQueryObject, Frame, SampleMixin, ABC):
 
         - a column containing entity values with an accepted serving name.
         - a column containing historical points-in-time in UTC. The column name must be "POINT_IN_TIME".
+        - optionally, a column named "OBSERVATION_WEIGHT" containing per-row weights. This column is
+          required when the associated target namespace has has_observation_weight enabled. During
+          materialization it is converted into the internal weight column used by downstream operations.
+          You can use columns_rename_mapping to rename an existing column to "OBSERVATION_WEIGHT".
 
         Parameters
         ----------

--- a/featurebyte/enum.py
+++ b/featurebyte/enum.py
@@ -645,6 +645,7 @@ class SpecialColumnName(StrEnum):
 
     POINT_IN_TIME = "POINT_IN_TIME"
     FORECAST_POINT = "FORECAST_POINT"
+    OBSERVATION_WEIGHT = "OBSERVATION_WEIGHT"
 
 
 class InternalName(StrEnum):

--- a/featurebyte/models/target_namespace.py
+++ b/featurebyte/models/target_namespace.py
@@ -63,6 +63,9 @@ class TargetNamespaceModel(BaseFeatureNamespaceModel):
     positive_label_candidates: List[PositiveLabelCandidatesItem] = Field(default_factory=list)
     positive_label: Optional[PositiveLabelType] = Field(default=None)
 
+    # whether observation tables for this target should include an OBSERVATION_WEIGHT column
+    has_observation_weight: bool = Field(default=False)
+
     # pydantic validators
     _sort_ids_validator = field_validator("target_ids", "entity_ids")(construct_sort_validator())
     _duration_validator = field_validator("window", mode="before")(duration_string_validator)

--- a/featurebyte/routes/target_namespace/controller.py
+++ b/featurebyte/routes/target_namespace/controller.py
@@ -163,6 +163,7 @@ class TargetNamespaceController(
             default_version_mode=target_namespace.default_version_mode,
             default_target_id=target_namespace.default_target_id,
             target_type=target_namespace.target_type,
+            has_observation_weight=target_namespace.has_observation_weight,
             created_at=target_namespace.created_at,
             updated_at=target_namespace.updated_at,
         )

--- a/featurebyte/schema/target_namespace.py
+++ b/featurebyte/schema/target_namespace.py
@@ -38,6 +38,7 @@ class TargetNamespaceCreate(FeatureByteBaseModel):
     window: Optional[str] = Field(default=None)
     target_type: Optional[TargetType] = Field(default=None)
     positive_label: Optional[PositiveLabelType] = Field(default=None)
+    has_observation_weight: bool = Field(default=False)
 
     @model_validator(mode="after")
     def _validate_settings(self) -> "TargetNamespaceCreate":
@@ -83,6 +84,7 @@ class TargetNamespaceUpdate(BaseDocumentServiceUpdateSchema):
     window: Optional[str] = Field(default=None)
     target_type: Optional[TargetType] = Field(default=None)
     positive_label: Optional[PositiveLabelUpdate] = Field(default=None)
+    has_observation_weight: Optional[bool] = Field(default=None)
 
 
 class TargetNamespaceClassificationMetadataUpdate(FeatureByteBaseModel):
@@ -122,3 +124,4 @@ class TargetNamespaceInfo(BaseInfo):
     default_version_mode: DefaultVersionMode
     default_target_id: Optional[PydanticObjectId]
     target_type: Optional[TargetType]
+    has_observation_weight: bool = Field(default=False)

--- a/featurebyte/service/materialized_table.py
+++ b/featurebyte/service/materialized_table.py
@@ -10,7 +10,7 @@ from bson import ObjectId
 from redis import Redis
 from sqlglot import expressions
 
-from featurebyte.enum import InternalName
+from featurebyte.enum import InternalName, SpecialColumnName
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.materialized_table import ColumnSpecWithEntityId
 from featurebyte.persistent import Persistent
@@ -227,3 +227,51 @@ class BaseMaterializedTableService(
             ).from_(quoted_identifier(table_details.table_name)),
             replace=True,
         )
+
+    @staticmethod
+    async def rename_observation_weight_column(
+        session: BaseSession,
+        table_details: TableDetails,
+    ) -> bool:
+        """
+        Rename the OBSERVATION_WEIGHT column to __FB_TABLE_ROW_WEIGHT if it exists.
+
+        Parameters
+        ----------
+        session: BaseSession
+            Database session
+        table_details: TableDetails
+            Table details of the materialized table
+
+        Returns
+        -------
+        bool
+            True if the column was renamed, False if OBSERVATION_WEIGHT was not found
+        """
+        table_schema = await session.list_table_schema(
+            table_name=table_details.table_name,
+            database_name=table_details.database_name,
+            schema_name=table_details.schema_name,
+        )
+        if SpecialColumnName.OBSERVATION_WEIGHT not in table_schema:
+            return False
+
+        # Rebuild the table with OBSERVATION_WEIGHT renamed to __FB_TABLE_ROW_WEIGHT
+        col_exprs = []
+        for col_name in table_schema:
+            if col_name == SpecialColumnName.OBSERVATION_WEIGHT:
+                col_exprs.append(
+                    expressions.alias_(
+                        quoted_identifier(col_name),
+                        alias=InternalName.TABLE_ROW_WEIGHT,
+                        quoted=True,
+                    )
+                )
+            else:
+                col_exprs.append(quoted_identifier(col_name))
+        await session.create_table_as(
+            table_details,
+            expressions.select(*col_exprs).from_(quoted_identifier(table_details.table_name)),
+            replace=True,
+        )
+        return True

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -1773,6 +1773,19 @@ class ObservationTableService(
                             f"Cannot add UseCase {data.use_case_id_to_add} due to mismatched treatments."
                         )
 
+                # validate observation weight column requirement
+                target_namespace = await self.target_namespace_service.get_document(
+                    document_id=use_case.target_namespace_id
+                )
+                if target_namespace.has_observation_weight:
+                    obs_table_column_names = {col.name for col in observation_table.columns_info}
+                    if SpecialColumnName.OBSERVATION_WEIGHT not in obs_table_column_names:
+                        raise ObservationTableInvalidUseCaseError(
+                            f"Cannot add UseCase {data.use_case_id_to_add} as the target requires an "
+                            f"'{SpecialColumnName.OBSERVATION_WEIGHT}' column in the observation table, "
+                            f"but the column is missing."
+                        )
+
                 use_case_ids.append(data.use_case_id_to_add)
 
             # validate use case id to remove

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -1777,13 +1777,20 @@ class ObservationTableService(
                 target_namespace = await self.target_namespace_service.get_document(
                     document_id=use_case.target_namespace_id
                 )
+                obs_table_column_names = {col.name for col in observation_table.columns_info}
                 if target_namespace.has_observation_weight:
-                    obs_table_column_names = {col.name for col in observation_table.columns_info}
                     if SpecialColumnName.OBSERVATION_WEIGHT not in obs_table_column_names:
                         raise ObservationTableInvalidUseCaseError(
                             f"Cannot add UseCase {data.use_case_id_to_add} as the target requires an "
                             f"'{SpecialColumnName.OBSERVATION_WEIGHT}' column in the observation table, "
                             f"but the column is missing."
+                        )
+                else:
+                    if SpecialColumnName.OBSERVATION_WEIGHT in obs_table_column_names:
+                        raise ObservationTableInvalidUseCaseError(
+                            f"Cannot add UseCase {data.use_case_id_to_add} as the observation table "
+                            f"contains an '{SpecialColumnName.OBSERVATION_WEIGHT}' column, but the "
+                            f"target does not have observation weight enabled."
                         )
 
                 use_case_ids.append(data.use_case_id_to_add)

--- a/featurebyte/worker/task/observation_table.py
+++ b/featurebyte/worker/task/observation_table.py
@@ -429,6 +429,20 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask[ObservationTableTaskPayl
                     session=db_session, table_details=missing_data_table_details
                 )
 
+        # rename OBSERVATION_WEIGHT to __FB_TABLE_ROW_WEIGHT if the target requires it
+        if target_namespace_id is not None:
+            target_ns = await self.target_namespace_service.get_document(
+                document_id=target_namespace_id
+            )
+            if target_ns.has_observation_weight:
+                weight_renamed = (
+                    await self.observation_table_service.rename_observation_weight_column(
+                        session=db_session, table_details=location.table_details
+                    )
+                )
+                if weight_renamed:
+                    output_table_has_row_weights = True
+
         # get the table with missing data if it has data
         table_with_missing_data = await self.get_table_with_missing_data(
             db_session=db_session,

--- a/tests/unit/api/test_target_namespace.py
+++ b/tests/unit/api/test_target_namespace.py
@@ -39,6 +39,7 @@ def test_target_namespace_create_and_delete(item_entity):
         "default_version_mode": "AUTO",
         "default_target_id": None,
         "target_type": "classification",
+        "has_observation_weight": False,
         "created_at": namespace_info["created_at"],
         "updated_at": namespace_info["updated_at"],
     }

--- a/tests/unit/routes/test_observation_table.py
+++ b/tests/unit/routes/test_observation_table.py
@@ -368,6 +368,77 @@ class TestObservationTableApi(BaseMaterializedTableTestSuite):
         assert response.status_code == HTTPStatus.OK, response.json()
 
     @pytest.mark.asyncio
+    async def test_update_use_case_observation_weight_not_expected(
+        self,
+        test_api_client_persistent,
+        create_success_response,
+        default_catalog_id,
+        user_id,
+    ):
+        """Test that adding use case fails when table has OBSERVATION_WEIGHT but target does not expect it"""
+        test_api_client, persistent = test_api_client_persistent
+        _ = create_success_response
+
+        use_case_payload = BaseMaterializedTableTestSuite.load_payload(
+            "tests/fixtures/request_payloads/use_case.json"
+        )
+
+        # Target namespace does NOT have has_observation_weight (default False)
+
+        # Create observation table WITH OBSERVATION_WEIGHT column
+        ob_table_id = ObjectId()
+        await persistent.insert_one(
+            collection_name="observation_table",
+            document={
+                "_id": ob_table_id,
+                "name": "ob_table_unexpected_weight",
+                "request_input": {
+                    "target_id": ObjectId(use_case_payload["target_id"]),
+                    "observation_table_id": ob_table_id,
+                    "type": "dataframe",
+                },
+                "location": {
+                    "feature_store_id": ObjectId("646f6c190ed28a5271fb02a1"),
+                    "table_details": {
+                        "database_name": "sf_database",
+                        "schema_name": "sf_schema",
+                        "table_name": "fb_materialized_table",
+                    },
+                },
+                "columns_info": [
+                    {"name": "a", "dtype": "INT"},
+                    {"name": "OBSERVATION_WEIGHT", "dtype": "FLOAT"},
+                ],
+                "num_rows": 1000,
+                "most_recent_point_in_time": "2023-01-15T10:00:00",
+                "context_id": ObjectId(use_case_payload["context_id"]),
+                "use_case_ids": [],
+                "primary_entity_ids": [],
+                "catalog_id": ObjectId(default_catalog_id),
+                "user_id": user_id,
+            },
+            user_id=user_id,
+        )
+
+        # Create use case
+        use_case_id = str(ObjectId())
+        uc_payload = BaseMaterializedTableTestSuite.load_payload(
+            "tests/fixtures/request_payloads/use_case.json"
+        )
+        uc_payload["_id"] = use_case_id
+        uc_payload["name"] = "test_use_case_no_weight"
+        response = test_api_client.post("/use_case", json=uc_payload)
+        assert response.status_code == HTTPStatus.CREATED, response.json()
+
+        # Adding use case should fail because table has OBSERVATION_WEIGHT but target doesn't expect it
+        response = test_api_client.patch(
+            f"{self.base_route}/{ob_table_id}",
+            json={"use_case_id_to_add": use_case_id},
+        )
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        assert "does not have observation weight enabled" in response.json()["detail"]
+
+    @pytest.mark.asyncio
     async def test_update_purpose(self, test_api_client_persistent, create_success_response):
         """Test update purpose"""
         test_api_client, _ = test_api_client_persistent

--- a/tests/unit/routes/test_observation_table.py
+++ b/tests/unit/routes/test_observation_table.py
@@ -268,6 +268,106 @@ class TestObservationTableApi(BaseMaterializedTableTestSuite):
         assert response.json()["use_case_ids"] == []
 
     @pytest.mark.asyncio
+    async def test_update_use_case_observation_weight_validation(
+        self,
+        test_api_client_persistent,
+        create_success_response,
+        create_observation_table,
+        default_catalog_id,
+        user_id,
+    ):
+        """Test that adding use case fails when target has observation weight but table lacks the column"""
+        test_api_client, persistent = test_api_client_persistent
+        _ = create_success_response
+
+        use_case_payload = BaseMaterializedTableTestSuite.load_payload(
+            "tests/fixtures/request_payloads/use_case.json"
+        )
+
+        # Get the target namespace id from the target
+        target_response = test_api_client.get(f"/target/{use_case_payload['target_id']}")
+        assert target_response.status_code == HTTPStatus.OK
+        target_namespace_id = target_response.json()["target_namespace_id"]
+
+        # Update target namespace to require observation weight
+        response = test_api_client.patch(
+            f"/target_namespace/{target_namespace_id}",
+            json={"has_observation_weight": True},
+        )
+        assert response.status_code == HTTPStatus.OK, response.json()
+        assert response.json()["has_observation_weight"] is True
+
+        # Create observation table WITHOUT OBSERVATION_WEIGHT column
+        new_ob_table_id = ObjectId()
+        await create_observation_table(
+            new_ob_table_id,
+            context_id=use_case_payload["context_id"],
+            target_input=True,
+            target_id=use_case_payload["target_id"],
+        )
+
+        # Create use case
+        use_case_id = str(ObjectId())
+        uc_payload = BaseMaterializedTableTestSuite.load_payload(
+            "tests/fixtures/request_payloads/use_case.json"
+        )
+        uc_payload["_id"] = use_case_id
+        uc_payload["name"] = "test_use_case_weight"
+        response = test_api_client.post("/use_case", json=uc_payload)
+        assert response.status_code == HTTPStatus.CREATED, response.json()
+
+        # Adding use case should fail because OBSERVATION_WEIGHT column is missing
+        response = test_api_client.patch(
+            f"{self.base_route}/{new_ob_table_id}",
+            json={"use_case_id_to_add": use_case_id},
+        )
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        assert "OBSERVATION_WEIGHT" in response.json()["detail"]
+
+        # Now create observation table WITH OBSERVATION_WEIGHT column
+        ob_table_with_weight_id = ObjectId()
+        await persistent.insert_one(
+            collection_name="observation_table",
+            document={
+                "_id": ob_table_with_weight_id,
+                "name": "ob_table_with_weight",
+                "request_input": {
+                    "target_id": ObjectId(use_case_payload["target_id"]),
+                    "observation_table_id": ob_table_with_weight_id,
+                    "type": "dataframe",
+                },
+                "location": {
+                    "feature_store_id": ObjectId("646f6c190ed28a5271fb02a1"),
+                    "table_details": {
+                        "database_name": "sf_database",
+                        "schema_name": "sf_schema",
+                        "table_name": "fb_materialized_table",
+                    },
+                },
+                "columns_info": [
+                    {"name": "a", "dtype": "INT"},
+                    {"name": "b", "dtype": "INT"},
+                    {"name": "OBSERVATION_WEIGHT", "dtype": "FLOAT"},
+                ],
+                "num_rows": 1000,
+                "most_recent_point_in_time": "2023-01-15T10:00:00",
+                "context_id": ObjectId(use_case_payload["context_id"]),
+                "use_case_ids": [],
+                "primary_entity_ids": [],
+                "catalog_id": ObjectId(default_catalog_id),
+                "user_id": user_id,
+            },
+            user_id=user_id,
+        )
+
+        # Adding use case should succeed with OBSERVATION_WEIGHT column present
+        response = test_api_client.patch(
+            f"{self.base_route}/{ob_table_with_weight_id}",
+            json={"use_case_id_to_add": use_case_id},
+        )
+        assert response.status_code == HTTPStatus.OK, response.json()
+
+    @pytest.mark.asyncio
     async def test_update_purpose(self, test_api_client_persistent, create_success_response):
         """Test update purpose"""
         test_api_client, _ = test_api_client_persistent

--- a/tests/unit/routes/test_target_namespace.py
+++ b/tests/unit/routes/test_target_namespace.py
@@ -94,6 +94,32 @@ class TestTargetNamespaceApi(BaseCatalogApiTestSuite):
         assert response.status_code == HTTPStatus.OK, response.json()
         assert response.json()["target_type"] == "regression"
 
+    def test_update_has_observation_weight_200(self, test_api_client_persistent):
+        """Test update has_observation_weight via route"""
+        test_api_client, _ = test_api_client_persistent
+        response = test_api_client.post(
+            "/target_namespace", json={**self.payload, "target_type": "regression"}
+        )
+        target_namespace_id = response.json()["_id"]
+        assert response.status_code == HTTPStatus.CREATED, response.json()
+        assert response.json()["has_observation_weight"] is False
+
+        # enable observation weight
+        response = test_api_client.patch(
+            f"/target_namespace/{target_namespace_id}",
+            json={"has_observation_weight": True},
+        )
+        assert response.status_code == HTTPStatus.OK, response.json()
+        assert response.json()["has_observation_weight"] is True
+
+        # disable observation weight
+        response = test_api_client.patch(
+            f"/target_namespace/{target_namespace_id}",
+            json={"has_observation_weight": False},
+        )
+        assert response.status_code == HTTPStatus.OK, response.json()
+        assert response.json()["has_observation_weight"] is False
+
     def test_delete_target_namespace(self, test_api_client_persistent, create_success_response):
         """Test delete target namespace"""
         test_api_client, _ = test_api_client_persistent

--- a/tests/unit/worker/task/test_observation_table.py
+++ b/tests/unit/worker/task/test_observation_table.py
@@ -2,13 +2,18 @@
 Test observation table
 """
 
+from collections import OrderedDict
+from unittest.mock import AsyncMock
+
 import pytest
 from bson import ObjectId
 
+from featurebyte.enum import DBVarType, InternalName, SpecialColumnName
 from featurebyte.models.observation_table import SourceTableObservationInput
 from featurebyte.query_graph.model.common_table import TabularSource
-from featurebyte.query_graph.node.schema import TableDetails
+from featurebyte.query_graph.node.schema import ColumnSpec, TableDetails
 from featurebyte.schema.worker.task.observation_table import ObservationTableTaskPayload
+from featurebyte.service.materialized_table import BaseMaterializedTableService
 from featurebyte.worker.task.observation_table import ObservationTableTask
 
 
@@ -34,3 +39,48 @@ async def test_get_task_description(catalog, app_container):
         await task.get_task_description(payload)
         == 'Save observation table "Test Observation Table" from source table.'
     )
+
+
+@pytest.mark.asyncio
+async def test_rename_observation_weight_column_present():
+    """Test rename_observation_weight_column when OBSERVATION_WEIGHT column exists"""
+    mock_session = AsyncMock()
+    mock_session.list_table_schema.return_value = OrderedDict({
+        "POINT_IN_TIME": ColumnSpec(name="POINT_IN_TIME", dtype=DBVarType.TIMESTAMP),
+        "cust_id": ColumnSpec(name="cust_id", dtype=DBVarType.VARCHAR),
+        SpecialColumnName.OBSERVATION_WEIGHT: ColumnSpec(
+            name=SpecialColumnName.OBSERVATION_WEIGHT, dtype=DBVarType.FLOAT
+        ),
+    })
+
+    table_details = TableDetails(table_name="test_table")
+    result = await BaseMaterializedTableService.rename_observation_weight_column(
+        session=mock_session, table_details=table_details
+    )
+
+    assert result is True
+    mock_session.create_table_as.assert_called_once()
+    call_args = mock_session.create_table_as.call_args
+    # create_table_as(table_details, select_expr, replace=True)
+    select_expr = call_args.args[1]
+    sql = select_expr.sql()
+    assert InternalName.TABLE_ROW_WEIGHT in sql
+    assert SpecialColumnName.OBSERVATION_WEIGHT in sql
+
+
+@pytest.mark.asyncio
+async def test_rename_observation_weight_column_absent():
+    """Test rename_observation_weight_column when OBSERVATION_WEIGHT column does not exist"""
+    mock_session = AsyncMock()
+    mock_session.list_table_schema.return_value = OrderedDict({
+        "POINT_IN_TIME": ColumnSpec(name="POINT_IN_TIME", dtype=DBVarType.TIMESTAMP),
+        "cust_id": ColumnSpec(name="cust_id", dtype=DBVarType.VARCHAR),
+    })
+
+    table_details = TableDetails(table_name="test_table")
+    result = await BaseMaterializedTableService.rename_observation_weight_column(
+        session=mock_session, table_details=table_details
+    )
+
+    assert result is False
+    mock_session.create_table_as.assert_not_called()


### PR DESCRIPTION
## Description

### Summary
* Add support for user-provided observation weights via an OBSERVATION_WEIGHT column on observation tables
* The weight requirement is configured at the target namespace level through a new has_observation_weight boolean field
* When has_observation_weight is enabled on a target namespace, any observation table added to a related use case must contain an OBSERVATION_WEIGHT column, otherwise validation raises an error
*  reverse validation: if a target does not have has_observation_weight enabled but the observation table contains an OBSERVATION_WEIGHT column, adding the use case is rejected with a clear error message.
* During observation table materialization, the OBSERVATION_WEIGHT column is automatically renamed to the internal __FB_TABLE_ROW_WEIGHT column, integrating with the existing weight system used by feature table caching, downloads, and downstream ML operations
* The weight column is correctly inherited when creating observation tables from other observation tables (copy, split, and downsampling paths)

### Changes
* Add OBSERVATION_WEIGHT to SpecialColumnName enum
* Add has_observation_weight field to TargetNamespaceModel, creation/update schemas, and info response
* Add update_has_observation_weight() method and has_observation_weight property to the TargetNamespace API class
* Add validation in ObservationTableService.update_observation_table() to require the OBSERVATION_WEIGHT column when the target namespace has observation weight enabled
* Add rename_observation_weight_column() method to BaseMaterializedTableService that renames OBSERVATION_WEIGHT to __FB_TABLE_ROW_WEIGHT in the materialized table
* Call the rename in the observation table worker task after materialization when the target namespace requires it, setting has_row_weights=True on the resulting observation table

### Tests
* PATCH route enable/disable — test_update_has_observation_weight_200 in tests/unit/routes/test_target_namespace.py
* Validation rejects missing column — test_update_use_case_observation_weight_validation in tests/unit/routes/test_observation_table.py (first assertion)
* Validation accepts present column — same test (second assertion with OBSERVATION_WEIGHT column present)
* Rename when present — test_rename_observation_weight_column_present in tests/unit/worker/task/test_observation_table.py
* No-op when absent — test_rename_observation_weight_column_absent in same file

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
