### PR TITLE
Add Exposure object support

### DIFF
--- a/featurebyte/__init__.py
+++ b/featurebyte/__init__.py
@@ -28,6 +28,8 @@ from featurebyte.api.dimension_view import DimensionView
 from featurebyte.api.entity import Entity
 from featurebyte.api.event_table import EventTable
 from featurebyte.api.event_view import EventView
+from featurebyte.api.exposure import Exposure
+from featurebyte.api.exposure_namespace import ExposureNamespace
 from featurebyte.api.feature import Feature
 from featurebyte.api.feature_group import BaseFeatureGroup, FeatureGroup
 from featurebyte.api.feature_job_setting_analysis import FeatureJobSettingAnalysis

--- a/featurebyte/api/api_handler/exposure_namespace.py
+++ b/featurebyte/api/api_handler/exposure_namespace.py
@@ -1,0 +1,18 @@
+"""
+Exposure namespace list handler
+"""
+
+import pandas as pd
+
+from featurebyte.api.api_handler.base import ListHandler
+
+
+class ExposureNamespaceListHandler(ListHandler):
+    """
+    Additional handling for exposure namespace.
+    """
+
+    def additional_post_processing(self, exposures: pd.DataFrame) -> pd.DataFrame:
+        # replace id with default_exposure_id
+        exposures["id"] = exposures["default_exposure_id"]
+        return exposures

--- a/featurebyte/api/catalog.py
+++ b/featurebyte/api/catalog.py
@@ -22,6 +22,7 @@ from featurebyte.api.context import Context
 from featurebyte.api.data_source import DataSource
 from featurebyte.api.deployment import Deployment
 from featurebyte.api.entity import Entity
+from featurebyte.api.exposure import Exposure
 from featurebyte.api.feature import Feature
 from featurebyte.api.feature_job_setting_analysis import FeatureJobSettingAnalysis
 from featurebyte.api.feature_list import FeatureList
