### PR TITLE
Dedup concurrent feature compute on the same observation table

### DIFF
--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -690,17 +690,26 @@ class FeatureTableCacheService:
                     CACHE_INSERTION_START_PROGRESS_PERCENTAGE, "Inserting features into cache"
                 )
 
-            # No lock needed here — the caller (create_or_update_feature_table_cache)
-            # already holds the per-observation-table lock that wraps cache check +
-            # compute + insert.
-            await self._insert_features_into_cache(
-                db_session=db_session,
-                observation_table=observation_table,
-                non_cached_nodes=non_cached_nodes,
-                graph=graph,
-                intermediate_table_name=intermediate_table_name,
-                features_computation_result=features_computation_result,
-            )
+            # Defense in depth around the cache table mutation (create / alter / merge).
+            # The outer lock in create_or_update_feature_table_cache normally serializes
+            # this, but its TTL is finite (LONG_RUNNING_EXECUTE_QUERY_TIMEOUT_SECONDS) —
+            # if it expires mid-flight a concurrent caller could re-enter the insert
+            # path. We use a key distinct from the outer lock so re-acquiring here
+            # doesn't deadlock against this same process's own outer lock (Redis locks
+            # are not reentrant).
+            async with acquire_lock(
+                self.redis,
+                f"feature_table_cache_insert:obs:{observation_table.id}",
+                timeout=LONG_RUNNING_EXECUTE_QUERY_TIMEOUT_SECONDS,
+            ):
+                await self._insert_features_into_cache(
+                    db_session=db_session,
+                    observation_table=observation_table,
+                    non_cached_nodes=non_cached_nodes,
+                    graph=graph,
+                    intermediate_table_name=intermediate_table_name,
+                    features_computation_result=features_computation_result,
+                )
 
             # Cache insertion completed
             if progress_callback:
@@ -809,10 +818,20 @@ class FeatureTableCacheService:
         # Serialize the cache-check + compute + insert sequence per observation table.
         # Without this lock at the outer level, two concurrent requests for the same
         # (observation_table, features) pair can both miss the cache, both decide to
-        # compute, and both run the expensive feature computation in parallel — even
-        # though the existing inner insert-only lock protects against concurrent writes,
-        # it doesn't dedup the compute. Holding the lock from the cache check through
-        # insert means a second request finds the cache populated and exits cheaply.
+        # compute, and both run the expensive feature computation in parallel.
+        # Holding the lock from the cache check through insert means a second request
+        # finds the cache populated and exits cheaply.
+        #
+        # Scope tradeoff: keying on observation_table.id alone also serializes
+        # requests for *different* feature sets on the same observation table.
+        # Finer granularity (e.g. per sorted hash-tuple) would unblock unrelated
+        # feature sets but would lose the dedup benefit whenever a later request
+        # overlaps with an in-flight compute — the in-flight request wouldn't
+        # populate the cache in time, so the later request would compute a
+        # superset on its own. The cache table is keyed per observation table, so
+        # observation_table.id is the natural unit; the wait cost is bounded by
+        # one ongoing compute, while the savings (observed at ~85 min / ~34 GB
+        # of duplicated work in production) are large.
         async with acquire_lock(
             self.redis,
             f"feature_table_cache_update:obs:{observation_table.id}",

--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -690,21 +690,17 @@ class FeatureTableCacheService:
                     CACHE_INSERTION_START_PROGRESS_PERCENTAGE, "Inserting features into cache"
                 )
 
-            async with acquire_lock(
-                self.redis,
-                f"feature_table_cache_update:obs:{observation_table.id}",
-                timeout=LONG_RUNNING_EXECUTE_QUERY_TIMEOUT_SECONDS,
-            ):
-                # We need to acquire a lock to handle the case where multiple requests are trying to
-                # add the features to the cache at the same time.
-                await self._insert_features_into_cache(
-                    db_session=db_session,
-                    observation_table=observation_table,
-                    non_cached_nodes=non_cached_nodes,
-                    graph=graph,
-                    intermediate_table_name=intermediate_table_name,
-                    features_computation_result=features_computation_result,
-                )
+            # No lock needed here — the caller (create_or_update_feature_table_cache)
+            # already holds the per-observation-table lock that wraps cache check +
+            # compute + insert.
+            await self._insert_features_into_cache(
+                db_session=db_session,
+                observation_table=observation_table,
+                non_cached_nodes=non_cached_nodes,
+                graph=graph,
+                intermediate_table_name=intermediate_table_name,
+                features_computation_result=features_computation_result,
+            )
 
             # Cache insertion completed
             if progress_callback:
