### PR TITLE
[Chore] Add option to skip audit in BaseDocumentService.update_document

### DIFF
--- a/featurebyte/feast/service/registry.py
+++ b/featurebyte/feast/service/registry.py
@@ -310,6 +310,7 @@ class FeastRegistryService(
         return_document: bool = True,
         skip_block_modification_check: bool = False,
         populate_remote_attributes: bool = True,
+        skip_audit: bool = False,
     ) -> Optional[FeastRegistryModel]:
         assert data.feature_store_id is None, "Not allowed to update feature store ID directly"
         if data.feature_lists is None:

--- a/featurebyte/service/base_document.py
+++ b/featurebyte/service/base_document.py
@@ -1259,6 +1259,7 @@ class BaseDocumentService(
         update_dict: Dict[str, Any],
         update_document_class: Optional[Type[DocumentUpdateSchema]],
         skip_block_modification_check: bool = False,
+        skip_audit: bool = False,
     ) -> None:
         """
         Update document to persistent
@@ -1274,6 +1275,8 @@ class BaseDocumentService(
         skip_block_modification_check: bool
             Whether to skip block modification check (use with caution,
             should only be used when updating document description)
+        skip_audit: bool
+            Whether to skip audit logging for this update (use with caution)
         """
         if not skip_block_modification_check:
             # check if document is modifiable