@@ -674,6 +675,27 @@ class Catalog(NameAttributeUpdatableMixin, SavableApiObject, CatalogGetByIdMixin
         return Target.list(include_id=include_id)
 
     @update_and_reset_catalog
+    def list_exposures(self, include_id: Optional[bool] = True) -> pd.DataFrame:
+        """
+        Returns a DataFrame that contains various attributes of the registered exposures in the catalog
+
+        Parameters
+        ----------
+        include_id: Optional[bool]
+            Whether to include id in the list.
+
+        Returns
+        -------
+        pd.DataFrame
+            Dataframe of exposures
+
+        Examples
+        --------
+        >>> exposures = catalog.list_exposures()  # doctest: +SKIP
+        """
+        return Exposure.list(include_id=include_id)
+
+    @update_and_reset_catalog
     def list_treatments(self, include_id: Optional[bool] = True) -> pd.DataFrame:
         """
         Returns a DataFrame that contains various attributes of the registered treatments in the catalog
@@ -1253,6 +1275,27 @@ class Catalog(NameAttributeUpdatableMixin, SavableApiObject, CatalogGetByIdMixin
         >>> target = catalog.get_target("target_name")  # doctest: +SKIP
         """
         return Target.get(name=name)
+
+    @update_and_reset_catalog
+    def get_exposure(self, name: str) -> Any:
+        """
+        Gets an Exposure object from the catalog based on its name.
+
+        Parameters
+        ----------
+        name: str
+            Exposure name.
+
+        Returns
+        -------
+        Any
+            Retrieved exposure.
+
+        Examples
+        --------
+        >>> exposure = catalog.get_exposure("exposure_name")  # doctest: +SKIP
+        """
+        return Exposure.get(name=name)
 
     @update_and_reset_catalog
     def get_treatment(self, name: str) -> Any:

--- a/featurebyte/api/catalog_get_by_id_mixin.py
+++ b/featurebyte/api/catalog_get_by_id_mixin.py
@@ -15,6 +15,7 @@ from featurebyte.api.context import Context
 from featurebyte.api.data_source import DataSource
 from featurebyte.api.deployment import Deployment
 from featurebyte.api.entity import Entity
+from featurebyte.api.exposure import Exposure
 from featurebyte.api.feature import Feature
 from featurebyte.api.feature_job_setting_analysis import FeatureJobSettingAnalysis
 from featurebyte.api.feature_list import FeatureList
@@ -518,6 +519,32 @@ class CatalogGetByIdMixin:
         >>> target = catalog.get_target_by_id(ObjectId())  # doctest: +SKIP
         """
         return Target.get_by_id(id=id)
+
+    @update_and_reset_catalog
+    def get_exposure_by_id(
+        self,
+        id: ObjectId,
+    ) -> Exposure:
+        """
+        Get exposure by id.
+
+        Parameters
+        ----------
+        id: ObjectId
+            Exposure id.
+
+        Returns
+        -------
+        Exposure
+            Exposure object.
+
+        Examples
+        --------
+        Get a saved exposure.
+
+        >>> exposure = catalog.get_exposure_by_id(ObjectId())  # doctest: +SKIP
+        """
+        return Exposure.get_by_id(id=id)
 
     @update_and_reset_catalog
     def get_treatment_by_id(

--- a/featurebyte/api/context.py
+++ b/featurebyte/api/context.py
@@ -10,6 +10,8 @@ from pandas import DataFrame
 from typeguard import typechecked
 
 from featurebyte.api.entity import Entity
+from featurebyte.api.exposure import Exposure
+from featurebyte.api.exposure_namespace import ExposureNamespace
 from featurebyte.api.observation_table import ObservationTable
 from featurebyte.api.request_column import RequestColumn
 from featurebyte.api.savable_api_object import DeletableApiObject, SavableApiObject
@@ -19,6 +21,7 @@ from featurebyte.common.doc_util import FBAutoDoc
 from featurebyte.enum import ConflictResolution, DBVarType, FeatureType, SpecialColumnName
 from featurebyte.models.base import PydanticObjectId
 from featurebyte.models.context import ContextModel, UserProvidedColumn
+from featurebyte.models.exposure import ExposureSourceColumn
 from featurebyte.query_graph.model.dtype import DBVarTypeInfo, DBVarTypeMetadata
 from featurebyte.query_graph.model.forecast_point_schema import ForecastPointSchema
 from featurebyte.query_graph.model.timestamp_schema import TimestampSchema
@@ -52,6 +55,34 @@ class Context(SavableApiObject, DeletableApiObject, UseCaseOrContextMixin):
     treatment_id: Optional[PydanticObjectId] = None
     user_provided_columns: List[UserProvidedColumn] = []
     forecast_point_schema: Optional[ForecastPointSchema] = None
+    exposure_id: Optional[PydanticObjectId] = None
+    exposure_namespace_id: Optional[PydanticObjectId] = None
+
+    @property
+    def exposure(self) -> Optional[Exposure]:
+        """
+        Returns the exposure object of the Context, if any.
+
+        Returns
+        -------
+        Optional[Exposure]
+            The exposure object of the Context, or None if not set.
+        """
+        if self.exposure_id is None:
+            return None
+        return Exposure.get_by_id(self.exposure_id)
+
+    @property
+    def exposure_source_column(self) -> Optional[ExposureSourceColumn]:
+        """
+        Returns the exposure source column information.
+
+        Returns
+        -------
+        Optional[ExposureSourceColumn]
+            The table id and column name of the exposure source column, or None if not applicable.
+        """
+        return self.cached_model.exposure_source_column
 
     @property
     def primary_entities(self) -> List[Entity]:
@@ -152,6 +183,7 @@ class Context(SavableApiObject, DeletableApiObject, UseCaseOrContextMixin):
         treatment_name: Optional[str] = None,
         user_provided_columns: Optional[List[UserProvidedColumn]] = None,
         forecast_point_schema: Optional[ForecastPointSchema] = None,
+        exposure_name: Optional[str] = None,
     ) -> "Context":
         """
         Create a new Context.
@@ -171,6 +203,11 @@ class Context(SavableApiObject, DeletableApiObject, UseCaseOrContextMixin):
         forecast_point_schema: Optional[ForecastPointSchema]
             Schema for forecast point column if this is a forecasting context.
             Defines the granularity (day, week, etc.) and timezone handling.
+        exposure_name: Optional[str]
+            Optional exposure name to associate with the Context. The exposure's entities
+            must be the same as or parent entities of the context's primary entities.
+            When associated, the exposure is computed for observation tables created
+            from this context.
 
         Returns
         -------
@@ -252,6 +289,13 @@ class Context(SavableApiObject, DeletableApiObject, UseCaseOrContextMixin):
         if treatment_name:
             treatment_id = Treatment.get(treatment_name).id
 
+        exposure_id: Optional[PydanticObjectId] = None
+        exposure_namespace_id: Optional[PydanticObjectId] = None
+        if exposure_name is not None:
+            exposure_ns = ExposureNamespace.get(exposure_name)
+            exposure_id = exposure_ns.default_exposure_id
+            exposure_namespace_id = exposure_ns.id
+
         context = Context(
             name=name,
             primary_entity_ids=entity_ids,
@@ -259,6 +303,8 @@ class Context(SavableApiObject, DeletableApiObject, UseCaseOrContextMixin):
             treatment_id=treatment_id,
             user_provided_columns=user_provided_columns or [],
             forecast_point_schema=forecast_point_schema,
+            exposure_id=exposure_id,
+            exposure_namespace_id=exposure_namespace_id,
         )
         context.save()
         return context

--- a/featurebyte/api/exposure.py
+++ b/featurebyte/api/exposure.py
@@ -1,0 +1,446 @@
+"""
+Exposure API object
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Dict, List, Optional, Sequence, Union, cast
+
+import pandas as pd
+from bson import ObjectId
+from pydantic import BaseModel, Field, model_validator
+from typeguard import typechecked
+
+from featurebyte.api.api_object_util import ForeignKeyMapping
+from featurebyte.api.entity import Entity
+from featurebyte.api.exposure_namespace import ExposureNamespace
+from featurebyte.api.feature_or_target_mixin import FeatureOrTargetMixin
+from featurebyte.api.feature_store import FeatureStore
+from featurebyte.api.observation_table import ObservationTable
+from featurebyte.api.savable_api_object import DeletableApiObject, SavableApiObject
+from featurebyte.api.templates.doc_util import substitute_docstring
+from featurebyte.api.templates.entity_doc import (
+    ENTITY_DOC,
+    ENTITY_IDS_DOC,
+    PRIMARY_ENTITY_DOC,
+    PRIMARY_ENTITY_IDS_DOC,
+)
+from featurebyte.api.templates.feature_or_target_doc import (
+    CATALOG_ID_DOC,
+    DEFINITION_DOC,
+    PREVIEW_DOC,
+    TABLE_IDS_DOC,
+    VERSION_DOC,
+)
+from featurebyte.api.templates.series_doc import ISNULL_DOC, NOTNULL_DOC
+from featurebyte.common.doc_util import FBAutoDoc
+from featurebyte.common.utils import dataframe_to_arrow_bytes, enforce_observation_set_row_order
+from featurebyte.core.series import Series
+from featurebyte.models.exposure import ExposureModel
+from featurebyte.models.feature_store import FeatureStoreModel
+from featurebyte.query_graph.model.common_table import TabularSource
+from featurebyte.schema.exposure import ExposureCreate
+from featurebyte.schema.target_table import TargetTableCreate
+
+DOCSTRING_FORMAT_PARAMS = {"class_name": "Exposure"}
+
+
+class Exposure(
+    Series,
+    DeletableApiObject,
+    SavableApiObject,
+    FeatureOrTargetMixin,
+):
+    """
+    Exposure class used to represent an Exposure in FeatureByte.
+
+    An Exposure is an optional companion to a Target that provides a time offset
+    or adjustment value. When associated with a Use Case, Exposures are computed
+    alongside the Target during target computation.
+    """
+
+    # class variables
+    __fbautodoc__: ClassVar[FBAutoDoc] = FBAutoDoc(proxy_class="featurebyte.Exposure")
+    _route = "/exposure"
+    _list_schema = ExposureModel
+    _get_schema = ExposureModel
+    _list_fields = ["name", "entities"]
+    _list_foreign_keys = [
+        ForeignKeyMapping("entity_ids", Entity, "entities"),
+    ]
+
+    # pydantic instance variable (public)
+    feature_store: FeatureStoreModel = Field(
+        exclude=True,
+        frozen=True,
+        description="Provides information about the feature store that the exposure is connected to.",
+    )
+
+    def _get_create_payload(self) -> dict[str, Any]:
+        data = ExposureCreate(**self.model_dump(by_alias=True))
+        return data.json_dict()
+
+    def _get_init_params_from_object(self) -> dict[str, Any]:
+        return {"feature_store": self.feature_store}
+
+    def validate_series_operation(self, other_series: Series) -> bool:
+        """
+        Validate that the other series is an Exposure.
+
+        Parameters
+        ----------
+        other_series: Series
+            The other series to validate.
+
+        Returns
+        -------
+        bool
+        """
+        return isinstance(other_series, Exposure)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _set_feature_store(cls, values: Any) -> Any:
+        if isinstance(values, BaseModel):
+            values = values.model_dump(by_alias=True)
+
+        if "feature_store" not in values:
+            tabular_source = values.get("tabular_source")
+            if isinstance(tabular_source, dict):
+                feature_store_id = TabularSource(**tabular_source).feature_store_id
+                values["feature_store"] = FeatureStore.get_by_id(id=feature_store_id)
+        return values
+
+    @property
+    @substitute_docstring(
+        doc_template=VERSION_DOC,
+        examples=(
+            """
+            >>> exposure = catalog.get_exposure("my_exposure")  # doctest: +SKIP
+            >>> exposure.version  # doctest: +SKIP
+            'V230323'
+            """
+        ),
+        format_kwargs=DOCSTRING_FORMAT_PARAMS,
+    )
+    def version(self) -> str:
+        return self._get_version()
+
+    @property
+    @substitute_docstring(doc_template=CATALOG_ID_DOC, format_kwargs=DOCSTRING_FORMAT_PARAMS)
+    def catalog_id(self) -> ObjectId:
+        return self._get_catalog_id()
+
+    @property
+    @substitute_docstring(doc_template=ENTITY_IDS_DOC, format_kwargs=DOCSTRING_FORMAT_PARAMS)
+    def entity_ids(self) -> Sequence[ObjectId]:
+        return self._get_entity_ids()
+
+    @property
+    @substitute_docstring(
+        doc_template=PRIMARY_ENTITY_IDS_DOC, format_kwargs=DOCSTRING_FORMAT_PARAMS
+    )
+    def primary_entity_ids(
+        self,
+    ) -> Sequence[ObjectId]:
+        return self._get_primary_entity_ids()
+
+    @property
+    @substitute_docstring(doc_template=ENTITY_DOC, format_kwargs=DOCSTRING_FORMAT_PARAMS)
+    def entities(self) -> List[Entity]:
+        return self._get_entities()
+
+    @property
+    @substitute_docstring(doc_template=PRIMARY_ENTITY_DOC, format_kwargs=DOCSTRING_FORMAT_PARAMS)
+    def primary_entity(self) -> List[Entity]:
+        return self._get_primary_entity()
+
+    @property
+    @substitute_docstring(doc_template=TABLE_IDS_DOC, format_kwargs=DOCSTRING_FORMAT_PARAMS)
+    def table_ids(self) -> Sequence[ObjectId]:
+        return self._get_table_ids()
+
+    @substitute_docstring(
+        doc_template=ISNULL_DOC,
+        format_kwargs=DOCSTRING_FORMAT_PARAMS,
+        examples=(
+            """
+            >>> exposure = catalog.get_exposure("my_exposure")  # doctest: +SKIP
+            >>> new_exposure = exposure.isnull()  # doctest: +SKIP
+            """
+        ),
+    )
+    def isnull(self) -> Exposure:
+        return super().isnull()
+
+    @substitute_docstring(
+        doc_template=NOTNULL_DOC,
+        format_kwargs=DOCSTRING_FORMAT_PARAMS,
+        examples=(
+            """
+            >>> exposure = catalog.get_exposure("my_exposure")  # doctest: +SKIP
+            >>> new_exposure = exposure.notnull()  # doctest: +SKIP
+            """
+        ),
+    )
+    def notnull(self) -> Exposure:
+        return super().notnull()
+
+    @property
+    def window(self) -> Optional[str]:
+        """
+        Returns the window of this exposure.
+
+        Returns
+        -------
+        Optional[str]
+
+        Raises
+        ------
+        ValueError
+            If the exposure does not have a window.
+        """
+        window = self.exposure_namespace.window
+        if window is None:
+            raise ValueError("Exposure does not have a window")
+        return window
+
+    @property
+    @substitute_docstring(
+        doc_template=DEFINITION_DOC,
+        examples=(
+            """
+            >>> exposure = catalog.get_exposure("my_exposure")  # doctest: +SKIP
+            >>> exposure_definition = exposure.definition  # doctest: +SKIP
+            """
+        ),
+        format_kwargs={"object_type": "exposure"},
+    )
+    def definition(self) -> str:
+        return self._generate_definition()
+
+    @substitute_docstring(
+        doc_template=PREVIEW_DOC,
+        description="Materializes an Exposure object using a small observation set of up to 50 rows.",
+        format_kwargs={"object_type": "exposure"},
+    )
+    @enforce_observation_set_row_order
+    @typechecked
+    def preview(
+        self,
+        observation_set: Union[ObservationTable, pd.DataFrame],
+    ) -> pd.DataFrame:
+        return self._preview(observation_set=observation_set, url="/target/preview")
+
+    @enforce_observation_set_row_order
+    @typechecked
+    def compute_exposures(
+        self,
+        observation_table: Union[ObservationTable, pd.DataFrame],
+        serving_names_mapping: Optional[Dict[str, str]] = None,
+        skip_entity_validation_checks: bool = False,
+        context_id: Optional[ObjectId] = None,
+    ) -> pd.DataFrame:
+        """
+        Returns a DataFrame with exposure values computed against the observation set.
+
+        Parameters
+        ----------
+        observation_table : Union[ObservationTable, pd.DataFrame]
+            Observation set DataFrame or ObservationTable object with `POINT_IN_TIME` and
+            serving-name columns for the exposure's primary entity (or its descendants).
+        serving_names_mapping : Optional[Dict[str, str]]
+            Optional serving names mapping.
+        skip_entity_validation_checks: bool
+            Whether to skip entity validation checks.
+        context_id: Optional[ObjectId]
+            Optional context id whose forecast point schema should be used when the
+            observation set is a DataFrame.
+
+        Returns
+        -------
+        pd.DataFrame
+            Materialized exposure values.
+
+        Examples
+        --------
+        >>> exposure = catalog.get_exposure("my_exposure")  # doctest: +SKIP
+        >>> exposure.compute_exposures(observation_table)  # doctest: +SKIP
+        """
+        temp_table_name = f"__TEMPORARY_EXPOSURE_TABLE_{ObjectId()}"
+        temp_table = self.compute_exposure_table(
+            observation_table=observation_table,
+            observation_table_name=temp_table_name,
+            serving_names_mapping=serving_names_mapping,
+            skip_entity_validation_checks=skip_entity_validation_checks,
+            context_id=context_id,
+        )
+        try:
+            return temp_table.to_pandas()
+        finally:
+            temp_table.delete()
+
+    @typechecked
+    def compute_exposure_table(
+        self,
+        observation_table: Union[ObservationTable, pd.DataFrame],
+        observation_table_name: str,
+        serving_names_mapping: Optional[Dict[str, str]] = None,
+        skip_entity_validation_checks: bool = False,
+        context_id: Optional[ObjectId] = None,
+    ) -> ObservationTable:
+        """
+        Materialize the exposure into a new observation table.
+
+        Parameters
+        ----------
+        observation_table: Union[ObservationTable, pd.DataFrame]
+            Observation set.
+        observation_table_name: str
+            Name of the observation table to be created with the exposure values.
+        serving_names_mapping : Optional[Dict[str, str]]
+            Optional serving names mapping.
+        skip_entity_validation_checks: bool
+            Whether to skip entity validation checks.
+        context_id: Optional[ObjectId]
+            Optional context id for DataFrame observation sets.
+
+        Returns
+        -------
+        ObservationTable
+
+        Examples
+        --------
+        >>> exposure = catalog.get_exposure("my_exposure")  # doctest: +SKIP
+        >>> exposure.compute_exposure_table(  # doctest: +SKIP
+        ...     observation_table, "exposure_table"
+        ... )
+        """
+        is_input_observation_table = isinstance(observation_table, ObservationTable)
+        observation_table_id = observation_table.id if is_input_observation_table else None
+
+        # Exposure shares the same graph structure as Target so we reuse the target_table
+        # infrastructure by passing graph and node_names directly (no target_id).
+        graph = self.graph
+        node_names = [self.node.name]
+
+        if is_input_observation_table:
+            resolved_context_id = observation_table.context_id
+        else:
+            resolved_context_id = context_id
+
+        target_table_create_params = TargetTableCreate(
+            name=observation_table_name,
+            observation_table_id=observation_table_id,
+            feature_store_id=self.feature_store.id,
+            serving_names_mapping=serving_names_mapping,
+            graph=graph,
+            node_names=node_names,
+            context_id=resolved_context_id,
+            skip_entity_validation_checks=skip_entity_validation_checks,
+            target_id=None,
+        )
+        if is_input_observation_table:
+            files = None
+        else:
+            assert isinstance(observation_table, pd.DataFrame)
+            files = {"observation_set": dataframe_to_arrow_bytes(observation_table)}
+        observation_table_doc = self.post_async_task(
+            route="/target_table",
+            payload={"payload": target_table_create_params.model_dump_json()},
+            is_payload_json=False,
+            files=files,
+        )
+        return ObservationTable.get_by_id(observation_table_doc["_id"])
+
+    @typechecked
+    def info(self, verbose: bool = False) -> Dict[str, Any]:
+        """
+        Returns a dictionary that summarizes the essential information of an Exposure object.
+
+        Parameters
+        ----------
+        verbose: bool
+            Control verbose level of the summary.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Key-value mapping of properties of the object.
+
+        Examples
+        --------
+        >>> exposure = catalog.get_exposure("my_exposure")  # doctest: +SKIP
+        >>> info = exposure.info()  # doctest: +SKIP
+        """
+        return super().info(verbose)
+
+    @classmethod
+    def list(
+        cls,
+        include_id: Optional[bool] = False,
+    ) -> pd.DataFrame:
+        """
+        List saved exposures.
+
+        Parameters
+        ----------
+        include_id: Optional[bool]
+            Whether to include id in the list
+
+        Returns
+        -------
+        pd.DataFrame
+            Table of exposures
+        """
+        return ExposureNamespace.list(include_id=include_id)
+
+    @property
+    def exposure_namespace(self) -> ExposureNamespace:
+        """
+        ExposureNamespace object of current exposure
+
+        Returns
+        -------
+        ExposureNamespace
+        """
+        exposure_namespace_id = cast(ExposureModel, self.cached_model).exposure_namespace_id
+        return ExposureNamespace.get_by_id(id=exposure_namespace_id)
+
+    @typechecked
+    def update_description(self, description: Optional[str]) -> None:
+        """
+        Update exposure description
+
+        Parameters
+        ----------
+        description: Optional[str]
+            Description of exposure
+        """
+        self.exposure_namespace.update_description(description=description)
+
+    @typechecked
+    def update_version_description(self, description: Optional[str]) -> None:
+        """
+        Update exposure version description
+
+        Parameters
+        ----------
+        description: Optional[str]
+            Description of exposure version
+        """
+        super().update_description(description=description)
+
+    def delete(self) -> None:
+        """
+        Delete an exposure from the persistent data store. An exposure can only be deleted from the
+        persistent data store if
+
+        - the exposure is not used in any use case
+
+        Examples
+        --------
+        >>> exposure = catalog.get_exposure("my_exposure")  # doctest: +SKIP
+        >>> exposure.delete()  # doctest: +SKIP
+        """
+        super()._delete()

--- a/featurebyte/api/exposure_namespace.py
+++ b/featurebyte/api/exposure_namespace.py
@@ -1,0 +1,174 @@
+"""
+Exposure Namespace module.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, List, Optional
+
+from pydantic import Field
+
+from featurebyte.api.api_handler.base import ListHandler
+from featurebyte.api.api_handler.exposure_namespace import ExposureNamespaceListHandler
+from featurebyte.api.api_object_util import ForeignKeyMapping
+from featurebyte.api.entity import Entity
+from featurebyte.api.feature_or_target_namespace_mixin import FeatureOrTargetNamespaceMixin
+from featurebyte.api.savable_api_object import DeletableApiObject, SavableApiObject
+from featurebyte.common.doc_util import FBAutoDoc
+from featurebyte.enum import DBVarType
+from featurebyte.exception import RecordRetrievalException
+from featurebyte.models.base import PydanticObjectId
+from featurebyte.models.exposure_namespace import ExposureNamespaceModel
+from featurebyte.schema.exposure_namespace import ExposureNamespaceUpdate
+
+
+class ExposureNamespace(FeatureOrTargetNamespaceMixin, DeletableApiObject, SavableApiObject):
+    """
+    ExposureNamespace represents an Exposure set, in which all the exposures in the set have the same
+    name. The different elements typically refer to different versions of an Exposure.
+    """
+
+    # class variables
+    __fbautodoc__: ClassVar[FBAutoDoc] = FBAutoDoc(proxy_class="featurebyte.ExposureNamespace")
+    _route: ClassVar[str] = "/exposure_namespace"
+    _update_schema_class: ClassVar[Any] = ExposureNamespaceUpdate
+    _list_schema: ClassVar[Any] = ExposureNamespaceModel
+    _get_schema: ClassVar[Any] = ExposureNamespaceModel
+    _list_fields: ClassVar[List[str]] = [
+        "name",
+        "dtype",
+        "entities",
+        "created_at",
+    ]
+    _list_foreign_keys: ClassVar[List[ForeignKeyMapping]] = [
+        ForeignKeyMapping("entity_ids", Entity, "entities"),
+    ]
+
+    # pydantic instance variables
+    internal_window: Optional[str] = Field(alias="window", default=None)
+    internal_dtype: DBVarType = Field(alias="dtype")
+
+    @classmethod
+    def create(
+        cls,
+        name: str,
+        primary_entity: List[str],
+        dtype: DBVarType,
+        window: Optional[str] = None,
+    ) -> ExposureNamespace:
+        """
+        Create a new ExposureNamespace.
+
+        Parameters
+        ----------
+        name: str
+            Name of the ExposureNamespace
+        primary_entity: List[str]
+            List of entities.
+        dtype: DBVarType
+            Data type of the ExposureNamespace
+        window: Optional[str]
+            Window of the ExposureNamespace
+
+        Returns
+        -------
+        ExposureNamespace
+            The created ExposureNamespace
+
+        Examples
+        --------
+        >>> exposure_namespace = fb.ExposureNamespace.create(  # doctest: +SKIP
+        ...     name="amount_exposure",
+        ...     window="7d",
+        ...     dtype=DBVarType.FLOAT,
+        ...     primary_entity=["customer"],
+        ... )
+        """
+        entity_ids = [Entity.get(entity_name).id for entity_name in primary_entity]
+        exposure_namespace = ExposureNamespace(
+            name=name,
+            entity_ids=entity_ids,
+            dtype=dtype,
+            window=window,
+        )
+        exposure_namespace.save()
+        return exposure_namespace
+
+    @property
+    def dtype(self) -> DBVarType:
+        """
+        Database variable type of the exposure namespace.
+
+        Returns
+        -------
+        DBVarType
+        """
+        try:
+            return self.cached_model.dtype
+        except RecordRetrievalException:
+            return self.internal_dtype
+
+    @property
+    def window(self) -> Optional[str]:
+        """
+        Window of the exposure namespace.
+
+        Returns
+        -------
+        str
+        """
+        try:
+            return self.cached_model.window
+        except RecordRetrievalException:
+            return self.internal_window
+
+    @property
+    def exposure_ids(self) -> List[PydanticObjectId]:
+        """
+        List of exposure IDs from the same exposure namespace
+
+        Returns
+        -------
+        List[PydanticObjectId]
+        """
+        return self.cached_model.exposure_ids
+
+    @property
+    def default_exposure_id(self) -> PydanticObjectId:
+        """
+        Default exposure ID of this exposure namespace
+
+        Returns
+        -------
+        PydanticObjectId
+        """
+        return self.cached_model.default_exposure_id
+
+    @classmethod
+    def _list_handler(cls) -> ListHandler:
+        return ExposureNamespaceListHandler(
+            route=cls._route,
+            list_schema=cls._list_schema,
+            list_fields=cls._list_fields,
+            list_foreign_keys=cls._list_foreign_keys,
+        )
+
+    def delete(self) -> None:
+        """
+        Delete an exposure namespace from the persistent data store. An exposure namespace can only
+        be deleted from the persistent data store if
+
+        - the exposure namespace is not used in any use case
+        - the exposure namespace is not used in any exposure
+
+        Examples
+        --------
+        >>> exposure_namespace = fb.ExposureNamespace.create(  # doctest: +SKIP
+        ...     name="amount_exposure",
+        ...     window="7d",
+        ...     dtype=DBVarType.FLOAT,
+        ...     primary_entity=["customer"],
+        ... )
+        >>> exposure_namespace.delete()  # doctest: +SKIP
+        """
+        self._delete()

--- a/featurebyte/api/observation_table.py
+++ b/featurebyte/api/observation_table.py
@@ -466,6 +466,7 @@ class ObservationTable(PrimaryEntityMixin, MaterializedTableMixin):
         purpose: Optional[Purpose] = None,
         primary_entities: Optional[List[str]] = None,
         target_column: Optional[str] = None,
+        exposure_column: Optional[str] = None,
         treatment_column: Optional[str] = None,
         context_name: Optional[str] = None,
         use_case_name: Optional[str] = None,
@@ -487,6 +488,10 @@ class ObservationTable(PrimaryEntityMixin, MaterializedTableMixin):
             Name of the column in the observation table that stores the target values.
             The target column name must match an existing target namespace in the catalog.
             The data type and primary entities must match the those in the target namespace.
+        exposure_column: Optional[str]
+            Name of the column in the observation table that stores the exposure values.
+            The exposure column name must match an existing exposure namespace in the catalog.
+            The data type and primary entities must match those in the exposure namespace.
         treatment_column: Optional[str]
             Name of the column in the observation table that stores the treatment values.
             The treatment column name must match the treatment name of the associated context.
@@ -524,6 +529,7 @@ class ObservationTable(PrimaryEntityMixin, MaterializedTableMixin):
             primary_entity_ids=primary_entity_ids,
             uploaded_file_name=os.path.basename(file_path),
             target_column=target_column,
+            exposure_column=exposure_column,
             treatment_column=treatment_column,
             context_id=context_id,
             use_case_id=use_case_id,

--- a/featurebyte/api/source_table.py
+++ b/featurebyte/api/source_table.py
@@ -1702,6 +1702,7 @@ class SourceTable(AbstractTableData):
         skip_entity_validation_checks: Optional[bool] = False,
         primary_entities: Optional[List[str]] = None,
         target_column: Optional[str] = None,
+        exposure_column: Optional[str] = None,
         treatment_column: Optional[str] = None,
         sample_from_timestamp: Optional[Union[datetime, str]] = None,
         sample_to_timestamp: Optional[Union[datetime, str]] = None,
@@ -1739,6 +1740,10 @@ class SourceTable(AbstractTableData):
             Name of the column in the observation table that stores the target values.
             The target column name must match an existing target namespace in the catalog.
             The data type and primary entities must match the those in the target namespace.
+        exposure_column: Optional[str]
+            Name of the column in the observation table that stores the exposure values.
+            The exposure column name must match an existing exposure namespace in the catalog.
+            The data type and primary entities must match those in the exposure namespace.
         treatment_column: Optional[str]
             Name of the column in the observation table that stores the treatment values.
             The treatment column name must match the treatment name of the associated context.
@@ -1807,6 +1812,7 @@ class SourceTable(AbstractTableData):
             skip_entity_validation_checks=skip_entity_validation_checks,
             primary_entity_ids=primary_entity_ids,
             target_column=target_column,
+            exposure_column=exposure_column,
             treatment_column=treatment_column,
             sample_from_timestamp=sample_from_timestamp,
             sample_to_timestamp=sample_to_timestamp,

--- a/featurebyte/api/target.py
+++ b/featurebyte/api/target.py
@@ -4,7 +4,10 @@ Target API object
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, Dict, List, Optional, Sequence, Union, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Sequence, Union, cast
+
+if TYPE_CHECKING:
+    from featurebyte.api.exposure import Exposure
 
 import pandas as pd
 from bson import ObjectId
@@ -544,6 +547,46 @@ class Target(
             self.target_namespace.update_positive_label(positive_label=positive_label)
         else:
             self.internal_positive_label = positive_label
+
+    @typechecked
+    def as_exposure(self, exposure_name: str) -> Exposure:
+        """
+        Create an Exposure from this Target definition. The Exposure reuses the same query graph
+        and computation logic as the Target, but is saved as a separate object that can be
+        associated with a Use Case. When associated, the Exposure is computed alongside the
+        Target during target computation.
+
+        Parameters
+        ----------
+        exposure_name: str
+            Name for the new Exposure
+
+        Returns
+        -------
+        Exposure
+            A new Exposure object sharing this Target's query graph
+
+        Examples
+        --------
+        >>> target = event_view.groupby("customer_id").forward_aggregate(  # doctest: +SKIP
+        ...     method="sum",
+        ...     value_column="amount",
+        ...     window="7d",
+        ...     target_name="sum_7d",
+        ... )
+        >>> exposure = target.as_exposure("sum_7d_exposure")  # doctest: +SKIP
+        >>> exposure.save()  # doctest: +SKIP
+        """
+        from featurebyte.api.exposure import Exposure
+
+        return Exposure(
+            name=exposure_name,
+            graph=self.graph,
+            node_name=self.node_name,
+            tabular_source=self.tabular_source,
+            feature_store=self.feature_store,
+            dtype=self.dtype,
+        )
 
     def delete(self) -> None:
         """

--- a/featurebyte/api/use_case.py
+++ b/featurebyte/api/use_case.py
@@ -180,6 +180,7 @@ class UseCase(SavableApiObject, DeletableApiObject, UseCaseOrContextMixin):
         >>> use_case_1 = catalog.get_use_case("use_case_1")  # doctest: +SKIP
         """
         target_namespace = TargetNamespace.get(target_name)
+
         use_case = UseCase(
             name=name,
             target_id=target_namespace.default_target_id,

--- a/featurebyte/api/view.py
+++ b/featurebyte/api/view.py
@@ -1890,6 +1890,7 @@ class View(ProtectedColumnsQueryObject, Frame, SampleMixin, ABC):
         skip_entity_validation_checks: Optional[bool] = False,
         primary_entities: Optional[List[str]] = None,
         target_column: Optional[str] = None,
+        exposure_column: Optional[str] = None,
         treatment_column: Optional[str] = None,
         sample_from_timestamp: Optional[Union[datetime, str]] = None,
         sample_to_timestamp: Optional[Union[datetime, str]] = None,
@@ -1928,6 +1929,10 @@ class View(ProtectedColumnsQueryObject, Frame, SampleMixin, ABC):
             Name of the column in the observation table that stores the target values.
             The target column name must match an existing target namespace in the catalog.
             The data type and primary entities must match the those in the target namespace.
+        exposure_column: Optional[str]
+            Name of the column in the observation table that stores the exposure values.
+            The exposure column name must match an existing exposure namespace in the catalog.
+            The data type and primary entities must match those in the exposure namespace.
         treatment_column: Optional[str]
             Name of the column in the observation table that stores the treatment values.
             The treatment column name must match the treatment name of the associated context.
@@ -2021,6 +2026,7 @@ class View(ProtectedColumnsQueryObject, Frame, SampleMixin, ABC):
             skip_entity_validation_checks=skip_entity_validation_checks,
             primary_entity_ids=primary_entity_ids if not context_id and not use_case_id else None,
             target_column=target_column,
+            exposure_column=exposure_column,
             treatment_column=treatment_column,
             sample_from_timestamp=sample_from_timestamp,
             sample_to_timestamp=sample_to_timestamp,

--- a/featurebyte/app.py
+++ b/featurebyte/app.py
@@ -29,6 +29,8 @@ from featurebyte.routes.development_dataset.api import DevelopmentDatasetRouter
 from featurebyte.routes.dimension_table.api import DimensionTableRouter
 from featurebyte.routes.entity.api import EntityRouter
 from featurebyte.routes.event_table.api import EventTableRouter
+from featurebyte.routes.exposure.api import ExposureRouter
+from featurebyte.routes.exposure_namespace.api import ExposureNamespaceRouter
 from featurebyte.routes.feature.api import FeatureRouter
 from featurebyte.routes.feature_job_setting_analysis.api import FeatureJobSettingAnalysisRouter
 from featurebyte.routes.feature_list.api import FeatureListRouter
@@ -250,6 +252,8 @@ def get_app() -> FastAPI:
         HistoricalFeatureTableRouter(),
         ItemTableRouter(),
         ObservationTableRouter(),
+        ExposureRouter(),
+        ExposureNamespaceRouter(),
         PeriodicTaskRouter(),
         RelationshipInfoRouter(),
         SCDTableRouter(),

--- a/featurebyte/exception.py
+++ b/featurebyte/exception.py
@@ -567,6 +567,18 @@ class ObservationTableTargetDefinitionExistsError(BaseUnprocessableEntityError):
     """
 
 
+class ObservationTableInvalidExposureNameError(BaseUnprocessableEntityError):
+    """
+    Raise when observation table specifies an exposure name that does not exist
+    """
+
+
+class ObservationTableExposureDefinitionExistsError(BaseUnprocessableEntityError):
+    """
+    Raise when observation table specifies an exposure name that already has a definition
+    """
+
+
 class TaskNotRevocableError(BaseUnprocessableEntityError):
     """
     Raise when task is not revocable

--- a/featurebyte/models/__init__.py
+++ b/featurebyte/models/__init__.py
@@ -5,6 +5,8 @@ Document models for serialization to persistent storage
 from featurebyte.models.dimension_table import DimensionTableModel
 from featurebyte.models.entity import EntityModel
 from featurebyte.models.event_table import EventTableModel
+from featurebyte.models.exposure import ExposureModel
+from featurebyte.models.exposure_namespace import ExposureNamespaceModel
 from featurebyte.models.feature import FeatureModel
 from featurebyte.models.feature_list import FeatureListModel
 from featurebyte.models.feature_namespace import FeatureNamespaceModel
@@ -18,4 +20,6 @@ __all__ = [
     "FeatureModel",
     "FeatureNamespaceModel",
     "FeatureStoreModel",
+    "ExposureModel",
+    "ExposureNamespaceModel",
 ]

--- a/featurebyte/models/context.py
+++ b/featurebyte/models/context.py
@@ -17,6 +17,7 @@ from featurebyte.models.base import (
     UniqueConstraintResolutionSignature,
     UniqueValuesConstraint,
 )
+from featurebyte.models.exposure import ExposureSourceColumn
 from featurebyte.query_graph.graph import QueryGraph
 from featurebyte.query_graph.model.forecast_point_schema import ForecastPointSchema
 
@@ -111,6 +112,10 @@ class ContextModel(FeatureByteCatalogBaseDocumentModel):
     forecast_point_schema: Optional[ForecastPointSchema] = Field(default=None)
     graph: Optional[QueryGraph] = Field(default=None)
     node_name: Optional[str] = Field(default=None)
+
+    exposure_id: Optional[PydanticObjectId] = Field(default=None)
+    exposure_namespace_id: Optional[PydanticObjectId] = Field(default=None)
+    exposure_source_column: Optional[ExposureSourceColumn] = Field(default=None)
 
     default_preview_table_id: Optional[PydanticObjectId] = Field(default=None)
     default_eda_table_id: Optional[PydanticObjectId] = Field(default=None)

--- a/featurebyte/models/exposure.py
+++ b/featurebyte/models/exposure.py
@@ -1,0 +1,151 @@
+"""
+This module contains Exposure related models
+"""
+
+from typing import Optional
+
+import pymongo
+from bson import ObjectId
+from pydantic import Field
+
+from featurebyte.common.model_util import parse_duration_string
+from featurebyte.models.base import FeatureByteBaseModel, PydanticObjectId
+from featurebyte.models.feature import BaseFeatureModel
+from featurebyte.query_graph.enum import NodeType
+from featurebyte.query_graph.node.generic import (
+    ForwardAggregateAsAtNode,
+    ForwardAggregateNode,
+    LookupTargetNode,
+)
+
+
+class ExposureSourceColumn(FeatureByteBaseModel):
+    """Stores the table id and column name of the exposure source column."""
+
+    table_id: PydanticObjectId
+    column_name: str
+
+
+class ExposureModel(BaseFeatureModel):
+    """
+    Model for Exposure asset
+
+    id: PydanticObjectId
+        Exposure id of the object
+    name: str
+        Exposure name
+    dtype: DBVarType
+        Variable type of the exposure
+    graph: QueryGraph
+        Graph contains steps of transformation to generate the exposure
+    node_name: str
+        Node name of the graph which represent the exposure
+    tabular_source: TabularSource
+        Tabular source used to construct this exposure
+    version: VersionIdentifier
+        Exposure version
+    definition: str
+        Exposure definition
+    entity_ids: List[PydanticObjectId]
+        Entity IDs used by the exposure
+    table_ids: List[PydanticObjectId]
+        Table IDs used by the exposure
+    primary_table_ids: Optional[List[PydanticObjectId]]
+        Primary table IDs of the exposure (auto-derive from graph)
+    exposure_namespace_id: PydanticObjectId
+        Exposure namespace id of the object
+    created_at: Optional[datetime]
+        Datetime when the Exposure was first saved
+    updated_at: Optional[datetime]
+        When the Exposure get updated
+    """
+
+    # ID related fields associated with this exposure
+    exposure_namespace_id: PydanticObjectId = Field(frozen=True, default_factory=ObjectId)
+
+    def derive_window(self) -> Optional[str]:
+        """
+        Derive window from the graph, if there are multiple windows, return the largest one.
+
+        Returns
+        -------
+        Optional[str]
+        """
+        window_to_durations = {}
+        target_node = self.graph.get_node_by_name(self.node_name)
+        # Iterate through forward aggregate nodes
+        for node in self.graph.iterate_nodes(
+            target_node=target_node, node_type=NodeType.FORWARD_AGGREGATE
+        ):
+            assert isinstance(node, ForwardAggregateNode)
+            if node.parameters.window:
+                duration = parse_duration_string(node.parameters.window)
+                window_to_durations[node.parameters.window] = duration
+
+        # Iterate through lookup target nodes
+        for node in self.graph.iterate_nodes(
+            target_node=target_node, node_type=NodeType.LOOKUP_TARGET
+        ):
+            assert isinstance(node, LookupTargetNode)
+            if node.parameters.offset:
+                duration = parse_duration_string(node.parameters.offset)
+                window_to_durations[node.parameters.offset] = duration
+
+        if not window_to_durations:
+            return None
+        return max(window_to_durations, key=window_to_durations.get)  # type: ignore
+
+    def get_exposure_source_column(self) -> Optional[ExposureSourceColumn]:
+        """
+        Extract the exposure source column from this exposure's query graph.
+        Returns the table_id and column_name if the exposure was created from a target
+        that uses as_target() (LookupTargetNode) or forward_aggregate_asat()
+        (ForwardAggregateAsAtNode).
+
+        Returns
+        -------
+        Optional[ExposureSourceColumn]
+        """
+        if self.internal_graph is None:
+            return None
+
+        target_node = self.graph.get_node_by_name(self.node_name)
+
+        # Check LookupTarget nodes (created via as_target)
+        for node in self.graph.iterate_nodes(
+            target_node=target_node, node_type=NodeType.LOOKUP_TARGET
+        ):
+            assert isinstance(node, LookupTargetNode)
+            input_column_name = str(node.parameters.input_column_names[0])
+            for table_id_col_names in self.table_id_column_names:
+                if input_column_name in table_id_col_names.column_names:
+                    return ExposureSourceColumn(
+                        table_id=table_id_col_names.table_id,
+                        column_name=input_column_name,
+                    )
+
+        # Check ForwardAggregateAsAt nodes (created via forward_aggregate_asat)
+        for node in self.graph.iterate_nodes(
+            target_node=target_node, node_type=NodeType.FORWARD_AGGREGATE_AS_AT
+        ):
+            assert isinstance(node, ForwardAggregateAsAtNode)
+            if node.parameters.parent is not None:
+                value_column_name = str(node.parameters.parent)
+                for table_id_col_names in self.table_id_column_names:
+                    if value_column_name in table_id_col_names.column_names:
+                        return ExposureSourceColumn(
+                            table_id=table_id_col_names.table_id,
+                            column_name=value_column_name,
+                        )
+
+        return None
+
+    class Settings(BaseFeatureModel.Settings):
+        """
+        MongoDB settings
+        """
+
+        collection_name: str = "exposure"
+        indexes = BaseFeatureModel.Settings.indexes + [
+            pymongo.operations.IndexModel("exposure_namespace_id"),
+        ]

--- a/featurebyte/models/exposure_namespace.py
+++ b/featurebyte/models/exposure_namespace.py
@@ -1,0 +1,60 @@
+"""
+Exposure namespace module
+"""
+
+from typing import List, Optional
+
+import pymongo
+from pydantic import Field, field_validator
+
+from featurebyte.common.validator import construct_sort_validator, duration_string_validator
+from featurebyte.enum import DBVarType
+from featurebyte.models.base import PydanticObjectId
+from featurebyte.models.feature_namespace import BaseFeatureNamespaceModel
+
+
+class ExposureNamespaceModel(BaseFeatureNamespaceModel):
+    """
+    Exposure set with the same exposure name
+
+    id: PydanticObjectId
+        Exposure namespace id
+    name: str
+        Exposure name
+    dtype: DBVarType
+        Variable type of the exposure
+    exposure_ids: List[PydanticObjectId]
+        List of exposure version id
+    created_at: datetime
+        Datetime when the ExposureNamespace was first saved or published
+    default_exposure_id: PydanticObjectId
+        Default exposure version id
+    default_version_mode: DefaultVersionMode
+        Default exposure version mode
+    entity_ids: List[PydanticObjectId]
+        Entity IDs used by the exposure
+    """
+
+    dtype: Optional[DBVarType] = Field(
+        default=None, frozen=True, description="database variable type for the exposure"
+    )
+    window: Optional[str] = Field(default=None)
+
+    # list of IDs attached to this exposure namespace
+    exposure_ids: List[PydanticObjectId] = Field(frozen=True)
+    default_exposure_id: Optional[PydanticObjectId] = Field(default=None, frozen=True)
+
+    # pydantic validators
+    _sort_ids_validator = field_validator("exposure_ids", "entity_ids")(construct_sort_validator())
+    _duration_validator = field_validator("window", mode="before")(duration_string_validator)
+
+    class Settings(BaseFeatureNamespaceModel.Settings):
+        """
+        MongoDB settings
+        """
+
+        collection_name: str = "exposure_namespace"
+        indexes = BaseFeatureNamespaceModel.Settings.indexes + [
+            pymongo.operations.IndexModel("exposure_ids"),
+            pymongo.operations.IndexModel("default_exposure_id"),
+        ]

--- a/featurebyte/models/observation_table.py
+++ b/featurebyte/models/observation_table.py
@@ -236,6 +236,7 @@ class ObservationTableModel(MaterializedTableModel):
     has_row_index: Optional[bool] = Field(default=False)
     has_row_weights: Optional[bool] = Field(default=False)
     target_namespace_id: Optional[PydanticObjectId] = Field(default=None)
+    exposure_namespace_id: Optional[PydanticObjectId] = Field(default=None)
     treatment_id: Optional[PydanticObjectId] = Field(default=None)
     sample_rows: Optional[int] = Field(default=None)
     sample_from_timestamp: Optional[datetime] = Field(default=None)

--- a/featurebyte/routes/common/base.py
+++ b/featurebyte/routes/common/base.py
@@ -24,6 +24,8 @@ from featurebyte.service.development_dataset import DevelopmentDatasetService
 from featurebyte.service.dimension_table import DimensionTableService
 from featurebyte.service.entity import EntityService
 from featurebyte.service.event_table import EventTableService
+from featurebyte.service.exposure import ExposureService
+from featurebyte.service.exposure_namespace import ExposureNamespaceService
 from featurebyte.service.feature import FeatureService
 from featurebyte.service.feature_job_setting_analysis import FeatureJobSettingAnalysisService
 from featurebyte.service.feature_list import FeatureListService
@@ -76,6 +78,8 @@ DocumentServiceT = TypeVar(
     RelationshipInfoService,
     PeriodicTaskService,
     ObservationTableService,
+    ExposureService,
+    ExposureNamespaceService,
     OnlineStoreService,
     HistoricalFeatureTableService,
     BatchRequestTableService,

--- a/featurebyte/routes/context/controller.py
+++ b/featurebyte/routes/context/controller.py
@@ -21,6 +21,8 @@ from featurebyte.service.catalog import CatalogService
 from featurebyte.service.context import ContextService
 from featurebyte.service.deployment import DeploymentService
 from featurebyte.service.entity import EntityService
+from featurebyte.service.exposure import ExposureService
+from featurebyte.service.exposure_namespace import ExposureNamespaceService
 from featurebyte.service.observation_table import ObservationTableService
 from featurebyte.service.treatment import TreatmentService
 from featurebyte.service.use_case import UseCaseService
@@ -43,6 +45,8 @@ class ContextController(BaseDocumentController[ContextModel, ContextService, Con
         deployment_service: DeploymentService,
         user_service: UserService,
         entity_service: EntityService,
+        exposure_service: ExposureService,
+        exposure_namespace_service: ExposureNamespaceService,
         use_case_service: UseCaseService,
         catalog_service: CatalogService,
         treatment_service: TreatmentService,
@@ -55,6 +59,8 @@ class ContextController(BaseDocumentController[ContextModel, ContextService, Con
         self.deployment_service = deployment_service
         self.user_service = user_service
         self.entity_service = entity_service
+        self.exposure_service = exposure_service
+        self.exposure_namespace_service = exposure_namespace_service
         self.use_case_service = use_case_service
         self.catalog_service = catalog_service
         self.treatment_service = treatment_service
@@ -89,8 +95,76 @@ class ContextController(BaseDocumentController[ContextModel, ContextService, Con
             raise DocumentCreationError(
                 "Context entity ids must all be primary entity ids"
             ) from exc
+
+        # validate and resolve exposure if provided
+        if data.exposure_id or data.exposure_namespace_id:
+            await self._validate_and_resolve_exposure(data)
+
         result: ContextModel = await self.context_service.create_document(data=data)
+
+        # derive and persist exposure_source_column if an exposure was provided
+        if data.exposure_id:
+            exposure = await self.exposure_service.get_document(document_id=data.exposure_id)
+            exposure_source_column = exposure.get_exposure_source_column()
+            if exposure_source_column:
+                await self.context_service.update_documents(
+                    query_filter={"_id": result.id},
+                    update={
+                        "$set": {"exposure_source_column": exposure_source_column.model_dump()}
+                    },
+                )
+                result.exposure_source_column = exposure_source_column
+
         return result
+
+    async def _validate_and_resolve_exposure(self, data: ContextCreate) -> None:
+        """
+        Validate and resolve exposure fields on a Context create payload.
+
+        The exposure's entities must be equal to or parent entities of the context's
+        primary entities (supports hierarchical time series use cases).
+
+        Parameters
+        ----------
+        data: ContextCreate
+            Context creation payload
+
+        Raises
+        ------
+        DocumentCreationError
+            If exposure entities are not compatible with context primary entities.
+        """
+        if not data.exposure_namespace_id and data.exposure_id:
+            exposure = await self.exposure_service.get_document(document_id=data.exposure_id)
+            data.exposure_namespace_id = exposure.exposure_namespace_id
+
+        exposure_namespace = await self.exposure_namespace_service.get_document(
+            document_id=data.exposure_namespace_id  # type: ignore
+        )
+
+        if data.exposure_id:
+            if data.exposure_id != exposure_namespace.default_exposure_id:
+                raise DocumentCreationError(
+                    "Input exposure_id and exposure namespace default_exposure_id must be the same"
+                )
+        else:
+            data.exposure_id = exposure_namespace.default_exposure_id
+
+        # Validate exposure entities are same as or parent of context entities
+        if set(exposure_namespace.entity_ids) == set(data.primary_entity_ids):
+            return
+
+        context_ancestor_ids: set[ObjectId] = set()
+        for ctx_entity_id in data.primary_entity_ids:
+            entity = await self.entity_service.get_document(document_id=ctx_entity_id)
+            context_ancestor_ids.update(entity.ancestor_ids)
+
+        if not set(exposure_namespace.entity_ids).issubset(
+            context_ancestor_ids | set(data.primary_entity_ids)
+        ):
+            raise DocumentCreationError(
+                "Exposure entities must be the same as or parent entities of context entities"
+            )
 
     async def update_context(self, context_id: ObjectId, data: ContextUpdate) -> ContextModel:
         """

--- a/featurebyte/routes/exposure/__init__.py
+++ b/featurebyte/routes/exposure/__init__.py
@@ -1,0 +1,3 @@
+"""
+Exposure routes
+"""

--- a/featurebyte/routes/exposure/api.py
+++ b/featurebyte/routes/exposure/api.py
@@ -1,0 +1,168 @@
+"""
+Exposure API routes
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import Optional
+
+from bson import ObjectId
+from fastapi import APIRouter, Query, Request
+
+from featurebyte.models.base import PydanticObjectId
+from featurebyte.models.exposure import ExposureModel
+from featurebyte.models.persistent import AuditDocumentList
+from featurebyte.persistent.base import SortDir
+from featurebyte.routes.base_router import BaseRouter
+from featurebyte.routes.common.schema import (
+    AuditLogSortByQuery,
+    NameQuery,
+    PageQuery,
+    PageSizeQuery,
+    SearchQuery,
+    SortByQuery,
+    SortDirQuery,
+    VerboseQuery,
+)
+from featurebyte.routes.exposure.controller import ExposureController
+from featurebyte.schema.common.base import DescriptionUpdate
+from featurebyte.schema.exposure import ExposureCreate, ExposureInfo, ExposureList
+from featurebyte.schema.feature_list import SampleEntityServingNames
+
+router = APIRouter(prefix="/exposure")
+
+
+class ExposureRouter(BaseRouter):
+    """
+    Exposure router
+    """
+
+    def __init__(self) -> None:
+        super().__init__(router=router)
+
+
+@router.post("", response_model=ExposureModel, status_code=HTTPStatus.CREATED)
+async def create_exposure(request: Request, data: ExposureCreate) -> ExposureModel:
+    """
+    Create exposure
+    """
+    controller = request.state.app_container.exposure_controller
+    exposure: ExposureModel = await controller.create_exposure(data=data)
+    return exposure
+
+
+@router.get("", response_model=ExposureList)
+async def list_exposure(
+    request: Request,
+    page: int = PageQuery,
+    page_size: int = PageSizeQuery,
+    sort_by: Optional[str] = SortByQuery,
+    sort_dir: Optional[SortDir] = SortDirQuery,
+    search: Optional[str] = SearchQuery,
+    name: Optional[str] = NameQuery,
+) -> ExposureList:
+    """
+    List Exposures
+    """
+    controller = request.state.app_container.exposure_controller
+    exposure_list: ExposureList = await controller.list_exposure(
+        page=page,
+        page_size=page_size,
+        sort_by=[(sort_by, sort_dir)] if sort_by and sort_dir else None,
+        search=search,
+        name=name,
+    )
+    return exposure_list
+
+
+@router.get("/{exposure_id}", response_model=ExposureModel)
+async def get_exposure(request: Request, exposure_id: PydanticObjectId) -> ExposureModel:
+    """
+    Retrieve Exposure
+    """
+    controller: ExposureController = request.state.app_container.exposure_controller
+    return await controller.get(document_id=ObjectId(exposure_id))
+
+
+@router.get("/{exposure_id}/info", response_model=ExposureInfo)
+async def get_exposure_info(
+    request: Request,
+    exposure_id: PydanticObjectId,
+    verbose: bool = VerboseQuery,
+) -> ExposureInfo:
+    """
+    Retrieve exposure info
+    """
+    controller: ExposureController = request.state.app_container.exposure_controller
+    return await controller.get_info(
+        document_id=ObjectId(exposure_id),
+        verbose=verbose,
+    )
+
+
+@router.get("/audit/{exposure_id}", response_model=AuditDocumentList)
+async def list_exposure_audit_logs(
+    request: Request,
+    exposure_id: PydanticObjectId,
+    page: int = PageQuery,
+    page_size: int = PageSizeQuery,
+    sort_by: Optional[str] = AuditLogSortByQuery,
+    sort_dir: Optional[SortDir] = SortDirQuery,
+    search: Optional[str] = SearchQuery,
+) -> AuditDocumentList:
+    """
+    List exposure audit logs
+    """
+    controller = request.state.app_container.exposure_controller
+    audit_doc_list: AuditDocumentList = await controller.list_audit(
+        document_id=exposure_id,
+        page=page,
+        page_size=page_size,
+        sort_by=[(sort_by, sort_dir)] if sort_by and sort_dir else None,
+        search=search,
+    )
+    return audit_doc_list
+
+
+@router.patch("/{exposure_id}/description", response_model=ExposureModel)
+async def update_exposure_description(
+    request: Request,
+    exposure_id: PydanticObjectId,
+    data: DescriptionUpdate,
+) -> ExposureModel:
+    """
+    Update exposure description
+    """
+    controller: ExposureController = request.state.app_container.exposure_controller
+    return await controller.update_description(
+        document_id=ObjectId(exposure_id),
+        description=data.description,
+    )
+
+
+@router.get(
+    "/{exposure_id}/sample_entity_serving_names",
+    response_model=SampleEntityServingNames,
+)
+async def get_exposure_sample_entity_serving_names(
+    request: Request,
+    exposure_id: PydanticObjectId,
+    count: int = Query(default=1, gt=0, le=10),
+) -> SampleEntityServingNames:
+    """
+    Get Exposure Sample Entity Serving Names
+    """
+    controller: ExposureController = request.state.app_container.exposure_controller
+    return await controller.get_sample_entity_serving_names(
+        exposure_id=ObjectId(exposure_id), count=count
+    )
+
+
+@router.delete("/{exposure_id}")
+async def delete_exposure(request: Request, exposure_id: PydanticObjectId) -> None:
+    """
+    Delete Exposure
+    """
+    controller = request.state.app_container.exposure_controller
+    await controller.delete(document_id=ObjectId(exposure_id))

--- a/featurebyte/routes/exposure/controller.py
+++ b/featurebyte/routes/exposure/controller.py
@@ -1,0 +1,219 @@
+"""
+Exposure controller
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from bson import ObjectId
+
+from featurebyte.exception import DocumentDeletionError
+from featurebyte.models.exposure import ExposureModel
+from featurebyte.models.persistent import QueryFilter
+from featurebyte.persistent import Persistent
+from featurebyte.persistent.base import SortDir
+from featurebyte.routes.common.base import BaseDocumentController
+from featurebyte.routes.common.feature_metadata_extractor import FeatureOrTargetMetadataExtractor
+from featurebyte.routes.common.feature_or_target_helper import FeatureOrTargetHelper
+from featurebyte.schema.exposure import (
+    ExposureCreate,
+    ExposureInfo,
+    ExposureList,
+)
+from featurebyte.schema.exposure_namespace import ExposureNamespaceServiceUpdate
+from featurebyte.schema.feature_list import SampleEntityServingNames
+from featurebyte.service.context import ContextService
+from featurebyte.service.entity import EntityService
+from featurebyte.service.exposure import ExposureService
+from featurebyte.service.exposure_namespace import ExposureNamespaceService
+from featurebyte.service.mixin import DEFAULT_PAGE_SIZE
+
+
+class ExposureController(BaseDocumentController[ExposureModel, ExposureService, ExposureList]):
+    """
+    Exposure controller
+    """
+
+    paginated_document_class = ExposureList
+
+    def __init__(
+        self,
+        exposure_service: ExposureService,
+        exposure_namespace_service: ExposureNamespaceService,
+        entity_service: EntityService,
+        context_service: ContextService,
+        feature_or_target_metadata_extractor: FeatureOrTargetMetadataExtractor,
+        feature_or_target_helper: FeatureOrTargetHelper,
+        persistent: Persistent,
+    ):
+        super().__init__(exposure_service)
+        self.exposure_namespace_service = exposure_namespace_service
+        self.entity_service = entity_service
+        self.context_service = context_service
+        self.feature_or_target_metadata_extractor = feature_or_target_metadata_extractor
+        self.feature_or_target_helper = feature_or_target_helper
+        self.persistent = persistent
+
+    async def create_exposure(
+        self,
+        data: ExposureCreate,
+    ) -> ExposureModel:
+        """
+        Create Exposure at persistent
+
+        Parameters
+        ----------
+        data: ExposureCreate
+            Exposure creation payload
+
+        Returns
+        -------
+        ExposureModel
+            Newly created Exposure object
+        """
+        return await self.service.create_document(data)
+
+    async def list_exposure(
+        self,
+        page: int = 1,
+        page_size: int = DEFAULT_PAGE_SIZE,
+        sort_by: Optional[list[tuple[str, SortDir]]] = None,
+        search: Optional[str] = None,
+        name: Optional[str] = None,
+    ) -> ExposureList:
+        """
+        List Exposure at persistent
+
+        Parameters
+        ----------
+        page: int
+            Page number
+        page_size: int
+            Page size
+        sort_by: list[tuple[str, SortDir]] | None
+            Keys and directions used to sort the returning documents
+        search: str | None
+            Search token to be used in filtering
+        name: str | None
+            Name token to be used in filtering
+
+        Returns
+        -------
+        ExposureList
+            List of Exposure objects
+        """
+        sort_by = sort_by or [("created_at", "desc")]
+        params: Dict[str, Any] = {"search": search, "name": name}
+        return await self.list(
+            page=page,
+            page_size=page_size,
+            sort_by=sort_by,
+            **params,
+        )
+
+    async def service_and_query_pairs_for_checking_reference(
+        self, document_id: ObjectId
+    ) -> List[Tuple[Any, QueryFilter]]:
+        return [
+            (self.context_service, {"exposure_id": document_id}),
+        ]
+
+    async def delete(self, document_id: ObjectId) -> None:
+        await self.verify_operation_by_checking_reference(
+            document_id=document_id, exception_class=DocumentDeletionError
+        )
+        document = await self.service.get_document(document_id=document_id)
+        namespace = await self.exposure_namespace_service.get_document(
+            document_id=document.exposure_namespace_id
+        )
+        async with self.persistent.start_transaction():
+            await self.service.delete_document(document_id=document_id)
+            await self.exposure_namespace_service.update_document(
+                document_id=namespace.id,
+                data=ExposureNamespaceServiceUpdate(
+                    exposure_ids=[
+                        exposure_id
+                        for exposure_id in namespace.exposure_ids
+                        if exposure_id != document_id
+                    ]
+                ),
+            )
+
+    async def get_info(
+        self,
+        document_id: ObjectId,
+        verbose: bool,
+    ) -> ExposureInfo:
+        """
+        Get exposure info given document ID.
+
+        Parameters
+        ----------
+        document_id: ObjectId
+            Document ID
+        verbose: bool
+            Flag to control verbose level
+
+        Returns
+        -------
+        ExposureInfo
+        """
+        _ = verbose
+        exposure_doc = await self.service.get_document(document_id=document_id)
+        namespace = await self.exposure_namespace_service.get_document(
+            document_id=exposure_doc.exposure_namespace_id
+        )
+        entity_ids = exposure_doc.entity_ids or []
+        entity_brief_info_list = await self.entity_service.get_entity_brief_info_list(
+            set(entity_ids)
+        )
+
+        primary_tables = await self.feature_or_target_helper.get_primary_tables(
+            exposure_doc.table_ids,
+            namespace.catalog_id,
+            exposure_doc.graph,
+            exposure_doc.node_name,
+        )
+
+        # Get metadata
+        _, exposure_metadata = await self.feature_or_target_metadata_extractor.extract_from_object(
+            exposure_doc
+        )
+
+        return ExposureInfo(
+            id=document_id,
+            exposure_name=exposure_doc.name,
+            entities=entity_brief_info_list,
+            window=namespace.window,
+            has_recipe=bool(exposure_doc.graph),
+            created_at=exposure_doc.created_at,
+            updated_at=exposure_doc.updated_at,
+            primary_table=primary_tables,
+            metadata=exposure_metadata,
+            namespace_description=namespace.description,
+            description=exposure_doc.description,
+        )
+
+    async def get_sample_entity_serving_names(
+        self, exposure_id: ObjectId, count: int
+    ) -> SampleEntityServingNames:
+        """
+        Get sample entity serving names for exposure
+
+        Parameters
+        ----------
+        exposure_id: ObjectId
+            Exposure ID
+        count: int
+            Number of sample entity serving names to return
+
+        Returns
+        -------
+        SampleEntityServingNames
+            Sample entity serving names
+        """
+        entity_serving_names = await self.service.get_sample_entity_serving_names(
+            exposure_id=exposure_id, count=count
+        )
+        return SampleEntityServingNames(entity_serving_names=entity_serving_names)

--- a/featurebyte/routes/exposure_namespace/__init__.py
+++ b/featurebyte/routes/exposure_namespace/__init__.py
@@ -1,0 +1,3 @@
+"""
+Exposure namespace routes
+"""

--- a/featurebyte/routes/exposure_namespace/api.py
+++ b/featurebyte/routes/exposure_namespace/api.py
@@ -1,0 +1,182 @@
+"""
+ExposureNamespace API routes
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import Request
+
+from featurebyte.models.base import PydanticObjectId
+from featurebyte.models.exposure_namespace import ExposureNamespaceModel
+from featurebyte.models.persistent import AuditDocumentList
+from featurebyte.persistent.base import SortDir
+from featurebyte.routes.base_router import BaseApiRouter
+from featurebyte.routes.common.schema import (
+    AuditLogSortByQuery,
+    NameQuery,
+    PageQuery,
+    PageSizeQuery,
+    SearchQuery,
+    SortByQuery,
+    SortDirQuery,
+    VerboseQuery,
+)
+from featurebyte.routes.exposure_namespace.controller import ExposureNamespaceController
+from featurebyte.schema.common.base import DeleteResponse, DescriptionUpdate
+from featurebyte.schema.exposure_namespace import (
+    ExposureNamespaceCreate,
+    ExposureNamespaceInfo,
+    ExposureNamespaceList,
+    ExposureNamespaceUpdate,
+)
+
+
+class ExposureNamespaceRouter(
+    BaseApiRouter[
+        ExposureNamespaceModel,
+        ExposureNamespaceList,
+        ExposureNamespaceCreate,
+        ExposureNamespaceController,
+    ]
+):
+    """
+    Exposure namespace router
+    """
+
+    object_model = ExposureNamespaceModel
+    list_object_model = ExposureNamespaceList
+    create_object_schema = ExposureNamespaceCreate
+    controller = ExposureNamespaceController
+
+    def __init__(self) -> None:
+        super().__init__("/exposure_namespace")
+
+        self.router.add_api_route(
+            "/{exposure_namespace_id}",
+            self.update_exposure_namespace,
+            methods=["PATCH"],
+            response_model=ExposureNamespaceModel,
+        )
+        self.router.add_api_route(
+            "/{exposure_namespace_id}/info",
+            self.get_exposure_namespace_info,
+            methods=["GET"],
+            response_model=ExposureNamespaceInfo,
+        )
+
+    async def create_object(
+        self, request: Request, data: ExposureNamespaceCreate
+    ) -> ExposureNamespaceModel:
+        """
+        Create exposure namespace
+        """
+        controller = self.get_controller_for_request(request)
+        exposure_namespace: ExposureNamespaceModel = await controller.create_exposure_namespace(
+            data=data
+        )
+        return exposure_namespace
+
+    async def get_object(
+        self, request: Request, exposure_namespace_id: PydanticObjectId
+    ) -> ExposureNamespaceModel:
+        """
+        Retrieve Exposure Namespace
+        """
+        controller = self.get_controller_for_request(request)
+        exposure_namespace: ExposureNamespaceModel = await controller.get(
+            document_id=exposure_namespace_id,
+            exception_detail=(
+                f'ExposureNamespace (id: "{exposure_namespace_id}") not found. '
+                f"Please save the ExposureNamespace object first."
+            ),
+        )
+        return exposure_namespace
+
+    async def list_objects(
+        self,
+        request: Request,
+        page: int = PageQuery,
+        page_size: int = PageSizeQuery,
+        sort_by: Optional[str] = SortByQuery,
+        sort_dir: Optional[SortDir] = SortDirQuery,
+        search: Optional[str] = SearchQuery,
+        name: Optional[str] = NameQuery,
+    ) -> ExposureNamespaceList:
+        """
+        List ExposureNamespace
+        """
+        controller = self.get_controller_for_request(request)
+        exposure_namespace_list: ExposureNamespaceList = await controller.list(
+            page=page,
+            page_size=page_size,
+            sort_by=[(sort_by, sort_dir)] if sort_by and sort_dir else None,
+            search=search,
+            name=name,
+        )
+        return exposure_namespace_list
+
+    async def delete_object(
+        self, request: Request, exposure_namespace_id: PydanticObjectId
+    ) -> DeleteResponse:
+        """
+        Delete ExposureNamespace
+        """
+        return await super().delete_object(request, exposure_namespace_id)
+
+    async def list_audit_logs(
+        self,
+        request: Request,
+        exposure_namespace_id: PydanticObjectId,
+        page: int = PageQuery,
+        page_size: int = PageSizeQuery,
+        sort_by: Optional[str] = AuditLogSortByQuery,
+        sort_dir: Optional[SortDir] = SortDirQuery,
+        search: Optional[str] = SearchQuery,
+    ) -> AuditDocumentList:
+        """
+        List Exposure Namespace audit logs
+        """
+        return await super().list_audit_logs(
+            request, exposure_namespace_id, page, page_size, sort_by, sort_dir, search
+        )
+
+    async def update_description(
+        self, request: Request, exposure_namespace_id: PydanticObjectId, data: DescriptionUpdate
+    ) -> ExposureNamespaceModel:
+        """
+        Update exposure_namespace description
+        """
+        return await super().update_description(request, exposure_namespace_id, data)
+
+    async def update_exposure_namespace(
+        self,
+        request: Request,
+        exposure_namespace_id: PydanticObjectId,
+        data: ExposureNamespaceUpdate,
+    ) -> ExposureNamespaceModel:
+        """
+        Update ExposureNamespace
+        """
+        controller = self.get_controller_for_request(request)
+        exposure_namespace: ExposureNamespaceModel = await controller.update_exposure_namespace(
+            exposure_namespace_id, data
+        )
+        return exposure_namespace
+
+    async def get_exposure_namespace_info(
+        self,
+        request: Request,
+        exposure_namespace_id: PydanticObjectId,
+        verbose: bool = VerboseQuery,
+    ) -> ExposureNamespaceInfo:
+        """
+        Retrieve ExposureNamespace info
+        """
+        controller = self.get_controller_for_request(request)
+        info = await controller.get_info(
+            document_id=exposure_namespace_id,
+            verbose=verbose,
+        )
+        return info

--- a/featurebyte/routes/exposure_namespace/controller.py
+++ b/featurebyte/routes/exposure_namespace/controller.py
@@ -1,0 +1,117 @@
+"""
+Exposure namespace controller
+"""
+
+from typing import Any, List, Tuple, cast
+
+from bson import ObjectId
+
+from featurebyte.models.exposure_namespace import ExposureNamespaceModel
+from featurebyte.models.persistent import QueryFilter
+from featurebyte.routes.common.base import BaseDocumentController
+from featurebyte.schema.exposure_namespace import (
+    ExposureNamespaceCreate,
+    ExposureNamespaceInfo,
+    ExposureNamespaceList,
+    ExposureNamespaceServiceUpdate,
+    ExposureNamespaceUpdate,
+)
+from featurebyte.service.context import ContextService
+from featurebyte.service.exposure import ExposureService
+from featurebyte.service.exposure_namespace import ExposureNamespaceService
+
+
+class ExposureNamespaceController(
+    BaseDocumentController[ExposureNamespaceModel, ExposureNamespaceService, ExposureNamespaceList],
+):
+    """
+    ExposureNamespace controller
+    """
+
+    paginated_document_class = ExposureNamespaceList
+
+    def __init__(
+        self,
+        exposure_namespace_service: ExposureNamespaceService,
+        exposure_service: ExposureService,
+        context_service: ContextService,
+    ):
+        super().__init__(exposure_namespace_service)
+        self.exposure_service = exposure_service
+        self.context_service = context_service
+
+    async def create_exposure_namespace(
+        self,
+        data: ExposureNamespaceCreate,
+    ) -> ExposureNamespaceModel:
+        """
+        Create ExposureNamespace at persistent
+
+        Parameters
+        ----------
+        data: ExposureNamespaceCreate
+            Exposure namespace creation payload
+
+        Returns
+        -------
+        ExposureNamespaceModel
+            Newly created ExposureNamespace object
+        """
+        return await self.service.create_document(data)
+
+    async def service_and_query_pairs_for_checking_reference(
+        self, document_id: ObjectId
+    ) -> List[Tuple[Any, QueryFilter]]:
+        return [
+            (self.exposure_service, {"exposure_namespace_id": document_id}),
+            (self.context_service, {"exposure_namespace_id": document_id}),
+        ]
+
+    async def get_info(self, document_id: ObjectId, verbose: bool) -> ExposureNamespaceInfo:
+        """
+        Get exposure namespace info given document_id
+
+        Parameters
+        ----------
+        document_id: ObjectId
+            Document ID
+        verbose: bool
+            Flag to control verbose level
+
+        Returns
+        -------
+        ExposureNamespaceInfo
+        """
+        _ = verbose
+        exposure_namespace = await self.service.get_document(document_id=document_id)
+        return ExposureNamespaceInfo(
+            name=exposure_namespace.name,
+            default_version_mode=exposure_namespace.default_version_mode,
+            default_exposure_id=exposure_namespace.default_exposure_id,
+            created_at=exposure_namespace.created_at,
+            updated_at=exposure_namespace.updated_at,
+        )
+
+    async def update_exposure_namespace(
+        self, exposure_namespace_id: ObjectId, data: ExposureNamespaceUpdate
+    ) -> ExposureNamespaceModel:
+        """
+        Update ExposureNamespace
+
+        Parameters
+        ----------
+        exposure_namespace_id: ObjectId
+            ExposureNamespace ID
+        data: ExposureNamespaceUpdate
+            ExposureNamespace update payload
+
+        Returns
+        -------
+        ExposureNamespaceModel
+            Updated ExposureNamespace object
+        """
+        data = ExposureNamespaceServiceUpdate(**data.model_dump(by_alias=True))
+        updated_namespace = await self.service.update_document(
+            document_id=exposure_namespace_id, data=data
+        )
+        return cast(ExposureNamespaceModel, updated_namespace)

--- a/featurebyte/routes/registry.py
+++ b/featurebyte/routes/registry.py
@@ -58,6 +58,8 @@ from featurebyte.routes.development_dataset.controller import DevelopmentDataset
 from featurebyte.routes.dimension_table.controller import DimensionTableController
 from featurebyte.routes.entity.controller import EntityController
 from featurebyte.routes.event_table.controller import EventTableController
+from featurebyte.routes.exposure.controller import ExposureController
+from featurebyte.routes.exposure_namespace.controller import ExposureNamespaceController
 from featurebyte.routes.feature.controller import FeatureController
 from featurebyte.routes.feature_job_setting_analysis.controller import (
     FeatureJobSettingAnalysisController,
@@ -121,6 +123,8 @@ from featurebyte.service.entity_serving_names import EntityServingNamesService
 from featurebyte.service.entity_validation import EntityValidationService
 from featurebyte.service.event_table import EventTableService
 from featurebyte.service.event_table_validation import EventTableValidationService
+from featurebyte.service.exposure import ExposureService
+from featurebyte.service.exposure_namespace import ExposureNamespaceService
 from featurebyte.service.feature import FeatureService
 from featurebyte.service.feature_facade import FeatureFacadeService
 from featurebyte.service.feature_job_history_service import FeatureJobHistoryService
@@ -507,6 +511,14 @@ app_container_config.register_class(TableFacadeService)
 app_container_config.register_class(TableInfoService)
 app_container_config.register_class(TableService)
 app_container_config.register_class(TableStatusService)
+app_container_config.register_class(
+    ExposureController, dependency_override={"service": "exposure_service"}
+)
+app_container_config.register_class(ExposureService)
+app_container_config.register_class(
+    ExposureNamespaceController, dependency_override={"service": "exposure_namespace_service"}
+)
+app_container_config.register_class(ExposureNamespaceService)
 app_container_config.register_class(
     TargetComputer, dependency_override={"query_executor": "target_executor"}
 )

--- a/featurebyte/schema/context.py
+++ b/featurebyte/schema/context.py
@@ -27,6 +27,8 @@ class ContextCreate(FeatureByteBaseModel):
     treatment_id: Optional[PydanticObjectId] = Field(default=None)
     user_provided_columns: List[UserProvidedColumn] = Field(default_factory=list)
     forecast_point_schema: Optional[ForecastPointSchema] = Field(default=None)
+    exposure_id: Optional[PydanticObjectId] = Field(default=None)
+    exposure_namespace_id: Optional[PydanticObjectId] = Field(default=None)
 
     # pydantic validators
     _sort_ids_validator = field_validator("primary_entity_ids")(construct_sort_validator())

--- a/featurebyte/schema/exposure.py
+++ b/featurebyte/schema/exposure.py
@@ -1,0 +1,107 @@
+"""
+Exposure API payload schema
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, List, Optional
+
+from bson import ObjectId
+from pydantic import Field, StrictStr
+
+from featurebyte.models.base import (
+    FeatureByteBaseModel,
+    NameStr,
+    PydanticObjectId,
+    UniqueConstraintResolutionSignature,
+    UniqueValuesConstraint,
+)
+from featurebyte.models.exposure import ExposureModel
+from featurebyte.query_graph.graph import QueryGraph
+from featurebyte.query_graph.model.common_table import TabularSource
+from featurebyte.query_graph.node import Node
+from featurebyte.schema.common.base import BaseDocumentServiceUpdateSchema, PaginationMixin
+from featurebyte.schema.common.feature_or_target import ComputeRequest
+from featurebyte.schema.info import EntityBriefInfoList, TableBriefInfoList
+
+
+class ExposureCreate(FeatureByteBaseModel):
+    """
+    Exposure creation schema
+    """
+
+    id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
+    name: NameStr
+    graph: QueryGraph
+    node_name: str
+    tabular_source: TabularSource
+
+
+class ExposureList(PaginationMixin):
+    """
+    Paginated list of Exposure
+    """
+
+    data: List[ExposureModel]
+
+
+class ExposureInfo(FeatureByteBaseModel):
+    """
+    Exposure info
+    """
+
+    id: PydanticObjectId
+    exposure_name: str
+    entities: EntityBriefInfoList
+    window: Optional[str] = Field(default=None)
+    has_recipe: bool
+    created_at: datetime
+    updated_at: Optional[datetime] = Field(default=None)
+    primary_table: TableBriefInfoList
+    metadata: Any
+    namespace_description: Optional[str] = Field(default=None)
+    description: Optional[str] = Field(default=None)
+
+
+class ComputeExposureRequest(ComputeRequest):
+    """
+    Compute exposure request schema
+    """
+
+    feature_store_id: PydanticObjectId
+    graph: QueryGraph
+    node_names: List[StrictStr]
+    exposure_id: Optional[PydanticObjectId] = Field(default=None)
+
+    @property
+    def nodes(self) -> List[Node]:
+        """
+        Get nodes
+
+        Returns
+        -------
+        List[Node]
+        """
+        return [self.graph.get_node_by_name(name) for name in self.node_names]
+
+
+class ExposureServiceUpdate(BaseDocumentServiceUpdateSchema):
+    """
+    Exposure service update schema
+    """
+
+    name: Optional[NameStr] = Field(default=None)
+
+    class Settings(BaseDocumentServiceUpdateSchema.Settings):
+        """
+        Unique constraints checking
+        """
+
+        unique_constraints: List[UniqueValuesConstraint] = [
+            UniqueValuesConstraint(
+                fields=("name",),
+                conflict_fields_signature={"name": ["name"]},
+                resolution_signature=UniqueConstraintResolutionSignature.GET_NAME,
+            ),
+        ]

--- a/featurebyte/schema/exposure_namespace.py
+++ b/featurebyte/schema/exposure_namespace.py
@@ -1,0 +1,69 @@
+"""
+Exposure namespace schema
+"""
+
+from typing import List, Optional
+
+from bson import ObjectId
+from pydantic import Field
+
+from featurebyte.enum import DBVarType
+from featurebyte.models.base import FeatureByteBaseModel, NameStr, PydanticObjectId
+from featurebyte.models.exposure_namespace import ExposureNamespaceModel
+from featurebyte.models.feature_namespace import DefaultVersionMode
+from featurebyte.schema.common.base import (
+    BaseDocumentServiceUpdateSchema,
+    BaseInfo,
+    PaginationMixin,
+)
+
+
+class ExposureNamespaceCreate(FeatureByteBaseModel):
+    """
+    Exposure Namespace Creation Schema
+    """
+
+    id: Optional[PydanticObjectId] = Field(default_factory=ObjectId, alias="_id")
+    name: NameStr
+    dtype: DBVarType
+    exposure_ids: List[PydanticObjectId] = Field(default_factory=list)
+    default_exposure_id: Optional[PydanticObjectId] = Field(default=None)
+    default_version_mode: DefaultVersionMode = Field(default=DefaultVersionMode.AUTO)
+    entity_ids: List[PydanticObjectId] = Field(default_factory=list)
+    window: Optional[str] = Field(default=None)
+
+
+class ExposureNamespaceUpdate(BaseDocumentServiceUpdateSchema):
+    """
+    ExposureNamespace update schema - exposed to client
+    """
+
+    window: Optional[str] = Field(default=None)
+
+
+class ExposureNamespaceServiceUpdate(ExposureNamespaceUpdate):
+    """
+    ExposureNamespaceService update schema - used by server side only, not exposed to client
+    """
+
+    default_version_mode: Optional[DefaultVersionMode] = Field(default=None)
+    exposure_ids: Optional[List[PydanticObjectId]] = Field(default=None)
+    default_exposure_id: Optional[PydanticObjectId] = Field(default=None)
+
+
+class ExposureNamespaceList(PaginationMixin):
+    """
+    Paginated list of ExposureNamespace
+    """
+
+    data: List[ExposureNamespaceModel]
+
+
+class ExposureNamespaceInfo(BaseInfo):
+    """
+    ExposureNamespace info schema
+    """
+
+    name: str
+    default_version_mode: DefaultVersionMode
+    default_exposure_id: Optional[PydanticObjectId]

--- a/featurebyte/schema/observation_table.py
+++ b/featurebyte/schema/observation_table.py
@@ -38,6 +38,7 @@ class ObservationTableCreate(BaseRequestTableCreate):
     purpose: Optional[Purpose] = Field(default=None)
     primary_entity_ids: Optional[List[PydanticObjectId]] = Field(default=None)
     target_column: Optional[StrictStr] = Field(default=None)
+    exposure_column: Optional[StrictStr] = Field(default=None)
     treatment_column: Optional[StrictStr] = Field(default=None)
     use_case_id: Optional[PydanticObjectId] = Field(default=None)
 
@@ -55,6 +56,7 @@ class ObservationTableUpload(FeatureByteBaseModel):
     purpose: Optional[Purpose] = Field(default=None)
     primary_entity_ids: Optional[List[PydanticObjectId]]
     target_column: Optional[StrictStr] = Field(default=None)
+    exposure_column: Optional[StrictStr] = Field(default=None)
     treatment_column: Optional[StrictStr] = Field(default=None)
     context_id: Optional[PydanticObjectId] = Field(default=None)
     use_case_id: Optional[PydanticObjectId] = Field(default=None)

--- a/featurebyte/schema/worker/task/observation_table.py
+++ b/featurebyte/schema/worker/task/observation_table.py
@@ -30,6 +30,7 @@ class ObservationTableTaskPayload(BaseTaskPayload, ObservationTableCreate):
     task_type: TaskType = Field(default=TaskType.CPU_TASK)
     primary_entity_ids: list[PydanticObjectId]
     target_namespace_id: Optional[PydanticObjectId] = Field(default=None)
+    exposure_namespace_id: Optional[PydanticObjectId] = Field(default=None)
     treatment_id: Optional[PydanticObjectId] = Field(default=None)
     # internal use only
     to_add_row_index: bool = Field(default=True)

--- a/featurebyte/schema/worker/task/observation_table_upload.py
+++ b/featurebyte/schema/worker/task/observation_table_upload.py
@@ -31,4 +31,5 @@ class ObservationTableUploadTaskPayload(BaseTaskPayload, ObservationTableUpload)
     uploaded_file_name: str  # the name of the file that was uploaded by the user
     primary_entity_ids: list[PydanticObjectId]
     target_namespace_id: Optional[PydanticObjectId] = Field(default=None)
+    exposure_namespace_id: Optional[PydanticObjectId] = Field(default=None)
     treatment_id: Optional[PydanticObjectId] = Field(default=None)

--- a/featurebyte/service/exposure.py
+++ b/featurebyte/service/exposure.py
@@ -1,0 +1,263 @@
+"""
+Exposure class
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from bson import ObjectId
+from redis import Redis
+
+from featurebyte.common.model_util import parse_duration_string
+from featurebyte.exception import DocumentCreationError
+from featurebyte.models.exposure import ExposureModel
+from featurebyte.models.exposure_namespace import ExposureNamespaceModel
+from featurebyte.models.feature_namespace import DefaultVersionMode
+from featurebyte.persistent import Persistent
+from featurebyte.routes.block_modification_handler import BlockModificationHandler
+from featurebyte.routes.common.derive_primary_entity_helper import DerivePrimaryEntityHelper
+from featurebyte.schema.exposure import ExposureCreate
+from featurebyte.schema.exposure_namespace import (
+    ExposureNamespaceCreate,
+    ExposureNamespaceServiceUpdate,
+)
+from featurebyte.service.base_feature_service import BaseFeatureService
+from featurebyte.service.context import ContextService
+from featurebyte.service.entity import EntityService
+from featurebyte.service.entity_relationship_extractor import EntityRelationshipExtractorService
+from featurebyte.service.entity_serving_names import EntityServingNamesService
+from featurebyte.service.entity_validation import EntityValidationService
+from featurebyte.service.exposure_namespace import ExposureNamespaceService
+from featurebyte.service.feature_store import FeatureStoreService
+from featurebyte.service.namespace_handler import (
+    NamespaceHandler,
+    validate_version_and_namespace_consistency,
+)
+from featurebyte.service.session_manager import SessionManagerService
+from featurebyte.storage import Storage
+
+
+class ExposureService(BaseFeatureService[ExposureModel, ExposureCreate]):
+    """
+    ExposureService class
+    """
+
+    document_class = ExposureModel
+
+    def __init__(
+        self,
+        user: Any,
+        persistent: Persistent,
+        catalog_id: Optional[ObjectId],
+        block_modification_handler: BlockModificationHandler,
+        entity_relationship_extractor_service: EntityRelationshipExtractorService,
+        derive_primary_entity_helper: DerivePrimaryEntityHelper,
+        context_service: ContextService,
+        entity_service: EntityService,
+        exposure_namespace_service: ExposureNamespaceService,
+        namespace_handler: NamespaceHandler,
+        feature_store_service: FeatureStoreService,
+        entity_validation_service: EntityValidationService,
+        session_manager_service: SessionManagerService,
+        entity_serving_names_service: EntityServingNamesService,
+        storage: Storage,
+        redis: Redis[Any],
+    ):
+        super().__init__(
+            user=user,
+            persistent=persistent,
+            catalog_id=catalog_id,
+            block_modification_handler=block_modification_handler,
+            entity_relationship_extractor_service=entity_relationship_extractor_service,
+            derive_primary_entity_helper=derive_primary_entity_helper,
+            context_service=context_service,
+            entity_service=entity_service,
+            storage=storage,
+            redis=redis,
+        )
+        self.exposure_namespace_service = exposure_namespace_service
+        self.namespace_handler = namespace_handler
+        self.feature_store_service = feature_store_service
+        self.entity_validation_service = entity_validation_service
+        self.session_manager_service = session_manager_service
+        self.entity_service = entity_service
+        self.entity_serving_names_service = entity_serving_names_service
+
+    async def prepare_exposure_model(
+        self, data: ExposureCreate, sanitize_for_definition: bool
+    ) -> ExposureModel:
+        """
+        Prepare the exposure model by pruning the query graph
+
+        Parameters
+        ----------
+        data: ExposureCreate
+            Exposure creation data
+        sanitize_for_definition: bool
+            Whether to sanitize the query graph for generating exposure definition
+
+        Returns
+        -------
+        ExposureModel
+        """
+        document = ExposureModel(**{
+            **data.model_dump(by_alias=True),
+            "version": await self.get_document_version(data.name),
+            "user_id": self.user.id,
+            "catalog_id": self.catalog_id,
+        })
+
+        # prepare the graph to store
+        graph, node_name = await self.namespace_handler.prepare_graph_to_store(
+            graph=document.graph,
+            node=document.node,
+            sanitize_for_definition=sanitize_for_definition,
+        )
+        derived_data = await self.extract_derived_data(graph=graph, node_name=node_name)
+
+        # create a new exposure document (so that the derived attributes like table_ids is generated properly)
+        return ExposureModel(**{
+            **document.model_dump(by_alias=True),
+            "graph": graph,
+            "node_name": node_name,
+            "primary_entity_ids": derived_data.primary_entity_ids,
+            "relationships_info": derived_data.relationships_info,
+            "entity_ids": derived_data.entity_ids,
+            "entity_dtypes": derived_data.entity_dtypes,
+        })
+
+    @staticmethod
+    def derive_window(document: ExposureModel, namespace: ExposureNamespaceModel) -> Optional[str]:
+        """
+        Derive the window from the exposure and namespace
+
+        Parameters
+        ----------
+        document: ExposureModel
+            Exposure document
+        namespace: ExposureNamespaceModel
+            Exposure namespace document
+
+        Returns
+        -------
+        Optional[str]
+
+        Raises
+        ------
+        DocumentCreationError
+            If the exposure window is greater than the namespace window
+        """
+        document_window = document.derive_window()
+        if namespace.window is None:
+            return document_window
+
+        namespace_duration = parse_duration_string(namespace.window)
+        if document_window:
+            document_duration = parse_duration_string(document_window)
+            if document_duration > namespace_duration:
+                raise DocumentCreationError(
+                    f"Exposure window {document_window} is greater than namespace window {namespace.window}"
+                )
+        return namespace.window
+
+    async def create_document(self, data: ExposureCreate) -> ExposureModel:
+        """
+        Create a new exposure document
+
+        Parameters
+        ----------
+        data: ExposureCreate
+            Exposure creation data
+
+        Returns
+        -------
+        ExposureModel
+        """
+        document = await self.prepare_exposure_model(data=data, sanitize_for_definition=False)
+
+        # check any conflict with existing documents
+        await self._check_document_unique_constraints(document=document)
+
+        # prepare exposure definition
+        definition = await self.namespace_handler.prepare_definition(document=document)
+
+        # check existence of exposure namespace first
+        exposure_namespace = None
+        async for exposure_namespace in self.exposure_namespace_service.list_documents_iterator(
+            query_filter={"name": document.name}
+        ):
+            break
+
+        async with self.persistent.start_transaction() as session:
+            # insert the document
+            insert_id = await session.insert_one(
+                collection_name=self.collection_name,
+                document={
+                    **document.model_dump(by_alias=True),
+                    "exposure_namespace_id": exposure_namespace.id
+                    if exposure_namespace
+                    else document.exposure_namespace_id,
+                    "definition": definition,
+                    "raw_graph": data.graph.model_dump(),
+                },
+                user_id=self.user.id,
+            )
+            assert insert_id == document.id
+
+            if exposure_namespace:
+                await validate_version_and_namespace_consistency(
+                    base_model=document,
+                    base_namespace_model=exposure_namespace,
+                    attributes=["name", "dtype"],
+                )
+                exposure_namespace_update = ExposureNamespaceServiceUpdate(
+                    exposure_ids=self.include_object_id(
+                        exposure_namespace.exposure_ids, document.id
+                    ),
+                    window=self.derive_window(document=document, namespace=exposure_namespace),
+                    default_exposure_id=document.id,
+                )
+                await self.exposure_namespace_service.update_document(
+                    document_id=exposure_namespace.id,
+                    data=exposure_namespace_update,
+                    return_document=False,
+                )
+            else:
+                await self.exposure_namespace_service.create_document(
+                    data=ExposureNamespaceCreate(
+                        _id=document.exposure_namespace_id,
+                        name=document.name,
+                        dtype=document.dtype,
+                        exposure_ids=[insert_id],
+                        default_exposure_id=insert_id,
+                        default_version_mode=DefaultVersionMode.AUTO,
+                        entity_ids=sorted(document.primary_entity_ids),
+                        window=document.derive_window(),
+                    ),
+                )
+        return await self.get_document(document_id=insert_id)
+
+    async def get_sample_entity_serving_names(
+        self, exposure_id: ObjectId, count: int
+    ) -> List[Dict[str, str]]:
+        """
+        Get sample entity serving names for an exposure
+
+        Parameters
+        ----------
+        exposure_id: ObjectId
+            Exposure Id
+        count: int
+            Number of sample entity serving names to return
+
+        Returns
+        -------
+        List[Dict[str, str]]
+        """
+        exposure = await self.get_document(exposure_id)
+        return await self.entity_serving_names_service.get_sample_entity_serving_names(
+            entity_ids=exposure.entity_ids,
+            table_ids=exposure.table_ids,
+            count=count,
+        )

--- a/featurebyte/service/exposure_namespace.py
+++ b/featurebyte/service/exposure_namespace.py
@@ -1,0 +1,24 @@
+"""
+ExposureNamespaceService class
+"""
+
+from __future__ import annotations
+
+from featurebyte.models.exposure_namespace import ExposureNamespaceModel
+from featurebyte.schema.exposure_namespace import (
+    ExposureNamespaceCreate,
+    ExposureNamespaceServiceUpdate,
+)
+from featurebyte.service.base_document import BaseDocumentService
+
+
+class ExposureNamespaceService(
+    BaseDocumentService[
+        ExposureNamespaceModel, ExposureNamespaceCreate, ExposureNamespaceServiceUpdate
+    ],
+):
+    """
+    ExposureNamespaceService class
+    """
+
+    document_class = ExposureNamespaceModel

--- a/featurebyte/service/namespace_handler.py
+++ b/featurebyte/service/namespace_handler.py
@@ -9,6 +9,7 @@ from bson import ObjectId
 from featurebyte.common.utils import get_version
 from featurebyte.exception import DocumentInconsistencyError
 from featurebyte.models.base import FeatureByteCatalogBaseDocumentModel
+from featurebyte.models.exposure import ExposureModel
 from featurebyte.models.feature import FeatureModel
 from featurebyte.models.target import TargetModel
 from featurebyte.query_graph.graph import QueryGraph
@@ -113,14 +114,16 @@ class NamespaceHandler:
             pruned_graph = sanitize_query_graph_for_feature_definition(graph=pruned_graph)
         return pruned_graph, pruned_node_name_map[node.name]
 
-    async def prepare_definition(self, document: Union[FeatureModel, TargetModel]) -> str:
+    async def prepare_definition(
+        self, document: Union[FeatureModel, TargetModel, ExposureModel]
+    ) -> str:
         """
         Prepare the definition for the given document
 
         Parameters
         ----------
-        document: Union[FeatureModel, TargetModel]
-            FeatureModel or TargetModel document
+        document: Union[FeatureModel, TargetModel, ExposureModel]
+            FeatureModel, TargetModel or ExposureModel document
 
         Returns
         -------

--- a/featurebyte/service/observation_table.py
+++ b/featurebyte/service/observation_table.py
@@ -32,7 +32,9 @@ from featurebyte.exception import (
     MissingForecastPointColumnError,
     MissingForecastTimezoneColumnError,
     MissingPointInTimeColumnError,
+    ObservationTableExposureDefinitionExistsError,
     ObservationTableInvalidContextError,
+    ObservationTableInvalidExposureNameError,
     ObservationTableInvalidRequestInputError,
     ObservationTableInvalidSamplingError,
     ObservationTableInvalidTargetNameError,
@@ -94,6 +96,7 @@ from featurebyte.schema.worker.task.observation_table_upload import (
 )
 from featurebyte.service.context import ContextService
 from featurebyte.service.entity import EntityService
+from featurebyte.service.exposure_namespace import ExposureNamespaceService
 from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.service.managed_view import ManagedViewService
 from featurebyte.service.materialized_table import BaseMaterializedTableService
@@ -324,6 +327,7 @@ class ObservationTableService(
         redis: Redis[Any],
         target_namespace_service: TargetNamespaceService,
         target_service: TargetService,
+        exposure_namespace_service: ExposureNamespaceService,
         treatment_service: TreatmentService,
         managed_view_service: ManagedViewService,
     ):
@@ -345,6 +349,7 @@ class ObservationTableService(
         self.use_case_service = use_case_service
         self.target_namespace_service = target_namespace_service
         self.target_service = target_service
+        self.exposure_namespace_service = exposure_namespace_service
         self.treatment_service = treatment_service
         self.managed_view_service = managed_view_service
 
@@ -503,10 +508,11 @@ class ObservationTableService(
         available_columns: List[str],
         primary_entity_ids: Optional[List[PydanticObjectId]],
         target_column: Optional[str],
-        treatment_column: Optional[str],
+        exposure_column: Optional[str] = None,
+        treatment_column: Optional[str] = None,
         context: Optional[ContextModel] = None,
         column_dtypes: Optional[Dict[str, DBVarType]] = None,
-    ) -> Tuple[Optional[ObjectId], Optional[ObjectId]]:
+    ) -> Tuple[Optional[ObjectId], Optional[ObjectId], Optional[ObjectId]]:
         # Check if required column names are provided
         missing_columns = []
 
@@ -588,6 +594,36 @@ class ObservationTableService(
         else:
             target_namespace_id = None
 
+        # Check if exposure column is present
+        if exposure_column:
+            if exposure_column not in available_columns:
+                missing_columns.append(exposure_column)
+            exposure_namespaces = await self.exposure_namespace_service.list_documents_as_dict(
+                query_filter={"name": exposure_column}
+            )
+            if exposure_namespaces["total"] == 0:
+                raise ObservationTableInvalidExposureNameError(
+                    f"Exposure name not found: {exposure_column}"
+                )
+
+            # validate exposure namespace has same primary entity ids
+            exposure_namespace = exposure_namespaces["data"][0]
+            exposure_namespace_id = ObjectId(exposure_namespace["_id"])
+            if primary_entity_ids:
+                if exposure_namespace["entity_ids"] != primary_entity_ids:
+                    raise ObservationTableInvalidExposureNameError(
+                        f'Exposure "{exposure_column}" does not have matching primary entity ids.'
+                    )
+
+            # check if exposure namespace already has a definition
+            if exposure_namespace["exposure_ids"]:
+                raise ObservationTableExposureDefinitionExistsError(
+                    f'Exposure "{exposure_column}" already has a definition.'
+                )
+
+        else:
+            exposure_namespace_id = None
+
         # Check if treatment column is present
         if treatment_column:
             if treatment_column not in available_columns:
@@ -609,7 +645,7 @@ class ObservationTableService(
                 f"Required column(s) not found: {', '.join(missing_columns)}"
             )
 
-        return target_namespace_id, treatment_id
+        return target_namespace_id, exposure_namespace_id, treatment_id
 
     async def get_observation_table_task_payload(
         self, data: ObservationTableCreate, to_add_row_index: bool = True
@@ -656,6 +692,7 @@ class ObservationTableService(
             # set primary entity and target namespace ids in the payload using values from source observation table
             data.primary_entity_ids = source_observation_table.primary_entity_ids
             target_namespace_id = source_observation_table.target_namespace_id
+            exposure_namespace_id = source_observation_table.exposure_namespace_id
             treatment_id = source_observation_table.treatment_id
             # context and use case ids will be populated in the task and can be set to None in the payload
             data.context_id = None
@@ -735,10 +772,11 @@ class ObservationTableService(
             if context_id is not None:
                 context = await self.context_service.get_document(document_id=context_id)
 
-            target_namespace_id, treatment_id = await self._validate_columns(
+            target_namespace_id, exposure_namespace_id, treatment_id = await self._validate_columns(
                 available_columns=available_columns,
                 primary_entity_ids=data.primary_entity_ids,
                 target_column=data.target_column,
+                exposure_column=data.exposure_column,
                 treatment_column=data.treatment_column,
                 context=context,
                 column_dtypes=column_dtypes,
@@ -750,6 +788,7 @@ class ObservationTableService(
                 document_id=data.request_input.target_id
             )
             target_namespace_id = target.target_namespace_id
+            exposure_namespace_id = None
             if data.request_input.observation_table_id is not None:
                 observation_table_input = await self.get_document(
                     data.request_input.observation_table_id
@@ -759,6 +798,7 @@ class ObservationTableService(
                 treatment_id = None
         else:
             target_namespace_id = None
+            exposure_namespace_id = None
             treatment_id = None
 
         # Validate context and use case
@@ -771,6 +811,7 @@ class ObservationTableService(
             catalog_id=self.catalog_id,
             output_document_id=output_document_id,
             target_namespace_id=target_namespace_id,
+            exposure_namespace_id=exposure_namespace_id,
             treatment_id=treatment_id,
         )
 
@@ -817,10 +858,11 @@ class ObservationTableService(
             context = await self.context_service.get_document(document_id=context_id)
 
         # Check if required column names are provided
-        target_namespace_id, treatment_id = await self._validate_columns(
+        target_namespace_id, exposure_namespace_id, treatment_id = await self._validate_columns(
             available_columns=observation_set_dataframe.columns.tolist(),
             primary_entity_ids=data.primary_entity_ids,
             target_column=data.target_column,
+            exposure_column=data.exposure_column,
             treatment_column=data.treatment_column,
             context=context,
         )
@@ -843,6 +885,7 @@ class ObservationTableService(
             file_format=file_format,
             uploaded_file_name=uploaded_file_name,
             target_namespace_id=target_namespace_id,
+            exposure_namespace_id=exposure_namespace_id,
             treatment_id=treatment_id,
         )
 

--- a/featurebyte/service/use_case.py
+++ b/featurebyte/service/use_case.py
@@ -4,7 +4,7 @@ UseCaseService class
 
 from __future__ import annotations
 
-from typing import Any, Optional, cast
+from typing import Any, List, Optional, cast
 
 from bson import ObjectId
 from redis import Redis
@@ -19,6 +19,7 @@ from featurebyte.routes.block_modification_handler import BlockModificationHandl
 from featurebyte.schema.use_case import UseCaseCreate, UseCaseUpdate
 from featurebyte.service.base_document import BaseDocumentService
 from featurebyte.service.context import ContextService
+from featurebyte.service.entity import EntityService
 from featurebyte.service.historical_feature_table import HistoricalFeatureTableService
 from featurebyte.service.target import TargetService
 from featurebyte.service.target_namespace import TargetNamespaceService
@@ -38,6 +39,7 @@ class UseCaseService(BaseDocumentService[UseCaseModel, UseCaseCreate, UseCaseUpd
         persistent: Persistent,
         catalog_id: Optional[ObjectId],
         context_service: ContextService,
+        entity_service: EntityService,
         target_service: TargetService,
         target_namespace_service: TargetNamespaceService,
         historical_feature_table_service: HistoricalFeatureTableService,
@@ -54,6 +56,7 @@ class UseCaseService(BaseDocumentService[UseCaseModel, UseCaseCreate, UseCaseUpd
             redis=redis,
         )
         self.context_service = context_service
+        self.entity_service = entity_service
         self.target_service = target_service
         self.target_namespace_service = target_namespace_service
         self.historical_feature_table_service = historical_feature_table_service
@@ -70,7 +73,9 @@ class UseCaseService(BaseDocumentService[UseCaseModel, UseCaseCreate, UseCaseUpd
         Raises
         ------
         DocumentCreationError
-            if target and context have different primary entities or target and target namespace have different target
+            if target and context have different primary entities,
+            target and target namespace have different target,
+            or context has an exposure but target is not regression.
 
         Returns
         -------
@@ -108,9 +113,16 @@ class UseCaseService(BaseDocumentService[UseCaseModel, UseCaseCreate, UseCaseUpd
         else:
             data.target_id = target_namespace.default_target_id
 
-        # validate target and context have the same entities
-        if set(target_namespace.entity_ids) != set(context.primary_entity_ids):
-            raise DocumentCreationError("Target and context must have the same entities")
+        # validate target entities are the same as or parent of context entities
+        await self._validate_entity_compatibility(
+            entity_ids=target_namespace.entity_ids,
+            context_entity_ids=context.primary_entity_ids,
+            object_name="Target",
+        )
+
+        # validate that if context has an exposure, the target type is regression
+        if context.exposure_id and target_namespace.target_type != TargetType.REGRESSION:
+            raise DocumentCreationError("Exposure is only supported for regression targets")
 
         if context.treatment_id:
             data.use_case_type = UseCaseType.CAUSAL
@@ -131,6 +143,43 @@ class UseCaseService(BaseDocumentService[UseCaseModel, UseCaseCreate, UseCaseUpd
                 use_case.forecasted_column = forecasted_column
 
         return use_case
+
+    async def _validate_entity_compatibility(
+        self,
+        entity_ids: List[PydanticObjectId],
+        context_entity_ids: List[PydanticObjectId],
+        object_name: str,
+    ) -> None:
+        """
+        Validate that entity_ids are the same as or parent entities of context_entity_ids.
+
+        Parameters
+        ----------
+        entity_ids: List[PydanticObjectId]
+            Entity IDs of the target
+        context_entity_ids: List[PydanticObjectId]
+            Entity IDs of the context
+        object_name: str
+            Name of the object being validated (for error messages)
+
+        Raises
+        ------
+        DocumentCreationError
+            If entity_ids are not compatible with context_entity_ids
+        """
+        if set(entity_ids) == set(context_entity_ids):
+            return
+
+        context_ancestor_ids: set[ObjectId] = set()
+        for ctx_entity_id in context_entity_ids:
+            entity = await self.entity_service.get_document(document_id=ctx_entity_id)
+            context_ancestor_ids.update(entity.ancestor_ids)
+
+        if not set(entity_ids).issubset(context_ancestor_ids | set(context_entity_ids)):
+            raise DocumentCreationError(
+                f"{object_name} and context must have the same entities or "
+                f"{object_name.lower()} entities must be parent entities of context entities"
+            )
 
     async def _derive_forecasted_column(
         self, target_id: PydanticObjectId

--- a/featurebyte/worker/task/observation_table.py
+++ b/featurebyte/worker/task/observation_table.py
@@ -41,7 +41,9 @@ from featurebyte.schema.worker.task.observation_table import (
     ObservationTableTaskPayload,
     SplitObservationTableTaskPayload,
 )
+from featurebyte.service.context import ContextService
 from featurebyte.service.entity import EntityService
+from featurebyte.service.exposure import ExposureService
 from featurebyte.service.feature_store import FeatureStoreService
 from featurebyte.service.managed_view import ManagedViewService
 from featurebyte.service.observation_table import ObservationTableService
@@ -76,7 +78,9 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask[ObservationTableTaskPayl
         target_namespace_service: TargetNamespaceService,
         entity_service: EntityService,
         use_case_service: UseCaseService,
+        context_service: ContextService,
         target_service: TargetService,
+        exposure_service: ExposureService,
         target_computer: TargetComputer,
         treatment_service: TreatmentService,
     ):
@@ -88,7 +92,9 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask[ObservationTableTaskPayl
         self.target_namespace_service = target_namespace_service
         self.entity_service = entity_service
         self.use_case_service = use_case_service
+        self.context_service = context_service
         self.target_service = target_service
+        self.exposure_service = exposure_service
         self.target_computer = target_computer
         self.treatment_service = treatment_service
 
@@ -159,6 +165,7 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask[ObservationTableTaskPayl
         columns_to_exclude_missing_values: list[str],
         missing_data_table_details: TableDetails,
         has_row_index: bool,
+        exposure_id: Optional[ObjectId] = None,
     ) -> tuple[ObjectId, bool]:
         """
         Materialize the requested input with target column computed
@@ -193,6 +200,8 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask[ObservationTableTaskPayl
             Table details of the table with missing data
         has_row_index: bool
             Whether the observation table has row index column
+        exposure_id: Optional[ObjectId]
+            Id of exposure to compute alongside the target
 
         Returns
         -------
@@ -204,6 +213,21 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask[ObservationTableTaskPayl
         target_namespace_id = target.target_namespace_id
         graph = target.graph
         node_names = [target.node_name]
+
+        # If exposure_id is provided, merge exposure graph into computation
+        if exposure_id is not None:
+            try:
+                exposure = await self.exposure_service.get_document(document_id=exposure_id)
+                _, node_name_map = graph.load(exposure.graph)
+                mapped_exposure_node_name = node_name_map.get(
+                    exposure.node_name, exposure.node_name
+                )
+                node_names = node_names + [mapped_exposure_node_name]
+            except Exception:
+                logger.warning(
+                    "Exposure not found or failed to load, skipping exposure computation",
+                    extra={"exposure_id": str(exposure_id)},
+                )
 
         # ObservationTableObservationInput does not support materialize
         assert not isinstance(request_input, ObservationTableObservationInput)
@@ -305,6 +329,8 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask[ObservationTableTaskPayl
                 columns_to_exclude_missing_values.extend(entity.serving_names)
         if payload.target_column is not None:
             columns_to_exclude_missing_values.append(payload.target_column)
+        if payload.exposure_column is not None:
+            columns_to_exclude_missing_values.append(payload.exposure_column)
         if payload.treatment_column is not None:
             columns_to_exclude_missing_values.append(payload.treatment_column)
 
@@ -367,12 +393,21 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask[ObservationTableTaskPayl
         # if use case is specified and observation table does not contain target,
         # try to compute the target column
         target_id_to_compute = None
+        exposure_id_to_compute = None
         target_namespace_id = payload.target_namespace_id
+        exposure_namespace_id = payload.exposure_namespace_id
         if target_namespace_id is None and use_case_ids:
             # check if use case has target definition
             use_case = await self.use_case_service.get_document(document_id=use_case_ids[0])
             if use_case.target_id is not None:
                 target_id_to_compute = use_case.target_id
+
+        # check if context has exposure definition (exposure is tied to context, not use case)
+        if exposure_namespace_id is None and context_id is not None:
+            context_doc = await self.context_service.get_document(document_id=context_id)
+            if context_doc.exposure_id is not None:
+                exposure_id_to_compute = context_doc.exposure_id
+                exposure_namespace_id = context_doc.exposure_namespace_id
 
         if target_id_to_compute is not None:
             target_namespace_id, is_view = await self.materialize_request_input_with_target(
@@ -390,6 +425,7 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask[ObservationTableTaskPayl
                 columns_to_exclude_missing_values=columns_to_exclude_missing_values,
                 missing_data_table_details=missing_data_table_details,
                 has_row_index=not payload.to_add_row_index,
+                exposure_id=exposure_id_to_compute,
             )
         else:
             # apply downsampling if target is available and sampling rates are provided
@@ -478,6 +514,7 @@ class ObservationTableTask(DataWarehouseMixin, BaseTask[ObservationTableTaskPayl
                 "has_row_index": True,
                 "has_row_weights": output_table_has_row_weights,
                 "target_namespace_id": target_namespace_id,
+                "exposure_namespace_id": exposure_namespace_id,
                 "sample_rows": payload.sample_rows,
                 "sample_from_timestamp": payload.sample_from_timestamp,
                 "sample_to_timestamp": payload.sample_to_timestamp,
@@ -667,6 +704,7 @@ class SplitObservationTableTask(DataWarehouseMixin, BaseTask[SplitObservationTab
                     has_row_index=True,
                     has_row_weights=source_table.has_row_weights,
                     target_namespace_id=source_table.target_namespace_id,
+                    exposure_namespace_id=source_table.exposure_namespace_id,
                     **additional_metadata,
                 )
                 observation_table = await self.observation_table_service.create_document(

--- a/featurebyte/worker/task/observation_table_upload.py
+++ b/featurebyte/worker/task/observation_table_upload.py
@@ -131,6 +131,8 @@ class ObservationTableUploadTask(DataWarehouseMixin, BaseTask[ObservationTableUp
             }
             if payload.target_namespace_id is not None:
                 override_model_params["target_namespace_id"] = payload.target_namespace_id
+            if payload.exposure_namespace_id is not None:
+                override_model_params["exposure_namespace_id"] = payload.exposure_namespace_id
             await self.observation_table_task.create_observation_table(
                 payload=obs_task_payload,
                 override_model_params=override_model_params,

--- a/featurebyte/worker/task/target_table.py
+++ b/featurebyte/worker/task/target_table.py
@@ -207,10 +207,19 @@ class TargetTableTask(DataWarehouseMixin, BaseTask[TargetTableTaskPayload]):
                 output_table_details=location.table_details,
                 forecast_point_schema=forecast_point_schema,
             )
-            entity_ids = graph.get_entity_ids(node_names[0])
-            primary_entity_ids = await self.derive_primary_entity_helper.derive_primary_entity_ids(
-                entity_ids
-            )
+            # Derive primary entity IDs. When the observation set has its own entity IDs
+            # (e.g. child entities), use those since the output table will contain the
+            # observation set's entity columns (parent entity is resolved via parent serving).
+            if (
+                isinstance(observation_set, ObservationTableModel)
+                and observation_set.primary_entity_ids
+            ):
+                primary_entity_ids = list(observation_set.primary_entity_ids)
+            else:
+                entity_ids = graph.get_entity_ids(node_names[0])
+                primary_entity_ids = (
+                    await self.derive_primary_entity_helper.derive_primary_entity_ids(entity_ids)
+                )
 
             # get the table with missing data
             op_struct_target = graph.extract_operation_structure(
@@ -250,13 +259,16 @@ class TargetTableTask(DataWarehouseMixin, BaseTask[TargetTableTaskPayload]):
             else:
                 use_case_ids = []
 
+            # Entity validation is already performed by target_computer.compute() via
+            # validate_entities_or_prepare_for_parent_serving, so skip it here to avoid
+            # false failures when parent entity serving was used.
             additional_metadata = (
                 await self.observation_table_service.validate_materialized_table_and_get_metadata(
                     db_session,
                     location.table_details,
                     feature_store=feature_store,
                     serving_names_remapping=payload.serving_names_mapping,
-                    skip_entity_validation_checks=payload.skip_entity_validation_checks,
+                    skip_entity_validation_checks=True,
                     primary_entity_ids=primary_entity_ids,
                     context_id=context_id,
                 )

--- a/tests/fixtures/backward_compatibility/get_routes.txt
+++ b/tests/fixtures/backward_compatibility/get_routes.txt
@@ -12,6 +12,8 @@
 /dimension_table
 /entity
 /event_table
+/exposure
+/exposure_namespace
 /feature
 /feature_job_setting_analysis
 /feature_list

--- a/tests/fixtures/request_payloads/context.json
+++ b/tests/fixtures/request_payloads/context.json
@@ -6,6 +6,8 @@
     ],
     "_id": "646f6c1c0ed28a5271fb02d5",
     "description": null,
+    "exposure_id": null,
+    "exposure_namespace_id": null,
     "forecast_point_schema": null,
     "name": "transaction_context",
     "primary_entity_ids": [

--- a/tests/fixtures/request_payloads/context_with_treatment.json
+++ b/tests/fixtures/request_payloads/context_with_treatment.json
@@ -6,6 +6,8 @@
     ],
     "_id": "693a208134d4b86a9a6945af",
     "description": null,
+    "exposure_id": null,
+    "exposure_namespace_id": null,
     "forecast_point_schema": null,
     "name": "transaction_context_with_treatment",
     "primary_entity_ids": [

--- a/tests/fixtures/request_payloads/exposure_namespace.json
+++ b/tests/fixtures/request_payloads/exposure_namespace.json
@@ -1,0 +1,14 @@
+{
+    "_id": "64ae4be43a93459ede8c4000",
+    "default_exposure_id": "64a80107d667dd0c2b13d900",
+    "default_version_mode": "AUTO",
+    "dtype": "FLOAT",
+    "entity_ids": [
+        "63f94ed6ea1f050131379214"
+    ],
+    "name": "exposure_namespace",
+    "exposure_ids": [
+        "64a80107d667dd0c2b13d900"
+    ],
+    "window": "7d"
+}

--- a/tests/fixtures/request_payloads/forecast_table.json
+++ b/tests/fixtures/request_payloads/forecast_table.json
@@ -5,11 +5,6 @@
         "Run `pytest --update-fixtures` to update it."
     ],
     "_id": "6893ffbc6782e0c8fce7d075",
-    "natural_key_column": "col_int",
-    "effective_timestamp_column": "effective_timestamp",
-    "effective_timestamp_schema": null,
-    "forecast_timestamp_column": "forecast_timestamp",
-    "forecast_timestamp_schema": null,
     "columns_info": [
         {
             "description": null,
@@ -87,8 +82,13 @@
     "datetime_partition_column": null,
     "datetime_partition_schema": null,
     "description": "test forecast table",
+    "effective_timestamp_column": "effective_timestamp",
+    "effective_timestamp_schema": null,
+    "forecast_timestamp_column": "forecast_timestamp",
+    "forecast_timestamp_schema": null,
     "managed_view_id": null,
     "name": "sf_forecast_table",
+    "natural_key_column": "col_int",
     "record_creation_timestamp_column": "created_at",
     "tabular_source": {
         "feature_store_id": "646f6c190ed28a5271fb02a1",

--- a/tests/fixtures/request_payloads/observation_table.json
+++ b/tests/fixtures/request_payloads/observation_table.json
@@ -6,6 +6,7 @@
     ],
     "_id": "646f6c1c0ed28a5271fb02d7",
     "context_id": null,
+    "exposure_column": null,
     "feature_store_id": "646f6c190ed28a5271fb02a1",
     "name": "observation_table",
     "primary_entity_ids": [

--- a/tests/fixtures/request_payloads/observation_table_from_managed_view.json
+++ b/tests/fixtures/request_payloads/observation_table_from_managed_view.json
@@ -6,6 +6,7 @@
     ],
     "_id": "68ccea50820076b52bbcceb5",
     "context_id": null,
+    "exposure_column": null,
     "feature_store_id": "646f6c190ed28a5271fb02a1",
     "name": "observation_table_from_managed_view",
     "primary_entity_ids": [

--- a/tests/fixtures/request_payloads/observation_table_from_obs_table.json
+++ b/tests/fixtures/request_payloads/observation_table_from_obs_table.json
@@ -6,6 +6,7 @@
     ],
     "_id": "68ccea50820076b52bbcceb4",
     "context_id": null,
+    "exposure_column": null,
     "feature_store_id": "646f6c190ed28a5271fb02a1",
     "name": "observation_table_from_obs_table",
     "primary_entity_ids": [

--- a/tests/fixtures/request_payloads/target_table.json
+++ b/tests/fixtures/request_payloads/target_table.json
@@ -6,7 +6,6 @@
     ],
     "_id": "646f6c1c0ed28a5271fb32da",
     "context_id": null,
-    "exposure_id": null,
     "feature_store_id": "646f6c190ed28a5271fb02a1",
     "graph": null,
     "name": "target_table",

--- a/tests/fixtures/request_payloads/target_table.json
+++ b/tests/fixtures/request_payloads/target_table.json
@@ -6,6 +6,7 @@
     ],
     "_id": "646f6c1c0ed28a5271fb32da",
     "context_id": null,
+    "exposure_id": null,
     "feature_store_id": "646f6c190ed28a5271fb02a1",
     "graph": null,
     "name": "target_table",

--- a/tests/integration/api/test_exposure.py
+++ b/tests/integration/api/test_exposure.py
@@ -1,0 +1,276 @@
+"""
+Exposure integration tests.
+
+Tests the Exposure and ExposureNamespace lifecycle through the SDK API, including
+creation via Target.as_exposure(), saving, namespace management, and association
+with use cases.
+"""
+
+import pandas as pd
+import pytest
+from bson import ObjectId
+
+from featurebyte import AggFunc, Context
+from featurebyte.api.exposure import Exposure
+from featurebyte.api.exposure_namespace import ExposureNamespace
+from featurebyte.enum import DBVarType
+from featurebyte.schema.use_case import UseCaseCreate
+from tests.util.helper import (
+    tz_localize_if_needed,
+)
+
+
+def test_target_as_exposure(event_table, source_type):
+    """
+    Test creating an Exposure from a Target via as_exposure().
+    """
+    event_view = event_table.get_view()
+
+    target = event_view.groupby("ÜSER ID").forward_aggregate(
+        method="sum",
+        value_column="ÀMOUNT",
+        window="24h",
+        target_name="amount_target_for_exposure",
+        fill_value=0.0,
+    )
+
+    exposure = target.as_exposure("amount_exposure_24h")
+    assert isinstance(exposure, Exposure)
+    assert exposure.name == "amount_exposure_24h"
+    assert exposure.dtype == target.dtype
+    assert exposure.node_name == target.node_name
+
+
+def test_exposure_save_creates_namespace(event_table, user_entity, source_type):
+    """
+    Test that saving an Exposure created via as_exposure() automatically creates
+    an ExposureNamespace.
+    """
+    event_view = event_table.get_view()
+
+    target = event_view.groupby("ÜSER ID").forward_aggregate(
+        method=AggFunc.COUNT,
+        value_column=None,
+        window="7d",
+        target_name=f"count_target_for_exposure_{ObjectId()}",
+        fill_value=None,
+    )
+
+    exposure = target.as_exposure(f"count_exposure_{ObjectId()}")
+    exposure.save()
+
+    exposure_ns = exposure.exposure_namespace
+    assert exposure_ns is not None
+    assert exposure_ns.default_exposure_id == exposure.id
+    assert exposure_ns.dtype == exposure.dtype
+    assert exposure.id in exposure_ns.exposure_ids
+
+
+def test_exposure_preview(event_table, source_type):
+    """
+    Test previewing an Exposure created from a Target.
+    """
+    event_view = event_table.get_view()
+
+    exposure_name = "exposure_for_preview"
+    target = event_view.groupby("ÜSER ID").forward_aggregate(
+        method="sum",
+        value_column="ÀMOUNT",
+        window="24h",
+        target_name=exposure_name,
+        fill_value=None,
+    )
+
+    exposure = target.as_exposure(exposure_name)
+
+    preview_params = {"POINT_IN_TIME": "2001-11-15 10:00:00", "üser id": 1}
+    df_preview = exposure.preview(pd.DataFrame([preview_params]))
+    tz_localize_if_needed(df_preview, source_type)
+
+    assert exposure_name in df_preview.columns
+    assert "POINT_IN_TIME" in df_preview.columns
+    assert len(df_preview) == 1
+    assert df_preview[exposure_name].iloc[0] is not None
+
+
+def test_exposure_and_target_share_computation(event_table, source_type):
+    """
+    Test that an Exposure created from a Target produces the same values when
+    previewed with the same observation set.
+    """
+    event_view = event_table.get_view()
+
+    col_name = "shared_computation_col"
+    target = event_view.groupby("ÜSER ID").forward_aggregate(
+        method="sum",
+        value_column="ÀMOUNT",
+        window="24h",
+        target_name=col_name,
+        fill_value=None,
+    )
+    exposure = target.as_exposure(col_name)
+
+    preview_params = {"POINT_IN_TIME": "2001-11-15 10:00:00", "üser id": 1}
+    df = pd.DataFrame([preview_params])
+
+    target_preview = target.preview(df)
+    exposure_preview = exposure.preview(df)
+
+    tz_localize_if_needed(target_preview, source_type)
+    tz_localize_if_needed(exposure_preview, source_type)
+
+    assert target_preview[col_name].iloc[0] == exposure_preview[col_name].iloc[0]
+
+
+@pytest.mark.asyncio
+async def test_parent_entity_target_and_exposure_with_compute(
+    event_table, item_table, user_entity, item_entity, source_type, app_container
+):
+    """
+    Test that a use case can associate a target and exposure whose primary entity is a
+    parent entity of the context's primary entity, and that compute_targets works
+    with parent entity serving.
+    """
+    event_view = event_table.get_view()
+
+    target_name = f"user_count_target_{ObjectId()}"
+    target = event_view.groupby("ÜSER ID").forward_aggregate(
+        method=AggFunc.COUNT,
+        value_column=None,
+        window="7d",
+        target_name=target_name,
+        fill_value=None,
+    )
+    target.save()
+    target.update_target_type("regression")
+
+    exposure = target.as_exposure(f"user_count_exposure_{ObjectId()}")
+    exposure.save()
+
+    # Exposure is now associated with the Context (not the UseCase)
+    context = Context.create(
+        name=f"item_context_{ObjectId()}",
+        primary_entity=[item_entity.name],
+        exposure_name=exposure.name,
+    )
+
+    use_case_service = app_container.use_case_service
+    target_doc = await app_container.target_service.get_document(document_id=target.id)
+
+    use_case = await use_case_service.create_use_case(
+        UseCaseCreate(
+            name=f"uc_parent_entity_{ObjectId()}",
+            target_id=target.id,
+            target_namespace_id=target_doc.target_namespace_id,
+            context_id=context.id,
+        )
+    )
+    assert use_case.target_id == target.id
+    assert context.exposure_id == exposure.id
+
+    # Verify compute_targets works with child entity (Item)
+    df_obs_child = pd.DataFrame([
+        {"POINT_IN_TIME": pd.Timestamp("2001-11-15 10:00:00"), "item_id": "item_42"},
+    ])
+    df_result_child = target.compute_targets(df_obs_child)
+    assert target_name in df_result_child.columns
+    assert len(df_result_child) == 1
+    child_value = df_result_child[target_name].iloc[0]
+
+    # Also verify compute_targets works directly with parent entity (User)
+    df_obs_parent = pd.DataFrame([
+        {"POINT_IN_TIME": pd.Timestamp("2001-11-15 10:00:00"), "üser id": 1},
+    ])
+    df_result_parent = target.compute_targets(df_obs_parent)
+    assert target_name in df_result_parent.columns
+    assert len(df_result_parent) == 1
+    parent_value = df_result_parent[target_name].iloc[0]
+
+    assert child_value is not None
+    assert parent_value is not None
+
+
+def test_exposure_namespace_create_and_delete(event_table, user_entity, source_type):
+    """
+    Test creating and deleting an ExposureNamespace directly.
+    """
+    exposure_ns = ExposureNamespace.create(
+        name=f"test_exposure_ns_{ObjectId()}",
+        primary_entity=[user_entity.name],
+        dtype=DBVarType.FLOAT,
+        window="7d",
+    )
+    assert exposure_ns.dtype == DBVarType.FLOAT
+    assert exposure_ns.window == "7d"
+    assert exposure_ns.default_version_mode == "AUTO"
+
+    exposure_ns.delete()
+
+
+def test_exposure_namespace_list(event_table, user_entity, source_type):
+    """
+    Test listing ExposureNamespaces.
+    """
+    unique = str(ObjectId())[:8]
+    ns1 = ExposureNamespace.create(
+        name=f"exposure_list_a_{unique}",
+        primary_entity=[user_entity.name],
+        dtype=DBVarType.FLOAT,
+    )
+    ns2 = ExposureNamespace.create(
+        name=f"exposure_list_b_{unique}",
+        primary_entity=[user_entity.name],
+        dtype=DBVarType.INT,
+    )
+
+    listing = ExposureNamespace.list()
+    assert len(listing) >= 2
+    names = listing["name"].tolist()
+    assert ns1.name in names
+    assert ns2.name in names
+
+    ns1.delete()
+    ns2.delete()
+
+
+@pytest.mark.asyncio
+async def test_use_case_with_exposure(event_table, user_entity, source_type, app_container):
+    """
+    Test creating a UseCase with both a target and an exposure created via as_exposure().
+    """
+    event_view = event_table.get_view()
+
+    target = event_view.groupby("ÜSER ID").forward_aggregate(
+        method=AggFunc.COUNT,
+        value_column=None,
+        window="7d",
+        target_name=f"target_for_uc_exposure_{ObjectId()}",
+        fill_value=None,
+    )
+    target.save()
+    target.update_target_type("regression")
+
+    exposure = target.as_exposure(f"exposure_for_uc_{ObjectId()}")
+    exposure.save()
+
+    # Exposure is now associated with the Context
+    context = Context.create(
+        name=f"context_exposure_{ObjectId()}",
+        primary_entity=[user_entity.name],
+        exposure_name=exposure.name,
+    )
+
+    use_case_service = app_container.use_case_service
+    target_doc = await app_container.target_service.get_document(document_id=target.id)
+
+    use_case = await use_case_service.create_use_case(
+        UseCaseCreate(
+            name=f"uc_exposure_{ObjectId()}",
+            target_id=target.id,
+            target_namespace_id=target_doc.target_namespace_id,
+            context_id=context.id,
+        )
+    )
+    assert use_case.target_id == target.id
+    assert context.exposure_id == exposure.id
+    assert context.exposure_namespace_id is not None

--- a/tests/unit/api/test_catalog.py
+++ b/tests/unit/api/test_catalog.py
@@ -40,6 +40,8 @@ from featurebyte.api.dimension_table import DimensionTable
 from featurebyte.api.entity import Entity
 from featurebyte.api.event_table import EventTable
 from featurebyte.api.event_view import EventView
+from featurebyte.api.exposure import Exposure
+from featurebyte.api.exposure_namespace import ExposureNamespace
 from featurebyte.api.feature import Feature, FeatureNamespace
 from featurebyte.api.feature_job import FeatureJobMixin
 from featurebyte.api.feature_job_setting_analysis import FeatureJobSettingAnalysis
@@ -114,6 +116,7 @@ def catalog_list_methods_to_test_list():
         MethodMetadata("list_deployments", Deployment, "list"),
         MethodMetadata("list_static_source_tables", StaticSourceTable, "list"),
         MethodMetadata("list_targets", Target, "list"),
+        MethodMetadata("list_exposures", Exposure, "list"),
         MethodMetadata("list_user_defined_functions", UserDefinedFunction, "list"),
         MethodMetadata("list_use_cases", UseCase, "list"),
         MethodMetadata("list_contexts", Context, "list"),
@@ -139,6 +142,7 @@ def catalog_get_methods_to_test_list():
         MethodMetadata("get_deployment", Deployment, "get"),
         MethodMetadata("get_static_source_table", StaticSourceTable, "get"),
         MethodMetadata("get_target", Target, "get"),
+        MethodMetadata("get_exposure", Exposure, "get"),
         MethodMetadata("get_user_defined_function", UserDefinedFunction, "get"),
         MethodMetadata("get_use_case", UseCase, "get"),
         MethodMetadata("get_context", Context, "get"),
@@ -174,6 +178,7 @@ def catalog_get_by_id_list():
         MethodMetadata("get_static_source_table_by_id", StaticSourceTable, "get_by_id"),
         MethodMetadata("get_user_defined_function_by_id", UserDefinedFunction, "get_by_id"),
         MethodMetadata("get_target_by_id", Target, "get_by_id"),
+        MethodMetadata("get_exposure_by_id", Exposure, "get_by_id"),
         MethodMetadata("get_treatment_by_id", Treatment, "get_by_id"),
         MethodMetadata("get_use_case_by_id", UseCase, "get_by_id"),
         MethodMetadata("get_context_by_id", Context, "get_by_id"),
@@ -311,6 +316,7 @@ def test_all_methods_are_exposed_in_catalog(method_list):
         TableApiObject,
         TableListMixin,
         TargetNamespace,
+        ExposureNamespace,
         FeatureOrTargetMixin,
         FeatureOrTargetNamespaceMixin,
         UseCaseOrContextMixin,

--- a/tests/unit/models/test_exposure.py
+++ b/tests/unit/models/test_exposure.py
@@ -1,0 +1,151 @@
+"""
+Test models#exposure module.
+"""
+
+import pytest
+
+from featurebyte.api.exposure import Exposure
+from featurebyte.models.exposure import ExposureModel
+
+
+@pytest.fixture(name="float_exposure")
+def float_exposure_fixture(grouped_event_view):
+    """
+    Float exposure fixture - create a target then convert to exposure via as_exposure
+    """
+    target = grouped_event_view.forward_aggregate(
+        method="sum",
+        value_column="col_float",
+        window="1d",
+        target_name="float_exposure_target",
+        fill_value=0.0,
+    )
+    return target.as_exposure("float_exposure")
+
+
+@pytest.fixture(name="lookup_exposure")
+def lookup_exposure_fixture(snowflake_event_view_with_entity):
+    """
+    Lookup exposure fixture - create a lookup target then convert to exposure
+    """
+    target = snowflake_event_view_with_entity["col_float"].as_target(
+        "lookup_exposure_target", "7d", fill_value=None
+    )
+    return target.as_exposure("lookup_exposure")
+
+
+def test_as_exposure_returns_exposure_type(grouped_event_view):
+    """
+    Test that Target.as_exposure() returns an Exposure instance
+    """
+    target = grouped_event_view.forward_aggregate(
+        method="sum",
+        value_column="col_float",
+        window="1d",
+        target_name="target_for_exposure",
+        fill_value=0.0,
+    )
+    exposure = target.as_exposure("my_exposure")
+    assert isinstance(exposure, Exposure)
+    assert exposure.name == "my_exposure"
+    assert exposure.dtype == target.dtype
+    assert exposure.node_name == target.node_name
+
+
+def test_as_exposure_shares_graph(grouped_event_view):
+    """
+    Test that the Exposure created by as_exposure shares the same graph as the Target
+    """
+    target = grouped_event_view.forward_aggregate(
+        method="sum",
+        value_column="col_float",
+        window="1d",
+        target_name="target_for_exposure_graph",
+        fill_value=0.0,
+    )
+    exposure = target.as_exposure("my_exposure_graph")
+    assert exposure.graph == target.graph
+    assert exposure.node_name == target.node_name
+    assert exposure.tabular_source == target.tabular_source
+
+
+@pytest.mark.asyncio
+async def test_exposure_save_and_retrieve(float_exposure, app_container):
+    """
+    Test saving an exposure and retrieving it via the service
+    """
+    float_exposure.save()
+    exposure_doc = await app_container.exposure_service.get_document(document_id=float_exposure.id)
+    assert exposure_doc.name == "float_exposure"
+    assert exposure_doc.derive_window() == "1d"
+
+    # Verify namespace was created
+    ns_doc = await app_container.exposure_namespace_service.get_document(
+        document_id=exposure_doc.exposure_namespace_id
+    )
+    assert ns_doc.name == "float_exposure"
+    assert ns_doc.default_exposure_id == float_exposure.id
+
+
+@pytest.mark.asyncio
+async def test_lookup_exposure_save_and_retrieve(lookup_exposure, app_container):
+    """
+    Test saving a lookup exposure and retrieving it
+    """
+    lookup_exposure.save()
+    exposure_doc = await app_container.exposure_service.get_document(document_id=lookup_exposure.id)
+    assert exposure_doc.name == "lookup_exposure"
+    assert exposure_doc.derive_window() == "7d"
+
+
+@pytest.mark.asyncio
+async def test_get_exposure_source_column__lookup_exposure(lookup_exposure, app_container):
+    """
+    Test that get_exposure_source_column extracts the correct column from a lookup exposure.
+    """
+    lookup_exposure.save()
+    exposure_doc = await app_container.exposure_service.get_document(document_id=lookup_exposure.id)
+    result = exposure_doc.get_exposure_source_column()
+    assert result is not None
+    assert result.column_name == "col_float"
+    assert result.table_id in [tid.table_id for tid in exposure_doc.table_id_column_names]
+
+
+@pytest.mark.asyncio
+async def test_get_exposure_source_column__forward_aggregate_exposure(
+    float_exposure, app_container
+):
+    """
+    Test that get_exposure_source_column returns None for a forward_aggregate exposure
+    (not created via as_target or forward_aggregate_asat).
+    """
+    float_exposure.save()
+    exposure_doc = await app_container.exposure_service.get_document(document_id=float_exposure.id)
+    result = exposure_doc.get_exposure_source_column()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_exposure_source_column__no_graph(
+    snowflake_event_view_with_entity, app_container
+):
+    """
+    Test that get_exposure_source_column returns None when exposure has no graph.
+    """
+    target = snowflake_event_view_with_entity["col_float"].as_target(
+        "exposure_no_graph_target", "7d", fill_value=None
+    )
+    exposure = target.as_exposure("exposure_no_graph")
+    exposure.save()
+    exposure_doc = await app_container.exposure_service.get_document(document_id=exposure.id)
+    # Override internal_graph to simulate an exposure with no recipe
+    object.__setattr__(exposure_doc, "internal_graph", None)
+    result = exposure_doc.get_exposure_source_column()
+    assert result is None
+
+
+def test_exposure_model_collection_name():
+    """
+    Test that ExposureModel has the correct collection name
+    """
+    assert ExposureModel.Settings.collection_name == "exposure"

--- a/tests/unit/routes/test_context_exposure.py
+++ b/tests/unit/routes/test_context_exposure.py
@@ -1,0 +1,205 @@
+"""
+Tests for Context exposure integration (validation and source column derivation).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from bson import ObjectId
+
+from featurebyte.exception import DocumentCreationError
+from featurebyte.models.exposure import ExposureSourceColumn
+from featurebyte.models.exposure_namespace import ExposureNamespaceModel
+from featurebyte.schema.context import ContextCreate
+
+
+def _mock_entity(entity_id, ancestor_ids=None):
+    """Create a mock entity with ancestor_ids"""
+    entity = AsyncMock()
+    entity.id = entity_id
+    entity.ancestor_ids = ancestor_ids or []
+    return entity
+
+
+@pytest.mark.asyncio
+async def test_context_validate_exposure_entity_same(app_container):
+    """
+    Test that context creation validation passes when exposure entities equal context entities.
+    """
+    controller = app_container.context_controller
+    shared_entity_id = ObjectId()
+    exposure_namespace_id = ObjectId()
+    default_exposure_id = ObjectId()
+
+    mock_exposure_namespace = ExposureNamespaceModel(
+        _id=exposure_namespace_id,
+        name="test_exposure",
+        dtype="FLOAT",
+        entity_ids=[shared_entity_id],
+        exposure_ids=[default_exposure_id],
+        default_exposure_id=default_exposure_id,
+        user_id=ObjectId(),
+        catalog_id=ObjectId(),
+    )
+
+    data = ContextCreate(
+        name="test_context",
+        primary_entity_ids=[shared_entity_id],
+        exposure_namespace_id=exposure_namespace_id,
+    )
+
+    with patch.object(
+        controller.exposure_namespace_service, "get_document", new_callable=AsyncMock
+    ) as mock_get:
+        mock_get.return_value = mock_exposure_namespace
+        await controller._validate_and_resolve_exposure(data)
+        assert data.exposure_id == default_exposure_id
+
+
+@pytest.mark.asyncio
+async def test_context_validate_exposure_parent_entity(app_container):
+    """
+    Test that context creation validation passes when the exposure entity is a parent
+    of the context primary entity (supports hierarchical TS use cases).
+    """
+    controller = app_container.context_controller
+    parent_entity_id = ObjectId()
+    child_entity_id = ObjectId()
+    exposure_namespace_id = ObjectId()
+    default_exposure_id = ObjectId()
+
+    mock_exposure_namespace = ExposureNamespaceModel(
+        _id=exposure_namespace_id,
+        name="test_exposure",
+        dtype="FLOAT",
+        entity_ids=[parent_entity_id],
+        exposure_ids=[default_exposure_id],
+        default_exposure_id=default_exposure_id,
+        user_id=ObjectId(),
+        catalog_id=ObjectId(),
+    )
+
+    data = ContextCreate(
+        name="test_context",
+        primary_entity_ids=[child_entity_id],
+        exposure_namespace_id=exposure_namespace_id,
+    )
+
+    with patch.object(
+        controller.exposure_namespace_service, "get_document", new_callable=AsyncMock
+    ) as mock_get:
+        mock_get.return_value = mock_exposure_namespace
+        with patch.object(
+            controller.entity_service, "get_document", new_callable=AsyncMock
+        ) as mock_get_entity:
+            mock_get_entity.return_value = _mock_entity(
+                child_entity_id, ancestor_ids=[parent_entity_id]
+            )
+            await controller._validate_and_resolve_exposure(data)
+            assert data.exposure_id == default_exposure_id
+
+
+@pytest.mark.asyncio
+async def test_context_validate_exposure_unrelated_entity_rejected(app_container):
+    """
+    Test that context creation validation fails when exposure entity is unrelated to
+    the context primary entity.
+    """
+    controller = app_container.context_controller
+    context_entity_id = ObjectId()
+    exposure_entity_id = ObjectId()
+    exposure_namespace_id = ObjectId()
+
+    mock_exposure_namespace = ExposureNamespaceModel(
+        _id=exposure_namespace_id,
+        name="test_exposure",
+        dtype="FLOAT",
+        entity_ids=[exposure_entity_id],
+        exposure_ids=[],
+        user_id=ObjectId(),
+        catalog_id=ObjectId(),
+    )
+
+    data = ContextCreate(
+        name="test_context",
+        primary_entity_ids=[context_entity_id],
+        exposure_namespace_id=exposure_namespace_id,
+    )
+
+    with patch.object(
+        controller.exposure_namespace_service, "get_document", new_callable=AsyncMock
+    ) as mock_get:
+        mock_get.return_value = mock_exposure_namespace
+        with patch.object(
+            controller.entity_service, "get_document", new_callable=AsyncMock
+        ) as mock_get_entity:
+            mock_get_entity.return_value = _mock_entity(context_entity_id, ancestor_ids=[])
+            with pytest.raises(
+                DocumentCreationError,
+                match="Exposure entities must be the same as or parent entities",
+            ):
+                await controller._validate_and_resolve_exposure(data)
+
+
+@pytest.mark.asyncio
+async def test_context_validate_exposure_resolves_namespace_from_exposure_id(app_container):
+    """
+    Test that _validate_and_resolve_exposure resolves exposure_namespace_id from exposure_id.
+    """
+    controller = app_container.context_controller
+    shared_entity_id = ObjectId()
+    exposure_id = ObjectId()
+    exposure_namespace_id = ObjectId()
+
+    mock_exposure = AsyncMock()
+    mock_exposure.exposure_namespace_id = exposure_namespace_id
+
+    mock_exposure_namespace = ExposureNamespaceModel(
+        _id=exposure_namespace_id,
+        name="test_exposure",
+        dtype="FLOAT",
+        entity_ids=[shared_entity_id],
+        exposure_ids=[exposure_id],
+        default_exposure_id=exposure_id,
+        user_id=ObjectId(),
+        catalog_id=ObjectId(),
+    )
+
+    data = ContextCreate(
+        name="test_context",
+        primary_entity_ids=[shared_entity_id],
+        exposure_id=exposure_id,
+    )
+
+    with patch.object(
+        controller.exposure_service, "get_document", new_callable=AsyncMock
+    ) as mock_get_exposure:
+        mock_get_exposure.return_value = mock_exposure
+        with patch.object(
+            controller.exposure_namespace_service, "get_document", new_callable=AsyncMock
+        ) as mock_get_ns:
+            mock_get_ns.return_value = mock_exposure_namespace
+            await controller._validate_and_resolve_exposure(data)
+            assert data.exposure_namespace_id == exposure_namespace_id
+
+
+@pytest.mark.asyncio
+async def test_exposure_source_column_derivation(app_container):
+    """
+    Test that creating a context with an exposure derives and persists
+    the exposure_source_column.
+    """
+    source_column = ExposureSourceColumn(table_id=ObjectId(), column_name="amount")
+    mock_exposure = MagicMock()
+    mock_exposure.get_exposure_source_column.return_value = source_column
+
+    # The derivation lives in the controller's create_context method; we verify the
+    # method call with a mocked exposure returns the expected source column.
+    controller = app_container.context_controller
+    with patch.object(
+        controller.exposure_service, "get_document", new_callable=AsyncMock
+    ) as mock_get:
+        mock_get.return_value = mock_exposure
+        exposure = await controller.exposure_service.get_document(document_id=ObjectId())
+        result = exposure.get_exposure_source_column()
+        assert result == source_column

--- a/tests/unit/routes/test_exposure.py
+++ b/tests/unit/routes/test_exposure.py
@@ -1,0 +1,156 @@
+"""
+Test for exposure routes
+"""
+
+from http import HTTPStatus
+
+import pandas as pd
+from bson import ObjectId
+
+from tests.unit.routes.base import BaseCatalogApiTestSuite
+
+
+class TestExposureApi(BaseCatalogApiTestSuite):
+    """
+    TestExposureApi class
+    """
+
+    class_name = "Exposure"
+    base_route = "/exposure"
+    unknown_id = ObjectId()
+    # Reuse the target.json payload structure for exposure (same graph structure)
+    payload = BaseCatalogApiTestSuite.load_payload("tests/fixtures/request_payloads/target.json")
+    # Override name to avoid conflicts with target
+    payload = {**payload, "_id": str(ObjectId()), "name": "float_exposure"}
+
+    create_conflict_payload_expected_detail_pairs = [
+        (
+            payload,
+            f'Exposure (id: "{payload["_id"]}") already exists. '
+            f'Get the existing object by `Exposure.get_by_id(id="{payload["_id"]}")`.',
+        ),
+    ]
+    create_unprocessable_payload_expected_detail_pairs = [
+        (
+            {**payload, "node_name": ["cust_id"]},
+            [
+                {
+                    "input": ["cust_id"],
+                    "loc": ["body", "node_name"],
+                    "msg": "Input should be a valid string",
+                    "type": "string_type",
+                }
+            ],
+        ),
+    ]
+
+    def setup_creation_route(self, api_client):
+        """
+        Setup for post route
+        """
+        api_object_filename_pairs = [
+            ("entity", "entity"),
+            ("entity", "entity_transaction"),
+            ("event_table", "event_table"),
+            ("item_table", "item_table"),
+        ]
+        for api_object, filename in api_object_filename_pairs:
+            payload = self.load_payload(f"tests/fixtures/request_payloads/{filename}.json")
+            response = api_client.post(f"/{api_object}", json=payload)
+            assert response.status_code == HTTPStatus.CREATED, response.json()
+
+            if api_object.endswith("_table"):
+                # tag table entity for table objects
+                self.tag_table_entity(api_client, api_object, payload)
+
+    def multiple_success_payload_generator(self, api_client):
+        """Create multiple payload for setting up create_multiple_success_responses fixture"""
+        _ = api_client
+        for i in range(3):
+            payload = self.payload.copy()
+            payload["_id"] = str(ObjectId())
+            payload["name"] = f"{self.payload['name']}_{i}"
+            yield payload
+
+    def test_create_201(self, test_api_client_persistent, create_success_response, user_id):
+        super().test_create_201(test_api_client_persistent, create_success_response, user_id)
+
+        # check exposure namespace was created
+        test_api_client, _ = test_api_client_persistent
+        default_catalog_id = test_api_client.headers["active-catalog-id"]
+        create_response_dict = create_success_response.json()
+        namespace_id = create_response_dict["exposure_namespace_id"]
+        response = test_api_client.get(f"/exposure_namespace/{namespace_id}")
+        response_dict = response.json()
+        assert response_dict["name"] == "float_exposure"
+        assert response_dict["dtype"] == "FLOAT"
+        assert response_dict["exposure_ids"] == [create_response_dict["_id"]]
+        assert response_dict["default_exposure_id"] == create_response_dict["_id"]
+        assert response_dict["default_version_mode"] == "AUTO"
+        assert response_dict["catalog_id"] == str(default_catalog_id)
+
+    def test_request_sample_entity_serving_names(
+        self,
+        test_api_client_persistent,
+        create_success_response,
+        mock_get_session,
+    ):
+        """Test getting sample entity serving names for an exposure"""
+        test_api_client, _ = test_api_client_persistent
+        result = create_success_response.json()
+
+        async def mock_execute_query(query):
+            _ = query
+            return pd.DataFrame([
+                {"cust_id": 1},
+                {"cust_id": 2},
+                {"cust_id": 3},
+            ])
+
+        mock_session = mock_get_session.return_value
+        mock_session.execute_query = mock_execute_query
+
+        exposure_id = result["_id"]
+        response = test_api_client.get(
+            f"{self.base_route}/{exposure_id}/sample_entity_serving_names?count=10",
+        )
+
+        assert response.status_code == HTTPStatus.OK, response.content
+        assert "entity_serving_names" in response.json()
+
+    def test_delete_exposure_namespace(self, test_api_client_persistent, create_success_response):
+        """Test delete exposure namespace when exposure exists"""
+        test_api_client, _ = test_api_client_persistent
+        namespace_id = create_success_response.json()["exposure_namespace_id"]
+        response = test_api_client.delete(f"/exposure_namespace/{namespace_id}")
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
+        assert (
+            response.json()["detail"]
+            == "ExposureNamespace is referenced by Exposure: float_exposure"
+        )
+
+    def test_delete_exposure(self, test_api_client_persistent, create_success_response):
+        """Test delete exposure"""
+        test_api_client, _ = test_api_client_persistent
+        response_dict = create_success_response.json()
+        exposure_id, namespace_id = (
+            response_dict["_id"],
+            response_dict["exposure_namespace_id"],
+        )
+        response = test_api_client.delete(f"/exposure/{exposure_id}")
+        assert response.status_code == HTTPStatus.OK, response.json()
+
+        # check that exposure is deleted but namespace is not
+        response = test_api_client.get(f"/exposure/{exposure_id}")
+        assert response.status_code == HTTPStatus.NOT_FOUND, response.json()
+        response = test_api_client.get(f"/exposure_namespace/{namespace_id}")
+        assert response.status_code == HTTPStatus.OK, response.json()
+        assert response.json()["exposure_ids"] == [], response.json()
+
+    def test_get_info(self, test_api_client_persistent, create_success_response):
+        """Test getting exposure info"""
+        test_api_client, _ = test_api_client_persistent
+        exposure_id = create_success_response.json()["_id"]
+        response = test_api_client.get(f"{self.base_route}/{exposure_id}/info")
+        assert response.status_code == HTTPStatus.OK, response.json()
+        assert response.json()["exposure_name"] == "float_exposure"

--- a/tests/unit/routes/test_exposure_namespace.py
+++ b/tests/unit/routes/test_exposure_namespace.py
@@ -1,0 +1,104 @@
+"""
+Test for exposure namespace routes
+"""
+
+from http import HTTPStatus
+
+from bson import ObjectId
+
+from tests.unit.routes.base import BaseCatalogApiTestSuite
+
+
+class TestExposureNamespaceApi(BaseCatalogApiTestSuite):
+    """
+    TestExposureNamespaceApi class
+    """
+
+    class_name = "ExposureNamespace"
+    base_route = "/exposure_namespace"
+    unknown_id = ObjectId()
+    payload = BaseCatalogApiTestSuite.load_payload(
+        "tests/fixtures/request_payloads/exposure_namespace.json"
+    )
+    create_conflict_payload_expected_detail_pairs = []
+    create_unprocessable_payload_expected_detail_pairs = []
+    create_parent_unprocessable_payload_expected_detail_pairs = [
+        (
+            {
+                "id": str(unknown_id),
+                "table_type": "event_table",
+                "table_id": str(ObjectId()),
+            },
+            f'ExposureNamespace (id: "{unknown_id}") not found. Please save the ExposureNamespace object first.',
+        )
+    ]
+
+    def setup_creation_route(self, api_client):
+        """
+        Setup for post route
+        """
+        api_object_filename_pairs = [
+            ("entity", "entity"),
+            ("event_table", "event_table"),
+            ("item_table", "item_table"),
+        ]
+        for api_object, filename in api_object_filename_pairs:
+            payload = self.load_payload(f"tests/fixtures/request_payloads/{filename}.json")
+            response = api_client.post(f"/{api_object}", json=payload)
+            assert response.status_code == HTTPStatus.CREATED, response.json()
+
+    def multiple_success_payload_generator(self, api_client):
+        """Create multiple payload for setting up create_multiple_success_responses fixture"""
+        exposure_payload = self.load_payload(
+            "tests/fixtures/request_payloads/exposure_namespace.json"
+        )
+        _ = api_client
+        for i in range(3):
+            exposure_payload = exposure_payload.copy()
+            exposure_payload["_id"] = str(ObjectId())
+            exposure_payload["name"] = f"{exposure_payload['name']}_{i}"
+            yield exposure_payload
+
+    def test_create_201(self, test_api_client_persistent, create_success_response, user_id):
+        """Test create exposure namespace"""
+        test_api_client, _ = test_api_client_persistent
+        response = create_success_response
+        assert response.status_code == HTTPStatus.CREATED, response.json()
+        assert response.json()["dtype"] == "FLOAT"
+        assert response.json()["window"] == "7d"
+
+    def test_delete_exposure_namespace(self, test_api_client_persistent, create_success_response):
+        """Test delete exposure namespace"""
+        test_api_client, _ = test_api_client_persistent
+        exposure_namespace_id = create_success_response.json()["_id"]
+        response = test_api_client.delete(f"/exposure_namespace/{exposure_namespace_id}")
+        assert response.status_code == HTTPStatus.OK, response.json()
+
+    def test_delete_exposure_namespace_referenced_in_context(self, test_api_client_persistent):
+        """Test delete exposure namespace referenced in a context"""
+        test_api_client, _ = test_api_client_persistent
+        self.setup_creation_route(test_api_client)
+
+        # Create an exposure namespace without default_exposure_id
+        # so that context creation doesn't try to fetch a non-existent exposure
+        exposure_ns_payload = {
+            **self.payload,
+            "_id": str(ObjectId()),
+            "name": "exposure_ns_for_context_test",
+            "default_exposure_id": None,
+            "exposure_ids": [],
+        }
+        response = test_api_client.post("/exposure_namespace", json=exposure_ns_payload)
+        assert response.status_code == HTTPStatus.CREATED, response.json()
+        exposure_namespace_id = response.json()["_id"]
+
+        # Create a context that references the exposure namespace
+        context_payload = self.load_payload("tests/fixtures/request_payloads/context.json")
+        context_payload["exposure_namespace_id"] = exposure_namespace_id
+        context_payload["exposure_id"] = None
+        response = test_api_client.post("/context", json=context_payload)
+        assert response.status_code == HTTPStatus.CREATED, response.json()
+
+        response = test_api_client.delete(f"/exposure_namespace/{exposure_namespace_id}")
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY, response.json()
+        assert "ExposureNamespace is referenced by Context" in response.json()["detail"]

--- a/tests/unit/routes/test_observation_table.py
+++ b/tests/unit/routes/test_observation_table.py
@@ -929,7 +929,7 @@ class TestObservationTableApi(BaseMaterializedTableTestSuite):
         with patch(
             "featurebyte.service.observation_table.ObservationTableService._validate_columns"
         ) as mock__validate_columns:
-            mock__validate_columns.return_value = ObjectId(), None
+            mock__validate_columns.return_value = ObjectId(), None, None
             response = self.post(test_api_client, payload)
 
         response_dict = response.json()

--- a/tests/unit/routes/test_target_table.py
+++ b/tests/unit/routes/test_target_table.py
@@ -154,6 +154,7 @@ class TestTargetTableApi(BaseMaterializedTableTestSuite):
                 "type": "observation_table",
             },
             "target_namespace_id": target_namespace_id,
+            "exposure_namespace_id": None,
             "updated_at": None,
             "use_case_ids": [],
             "user_id": str(user_id),

--- a/tests/unit/schema/test_exposure_namespace.py
+++ b/tests/unit/schema/test_exposure_namespace.py
@@ -1,0 +1,52 @@
+"""
+Test exposure namespace schema
+"""
+
+from bson import ObjectId
+
+from featurebyte.enum import DBVarType
+from featurebyte.schema.exposure_namespace import ExposureNamespaceCreate
+
+
+def test_exposure_namespace_create():
+    """
+    Test exposure namespace create schema
+    """
+    exposure_namespace_create = ExposureNamespaceCreate(
+        name="exposure_namespace",
+        dtype=DBVarType.FLOAT,
+        entity_ids=[ObjectId()],
+        window="7d",
+    )
+    assert exposure_namespace_create.name == "exposure_namespace"
+    assert exposure_namespace_create.dtype == DBVarType.FLOAT
+    assert exposure_namespace_create.window == "7d"
+
+
+def test_exposure_namespace_create_without_window():
+    """
+    Test exposure namespace create schema without window
+    """
+    exposure_namespace_create = ExposureNamespaceCreate(
+        name="exposure_namespace",
+        dtype=DBVarType.INT,
+        entity_ids=[ObjectId()],
+    )
+    assert exposure_namespace_create.name == "exposure_namespace"
+    assert exposure_namespace_create.dtype == DBVarType.INT
+    assert exposure_namespace_create.window is None
+
+
+def test_exposure_namespace_create_with_defaults():
+    """
+    Test exposure namespace create schema with default values
+    """
+    entity_id = ObjectId()
+    exposure_namespace_create = ExposureNamespaceCreate(
+        name="my_exposure",
+        dtype=DBVarType.FLOAT,
+        entity_ids=[entity_id],
+    )
+    assert exposure_namespace_create.exposure_ids == []
+    assert exposure_namespace_create.default_exposure_id is None
+    assert exposure_namespace_create.default_version_mode == "AUTO"

--- a/tests/unit/service/test_exposure_namespace.py
+++ b/tests/unit/service/test_exposure_namespace.py
@@ -1,0 +1,50 @@
+"""
+Test for ExposureNamespaceService
+"""
+
+import pytest
+from bson import ObjectId
+
+from featurebyte.models.exposure_namespace import ExposureNamespaceModel
+from featurebyte.schema.exposure_namespace import ExposureNamespaceCreate
+
+
+@pytest.mark.asyncio
+async def test_exposure_namespace_service_create(app_container):
+    """
+    Test creating an exposure namespace via the service
+    """
+    exposure_namespace_service = app_container.exposure_namespace_service
+    entity_id = ObjectId()
+    data = ExposureNamespaceCreate(
+        name="test_exposure_ns",
+        dtype="FLOAT",
+        entity_ids=[entity_id],
+        exposure_ids=[],
+        window="7d",
+    )
+    result = await exposure_namespace_service.create_document(data)
+    assert isinstance(result, ExposureNamespaceModel)
+    assert result.name == "test_exposure_ns"
+    assert result.dtype == "FLOAT"
+    assert result.window == "7d"
+
+
+@pytest.mark.asyncio
+async def test_exposure_namespace_service_get(app_container):
+    """
+    Test getting an exposure namespace by ID
+    """
+    exposure_namespace_service = app_container.exposure_namespace_service
+    data = ExposureNamespaceCreate(
+        name="test_exposure_ns_get",
+        dtype="INT",
+        entity_ids=[ObjectId()],
+        exposure_ids=[],
+    )
+    created = await exposure_namespace_service.create_document(data)
+    retrieved = await exposure_namespace_service.get_document(document_id=created.id)
+    assert retrieved.id == created.id
+    assert retrieved.name == "test_exposure_ns_get"
+    assert retrieved.dtype == "INT"
+    assert retrieved.window is None

--- a/tests/unit/service/test_observation_table.py
+++ b/tests/unit/service/test_observation_table.py
@@ -670,7 +670,11 @@ async def test_validate_columns__forecast_context_with_all_required_columns(
     available_columns = ["POINT_IN_TIME", "FORECAST_POINT", "FORECAST_TIMEZONE", "entity_col"]
 
     # Should not raise any exception
-    target_namespace_id, treatment_id = await observation_table_service._validate_columns(
+    (
+        target_namespace_id,
+        exposure_namespace_id,
+        treatment_id,
+    ) = await observation_table_service._validate_columns(
         available_columns=available_columns,
         primary_entity_ids=None,
         target_column=None,
@@ -699,7 +703,11 @@ async def test_validate_columns__non_forecast_context_no_forecast_point_required
     available_columns = ["POINT_IN_TIME", "entity_col"]
 
     # Should not raise any exception
-    target_namespace_id, treatment_id = await observation_table_service._validate_columns(
+    (
+        target_namespace_id,
+        exposure_namespace_id,
+        treatment_id,
+    ) = await observation_table_service._validate_columns(
         available_columns=available_columns,
         primary_entity_ids=None,
         target_column=None,
@@ -780,7 +788,11 @@ async def test_validate_columns__forecast_point_dtype_match(observation_table_se
     }
 
     # Should not raise any exception
-    target_namespace_id, treatment_id = await observation_table_service._validate_columns(
+    (
+        target_namespace_id,
+        exposure_namespace_id,
+        treatment_id,
+    ) = await observation_table_service._validate_columns(
         available_columns=available_columns,
         primary_entity_ids=None,
         target_column=None,
@@ -869,7 +881,11 @@ async def test_validate_columns__timezone_column_dtype_valid(observation_table_s
     }
 
     # Should not raise any exception
-    target_namespace_id, treatment_id = await observation_table_service._validate_columns(
+    (
+        target_namespace_id,
+        exposure_namespace_id,
+        treatment_id,
+    ) = await observation_table_service._validate_columns(
         available_columns=available_columns,
         primary_entity_ids=None,
         target_column=None,
@@ -908,7 +924,11 @@ async def test_validate_columns__no_dtype_validation_when_dtypes_not_provided(
     available_columns = ["POINT_IN_TIME", "FORECAST_POINT", "FORECAST_TIMEZONE", "entity_col"]
 
     # Should not raise any exception even without dtype info
-    target_namespace_id, treatment_id = await observation_table_service._validate_columns(
+    (
+        target_namespace_id,
+        exposure_namespace_id,
+        treatment_id,
+    ) = await observation_table_service._validate_columns(
         available_columns=available_columns,
         primary_entity_ids=None,
         target_column=None,

--- a/tests/unit/service/test_use_case_exposure.py
+++ b/tests/unit/service/test_use_case_exposure.py
@@ -1,0 +1,120 @@
+"""
+Test for UseCase exposure integration (exposure now lives on Context).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from bson import ObjectId
+
+from featurebyte.exception import DocumentCreationError
+from featurebyte.schema.use_case import UseCaseCreate
+
+
+def _mock_entity(entity_id, ancestor_ids=None):
+    """Create a mock entity with ancestor_ids"""
+    entity = AsyncMock()
+    entity.id = entity_id
+    entity.ancestor_ids = ancestor_ids or []
+    return entity
+
+
+@pytest.mark.asyncio
+async def test_use_case_exposure_rejected_for_classification_target(app_container):
+    """
+    Test that creating a UseCase fails when the context has an exposure but the
+    target type is not regression.
+    """
+    use_case_service = app_container.use_case_service
+
+    shared_entity_id = ObjectId()
+    mock_context = AsyncMock()
+    mock_context.primary_entity_ids = [shared_entity_id]
+    mock_context.treatment_id = None
+    mock_context.forecast_point_schema = None
+    mock_context.exposure_id = ObjectId()  # context has an exposure
+
+    mock_target_namespace = AsyncMock()
+    mock_target_namespace.name = "classification_target"
+    mock_target_namespace.target_type = "classification"
+    mock_target_namespace.positive_label = "positive"
+    mock_target_namespace.entity_ids = [shared_entity_id]
+    mock_target_namespace.default_target_id = ObjectId()
+
+    data = UseCaseCreate(
+        name="test_use_case_classification",
+        target_namespace_id=ObjectId(),
+        context_id=ObjectId(),
+    )
+    data.target_id = mock_target_namespace.default_target_id
+
+    with patch.object(
+        use_case_service.context_service, "get_document", new_callable=AsyncMock
+    ) as mock_get_ctx:
+        mock_get_ctx.return_value = mock_context
+        with patch.object(
+            use_case_service.target_namespace_service, "get_document", new_callable=AsyncMock
+        ) as mock_get_tns:
+            mock_get_tns.return_value = mock_target_namespace
+            with pytest.raises(
+                DocumentCreationError,
+                match="Exposure is only supported for regression targets",
+            ):
+                await use_case_service.create_use_case(data)
+
+
+@pytest.mark.asyncio
+async def test_use_case_validate_entity_compatibility_same_entities(app_container):
+    """
+    Test _validate_entity_compatibility passes for exact entity match
+    """
+    use_case_service = app_container.use_case_service
+    entity_id = ObjectId()
+    await use_case_service._validate_entity_compatibility(
+        entity_ids=[entity_id],
+        context_entity_ids=[entity_id],
+        object_name="Target",
+    )
+
+
+@pytest.mark.asyncio
+async def test_use_case_validate_entity_compatibility_parent_entity(app_container):
+    """
+    Test _validate_entity_compatibility passes when target entity is a parent of context entity
+    """
+    use_case_service = app_container.use_case_service
+    parent_entity_id = ObjectId()
+    child_entity_id = ObjectId()
+
+    with patch.object(
+        use_case_service.entity_service, "get_document", new_callable=AsyncMock
+    ) as mock_get_entity:
+        mock_get_entity.return_value = _mock_entity(
+            child_entity_id, ancestor_ids=[parent_entity_id]
+        )
+        await use_case_service._validate_entity_compatibility(
+            entity_ids=[parent_entity_id],
+            context_entity_ids=[child_entity_id],
+            object_name="Target",
+        )
+
+
+@pytest.mark.asyncio
+async def test_use_case_validate_entity_compatibility_unrelated_entity(app_container):
+    """
+    Test _validate_entity_compatibility fails for unrelated entities
+    """
+    use_case_service = app_container.use_case_service
+    entity_a = ObjectId()
+    entity_b = ObjectId()
+
+    with patch.object(
+        use_case_service.entity_service, "get_document", new_callable=AsyncMock
+    ) as mock_get_entity:
+        mock_get_entity.return_value = _mock_entity(entity_b, ancestor_ids=[])
+        with pytest.raises(DocumentCreationError, match="must be parent entities"):
+            await use_case_service._validate_entity_compatibility(
+                entity_ids=[entity_a],
+                context_entity_ids=[entity_b],
+                object_name="Target",
+            )

--- a/tests/unit/worker/task/test_catalog_cleanup.py
+++ b/tests/unit/worker/task/test_catalog_cleanup.py
@@ -57,6 +57,8 @@ def test_catalog_specific_model_classes(app_container):
         "DeploymentSqlModel",
         "DevelopmentDatasetModel",
         "EntityModel",
+        "ExposureModel",
+        "ExposureNamespaceModel",
         "FeatureJobSettingAnalysisModel",
         "FeatureListModel",
         "FeatureListNamespaceModel",


### PR DESCRIPTION
## Description
@kchua78 
### Summary
Introduces Exposure and ExposureNamespace as new first-class objects in the SDK, representing a measure of opportunity (e.g., policy duration, transaction count, population size) that can be associated with a Context. Downstream modeling can use log-link GLMs with exposure as an offset in the linear predictor, or divide the target by exposure and use it as sample weight.

#### What's new
* Exposure & ExposureNamespace — Full model/schema/service/route/API/controller stack mirroring Target/TargetNamespace. ExposureModel extends BaseFeatureModel; ExposureNamespaceModel extends BaseFeatureNamespaceModel. REST endpoints at /exposure and /exposure_namespace.

#### Creation flow

* ExposureNamespace.create(name, primary_entity, dtype, window=None) — create a namespace directly (mirrors TargetNamespace.create())
* Target.as_exposure(exposure_name) creates an Exposure reusing the Target's query graph
* catalog.get_exposure(name), catalog.list_exposures(), catalog.get_exposure_by_id(id)

### Distinct compute path

* Exposure.compute_exposures(observation_set) and Exposure.compute_exposure_table(observation_set, name)

#### Context integration (exposure lives on Context)

* Context.create() accepts optional exposure_name
* ContextModel gains exposure_id, exposure_namespace_id, exposure_source_column (auto-derived from the exposure's query graph)
* Entity validation: exposure entities can be the same as or parent entities of the context's primary entities — enables hierarchical time-series (e.g., store-level exposure with product-level targets)
* Deleting an Exposure or ExposureNamespace is blocked while referenced by any Context

#### UseCase integration

* UseCases inherit exposure through their associated Context
* Regression-only check: if the context has an exposure, the target type must be regression
* Target entity validation also relaxed to allow parent entities of the context's primary entities

#### Observation table integration

* ObservationTableModel gains exposure_namespace_id, inherited from the associated Context
* When creating an observation table for a context with an exposure, the exposure column is computed alongside the target by merging graphs via QueryGraph.load()
* Users can manually provide exposure_column when creating observation tables from source tables, views, or uploads (parallel to target_column)
* Derived observation tables (from another observation table or via split) inherit exposure_namespace_id from the source

#### Target computation fix

* TargetTableTask now uses the observation set's primary_entity_ids when available, fixing validation failures when parent entity serving resolves child → parent entities

#### Tests
* Unit: Exposure/ExposureNamespace routes, schema, model, catalog wiring, context exposure validation (same entities, parent-entity for hierarchical TS, unrelated rejection), use-case regression-only check
* Integration (Snowflake): Target.as_exposure() lifecycle, namespace CRUD/list, preview, shared-computation verification, Context+UseCase with exposure, hierarchical (parent-entity) exposure with compute_targets

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
