### PR TITLE
Fix OfflineStoreFeatureTableBadStateError when generating SQL for forecast features

### DIFF
--- a/featurebyte/service/deployment_sql_generation.py
+++ b/featurebyte/service/deployment_sql_generation.py
@@ -17,6 +17,7 @@ from featurebyte.models.offline_store_feature_table import (
     OfflineStoreFeatureTableModel,
     get_combined_ingest_graph,
 )
+from featurebyte.query_graph.enum import NodeType
 from featurebyte.query_graph.sql.adapter import get_sql_adapter
 from featurebyte.query_graph.sql.common import (
     CURRENT_TIMESTAMP_PLACEHOLDER,
@@ -298,6 +299,18 @@ class DeploymentSqlGenerationService:
         graph_container = OfflineIngestGraphContainer.build_from_feature_infos(feature_infos)
 
         for table_name, ingest_graphs in graph_container.offline_store_table_name_to_graphs.items():
+            # Skip tables whose features are pure request-column derivations (e.g., functions of
+            # FORECAST_POINT or POINT_IN_TIME with no source-data aggregation). They have no
+            # entity universe to materialize from and are served on-demand from request inputs.
+            # Note: non-decomposed features include RequestColumnNodes in aggregation_nodes_info
+            # (the decomposition-time filter at offline_store_ingest.py does not run for them),
+            # so we must filter by node type here rather than checking emptiness.
+            if not any(
+                info.node_type != NodeType.REQUEST_COLUMN
+                for g in ingest_graphs
+                for info in g.aggregation_nodes_info
+            ):
+                continue
             features = graph_container.offline_store_table_name_to_features[table_name]
             ingest_graph = ingest_graphs[0]
             primary_entities = await self._get_entities(

--- a/tests/unit/service/test_deployment_sql_generation.py
+++ b/tests/unit/service/test_deployment_sql_generation.py
@@ -713,3 +713,87 @@ async def test_deployment_sql__not_supported(
     with pytest.raises(DeploymentSqlGenerationError) as exc:
         _ = await deployment_sql_generation_service.generate_deployment_sql(deployment_id)
     assert "Deployment SQL generation is not supported" in str(exc.value)
+
+
+@pytest_asyncio.fixture
+async def deployed_forecast_point_only_feature_list(
+    app_container,
+    forecast_point_dt_feature,
+    deployment_id,
+    mock_update_data_warehouse,
+    mock_offline_store_feature_manager_dependencies,
+):
+    """
+    Fixture for a feature list containing only a forecast-point-derived feature (no source-data
+    aggregation). The feature is a pure transformation of FORECAST_POINT. Feast integration is
+    disabled to mirror the user-reported scenario, where the bug surfaces only during deployment
+    SQL generation.
+    """
+    _ = mock_update_data_warehouse
+    _ = mock_offline_store_feature_manager_dependencies
+    with mock.patch.dict(os.environ, {"FEATUREBYTE_FEAST_INTEGRATION_ENABLED": "False"}):
+        feature_list = await deploy_feature(
+            app_container,
+            forecast_point_dt_feature,
+            return_type="feature_list",
+            deployment_id=deployment_id,
+        )
+    return feature_list
+
+
+@pytest_asyncio.fixture
+async def deployed_forecast_point_with_aggregate_feature_list(
+    app_container,
+    forecast_point_dt_feature,
+    ts_window_aggregate_feature,
+    deployment_id,
+    mock_update_data_warehouse,
+    mock_offline_store_feature_manager_dependencies,
+):
+    """
+    Fixture for a feature list mixing a forecast-point-derived feature with a real time-series
+    aggregate feature. Only the aggregate should produce an offline feature table SQL.
+    """
+    _ = mock_update_data_warehouse
+    _ = mock_offline_store_feature_manager_dependencies
+    with mock.patch.dict(os.environ, {"FEATUREBYTE_FEAST_INTEGRATION_ENABLED": "False"}):
+        feature_list = await deploy_features(
+            app_container,
+            [forecast_point_dt_feature, ts_window_aggregate_feature],
+            feature_list_name=f"feature_list_{ObjectId()}",
+            deployment_id=deployment_id,
+        )
+    return feature_list
+
+
+@pytest.mark.asyncio
+async def test_deployment_sql__forecast_point_only(
+    deployed_forecast_point_only_feature_list,
+    deployment_sql_generation_service,
+    deployment_id,
+):
+    """
+    Test that a feature list with only forecast-point-derived features generates no offline
+    feature table SQL (these features are served on-demand from request inputs).
+    """
+    _ = deployed_forecast_point_only_feature_list
+    deployment_sql = await deployment_sql_generation_service.generate_deployment_sql(deployment_id)
+    assert deployment_sql.feature_table_sqls == []
+
+
+@pytest.mark.asyncio
+async def test_deployment_sql__forecast_point_with_aggregate(
+    deployed_forecast_point_with_aggregate_feature_list,
+    deployment_sql_generation_service,
+    deployment_id,
+):
+    """
+    Test that mixing forecast-point-derived features with real aggregates yields offline SQL
+    only for the real aggregate; the forecast feature is omitted (served on-demand).
+    """
+    _ = deployed_forecast_point_with_aggregate_feature_list
+    deployment_sql = await deployment_sql_generation_service.generate_deployment_sql(deployment_id)
+    feature_names = [
+        name for sql in deployment_sql.feature_table_sqls for name in sql.feature_names
+    ]
+    assert feature_names == ["col_float_sum_3month"]


### PR DESCRIPTION
## Description
@YS-L 
Fix OfflineStoreFeatureTableBadStateError when generating deployment SQL for pure-request-column features

### Summary
Generating deployment SQL for a feature list containing a feature that is purely derived from a request column — e.g. forecast_week = (context.get_forecast_point_feature().dt.week - 1) % 52 — failed with:
OfflineStoreFeatureTableBadStateError: Failed to create entity universe for offline store feature table temp_dept_store_id

### Root cause
For such features, the offline ingest graph has no source-data aggregation node. feature.primary_entity_ids is still inherited from the context (e.g. dept_store_id), so the feature gets grouped under a temp_<entity> offline store table. When _process_features then calls get_entity_universe_model, every entry in aggregation_nodes_info is a RequestColumnNode (or the list is empty). get_combined_universe returns None, and OfflineStoreFeatureTableBadStateError is raised.

The decomposition-time filter at offline_store_ingest.py:212-213 already removes RequestColumnNodes from aggregation_nodes_info, but it only runs on decomposed graphs. Small features like forecast_week are not decomposed and use feature.extract_aggregation_nodes_info(), which does not filter.

### Fix
In DeploymentSqlGenerationService._process_features, skip offline-table SQL generation for tables whose ingest graphs contain only REQUEST_COLUMN nodes. Such features have no source data to materialize from and are served on-demand from request inputs.

### Tests
 test_deployment_sql__forecast_point_only — pure forecast feature → no feature_table_sqls produced.
 test_deployment_sql__forecast_point_with_aggregate — mixed list → only the real aggregate gets a feature table SQL.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
