### PR TITLE
[chore] Bump GitHub Actions versions

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: arduino/setup-task@v2
+      - uses: arduino/setup-task@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -31,7 +31,7 @@ jobs:
         python-version:
           - 3.10.14
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Checkout branch

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -30,12 +30,12 @@ jobs:
         python-version:
           - 3.10.14
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Checkout branch
         run: git checkout "origin/${{ github.head_ref }}"
-      - uses: arduino/setup-task@v2
+      - uses: arduino/setup-task@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -76,7 +76,7 @@ jobs:
       - name: Generate HTML
         run: cat diff.txt | diff2html -i stdin --title="Documentation Differences" -F diff.html --style="side" --renderNothingWhenEmpty
       - name: Upload diff html
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: docs-diff.html
           path: diff.html

--- a/.github/workflows/expire-tags.yaml
+++ b/.github/workflows/expire-tags.yaml
@@ -13,7 +13,7 @@ jobs:
   tags:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Set Github Committer Settings

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,8 +18,8 @@ jobs:
         python-version:
           - 3.10.14
     steps:
-      - uses: actions/checkout@v6
-      - uses: arduino/setup-task@v2
+      - uses: actions/checkout@v7
+      - uses: arduino/setup-task@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -43,7 +43,7 @@ jobs:
     needs:
       - lint
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - if: ${{ github.event_name == 'pull_request' }}
@@ -62,7 +62,7 @@ jobs:
       - name: Load REPOSITORY into env
         run: echo "REPOSITORY=$(echo '${{ github.repository }}' | cut -d / -f2)" >> $GITHUB_ENV
       - name: Send Slack notification with workflow result.
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_OAUTH }}

--- a/.github/workflows/notify.yaml
+++ b/.github/workflows/notify.yaml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'breaking') }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - env:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_OAUTH }}
       name: Send Slack notification to user-experience channel
-      uses: slackapi/slack-github-action@v3.0.1
+      uses: slackapi/slack-github-action@v3.0.3
       with:
         method: chat.postMessage
         token: ${{ secrets.SLACK_OAUTH }}

--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -31,8 +31,8 @@ jobs:
     outputs:
       DEV_VERSION: ${{ steps.get_version.outputs.DEV_VERSION }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: arduino/setup-task@v2
+      - uses: actions/checkout@v7
+      - uses: arduino/setup-task@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -124,7 +124,7 @@ jobs:
     needs:
       - publish
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - if: ${{ github.event_name == 'pull_request' }}
@@ -144,7 +144,7 @@ jobs:
         run: |
           echo "REPOSITORY=$(echo '${{ github.repository }}' | cut -d / -f2)" >> $GITHUB_ENV
       - name: Send Slack notification with workflow result.
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_OAUTH }}

--- a/.github/workflows/publish-public.yaml
+++ b/.github/workflows/publish-public.yaml
@@ -43,10 +43,10 @@ jobs:
         python-version:
           - 3.10.14
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: arduino/setup-task@v2
+      - uses: arduino/setup-task@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -108,7 +108,7 @@ jobs:
     needs:
       - publish
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - if: ${{ github.event_name == 'pull_request' }}
@@ -129,7 +129,7 @@ jobs:
           echo "REPOSITORY=$(echo '${{ github.repository }}' | cut -d / -f2)" >> $GITHUB_ENV
           echo "REPOSITORY_URL=https://github.com/$(echo '${{ github.repository }}')" >> $GITHUB_ENV
       - name: Send Slack notification with workflow result.
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_OAUTH }}

--- a/.github/workflows/test-notebooks.yaml
+++ b/.github/workflows/test-notebooks.yaml
@@ -30,8 +30,8 @@ jobs:
         python-version:
           - 3.10.14
     steps:
-      - uses: actions/checkout@v6
-      - uses: arduino/setup-task@v2
+      - uses: actions/checkout@v7
+      - uses: arduino/setup-task@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -64,8 +64,8 @@ jobs:
         python-version:
           - 3.10.14
     steps:
-      - uses: actions/checkout@v6
-      - uses: arduino/setup-task@v2
+      - uses: actions/checkout@v7
+      - uses: arduino/setup-task@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -98,8 +98,8 @@ jobs:
         python-version:
           - 3.10.14
     steps:
