### PR TITLE
Fix parquet download producing excessive row groups

### DIFF
--- a/featurebyte/api/utils.py
+++ b/featurebyte/api/utils.py
@@ -68,20 +68,32 @@ def parquet_from_arrow_stream(buffer: Any, output_path: Path, num_rows: int) -> 
     num_rows: int
         Number of rows to write
     """
+    row_group_size = 128_000
+
     reader = pa.ipc.open_stream(buffer)
     batch = reader.read_next_batch()
     with pq.ParquetWriter(output_path, batch.schema) as writer:
         try:
+            buffered_batches = [batch]
+            buffered_rows = batch.num_rows
             with alive_bar(
                 total=num_rows,
                 title="Downloading table",
                 **get_alive_bar_additional_params(),
             ) as progress_bar:
                 while True:
-                    table = pa.Table.from_batches([batch])
-                    writer.write_table(table)
-                    if table.num_rows > 0:
-                        progress_bar(table.num_rows)
+                    if buffered_batches[-1].num_rows > 0:
+                        progress_bar(buffered_batches[-1].num_rows)
                     batch = reader.read_next_batch()
+                    buffered_batches.append(batch)
+                    buffered_rows += batch.num_rows
+                    if buffered_rows >= row_group_size:
+                        table = pa.Table.from_batches(buffered_batches)
+                        writer.write_table(table)
+                        buffered_batches = []
+                        buffered_rows = 0
         except StopIteration:
             pass
+        if buffered_batches:
+            table = pa.Table.from_batches(buffered_batches)
+            writer.write_table(table)

--- a/featurebyte/routes/common/base_materialized_table.py
+++ b/featurebyte/routes/common/base_materialized_table.py
@@ -137,6 +137,8 @@ class BaseMaterializedTableController(
         -------
         AsyncGenerator[bytes, None]
         """
+        row_group_size = 128_000
+
         bytestream = await self.feature_store_warehouse_service.download_table(
             location=location,
         )
@@ -146,6 +148,8 @@ class BaseMaterializedTableController(
         out_buffer = BytesIO()
         reader: Optional[pa.RecordBatchStreamReader] = None
         writer: Optional[pq.ParquetWriter] = None
+        buffered_tables: list[pa.Table] = []
+        buffered_rows = 0
         async for in_chunk in bytestream:
             in_buffer.write(in_chunk)
             in_buffer.seek(0)
@@ -157,19 +161,32 @@ class BaseMaterializedTableController(
 
             if not writer:
                 writer = pq.ParquetWriter(out_buffer, table.schema)
-            writer.write_table(table)
-            out_buffer.seek(0)
-            out_chunk = out_buffer.getvalue()
-            if out_chunk:
-                yield out_chunk
+
+            buffered_tables.append(table)
+            buffered_rows += table.num_rows
+
+            # Flush buffered tables as a single row group when threshold is reached
+            if buffered_rows >= row_group_size:
+                combined = pa.concat_tables(buffered_tables)
+                writer.write_table(combined)
+                buffered_tables = []
+                buffered_rows = 0
                 out_buffer.seek(0)
-                out_buffer.truncate(0)
+                out_chunk = out_buffer.getvalue()
+                if out_chunk:
+                    yield out_chunk
+                    out_buffer.seek(0)
+                    out_buffer.truncate(0)
+
+        # Flush remaining buffered tables
+        if writer and buffered_tables:
+            combined = pa.concat_tables(buffered_tables)
+            writer.write_table(combined)
 
         # read final chunk
         if reader:
             reader.close()
             if writer:
-                writer.write_table(reader.read_all())
                 writer.close()
         out_chunk = out_buffer.getvalue()
         if out_chunk:


### PR DESCRIPTION
## Description

Parquet files downloaded from materialized tables (historical feature tables, observation tables, etc.) were written with one row group per database batch (~460 rows), producing thousands of row groups for large tables. This caused ~3x file size bloat due to metadata overhead (~98 MB of metadata for a 1M row table).

Buffer incoming batches and flush them as single row groups at 128K rows. Applies to both the server-side streaming download (base_materialized_table.py) and the client-side IPC-to-parquet conversion (api/utils.py).

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