@@ -1297,7 +1300,7 @@ class BaseDocumentService(
                 query_filter=await self.construct_get_query_filter(document_id=document.id),
                 update={"$set": update_dict},
                 user_id=self.user.id,
-                disable_audit=self.should_disable_audit,
+                disable_audit=self.should_disable_audit or skip_audit,
             )
 
     async def update_document(
@@ -1309,6 +1312,7 @@ class BaseDocumentService(
         return_document: bool = True,
         skip_block_modification_check: bool = False,
         populate_remote_attributes: bool = True,
+        skip_audit: bool = False,
     ) -> Optional[Document]:
         """
         Update document at persistent
@@ -1329,6 +1333,8 @@ class BaseDocumentService(
             Whether to skip block modification check (use with caution, only use when updating document description)
         populate_remote_attributes: bool
             Whether to populate remote attributes (e.g. file paths) when returning document
+        skip_audit: bool
+            Whether to skip audit logging for this update (use with caution)
 
         Returns
         -------
@@ -1352,6 +1358,7 @@ class BaseDocumentService(
             update_dict=update_dict,
             update_document_class=type(data),
             skip_block_modification_check=skip_block_modification_check,
+            skip_audit=skip_audit,
         )
 
         if return_document:

--- a/featurebyte/service/context.py
+++ b/featurebyte/service/context.py
@@ -217,6 +217,7 @@ class ContextService(BaseDocumentService[ContextModel, ContextCreate, ContextUpd
         return_document: bool = True,
         skip_block_modification_check: bool = False,
         populate_remote_attributes: bool = True,
+        skip_audit: bool = False,
     ) -> Optional[ContextModel]:
         document = await self.get_document(
             document_id=document_id, populate_remote_attributes=False

--- a/featurebyte/service/credential.py
+++ b/featurebyte/service/credential.py
@@ -160,6 +160,8 @@ class CredentialService(
             Whether to skip block modification check (used only when updating description)
         populate_remote_attributes: bool
             Whether to populate remote attributes
+        skip_audit: bool
+            Whether to skip audit logging for this update (use with caution)
 
         Returns
         -------

--- a/featurebyte/service/credential.py
+++ b/featurebyte/service/credential.py
@@ -139,6 +139,7 @@ class CredentialService(
         return_document: bool = True,
         skip_block_modification_check: bool = False,
         populate_remote_attributes: bool = True,
+        skip_audit: bool = False,
     ) -> Optional[CredentialModel]:
         """
         Update document at persistent

--- a/featurebyte/service/development_dataset.py
+++ b/featurebyte/service/development_dataset.py
@@ -286,6 +286,7 @@ class DevelopmentDatasetService(
         return_document: bool = True,
         skip_block_modification_check: bool = False,
         populate_remote_attributes: bool = True,
+        skip_audit: bool = False,
     ) -> Optional[DevelopmentDatasetModel]:
         original_document = await self.get_document(
             document_id=document_id, populate_remote_attributes=False

--- a/featurebyte/service/event_table.py
+++ b/featurebyte/service/event_table.py
@@ -41,6 +41,7 @@ class EventTableService(
         return_document: bool = True,
         skip_block_modification_check: bool = False,
         populate_remote_attributes: bool = True,
+        skip_audit: bool = False,
     ) -> Optional[EventTableModel]:
         if isinstance(data, EventTableServiceUpdate) and isinstance(
             data.default_feature_job_setting, CronFeatureJobSetting

--- a/featurebyte/service/offline_store_feature_table.py
+++ b/featurebyte/service/offline_store_feature_table.py
@@ -199,6 +199,7 @@ class OfflineStoreFeatureTableService(
         return_document: bool = True,
         skip_block_modification_check: bool = False,
         populate_remote_attributes: bool = True,
+        skip_audit: bool = False,
     ) -> Optional[OfflineStoreFeatureTableModel]:
         if isinstance(data, FeaturesUpdate):
             with self.get_feature_cluster_storage_lock(

--- a/featurebyte/service/online_store.py
+++ b/featurebyte/service/online_store.py
@@ -151,6 +151,7 @@ class OnlineStoreService(
         update_dict: Dict[str, Any],
         update_document_class: Optional[Type[DocumentUpdateSchema]],
         skip_block_modification_check: bool = False,
+        skip_audit: bool = False,
     ) -> None:
         # encrypt credential if present in update_dict
         if "details" in update_dict:

--- a/featurebyte/service/snapshots_table.py
+++ b/featurebyte/service/snapshots_table.py
@@ -61,6 +61,7 @@ class SnapshotsTableService(
         return_document: bool = True,
         skip_block_modification_check: bool = False,
         populate_remote_attributes: bool = True,
+        skip_audit: bool = False,
     ) -> Optional[SnapshotsTableModel]:
         if isinstance(data, SnapshotsTableServiceUpdate) and data.default_feature_job_setting:
             # if default feature job setting is to be updated

--- a/featurebyte/service/table.py
+++ b/featurebyte/service/table.py
@@ -38,6 +38,7 @@ class TableService(BaseDocumentService[BaseDataModel, TableCreate, TableServiceU
         return_document: bool = True,
         skip_block_modification_check: bool = False,
         populate_remote_attributes: bool = True,
+        skip_audit: bool = False,
     ) -> Optional[Document]:
         raise NotImplementedError
 

--- a/featurebyte/service/time_series_table.py
+++ b/featurebyte/service/time_series_table.py
@@ -58,6 +58,7 @@ class TimeSeriesTableService(
         return_document: bool = True,
         skip_block_modification_check: bool = False,
         populate_remote_attributes: bool = True,
+        skip_audit: bool = False,
     ) -> Optional[TimeSeriesTableModel]:
         if isinstance(data, TimeSeriesTableServiceUpdate) and data.default_feature_job_setting:
             # if default feature job setting is to be updated

--- a/tests/unit/service/test_base_document.py
+++ b/tests/unit/service/test_base_document.py
@@ -778,6 +778,48 @@ async def test_app_container__disable_block_modification_check(app_container, en
 
 
 @pytest.mark.asyncio
+async def test_update_document_skip_audit(document_service):
+    """Test that update_document with skip_audit=True does not create an audit record"""
+    document = await document_service.create_document(data=Document(name="original_name"))
+
+    # confirm the insertion was audited
+    audits_before = await document_service.list_document_audits(document_id=document.id)
+    assert audits_before["total"] == 1
+    assert audits_before["data"][0]["action_type"] == AuditActionType.INSERT
+
+    # update with skip_audit=True
+    updated = await document_service.update_document(
+        document_id=document.id,
+        data=Document(name="updated_name"),
+        skip_audit=True,
+    )
+    assert updated.name == "updated_name"
+
+    # no additional audit record should have been created
+    audits_after = await document_service.list_document_audits(document_id=document.id)
+    assert audits_after["total"] == 1
+    assert audits_after["data"][0]["action_type"] == AuditActionType.INSERT
+
+
+@pytest.mark.asyncio
+async def test_update_document_audit_recorded_by_default(document_service):
+    """Test that update_document records an audit entry by default"""
+    document = await document_service.create_document(data=Document(name="original_name"))
+
+    # update without skip_audit (default behaviour)
+    updated = await document_service.update_document(
+        document_id=document.id,
+        data=Document(name="updated_name"),
+    )
+    assert updated.name == "updated_name"
+
+    # an UPDATE audit record should have been created
+    audits = await document_service.list_document_audits(document_id=document.id)
+    action_types = [audit["action_type"] for audit in audits["data"]]
+    assert AuditActionType.UPDATE in action_types
+
+
+@pytest.mark.asyncio
 async def test_soft_delete_document(document_service):
     """Test soft delete document"""
     documents = [


### PR DESCRIPTION
## Description

Add option to skip audit in `BaseDocumentService.update_document` for updates that does not need to be tracked

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