-      - uses: actions/checkout@v6
-      - uses: arduino/setup-task@v2
+      - uses: actions/checkout@v7
+      - uses: arduino/setup-task@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -133,7 +133,7 @@ jobs:
       - test-deep-dive-notebooks
       - test-playground-notebooks
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - if: ${{ github.event_name == 'pull_request' }}
@@ -153,7 +153,7 @@ jobs:
         run: |
           echo "REPOSITORY=$(echo '${{ github.repository }}' | cut -d / -f2)" >> $GITHUB_ENV
       - name: Send Slack notification with workflow result.
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_OAUTH }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,25 +52,25 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: arduino/setup-task@v2
+      - uses: actions/checkout@v7
+      - uses: arduino/setup-task@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
       - name: Setup gradle cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: hive-udf/.gradle
           key: gradle-cache-${{ runner.os }}
       - name: Setup gradle build cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: hive-udf/lib/build
           key: gradle-build-cache-${{ runner.os }}
       - name: Building hive-udf
         run: task build-jar
       - name: Upload hive-udf
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: hive-udf
           path: hive-udf/lib/build/libs/*
@@ -84,8 +84,8 @@ jobs:
         python-version:
           - 3.10.14
     steps:
-      - uses: actions/checkout@v6
-      - uses: arduino/setup-task@v2
+      - uses: actions/checkout@v7
+      - uses: arduino/setup-task@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -110,12 +110,12 @@ jobs:
       - name: Renaming test assets
         run: mv .coverage .coverage.0
       - name: Upload test results
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-${{ matrix.python-version }}-pytest.xml.0
           path: pytest.xml.0
       - name: Upload coverage results
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-${{ matrix.python-version }}-.coverage.0
           path: .coverage.0
@@ -136,8 +136,8 @@ jobs:
     env:
       PYTEST_SPLITS: 2  # This needs to be EQ the count of strategy.matrix.pytest-group
     steps:
-      - uses: actions/checkout@v6
-      - uses: arduino/setup-task@v2
+      - uses: actions/checkout@v7
+      - uses: arduino/setup-task@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -165,20 +165,20 @@ jobs:
           mv pytest.xml.1 pytest.xml.1.${{ matrix.pytest-group }}
           mv .test_durations .test_durations.1.${{ matrix.pytest-group }}
       - name: Upload test results
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-${{ matrix.python-version }}-pytest.xml.1.${{ matrix.pytest-group }}
           path: pytest.xml.1.${{ matrix.pytest-group }}
           overwrite: true
       - name: Upload coverage results
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-${{ matrix.python-version }}-.coverage.1.${{ matrix.pytest-group }}
           path: .coverage.1.${{ matrix.pytest-group }}
           overwrite: true
           include-hidden-files: true
       - name: Upload test durations
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-${{ matrix.python-version }}-.test_durations.1.${{ matrix.pytest-group }}
           path: .test_durations.1.${{ matrix.pytest-group }}
@@ -199,8 +199,8 @@ jobs:
     env:
       PYTEST_SPLITS: 1  # This needs to be EQ the count of strategy.matrix.pytest-group
     steps:
-      - uses: actions/checkout@v6
-      - uses: arduino/setup-task@v2
+      - uses: actions/checkout@v7
+      - uses: arduino/setup-task@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -232,20 +232,20 @@ jobs:
           mv pytest.xml.1b pytest.xml.1b.${{ matrix.pytest-group }}
           mv .test_durations .test_durations.1b.${{ matrix.pytest-group }}
       - name: Upload test results
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-${{ matrix.python-version }}-pytest.xml.1b.${{ matrix.pytest-group }}
           path: pytest.xml.1b.${{ matrix.pytest-group }}
           overwrite: true
       - name: Upload coverage results
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-${{ matrix.python-version }}-.coverage.1b.${{ matrix.pytest-group }}
           path: .coverage.1b.${{ matrix.pytest-group }}
           overwrite: true
           include-hidden-files: true
       - name: Upload test durations
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-${{ matrix.python-version }}-.test_durations.1b.${{ matrix.pytest-group }}
           path: .test_durations.1b.${{ matrix.pytest-group }}
@@ -271,8 +271,8 @@ jobs:
     env:
       PYTEST_SPLITS: 4  # This needs to be EQ the count of strategy.matrix.pytest-group
     steps:
-      - uses: actions/checkout@v6
-      - uses: arduino/setup-task@v2
+      - uses: actions/checkout@v7
+      - uses: arduino/setup-task@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -314,7 +314,7 @@ jobs:
           mv pytest.xml.2 pytest.xml.2.${{ matrix.pytest-group }}
           mv .test_durations .test_durations.2.${{ matrix.pytest-group }}
       - name: Upload spark-thrift log file
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: spark-thrift-logs-${{ matrix.python-version }}-${{ matrix.spark-version }}-${{ matrix.pytest-group }}
           path: spark-thrift-${{ matrix.python-version }}-${{ matrix.spark-version }}-${{ matrix.pytest-group }}.log
@@ -322,20 +322,20 @@ jobs:
 
       # NOTE: Only holding 1 test result to be used in pytest report
       - name: Upload test results
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-${{ matrix.python-version }}-pytest.xml.2.${{ matrix.pytest-group }}
           path: pytest.xml.2.${{ matrix.pytest-group }}
           overwrite: true
       - name: Upload coverage results
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-${{ matrix.python-version }}-.coverage.2.${{ matrix.pytest-group }}
           path: .coverage.2.${{ matrix.pytest-group }}
           overwrite: true
           include-hidden-files: true
       - name: Upload test durations
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-${{ matrix.python-version }}-.test_durations.2.${{ matrix.pytest-group }}
           path: .test_durations.2.${{ matrix.pytest-group }}
@@ -366,8 +366,8 @@ jobs:
     env:
       PYTEST_SPLITS: 5  # This needs to be EQ the count of strategy.matrix.pytest-group
     steps:
-      - uses: actions/checkout@v6
-      - uses: arduino/setup-task@v2
+      - uses: actions/checkout@v7
+      - uses: arduino/setup-task@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -390,18 +390,18 @@ jobs:
           mv pytest.xml.4 pytest.xml.4.${{ matrix.pytest-group }}
           mv .test_durations .test_durations.4.${{ matrix.pytest-group }}
       - name: Upload test results
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-${{ matrix.python-version }}-pytest.xml.4.${{ matrix.pytest-group }}
           path: pytest.xml.4.${{ matrix.pytest-group }}
       - name: Upload coverage results
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-${{ matrix.python-version }}-.coverage.4.${{ matrix.pytest-group }}
           path: .coverage.4.${{ matrix.pytest-group }}
           include-hidden-files: true
       - name: Upload test durations
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-${{ matrix.python-version }}-.test_durations.4.${{ matrix.pytest-group }}
           path: .test_durations.4.${{ matrix.pytest-group }}
@@ -425,8 +425,8 @@ jobs:
     env:
       PYTEST_SPLITS: 3  # This needs to be EQ the count of strategy.matrix.pytest-group
     steps:
-      - uses: actions/checkout@v6
-      - uses: arduino/setup-task@v2
+      - uses: actions/checkout@v7
+      - uses: arduino/setup-task@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -454,20 +454,20 @@ jobs:
           mv pytest.xml.5 pytest.xml.5.${{ matrix.pytest-group }}
           mv .test_durations .test_durations.5.${{ matrix.pytest-group }}
       - name: Upload test results
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-${{ matrix.python-version }}-pytest.xml.5.${{ matrix.pytest-group }}
           path: pytest.xml.5.${{ matrix.pytest-group }}
           overwrite: true
       - name: Upload coverage results
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-${{ matrix.python-version }}-.coverage.5.${{ matrix.pytest-group }}
           path: .coverage.5.${{ matrix.pytest-group }}
           overwrite: true
           include-hidden-files: true
       - name: Upload test durations
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: python-${{ matrix.python-version }}-.test_durations.5.${{ matrix.pytest-group }}
           path: .test_durations.5.${{ matrix.pytest-group }}
@@ -484,8 +484,8 @@ jobs:
         python-version:
           - 3.10.14
     steps:
-      - uses: actions/checkout@v6
-      - uses: arduino/setup-task@v2
+      - uses: actions/checkout@v7
+      - uses: arduino/setup-task@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -522,10 +522,10 @@ jobs:
         python-version:
           - 3.10.14
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: arduino/setup-task@v2
+      - uses: arduino/setup-task@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -550,7 +550,7 @@ jobs:
       - name: Merge test results
         run: task test-merge
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: pytest-coverage.txt
           path: pytest-coverage.txt
@@ -585,10 +585,10 @@ jobs:
         python-version:
           - 3.10.14
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: arduino/setup-task@v2
+      - uses: arduino/setup-task@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
@@ -600,7 +600,7 @@ jobs:
       - name: Merge test durations
         run: cat .test_durations.* | jq --slurp --sort-keys add > .test_durations
       - name: Upload combined test durations
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: .test_durations
           path: .test_durations
@@ -618,7 +618,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - if: ${{ github.event_name == 'pull_request' }}
@@ -638,7 +638,7 @@ jobs:
         run: |
           echo "REPOSITORY=$(echo '${{ github.repository }}' | cut -d / -f2)" >> $GITHUB_ENV
       - name: Send Slack notification with workflow result.
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_OAUTH }}


### PR DESCRIPTION
Bumps actions/checkout 6->7, arduino/setup-task 2->3, actions/cache 5->6, actions/upload-artifact 7.0.0->7.0.1, and slackapi/slack-github-action 3.0.1->3.0.3 across all workflows, consolidating dependabot PRs #3342-#3346.

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

Label this pull request to place it under the correct category in Release Notes:

|        **Pull Request Label**         | **Category in Release Notes** |
|:-------------------------------------:|:-----------------------------:|
|       `enhancement`, `feature`        |          🚀 Features          |
| `bug`, `refactoring`, `bugfix`, `fix` |    🔧 Fixes & Refactoring     |
|       `build`, `ci`, `testing`        |    📦 Build System & CI/CD    |
|              `breaking`               |      💥 Breaking Changes      |
|            `documentation`            |       📝 Documentation        |
|            `dependencies`             |    ⬆️ Dependencies updates    |



## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I have read the [`CODE_OF_CONDUCT.md`](https://github.com/featurebyte/featurebyte/blob/main/CODE_OF_CONDUCT.md) and [`CONTRIBUTING.md`](https://github.com/featurebyte/featurebyte/blob/main/CONTRIBUTING.md) guides.
- [ ] I have written tests for the changes made.
- [ ] I have written docstrings in [NumpyDoc format](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
- [ ] I have labeled my Pull Request correctly