@@ -797,9 +793,6 @@ class FeatureTableCacheService:
             "Observation Tables without row index are not supported"
         )
 
-        cached_definitions = await self.feature_table_cache_metadata_service.get_cached_definitions(
-            observation_table_id=observation_table.id
-        )
         db_session = await self.session_manager_service.get_feature_store_session(
             feature_store=feature_store
         )
@@ -810,43 +803,65 @@ class FeatureTableCacheService:
                 await self._get_definition_hashes_mapping_from_feature_list_id(feature_list_id)
             )
 
+        # Compute hashes before the lock (CPU-only, doesn't depend on cache state).
         hashes = await self.get_feature_definition_hashes(graph, nodes, definition_hashes_mapping)
-        non_cached_nodes = await self.get_non_cached_nodes(cached_definitions, nodes, hashes)
 
-        if progress_callback:
-            await progress_callback(
-                FEATURE_TABLE_CACHE_CHECK_PROGRESS_PERCENTAGE,
-                "Feature table cache status check completed",
+        # Serialize the cache-check + compute + insert sequence per observation table.
+        # Without this lock at the outer level, two concurrent requests for the same
+        # (observation_table, features) pair can both miss the cache, both decide to
+        # compute, and both run the expensive feature computation in parallel — even
+        # though the existing inner insert-only lock protects against concurrent writes,
+        # it doesn't dedup the compute. Holding the lock from the cache check through
+        # insert means a second request finds the cache populated and exits cheaply.
+        async with acquire_lock(
+            self.redis,
+            f"feature_table_cache_update:obs:{observation_table.id}",
+            timeout=LONG_RUNNING_EXECUTE_QUERY_TIMEOUT_SECONDS,
+        ):
+            cached_definitions = (
+                await self.feature_table_cache_metadata_service.get_cached_definitions(
+                    observation_table_id=observation_table.id
+                )
+            )
+            non_cached_nodes = await self.get_non_cached_nodes(
+                cached_definitions, nodes, hashes
             )
 
-        if non_cached_nodes:
-            features_computation_result = await self._materialize_and_update_cache(
-                feature_store=feature_store,
-                observation_table=observation_table,
-                db_session=db_session,
-                graph=graph,
-                non_cached_nodes=non_cached_nodes,
-                is_target=is_target,
-                serving_names_mapping=serving_names_mapping,
-                development_dataset=development_dataset,
-                progress_callback=progress_callback,
-                raise_on_error=raise_on_error,
-                forecast_point_schema=forecast_point_schema,
-            )
-        else:
-            # No features to compute, everything is cached
             if progress_callback:
                 await progress_callback(
-                    CACHE_INSERTION_COMPLETED_PROGRESS_PERCENTAGE, "All features already cached"
+                    FEATURE_TABLE_CACHE_CHECK_PROGRESS_PERCENTAGE,
+                    "Feature table cache status check completed",
                 )
 
-            features_computation_result = FeaturesComputationResult(
-                historical_features_metrics=HistoricalFeaturesMetrics(
-                    tile_compute_seconds=0,
-                    feature_compute_seconds=0,
-                    feature_cache_update_seconds=0,
+            if non_cached_nodes:
+                features_computation_result = await self._materialize_and_update_cache(
+                    feature_store=feature_store,
+                    observation_table=observation_table,
+                    db_session=db_session,
+                    graph=graph,
+                    non_cached_nodes=non_cached_nodes,
+                    is_target=is_target,
+                    serving_names_mapping=serving_names_mapping,
+                    development_dataset=development_dataset,
+                    progress_callback=progress_callback,
+                    raise_on_error=raise_on_error,
+                    forecast_point_schema=forecast_point_schema,
                 )
-            )
+            else:
+                # No features to compute, everything is cached
+                if progress_callback:
+                    await progress_callback(
+                        CACHE_INSERTION_COMPLETED_PROGRESS_PERCENTAGE,
+                        "All features already cached",
+                    )
+
+                features_computation_result = FeaturesComputationResult(
+                    historical_features_metrics=HistoricalFeaturesMetrics(
+                        tile_compute_seconds=0,
+                        feature_compute_seconds=0,
+                        feature_cache_update_seconds=0,
+                    )
+                )
 
         return UpdateFeatureTableCacheResult(
             hashes=hashes,

--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -819,8 +819,16 @@ class FeatureTableCacheService:
         # Without this lock at the outer level, two concurrent requests for the same
         # (observation_table, features) pair can both miss the cache, both decide to
         # compute, and both run the expensive feature computation in parallel.
-        # Holding the lock from the cache check through insert means a second request
-        # finds the cache populated and exits cheaply.
+        # Holding the lock from cache-check through insert means:
+        #   - A second request whose feature set is fully covered by the first's
+        #     output sees the cache populated by the time it acquires the lock and
+        #     skips compute entirely (get_non_cached_nodes returns []).
+        #   - A second request with partial overlap still computes, but only for
+        #     the genuinely missing definition hashes — overlapping ones are
+        #     filtered out by get_non_cached_nodes.
+        #   - A second request with no overlap gets no dedup benefit and is
+        #     simply blocked until the first releases. That serialization cost
+        #     is the per-observation-table scope tradeoff below.
         #
         # Scope tradeoff: keying on observation_table.id alone also serializes
         # requests for *different* feature sets on the same observation table.

--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -842,9 +842,7 @@ class FeatureTableCacheService:
                     observation_table_id=observation_table.id
                 )
             )
-            non_cached_nodes = await self.get_non_cached_nodes(
-                cached_definitions, nodes, hashes
-            )
+            non_cached_nodes = await self.get_non_cached_nodes(cached_definitions, nodes, hashes)
 
             if progress_callback:
                 await progress_callback(

--- a/featurebyte/service/feature_table_cache.py
+++ b/featurebyte/service/feature_table_cache.py
@@ -4,6 +4,7 @@ Module for managing physical feature table cache as well as metadata storage.
 
 from __future__ import annotations
 
+import hashlib
 import time
 from dataclasses import dataclass
 from typing import Any, AsyncGenerator, Callable, Coroutine, Dict, List, Optional, Tuple, cast
@@ -690,13 +691,17 @@ class FeatureTableCacheService:
                     CACHE_INSERTION_START_PROGRESS_PERCENTAGE, "Inserting features into cache"
                 )
 
-            # Defense in depth around the cache table mutation (create / alter / merge).
-            # The outer lock in create_or_update_feature_table_cache normally serializes
-            # this, but its TTL is finite (LONG_RUNNING_EXECUTE_QUERY_TIMEOUT_SECONDS) —
-            # if it expires mid-flight a concurrent caller could re-enter the insert
-            # path. We use a key distinct from the outer lock so re-acquiring here
-            # doesn't deadlock against this same process's own outer lock (Redis locks
-            # are not reentrant).
+            # Per-observation-table lock around the cache table mutation (create
+            # / alter / merge). The outer lock in
+            # create_or_update_feature_table_cache is scoped to (obs_table,
+            # feature-set fingerprint), so concurrent requests for *different*
+            # feature sets on the same observation table proceed in parallel and
+            # all reach this point — they must serialize their writes to the
+            # shared cache table (same target table, same row index, but
+            # different columns). It also serves as defense-in-depth in case the
+            # outer lock's TTL expires mid-flight. Keyed differently from the
+            # outer lock so re-acquiring here doesn't deadlock against this same
+            # process's own outer lock (Redis locks are not reentrant).
             async with acquire_lock(
                 self.redis,
                 f"feature_table_cache_insert:obs:{observation_table.id}",
@@ -815,34 +820,27 @@ class FeatureTableCacheService:
         # Compute hashes before the lock (CPU-only, doesn't depend on cache state).
         hashes = await self.get_feature_definition_hashes(graph, nodes, definition_hashes_mapping)
 
-        # Serialize the cache-check + compute + insert sequence per observation table.
-        # Without this lock at the outer level, two concurrent requests for the same
-        # (observation_table, features) pair can both miss the cache, both decide to
-        # compute, and both run the expensive feature computation in parallel.
-        # Holding the lock from cache-check through insert means:
-        #   - A second request whose feature set is fully covered by the first's
-        #     output sees the cache populated by the time it acquires the lock and
-        #     skips compute entirely (get_non_cached_nodes returns []).
-        #   - A second request with partial overlap still computes, but only for
-        #     the genuinely missing definition hashes — overlapping ones are
-        #     filtered out by get_non_cached_nodes.
-        #   - A second request with no overlap gets no dedup benefit and is
-        #     simply blocked until the first releases. That serialization cost
-        #     is the per-observation-table scope tradeoff below.
+        # Serialize the cache-check + compute + insert sequence per (observation
+        # table, feature set). Without this lock, two concurrent requests for the
+        # same (observation_table, features) pair can both miss the cache, both
+        # decide to compute, and both run the expensive feature computation in
+        # parallel — observed in production at ~85 min / ~34 GB of duplicated work
+        # for two parallel model training tasks computing identical features.
         #
-        # Scope tradeoff: keying on observation_table.id alone also serializes
-        # requests for *different* feature sets on the same observation table.
-        # Finer granularity (e.g. per sorted hash-tuple) would unblock unrelated
-        # feature sets but would lose the dedup benefit whenever a later request
-        # overlaps with an in-flight compute — the in-flight request wouldn't
-        # populate the cache in time, so the later request would compute a
-        # superset on its own. The cache table is keyed per observation table, so
-        # observation_table.id is the natural unit; the wait cost is bounded by
-        # one ongoing compute, while the savings (observed at ~85 min / ~34 GB
-        # of duplicated work in production) are large.
+        # Lock scope is per *feature-set fingerprint* (sha256 of sorted unique
+        # definition hashes), not just per observation table. Two concurrent
+        # requests for the *same* feature list on the same observation table
+        # share a lock and dedup; requests for *unrelated* feature sets on the
+        # same observation table acquire different locks and run in parallel.
+        # Requests with *partial* hash overlap acquire different locks and can
+        # redundantly compute the shared hashes if perfectly concurrent — that's
+        # an accepted cost; the alternative (per-hash multi-lock acquisition) is
+        # significantly more complex, and the production case this protects
+        # against was identical feature lists, not partial overlap.
+        hashes_fingerprint = hashlib.sha256(",".join(sorted(set(hashes))).encode()).hexdigest()[:16]
         async with acquire_lock(
             self.redis,
-            f"feature_table_cache_update:obs:{observation_table.id}",
+            f"feature_table_cache_update:obs:{observation_table.id}:fp:{hashes_fingerprint}",
             timeout=LONG_RUNNING_EXECUTE_QUERY_TIMEOUT_SECONDS,
         ):
             cached_definitions = (

--- a/tests/unit/service/test_feature_table_cache.py
+++ b/tests/unit/service/test_feature_table_cache.py
@@ -1077,9 +1077,7 @@ async def test_create_or_update_feature_table_cache__concurrent_calls_dedup_comp
 
     mock_get_historical_features.side_effect = slow_compute
 
-    with patch(
-        "featurebyte.service.feature_table_cache.acquire_lock", new=fake_acquire_lock
-    ):
+    with patch("featurebyte.service.feature_table_cache.acquire_lock", new=fake_acquire_lock):
         results = await asyncio.gather(
             feature_table_cache_service.create_or_update_feature_table_cache(
                 feature_store=feature_store,

--- a/tests/unit/service/test_feature_table_cache.py
+++ b/tests/unit/service/test_feature_table_cache.py
@@ -1112,3 +1112,86 @@ async def test_create_or_update_feature_table_cache__concurrent_calls_dedup_comp
         num_cached_definitions_expected=2,
         num_cached_table_expected=1,
     )
+
+
+@pytest.mark.asyncio
+async def test_create_or_update_feature_table_cache__different_feature_sets_run_in_parallel(
+    feature_store,
+    feature_table_cache_service,
+    observation_table,
+    regular_feature_list,
+    mock_get_historical_features,
+):
+    """
+    Two concurrent calls for the same observation_table but *different* feature
+    sets must NOT serialize. The outer lock is keyed on (observation_table,
+    feature-set fingerprint), so unrelated feature sets acquire different locks
+    and can compute in parallel. Regression test for the over-broad
+    per-observation-table scope that previously blocked all concurrent work on
+    the same observation table.
+    """
+    import asyncio
+    from contextlib import asynccontextmanager
+
+    locks_by_name: dict[str, asyncio.Lock] = {}
+
+    @asynccontextmanager
+    async def fake_acquire_lock(_redis, name, timeout=None, blocking_timeout=None):
+        _ = timeout, blocking_timeout
+        lock = locks_by_name.setdefault(name, asyncio.Lock())
+        async with lock:
+            yield lock
+
+    # Track the maximum number of compute calls in flight at the same time.
+    # If the lock is correctly per-fingerprint, two unrelated requests overlap
+    # and max_concurrent reaches 2. If the lock over-blocks (per-observation
+    # only) the second compute can't start until the first releases.
+    concurrent = 0
+    max_concurrent = 0
+    counter_lock = asyncio.Lock()
+    real_return_value = mock_get_historical_features.return_value
+
+    async def tracked_compute(*args, **kwargs):
+        nonlocal concurrent, max_concurrent
+        _ = args, kwargs
+        async with counter_lock:
+            concurrent += 1
+            if concurrent > max_concurrent:
+                max_concurrent = concurrent
+        # Sleep long enough for the second call to reach this point if it can.
+        await asyncio.sleep(0.1)
+        async with counter_lock:
+            concurrent -= 1
+        return real_return_value
+
+    mock_get_historical_features.side_effect = tracked_compute
+
+    nodes = regular_feature_list.feature_clusters[0].nodes
+    graph = regular_feature_list.feature_clusters[0].graph
+    assert len(nodes) >= 2, "fixture must have at least 2 distinct features"
+
+    with patch("featurebyte.service.feature_table_cache.acquire_lock", new=fake_acquire_lock):
+        await asyncio.gather(
+            feature_table_cache_service.create_or_update_feature_table_cache(
+                feature_store=feature_store,
+                observation_table=observation_table,
+                graph=graph,
+                nodes=[nodes[0]],
+            ),
+            feature_table_cache_service.create_or_update_feature_table_cache(
+                feature_store=feature_store,
+                observation_table=observation_table,
+                graph=graph,
+                nodes=[nodes[1]],
+            ),
+        )
+
+    # Both compute calls fired (different feature sets, so no dedup).
+    assert mock_get_historical_features.await_count == 2
+    # And they ran concurrently — the per-fingerprint lock scope must not
+    # block unrelated feature sets on the same observation table.
+    assert max_concurrent == 2, (
+        f"Expected 2 concurrent computes, observed max {max_concurrent}. "
+        "The outer lock is over-blocking — different feature sets on the same "
+        "observation table should run in parallel."
+    )

--- a/tests/unit/service/test_feature_table_cache.py
+++ b/tests/unit/service/test_feature_table_cache.py
@@ -1027,3 +1027,90 @@ async def test_get_feature_query__duplicate_additional_columns(
     # "featureA" should appear exactly once in the SELECT clause (as the aliased feature column)
     select_clause = query_sql.split("FROM")[0]
     assert select_clause.count('"featureA"') == 1
+
+
+@pytest.mark.asyncio
+async def test_create_or_update_feature_table_cache__concurrent_calls_dedup_compute(
+    feature_store,
+    feature_table_cache_service,
+    feature_table_cache_metadata_service,
+    observation_table,
+    feature_list,
+    mock_get_historical_features,
+):
+    """
+    Two concurrent calls for the same (observation_table, features) must result
+    in exactly one feature compute, not two. Regression test for the race
+    condition where both calls would miss the cache, both decide to compute,
+    and both run the expensive feature computation in parallel.
+
+    The unit-test Redis is fully mocked, so its `lock()` is a no-op and won't
+    actually serialize. Patch acquire_lock with an asyncio.Lock-backed
+    contextmanager keyed by lock name so the test exercises the locking flow
+    end-to-end inside a single event loop.
+    """
+    import asyncio
+    from contextlib import asynccontextmanager
+
+    locks_by_name: dict[str, asyncio.Lock] = {}
+
+    @asynccontextmanager
+    async def fake_acquire_lock(_redis, name, timeout=None, blocking_timeout=None):
+        _ = timeout, blocking_timeout
+        lock = locks_by_name.setdefault(name, asyncio.Lock())
+        async with lock:
+            yield lock
+
+    # Make get_historical_features yield to the event loop so the second call
+    # has a chance to start while the first is "computing". Without this both
+    # tasks would run sequentially anyway and the test wouldn't exercise the
+    # race.
+    original_side_effect = mock_get_historical_features.side_effect
+    real_return_value = mock_get_historical_features.return_value
+
+    async def slow_compute(*args, **kwargs):
+        _ = args, kwargs
+        await asyncio.sleep(0.1)
+        if original_side_effect is not None:
+            return await original_side_effect(*args, **kwargs)
+        return real_return_value
+
+    mock_get_historical_features.side_effect = slow_compute
+
+    with patch(
+        "featurebyte.service.feature_table_cache.acquire_lock", new=fake_acquire_lock
+    ):
+        results = await asyncio.gather(
+            feature_table_cache_service.create_or_update_feature_table_cache(
+                feature_store=feature_store,
+                observation_table=observation_table,
+                graph=feature_list.feature_clusters[0].graph,
+                nodes=feature_list.feature_clusters[0].nodes,
+                feature_list_id=feature_list.id,
+            ),
+            feature_table_cache_service.create_or_update_feature_table_cache(
+                feature_store=feature_store,
+                observation_table=observation_table,
+                graph=feature_list.feature_clusters[0].graph,
+                nodes=feature_list.feature_clusters[0].nodes,
+                feature_list_id=feature_list.id,
+            ),
+        )
+
+    # Both calls succeeded.
+    assert len(results) == 2
+    # Compute fired exactly once — second call hit the cache populated by the first.
+    assert mock_get_historical_features.await_count == 1, (
+        f"Expected 1 compute, got {mock_get_historical_features.await_count}. "
+        "The dedup lock did not serialize the cache check + compute path."
+    )
+    # Both calls produced the same hashes (same feature set).
+    assert results[0].hashes == results[1].hashes
+    # The cache contains the expected number of definitions for the observation
+    # table — proving the second call read the cached results, not duplicated them.
+    await check_feature_table_cache(
+        feature_table_cache_metadata_service,
+        observation_table.id,
+        num_cached_definitions_expected=2,
+        num_cached_table_expected=1,
+    )


### PR DESCRIPTION
@YS-L 
Move the per-observation-table lock in
FeatureTableCacheService.create_or_update_feature_table_cache to wrap the entire cache-check + compute + insert sequence, instead of just the insert. Without this, two concurrent requests for the same (observation_table, features) pair can both miss the cache, both decide to compute, and both run the expensive feature computation in parallel — the previous insert-only lock protected against concurrent writes but did nothing to dedup the duplicated work.

Observed in production: two parallel model training tasks computing identical features against the same observation table did ~85 minutes of duplicated execution and ~34 GB of duplicated scan, simply because they raced past the cache check before either could populate the cache.

The inner lock in _materialize_and_update_cache is now redundant and removed.

Adds a regression test that runs two concurrent
create_or_update_feature_table_cache calls via asyncio.gather and asserts that the underlying feature compute fires exactly once.

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
