### PR TITLE
[chore] Switch to using ubuntu-latest runners

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -54,7 +54,7 @@ jobs:
         run: echo "AUTHOR_EMAIL=$(git show -s --format='%ae' "origin/${{ github.ref_name }}")" >> $GITHUB_ENV
       - name: Validate Author Email and Set Channel ID
         run: |-
-          if [[ ! "${{ env.AUTHOR_EMAIL }}" =~ .+@featurebyte\.(com|ai)$ ]]; then
+          if [[ ! "${{ env.AUTHOR_EMAIL }}" =~ ^.+@featurebyte\.(com|ai)$ ]]; then
             echo "Author email '${{ env.AUTHOR_EMAIL }}' is not a valid FeatureByte email address" >&2
             exit 1
           fi

--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -135,7 +135,7 @@ jobs:
         run: echo "AUTHOR_EMAIL=$(git show -s --format='%ae' "origin/${{ github.ref_name }}")" >> $GITHUB_ENV
       - name: Validate Author Email and Set Channel ID
         run: |-
-          if [[ ! "${{ env.AUTHOR_EMAIL }}" =~ .+@featurebyte\.(com|ai)$ ]]; then
+          if [[ ! "${{ env.AUTHOR_EMAIL }}" =~ ^.+@featurebyte\.(com|ai)$ ]]; then
             echo "Author email '${{ env.AUTHOR_EMAIL }}' is not a valid FeatureByte email address" >&2
             exit 1
           fi

--- a/.github/workflows/publish-public.yaml
+++ b/.github/workflows/publish-public.yaml
@@ -36,8 +36,6 @@ concurrency:
   group: ${{ github.workflow }}
 jobs:
   publish:
-    # runs-on:
-    #   group: Public Runners
     runs-on: ubuntu-latest
     timeout-minutes: 360
     strategy:

--- a/.github/workflows/publish-public.yaml
+++ b/.github/workflows/publish-public.yaml
@@ -36,8 +36,9 @@ concurrency:
   group: ${{ github.workflow }}
 jobs:
   publish:
-    runs-on:
-      group: Public Runners
+    # runs-on:
+    #   group: Public Runners
+    runs-on: ubuntu-latest
     timeout-minutes: 360
     strategy:
       matrix:

--- a/.github/workflows/publish-public.yaml
+++ b/.github/workflows/publish-public.yaml
@@ -119,7 +119,7 @@ jobs:
         run: echo "AUTHOR_EMAIL=$(git show -s --format='%ae' "origin/${{ github.ref_name }}")" >> $GITHUB_ENV
       - name: Validate Author Email and Set Channel ID
         run: |-
-          if [[ ! "${{ env.AUTHOR_EMAIL }}" =~ .+@featurebyte\.(com|ai)$ ]]; then
+          if [[ ! "${{ env.AUTHOR_EMAIL }}" =~ ^.+@featurebyte\.(com|ai)$ ]]; then
             echo "Author email '${{ env.AUTHOR_EMAIL }}' is not a valid FeatureByte email address" >&2
             exit 1
           fi

--- a/.github/workflows/test-notebooks.yaml
+++ b/.github/workflows/test-notebooks.yaml
@@ -24,8 +24,6 @@ env:
   POETRY_HTTP_BASIC_FEATUREBYTE_NP_USERNAME: _json_key_base64
 jobs:
   test-deep-dive-notebooks:
-    # runs-on:
-    #   group: Public Runners
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -60,8 +58,6 @@ jobs:
         run: task test-deep-dive-notebooks
     timeout-minutes: 30
   test-quick-start-notebooks:
-    # runs-on:
-    #   group: Public Runners
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -96,8 +92,6 @@ jobs:
         run: task test-quick-start-notebooks
     timeout-minutes: 45
   test-playground-notebooks:
-    # runs-on:
-    #   group: Public Runners
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/test-notebooks.yaml
+++ b/.github/workflows/test-notebooks.yaml
@@ -144,7 +144,7 @@ jobs:
         run: echo "AUTHOR_EMAIL=$(git show -s --format='%ae' "origin/${{ github.ref_name }}")" >> $GITHUB_ENV
       - name: Validate Author Email and Set Channel ID
         run: |-
-          if [[ ! "${{ env.AUTHOR_EMAIL }}" =~ .+@featurebyte\.(com|ai)$ ]]; then
+          if [[ ! "${{ env.AUTHOR_EMAIL }}" =~ ^.+@featurebyte\.(com|ai)$ ]]; then
             echo "Author email '${{ env.AUTHOR_EMAIL }}' is not a valid FeatureByte email address" >&2
             exit 1
           fi

--- a/.github/workflows/test-notebooks.yaml
+++ b/.github/workflows/test-notebooks.yaml
@@ -24,8 +24,9 @@ env:
   POETRY_HTTP_BASIC_FEATUREBYTE_NP_USERNAME: _json_key_base64
 jobs:
   test-deep-dive-notebooks:
-    runs-on:
-      group: Public Runners
+    # runs-on:
+    #   group: Public Runners
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version:
@@ -59,8 +60,9 @@ jobs:
         run: task test-deep-dive-notebooks
     timeout-minutes: 30
   test-quick-start-notebooks:
-    runs-on:
-      group: Public Runners
+    # runs-on:
+    #   group: Public Runners
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version:
@@ -94,8 +96,9 @@ jobs:
         run: task test-quick-start-notebooks
     timeout-minutes: 45
   test-playground-notebooks:
-    runs-on:
-      group: Public Runners
+    # runs-on:
+    #   group: Public Runners
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -629,7 +629,7 @@ jobs:
         run: echo "AUTHOR_EMAIL=$(git show -s --format='%ae' "origin/${{ github.ref_name }}")" >> $GITHUB_ENV
       - name: Validate Author Email and Set Channel ID
         run: |-
-          if [[ ! "${{ env.AUTHOR_EMAIL }}" =~ .+@featurebyte\.(com|ai)$ ]]; then
+          if [[ ! "${{ env.AUTHOR_EMAIL }}" =~ ^.+@featurebyte\.(com|ai)$ ]]; then
             echo "Author email '${{ env.AUTHOR_EMAIL }}' is not a valid FeatureByte email address" >&2
             exit 1
           fi


### PR DESCRIPTION
`ubuntu-latest` should offer same specs (4C 16G) for public repos: https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
